### PR TITLE
Allow map blocks in return and yield expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Map blocks can now be used in return and yield expressions
+
 ## [0.2.0] - 2020.12.02
 
 ### Added

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -209,6 +209,15 @@ impl ExpressionContext {
             expected_indentation: None,
         }
     }
+
+    fn start_new_expression(&self) -> Self {
+        Self {
+            allow_space_separated_call: true,
+            allow_initial_indentation: true,
+            expected_indentation: None,
+            ..*self
+        }
+    }
 }
 
 pub struct Parser<'source> {
@@ -1274,14 +1283,9 @@ impl<'source> Parser<'source> {
                 }
                 Token::Yield => {
                     self.consume_next_token(context);
-                    if let Some(expression) = self.parse_expressions(
-                        &mut ExpressionContext {
-                            allow_space_separated_call: true,
-                            expected_indentation: None,
-                            ..*context
-                        },
-                        false,
-                    )? {
+                    if let Some(expression) =
+                        self.parse_expressions(&mut context.start_new_expression(), false)?
+                    {
                         let result = self.push_node(Node::Yield(expression))?;
                         self.frame_mut()?.contains_yield = true;
                         Some(result)
@@ -1299,14 +1303,9 @@ impl<'source> Parser<'source> {
                 }
                 Token::Return => {
                     self.consume_next_token(context);
-                    let result = if let Some(expression) = self.parse_expressions(
-                        &mut ExpressionContext {
-                            allow_space_separated_call: true,
-                            expected_indentation: None,
-                            ..*context
-                        },
-                        false,
-                    )? {
+                    let result = if let Some(expression) =
+                        self.parse_expressions(&mut context.start_new_expression(), false)?
+                    {
                         self.push_node(Node::ReturnExpression(expression))?
                     } else {
                         self.push_node(Node::Return)?

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -2422,6 +2422,37 @@ y z";
                 None,
             )
         }
+
+        #[test]
+        fn generator_yielding_a_map() {
+            let source = "
+||
+  yield
+    foo: 42
+";
+            check_ast(
+                source,
+                &[
+                    Number(1),
+                    Map(vec![(0, Some(0))]),
+                    Yield(1),
+                    Function(koto_parser::Function {
+                        args: vec![],
+                        local_count: 0,
+                        accessed_non_locals: vec![],
+                        body: 2,
+                        is_instance_function: false,
+                        is_variadic: false,
+                        is_generator: true,
+                    }),
+                    MainBlock {
+                        body: vec![3],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("foo"), Constant::Number(42.0)]),
+            )
+        }
     }
 
     mod lookups {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -937,6 +937,17 @@ f -42";
         }
 
         #[test]
+        fn return_map() {
+            let script = "
+f = ||
+  return
+    foo: 42
+    bar: 99
+f().bar";
+            test_script(script, Number(99.0));
+        }
+
+        #[test]
         fn captured_value() {
             let script = "
 f = |x|


### PR DESCRIPTION
This PR allows map blocks to be used in return and yield expressions.

e.g.

```
f = ||
  return
    foo: 42 # An 'expected expression' error would occur here
    bar: 99
```
