### PR TITLE
Revert to original terminal mode on quit

### DIFF
--- a/src/cli/src/repl.rs
+++ b/src/cli/src/repl.rs
@@ -191,6 +191,9 @@ impl Repl {
                     if self.input.is_empty() {
                         write!(stdout, "^C\r\n").unwrap();
                         stdout.flush().unwrap();
+                        if let Some(tty) = tty {
+                            tty.suspend_raw_mode().unwrap();
+                        }
                         std::process::exit(0)
                     } else {
                         self.input.clear();
@@ -200,6 +203,9 @@ impl Repl {
                 'd' if self.input.is_empty() => {
                     write!(stdout, "^D\r\n").unwrap();
                     stdout.flush().unwrap();
+                    if let Some(tty) = tty {
+                        tty.suspend_raw_mode().unwrap();
+                    }
                     std::process::exit(0)
                 }
                 _ => {}


### PR DESCRIPTION
std::process::exit prevents any destructors from being called,
so the termion::raw::RawTerminal is not destroyed and the terminal
remains in raw mode on exit.

Another method to achieve this could be to have ctrl+c/d break the
run loop instead of calling std::process::exit.