### PR TITLE
Allow external functions to be used as functors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 
 ### Changed
 - Error messages in core ops that call functors have been made a bit clearer.
+- Core ops that accept function arguments can now take external functions.
+  - e.g.
+    ```
+    x = [[1, 2, 3], [1], [1, 2]]
+    x.sort list.size
+    assert_eq x [[1], [1, 2], [1, 2, 3]]
+    ```
 
 
 ## [0.5.0] 2020.12.17

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -113,8 +113,9 @@ export tests =
     z.sort |n| -n # reverse sorting
     assert_eq z [3, 2, 2, 1]
 
+    # Sorting with a core op
     z = [[4, 5, 6], [1], [2, 3]]
-    z.sort |l| l.size()
+    z.sort list.size
     assert_eq z [[1], [2, 3], [4, 5, 6]]
 
   test_sort_copy: ||

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -1,0 +1,27 @@
+from test import assert, assert_eq, assert_ne, assert_near
+
+# A script can export a map named 'tests' to have the tests automatically run when
+# the script is loaded.
+export tests =
+  # 'pre_test' will be run before each test
+  pre_test: |self|
+    self.test_data = 1, 2, 3
+
+  # 'post_test' will be run after each test
+  post_test: |self|
+    self.test_data = ()
+
+  # Functions with a name starting with 'test_' will be automatically run as tests
+  test_size: |self|
+    # assert_eq checks that its two arguments are equal
+    assert_eq self.test_data.size() 3
+    # assert_ne checks that its two arguments are not equal
+    assert_ne self.test_data.size() 1
+
+  # Test functions don't have to be instance functions
+  test_extra: ||
+    # assert checks that its argument is true
+    assert 1 > 0
+    # assert_near checks that its arguments are equal, within a specied margin
+    allowed_error = 0.1
+    assert_near 1.3 1.301 allowed_error

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -33,9 +33,7 @@ use {
         chunk_to_string, chunk_to_string_annotated, Chunk, CompilerError, LoaderError,
     },
     koto_parser::{ParserError, Position},
-    koto_runtime::{
-        type_as_string, Error, Loader, RuntimeFunction, Value, ValueList, ValueMap, ValueVec, Vm,
-    },
+    koto_runtime::{type_as_string, Error, Loader, Value, ValueList, ValueMap, ValueVec, Vm},
     std::{path::PathBuf, sync::Arc},
 };
 
@@ -136,7 +134,7 @@ impl Koto {
 
             if let Some(main) = self.runtime.get_global_function("main") {
                 self.runtime
-                    .run_function(&main, &[])
+                    .run_function(main, &[])
                     .map_err(|e| self.format_error(e))
             } else {
                 Ok(result)
@@ -216,7 +214,7 @@ impl Koto {
         args: &[Value],
     ) -> Result<Value, String> {
         match self.runtime.get_global_function(function_name) {
-            Some(f) => self.call_function(&f, args),
+            Some(f) => self.call_function(f, args),
             None => Err(format!(
                 "Runtime error: function '{}' not found",
                 function_name
@@ -224,11 +222,7 @@ impl Koto {
         }
     }
 
-    pub fn call_function(
-        &mut self,
-        function: &RuntimeFunction,
-        args: &[Value],
-    ) -> Result<Value, String> {
+    pub fn call_function(&mut self, function: Value, args: &[Value]) -> Result<Value, String> {
         self.runtime
             .run_function(function, args)
             .map_err(|e| self.format_error(e))

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -117,6 +117,7 @@ assert_near 1 2 0.1
     koto_test!(primes);
     koto_test!(ranges);
     koto_test!(strings);
+    koto_test!(tests);
     koto_test!(threads);
     koto_test!(tuples);
     koto_test!(types);

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -1,10 +1,9 @@
 use {
     crate::{
         external_error, type_as_string, value,
-        value::{add_values, multiply_values},
+        value::{add_values, multiply_values, value_is_callable, value_is_iterable},
         value_iterator::{
-            is_iterable, make_iterator, ValueIterator, ValueIteratorOutput as Output,
-            ValueIteratorResult,
+            make_iterator, ValueIterator, ValueIteratorOutput as Output, ValueIteratorResult,
         },
         RuntimeResult, Value, ValueHashMap, ValueList, ValueMap, ValueVec,
     },
@@ -17,14 +16,14 @@ pub fn make_module() -> ValueMap {
     let mut result = ValueMap::new();
 
     result.add_fn("all", |vm, args| match vm.get_args(args) {
-        [iterable, Function(f)] if is_iterable(iterable) => {
+        [iterable, f] if value_is_iterable(iterable) && value_is_callable(f) => {
             let f = f.clone();
             let iter = make_iterator(iterable).unwrap().map(collect_pair);
             let mut vm = vm.spawn_shared_vm();
 
             for iter_output in iter {
                 match iter_output {
-                    Ok(Output::Value(value)) => match vm.run_function(&f, &[value]) {
+                    Ok(Output::Value(value)) => match vm.run_function(f.clone(), &[value]) {
                         Ok(Bool(result)) => {
                             if !result {
                                 return Ok(Bool(false));
@@ -49,14 +48,14 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("any", |vm, args| match vm.get_args(args) {
-        [iterable, Function(f)] if is_iterable(iterable) => {
+        [iterable, f] if value_is_iterable(iterable) && value_is_callable(f) => {
             let f = f.clone();
             let iter = make_iterator(iterable).unwrap().map(collect_pair);
             let mut vm = vm.spawn_shared_vm();
 
             for iter_output in iter {
                 match iter_output {
-                    Ok(Output::Value(value)) => match vm.run_function(&f, &[value]) {
+                    Ok(Output::Value(value)) => match vm.run_function(f.clone(), &[value]) {
                         Ok(Bool(result)) => {
                             if result {
                                 return Ok(Bool(true));
@@ -81,7 +80,9 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("chain", |vm, args| match vm.get_args(args) {
-        [iterable_a, iterable_b] if is_iterable(iterable_a) && is_iterable(iterable_b) => {
+        [iterable_a, iterable_b]
+            if value_is_iterable(iterable_a) && value_is_iterable(iterable_b) =>
+        {
             let iter_a = make_iterator(iterable_a).unwrap();
             let iter_b = make_iterator(iterable_b).unwrap();
 
@@ -93,7 +94,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("consume", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let iter = make_iterator(iterable).unwrap();
             for output in iter {
                 if let Err(error) = output {
@@ -106,7 +107,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("count", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let iter = make_iterator(iterable).unwrap();
             let mut result = 0;
             for output in iter {
@@ -121,13 +122,13 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("each", |vm, args| match vm.get_args(args) {
-        [iterable, Function(f)] if is_iterable(iterable) => {
+        [iterable, f] if value_is_iterable(iterable) && value_is_callable(f) => {
             let iter = make_iterator(iterable).unwrap().map(collect_pair);
             let f = f.clone();
             let mut vm = vm.spawn_shared_vm();
 
             let mut iter = iter.map(move |iter_output| match iter_output {
-                Ok(Output::Value(value)) => match vm.run_function(&f, &[value]) {
+                Ok(Output::Value(value)) => match vm.run_function(f.clone(), &[value]) {
                     Ok(result) => Ok(Output::Value(result)),
                     Err(error) => Err(error.with_prefix("iterator.each")),
                 },
@@ -141,7 +142,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("enumerate", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let mut iter = make_iterator(iterable)
                 .unwrap()
                 .enumerate()
@@ -157,7 +158,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("fold", |vm, args| {
         match vm.get_args(args) {
-            [iterable, result, Function(f)] if is_iterable(iterable) => {
+            [iterable, result, f] if value_is_iterable(iterable) && value_is_callable(f) => {
                 let result = result.clone();
                 let f = f.clone();
                 let mut iter = make_iterator(iterable).unwrap();
@@ -169,7 +170,7 @@ pub fn make_module() -> ValueMap {
                         for value in iterator.map(collect_pair) {
                             match value {
                                 Ok(Output::Value(value)) => {
-                                    match vm.run_function(&f, &[fold_result, value]) {
+                                    match vm.run_function(f.clone(), &[fold_result, value]) {
                                         Ok(result) => fold_result = result,
                                         Err(error) => {
                                             return Some(Err(error.with_prefix("iterator.each")))
@@ -198,7 +199,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("keep", |vm, args| match vm.get_args(args) {
-        [iterable, Function(f)] if is_iterable(iterable) => {
+        [iterable, f] if value_is_iterable(iterable) && value_is_callable(f) => {
             let mut iter = make_iterator(iterable).unwrap().map(collect_pair);
             let f = f.clone();
             let mut vm = vm.spawn_shared_vm();
@@ -206,23 +207,25 @@ pub fn make_module() -> ValueMap {
             Ok(Iterator(ValueIterator::make_external(move || {
                 for output in &mut iter {
                     match output {
-                        Ok(Output::Value(value)) => match vm.run_function(&f, &[value.clone()]) {
-                            Ok(Bool(result)) => {
-                                if result {
-                                    return Some(Ok(Output::Value(value)));
-                                } else {
-                                    continue;
+                        Ok(Output::Value(value)) => {
+                            match vm.run_function(f.clone(), &[value.clone()]) {
+                                Ok(Bool(result)) => {
+                                    if result {
+                                        return Some(Ok(Output::Value(value)));
+                                    } else {
+                                        continue;
+                                    }
                                 }
-                            }
-                            Ok(unexpected) => {
-                                return Some(external_error!(
-                                    "iterator.keep expects a Bool to be returned from the \
+                                Ok(unexpected) => {
+                                    return Some(external_error!(
+                                        "iterator.keep expects a Bool to be returned from the \
                                          predicate, found '{}'",
-                                    value::type_as_string(&unexpected),
-                                ))
+                                        value::type_as_string(&unexpected),
+                                    ))
+                                }
+                                Err(error) => return Some(Err(error.with_prefix("iterator.keep"))),
                             }
-                            Err(error) => return Some(Err(error.with_prefix("iterator.keep"))),
-                        },
+                        }
                         Err(error) => return Some(Err(error)),
                         _ => unreachable!(),
                     }
@@ -234,7 +237,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("max", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let mut result = None;
 
             for iter_output in make_iterator(iterable).unwrap().map(collect_pair) {
@@ -256,7 +259,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("min", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let mut result = None;
 
             for iter_output in make_iterator(iterable).unwrap().map(collect_pair) {
@@ -278,7 +281,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("min_max", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let mut result = None;
 
             for iter_output in make_iterator(iterable).unwrap().map(collect_pair) {
@@ -315,28 +318,30 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("position", |vm, args| match vm.get_args(args) {
-        [iterable, Function(f)] if is_iterable(iterable) => {
+        [iterable, f] if value_is_iterable(iterable) && value_is_callable(f) => {
             let iter = make_iterator(iterable).unwrap().map(collect_pair);
             let f = f.clone();
             let mut vm = vm.spawn_shared_vm();
 
             for (i, output) in iter.enumerate() {
                 match output {
-                    Ok(Output::Value(value)) => match vm.run_function(&f, &[value.clone()]) {
-                        Ok(Bool(result)) => {
-                            if result {
-                                return Ok(Number(i.into()));
+                    Ok(Output::Value(value)) => {
+                        match vm.run_function(f.clone(), &[value.clone()]) {
+                            Ok(Bool(result)) => {
+                                if result {
+                                    return Ok(Number(i.into()));
+                                }
                             }
-                        }
-                        Ok(unexpected) => {
-                            return external_error!(
-                                "iterator.position expects a Bool to be returned from the \
+                            Ok(unexpected) => {
+                                return external_error!(
+                                    "iterator.position expects a Bool to be returned from the \
                                  predicate, found '{}'",
-                                value::type_as_string(&unexpected),
-                            )
+                                    value::type_as_string(&unexpected),
+                                )
+                            }
+                            Err(error) => return Err(error.with_prefix("iterator.position")),
                         }
-                        Err(error) => return Err(error.with_prefix("iterator.position")),
-                    },
+                    }
                     Err(error) => return Err(error),
                     _ => unreachable!(),
                 }
@@ -348,15 +353,17 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("product", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => iterator_product(iterable, &Value::Number(1.into())),
-        [iterable, initial_value] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
+            iterator_product(iterable, &Value::Number(1.into()))
+        }
+        [iterable, initial_value] if value_is_iterable(iterable) => {
             iterator_product(iterable, initial_value)
         }
         _ => external_error!("iterator.product: Expected iterable as argument"),
     });
 
     result.add_fn("skip", |vm, args| match vm.get_args(args) {
-        [iterable, Number(n)] if is_iterable(iterable) && *n >= 0.0 => {
+        [iterable, Number(n)] if value_is_iterable(iterable) && *n >= 0.0 => {
             let mut iter = make_iterator(iterable).unwrap();
 
             for _ in 0..n.into() {
@@ -373,13 +380,17 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("sum", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => iterator_sum(iterable, &Value::Number(0.into())),
-        [iterable, initial_value] if is_iterable(iterable) => iterator_sum(iterable, initial_value),
+        [iterable] if value_is_iterable(iterable) => {
+            iterator_sum(iterable, &Value::Number(0.into()))
+        }
+        [iterable, initial_value] if value_is_iterable(iterable) => {
+            iterator_sum(iterable, initial_value)
+        }
         _ => external_error!("iterator.sum: Expected iterable as argument"),
     });
 
     result.add_fn("take", |vm, args| match vm.get_args(args) {
-        [iterable, Number(n)] if is_iterable(iterable) && *n >= 0.0 => {
+        [iterable, Number(n)] if value_is_iterable(iterable) && *n >= 0.0 => {
             let mut iter = make_iterator(iterable).unwrap().take(n.into());
 
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
@@ -390,7 +401,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("to_list", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let mut iterator = make_iterator(iterable).unwrap();
             let mut result = ValueVec::new();
 
@@ -409,7 +420,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("to_map", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let mut iterator = make_iterator(iterable).unwrap();
             let mut result = ValueHashMap::new();
 
@@ -437,7 +448,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("to_tuple", |vm, args| match vm.get_args(args) {
-        [iterable] if is_iterable(iterable) => {
+        [iterable] if value_is_iterable(iterable) => {
             let mut iterator = make_iterator(iterable).unwrap();
             let mut result = Vec::new();
 
@@ -456,7 +467,9 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("zip", |vm, args| match vm.get_args(args) {
-        [iterable_a, iterable_b] if is_iterable(iterable_a) && is_iterable(iterable_b) => {
+        [iterable_a, iterable_b]
+            if value_is_iterable(iterable_a) && value_is_iterable(iterable_b) =>
+        {
             let iter_a = make_iterator(iterable_a).unwrap().map(collect_pair);
             let iter_b = make_iterator(iterable_b).unwrap().map(collect_pair);
 

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -359,12 +359,24 @@ pub fn make_external_value(value: impl ExternalValue) -> Value {
     Value::ExternalValue(Arc::new(RwLock::new(value)))
 }
 
+pub fn value_is_callable(value: &Value) -> bool {
+    use Value::*;
+    matches!(value, Function{..} | ExternalFunction(_))
+}
+
 pub fn value_is_immutable(value: &Value) -> bool {
     use Value::*;
-
     matches!(
         value,
         Empty | ExternalDataId | Bool(_) | Number(_) | Num2(_) | Num4(_) | Range(_) | Str(_)
+    )
+}
+
+pub fn value_is_iterable(value: &Value) -> bool {
+    use Value::*;
+    matches!(
+        value,
+        Range(_) | List(_) | Tuple(_) | Map(_) | Str(_) | Iterator(_)
     )
 }
 

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -215,14 +215,6 @@ impl Iterator for ValueIterator {
     }
 }
 
-pub fn is_iterable(value: &Value) -> bool {
-    use Value::*;
-    matches!(
-        value,
-        Range(_) | List(_) | Tuple(_) | Map(_) | Str(_) | Iterator(_)
-    )
-}
-
 pub fn make_iterator(value: &Value) -> Result<ValueIterator, ()> {
     use Value::*;
     let result = match value {


### PR DESCRIPTION
This PR enables the use of external functions as functors in core operations
that could previously only accept Koto runtime functions.
