### PR TITLE
Advent of Code Day 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@
         m.foo then "x == m.foo"
         z[10] then "x == z[10]"
       ```
+  - match arms that have indented bodies can now optionally use `then`, which
+    can look clearer when the match pattern is short.
+    - e.g.
+      ```
+      match x
+        0 then # <-- `then` was previously disallowed here
+          "zero"
+        1 then
+          "one"
+      ```
 - Tuples may now be added to lists with the `+` and `+=` operators.
   - e.g.
     ```
@@ -43,7 +53,7 @@
     ```
 
 ### Changed
-- thread.join now returns the result of the thread's function
+- thread.join now returns the result of the thread's function.
 
 ### Fixed
 - else and else if blocks with the incorrect indentation will now trigger a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@
         m.foo then "x == m.foo"
         z[10] then "x == z[10]"
       ```
-  - match arms that have indented bodies can now optionally use `then`, which
-    can look clearer when the match pattern is short.
+  - match arms that have indented bodies can now optionally use `then`,
+    which can look clearer when the match pattern is short.
     - e.g.
       ```
       match x
@@ -56,10 +56,10 @@
 - thread.join now returns the result of the thread's function.
 
 ### Fixed
-- else and else if blocks with the incorrect indentation will now trigger a
+- else and else if blocks with unexpected indentation will now trigger a
   parser error.
 - Multi-assignment of values where the values are used in the expressions now
-  works correctly.
+  works as expected.
   - e.g.
     ```
     a, b = 1, 2
@@ -67,6 +67,7 @@
     # Previously this would result in b being re-assigned to itself
     assert_eq b 1
     ```
+- Generator functions can now capture non-local values.
 
 ## [0.4.0] 2020.12.10
 

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -49,10 +49,14 @@ export tests =
   test_match_with_value: ||
     inspect = |n|
       match n
-        x if x < 0 then "negative"
-        0 or 2 or 4 or 6 or 8 then "even"
-        1 or 3 or 5 or 7 or 9 then "odd"
-        else ">= 10"
+        x if x < 0 then # 'then' is optional in a match arm when the body is indented
+          "negative"
+        0 or 2 or 4 or 6 or 8
+          "even"
+        1 or 3 or 5 or 7 or 9
+          "odd"
+        else
+          ">= 10"
     assert_eq (inspect 7) "odd"
 
   test_match_against_lookups: ||

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1916,7 +1916,13 @@ impl<'source> Parser<'source> {
                     self.consume_next_token_on_same_line();
                     match self.parse_expressions(&mut ExpressionContext::inline(), true)? {
                         Some(expression) => expression,
-                        None => return syntax_error!(ExpectedMatchArmExpressionAfterThen, self),
+                        None => {
+                            if let Some(indented_expression) = self.parse_indented_map_or_block()? {
+                                indented_expression
+                            } else {
+                                return syntax_error!(ExpectedMatchArmExpressionAfterThen, self);
+                            }
+                        }
                     }
                 }
                 Some(Token::If) => return syntax_error!(UnexpectedMatchIf, self),

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3508,7 +3508,8 @@ match x
   z if z > 5 then 0
   z if z < 10
     1
-  z then -1
+  z then
+    -1
 "#;
             check_ast(
                 source,
@@ -3574,7 +3575,7 @@ match x
             let source = "
 match x, y
   0, 1 or 2, 3 if z then 0
-  a, ()
+  a, () then
     a
   else 0
 ";

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1053,25 +1053,28 @@ impl Vm {
         value: u8,
         instruction_ip: usize,
     ) -> InstructionResult {
-        match self.get_register(function) {
-            Value::Function(f) => match &f.captures {
-                Some(captures) => {
-                    captures.data_mut()[capture_index as usize] = self.clone_register(value)
-                }
-                None => {
-                    return vm_error!(
-                        self.chunk(),
-                        instruction_ip,
-                        "Capture: missing capture list for function"
-                    )
-                }
-            },
+        let capture_list = match self.get_register(function) {
+            Value::Function(f) => &f.captures,
+            Value::Generator(g) => &g.captures,
             unexpected => {
                 return self.unexpected_type_error(
                     "Capture: expected Function",
                     unexpected,
                     instruction_ip,
                 );
+            }
+        };
+
+        match capture_list {
+            Some(capture_list) => {
+                capture_list.data_mut()[capture_index as usize] = self.clone_register(value)
+            }
+            None => {
+                return vm_error!(
+                    self.chunk(),
+                    instruction_ip,
+                    "Capture: missing capture list for function"
+                )
             }
         }
 

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1691,6 +1691,18 @@ z = gen(1..=5).to_tuple()
 z[1]";
             test_script(script, number_tuple(&[1, 2]));
         }
+
+        #[test]
+        fn generator_with_captured_data() {
+            let script = "
+x = 1, 2, 3
+gen = ||
+  for y in x
+    yield y
+gen().to_tuple()
+";
+            test_script(script, number_tuple(&[1, 2, 3]));
+        }
     }
 
     mod num2_test {


### PR DESCRIPTION
This PR fixes some issues encountered while working on Advent of Code Day 14.

- Make 'then' optional in match arms with indented bodies
- Allow generator functions to capture non-local values
