### PR TITLE
Allow unparenthesized expressions in range boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - iterator.each and iterator.keep now collect iterator pairs into tuples.
 - Space-separated function calls are allowed in function args when the arg is on
   a new line.
+- Unparenthesized expressions can now be used for range boundaries.
+  - e.g. `(1 + 1)..(2 + 2)` can now be written as `1 + 1..2 + 2`.
 
 ### Removed
 - Vim support has been moved to [its own repo][vim].

--- a/koto/tests/ranges.koto
+++ b/koto/tests/ranges.koto
@@ -20,8 +20,8 @@ export tests =
   test_evaluated_boundaries: ||
     z = |n| n
     x = [(z 10)..=(z 20)]
-    y = x[z(5)..(10 + 0)]
-    assert_eq 15 y[0]
+    y = x[1 + 1..x.size() / 2]
+    assert_eq y[0] 12
 
   test_from_and_to_ranges: ||
     n = [0..=10]

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -24,7 +24,7 @@ fn run_script(script: &str, path: Option<PathBuf>, should_fail_at_runtime: bool)
             }
         },
         Err(error) => {
-            panic!("{}", error);
+            panic!("{}", koto.format_loader_error(error, &script));
         }
     }
 }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -334,7 +334,7 @@ x"#;
 
         #[test]
         fn range_from_expressions() {
-            let source = "(0 + 1)..(1 + 1)";
+            let source = "0 + 1..1 + 0";
             check_ast(
                 source,
                 &[
@@ -346,7 +346,7 @@ x"#;
                         rhs: 1,
                     },
                     Number1,
-                    Number1,
+                    Number0,
                     BinaryOp {
                         op: AstOp::Add,
                         lhs: 3,

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -194,56 +194,14 @@ a = 99
         fn range() {
             test_script("0..10", Range(IntRange { start: 0, end: 10 }));
             test_script("0..-10", Range(IntRange { start: 0, end: -10 }));
+            test_script("1 + 1..2 + 2", Range(IntRange { start: 2, end: 4 }));
         }
 
         #[test]
         fn range_inclusive() {
             test_script("10..=20", Range(IntRange { start: 10, end: 21 }));
             test_script("4..=0", Range(IntRange { start: 4, end: -1 }));
-        }
-
-        #[test]
-        fn subtract_divide_modulo() {
-            test_script("(20 - 2) / 3 % 4", Number(2.0));
-        }
-
-        #[test]
-        fn comparison() {
-            test_script(
-                "false or 1 < 2 <= 2 <= 3 and 3 >= 2 >= 2 > 1 or false",
-                Bool(true),
-            );
-        }
-
-        #[test]
-        fn equality() {
-            test_script("1 + 1 == 2 and 2 + 2 != 5", Bool(true));
-        }
-
-        #[test]
-        fn not_bool() {
-            test_script("not false", Bool(true));
-        }
-
-        #[test]
-        fn not_expression() {
-            test_script("not 1 + 1 == 2", Bool(false));
-        }
-
-        #[test]
-        fn assignment() {
-            let script = "
-a = 1 * 3
-a + 1";
-            test_script(script, Number(4.0));
-        }
-
-        #[test]
-        fn negation() {
-            let script = "
-a = 99
--a";
-            test_script(script, Number(-99.0));
+            test_script("2 * 2..=3 * 3", Range(IntRange { start: 4, end: 10 }));
         }
     }
 
@@ -1494,6 +1452,16 @@ equal
   5
 "#;
             test_script(script, Bool(true));
+        }
+
+        #[test]
+        fn range_in_space_separated_call_args() {
+            let script = r#"
+foo = |range, x| range.size() + x
+min, max = 0, 10
+foo min..max 20
+"#;
+            test_script(script, Number(30.0));
         }
     }
 


### PR DESCRIPTION
This PR allows unparenthesized expressions to be used in range boundaries.

e.g.

Before:
```koto
(1 + 1)..(2 + 2)
```

After:
```koto
1 + 1..2 + 2
```
