### PR TITLE
Fix iterator.fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ### Removed
 - Vim support has been moved to [its own repo][vim].
 
+### Fixed
+- iterator.fold, list.retain, and list.transform could cause runtime errors or
+  stack overflows when being called after other functions.
+  - [Bug report](https://github.com/koto-lang/koto/issues/6)
+
 [vim]: https://github.com/koto-lang/koto.vim
 
 

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -70,11 +70,14 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("fold", |vm, args| {
-        let args = vm.get_args_as_vec(args);
-        match args.as_slice() {
+        match vm.get_args(args) {
             [iterable, result, Function(f)] if is_iterable(iterable) => {
-                match make_iterator(iterable)
-                    .unwrap()
+                let result = result.clone();
+                let f = f.clone();
+                let mut iter = make_iterator(iterable).unwrap();
+                let mut vm = vm.spawn_shared_vm();
+
+                match iter
                     .lock_internals(|iterator| {
                         let mut fold_result = result.clone();
                         for value in iterator {

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -201,11 +201,9 @@ pub fn make_module() -> ValueMap {
         _ => external_error!("list.sort_copy: Expected list as argument"),
     });
 
-    result.add_fn("to_tuple", |vm, args| {
-        match vm.get_args_as_vec(args).as_slice() {
-            [List(l)] => Ok(Value::Tuple(l.data().as_slice().into())),
-            _ => external_error!("list.to_tuple expects a list as argument"),
-        }
+    result.add_fn("to_tuple", |vm, args| match vm.get_args(args) {
+        [List(l)] => Ok(Value::Tuple(l.data().as_slice().into())),
+        _ => external_error!("list.to_tuple expects a list as argument"),
     });
 
     result.add_fn("transform", |vm, args| match vm.get_args(args) {

--- a/src/runtime/src/core/test.rs
+++ b/src/runtime/src/core/test.rs
@@ -97,12 +97,12 @@ pub fn make_module() -> ValueMap {
         _ => external_error!("assert_eq expects three arguments"),
     });
 
-    result.add_fn("run_tests", |vm, args| {
-        let args = vm.get_args_as_vec(args);
-        match args.as_slice() {
-            [Map(tests)] => vm.run_tests(tests.clone()),
-            _ => external_error!("run_tests expects a map as argument"),
+    result.add_fn("run_tests", |vm, args| match vm.get_args(args) {
+        [Map(tests)] => {
+            let tests = tests.clone();
+            vm.run_tests(tests)
         }
+        _ => external_error!("run_tests expects a map as argument"),
     });
 
     result

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -2576,10 +2576,6 @@ impl Vm {
         self.register_slice(args.register, args.count)
     }
 
-    pub fn get_args_as_vec(&self, args: &Args) -> ValueVec {
-        self.get_args(args).iter().cloned().collect()
-    }
-
     fn get_constant_str(&self, constant_index: ConstantIndex) -> &str {
         self.reader.chunk.constants.get_str(constant_index)
     }

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -194,6 +194,14 @@ impl Vm {
     }
 
     pub fn run_function(&mut self, function: &RuntimeFunction, args: &[Value]) -> RuntimeResult {
+        if !self.call_stack.is_empty() {
+            return vm_error!(
+                self.chunk(),
+                self.ip(),
+                "run_function: the call stack isn't empty"
+            );
+        }
+
         let current_chunk = self.chunk();
         let current_ip = self.ip();
 

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1058,6 +1058,17 @@ f3 = |x| f2() x
 f3 1";
             test_script(script, Number(1.0));
         }
+
+        #[test]
+        fn iterator_fold_after_function_call_shouldnt_error() {
+            // Reported in https://github.com/koto-lang/koto/issues/6
+            // iterator.fold() was incorrectly reusing its vm rather than spawning a new one
+            let script = "
+f = || 1, 2, 3
+f().fold 0 |x, n| x += n
+";
+            test_script(script, Number(6.0));
+        }
     }
 
     mod loops {


### PR DESCRIPTION
Fixes #6.

External functions that need to call Koto functions should spawn a shared VM,
rather than calling the function in its own VM, otherwise Bad Things happen when
the function fails to return as expected, like runtime errors and stack
overflows.
