### PR TITLE
Add support for emulating enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - list.clear
   - list.swap
   - map.clear
+  - map.get_index
   - os.cpu_count
   - os.physical_cpu_count
   - tuple.first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
         n == 1 then "one"
         else "???"
       ```
+  - The results of list/map accesses or function calls can be used as match
+    patterns.
+    - e.g.
+      ```
+      match x
+        f y then "x == f y"
+        m.foo then "x == m.foo"
+        z[10] then "x == z[10]"
+      ```
 - Tuples may now be added to lists with the `+` and `+=` operators.
   - e.g.
     ```

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -55,6 +55,15 @@ export tests =
         else ">= 10"
     assert_eq (inspect 7) "odd"
 
+  test_match_against_lookups: ||
+    m = {foo: 42, bar: 99}
+    z = match 99
+      # Lookups (map/list accesses, function calls) match if their results are equal
+      m.foo then "foo"
+      m.bar then "bar"
+      other then "{}".format other
+    assert_eq z "bar"
+
   test_match_multiple_values: ||
     fizz_buzz = |n|
       match n % 3, n % 5

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -32,3 +32,12 @@ export tests =
     assert_eq (enum.get 0) "foo"
     assert_eq (enum.get 1) "bar"
     assert_eq (enum.get 2) "baz"
+
+  test_match_against_enum_values: ||
+    enum = make_enum "a" "b" "c"
+    x = enum.b
+    y = match x
+      enum.a then 1
+      enum.b then 2
+      enum.c then 3
+    assert_eq y 2

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -1,0 +1,34 @@
+import test.assert_eq
+
+make_enum = |entries...|
+  entries
+    .enumerate()
+    .each |(index, id)| id, index
+    .to_map()
+
+make_bidirectional_enum = |entries...|
+  entries
+    .enumerate()
+    .fold {} |enum, (index, id)|
+      enum.insert id index
+      enum.insert index id
+      enum
+
+export tests =
+  test_make_enum: ||
+    enum = make_enum "foo" "bar" "baz"
+    assert_eq enum.foo 0
+    assert_eq enum.bar 1
+    assert_eq enum.baz 2
+    assert_eq (enum.get_index 0)[0] "foo"
+    assert_eq (enum.get_index 1)[0] "bar"
+    assert_eq (enum.get_index 2)[0] "baz"
+
+  test_make_bidirectional_enum: ||
+    enum = make_bidirectional_enum "foo" "bar" "baz"
+    assert_eq enum.foo 0
+    assert_eq enum.bar 1
+    assert_eq enum.baz 2
+    assert_eq (enum.get 0) "foo"
+    assert_eq (enum.get 1) "bar"
+    assert_eq (enum.get 2) "baz"

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -57,6 +57,11 @@ export tests =
     assert_eq (m.get 1) "O_o"
     assert_eq (m.get (num2 1 2)) ()
 
+  test_get_index: ||
+    m = {foo: 42, bar: 99, baz: 123}
+    assert_eq (m.get_index 1) ("bar", 99)
+    assert_eq (m.get_index 2) ("baz", 123)
+
   test_keys: ||
     m = {foo: 42}
     assert_eq m.keys().to_tuple() ("foo",)

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -2649,7 +2649,8 @@ impl Compiler {
                 | Node::Number0
                 | Node::Number1
                 | Node::Number(_)
-                | Node::Str(_) => {
+                | Node::Str(_)
+                | Node::Lookup(_) => {
                     let pattern = self.push_register()?;
                     self.compile_node(ResultRegister::Fixed(pattern), pattern_node, ast)?;
                     let comparison = self.push_register()?;

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -95,6 +95,7 @@ assert_near 1 2 0.1
     koto_test!(assignment);
     koto_test!(comments);
     koto_test!(control_flow);
+    koto_test!(enums);
     koto_test!(error_handling);
     koto_test!(function_closures);
     koto_test!(functions);

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3678,5 +3678,36 @@ match x.foo 42
                 ]),
             )
         }
+
+        #[test]
+        fn match_pattern_is_lookup() {
+            let source = "
+match x
+  y.foo then 0
+";
+            check_ast(
+                source,
+                &[
+                    Id(0),
+                    Id(1),
+                    Lookup((LookupNode::Id(2), None)),
+                    Lookup((LookupNode::Root(1), Some(2))),
+                    Number0,
+                    Match {
+                        expression: Some(0),
+                        arms: vec![MatchArm {
+                            patterns: vec![3],
+                            condition: None,
+                            expression: 4,
+                        }],
+                    },
+                    MainBlock {
+                        body: vec![5],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x"), Constant::Str("y"), Constant::Str("foo")]),
+            )
+        }
     }
 }

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -50,6 +50,19 @@ pub fn make_module() -> ValueMap {
         _ => external_error!("map.get: Expected map and key as arguments"),
     });
 
+    result.add_fn("get_index", |vm, args| match vm.get_args(args) {
+        [Map(m), Number(n)] => {
+            if *n < 0.0 {
+                return external_error!("map.get_index: Negative indices aren't allowed");
+            }
+            match m.data().get_index(*n as usize) {
+                Some((key, value)) => Ok(Tuple(vec![key.clone(), value.clone()].into())),
+                None => Ok(Empty),
+            }
+        }
+        _ => external_error!("map.get_index: Expected map and index as arguments"),
+    });
+
     result.add_fn("insert", |vm, args| match vm.get_args(args) {
         [Map(m), key] if value_is_immutable(key) => match m.data_mut().insert(key.clone(), Empty) {
             Some(old_value) => Ok(old_value),

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -710,6 +710,32 @@ match 0, 1
         }
 
         #[test]
+        fn match_with_lookup_as_pattern() {
+            let script = "
+x = {foo: 42, bar: 99}
+match 99
+  x.foo then 1
+  x.bar then 2
+  else -1
+";
+            test_script(script, Number(2.0));
+        }
+
+        #[test]
+        fn match_with_lookup_as_pattern_in_function() {
+            let script = "
+x = {foo: 42, bar: 99}
+f = ||
+  match 42
+    x.foo then 1
+    x.bar then 2
+    else -1
+f()
+";
+            test_script(script, Number(1.0));
+        }
+
+        #[test]
         fn match_map_result() {
             let script = r#"
 m = match "hello"


### PR DESCRIPTION
This PR adds better support for emulating enums with maps. 

The language feature added here is allowing enum entries to be matched against directly, which is achieved by allowing the results of map accesses to be used as match patterns.

e.g.

```
x = {foo: 0, bar: 1}
match 1
  x.foo then 100
  x.bar then 101
  else -1
```
