### PR TITLE
Rename valueless match expressions to switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - `range.union`
 
 ### Changed
+- `match` when used without a value to match against has been renamed to
+  `switch`.
 - Error messages in core ops that call functors have been made a bit clearer.
 - Core ops that accept function arguments can now take external functions.
   - e.g.
@@ -57,6 +59,8 @@
         n == 1 then "one"
         else "???"
       ```
+    - *Note* (20.12.2020): After v0.5.0 this form of expression was renamed to
+      `switch`.
   - The results of list/map accesses or function calls can be used as match
     patterns.
     - e.g.

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -1,7 +1,7 @@
 import koto, test.assert_eq
 
 fib = |n|
-  match
+  switch
     n <= 0 then 0
     n == 1 then 1
     else (fib n - 1) + (fib n - 2)

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -37,16 +37,16 @@ export tests =
           # or this one
         assert true
 
-  test_match: ||
+  test_switch: ||
     fib = |n|
-      match
+      switch
         n <= 0 then 0
         n == 1 then 1
         else (fib n - 1) + (fib n - 2)
 
     assert_eq 13 (fib 7)
 
-  test_match_with_value: ||
+  test_match: ||
     inspect = |n|
       match n
         x if x < 0 then # 'then' is optional in a match arm when the body is indented

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -77,6 +77,7 @@ pub enum Token {
     Num4,
     Or,
     Return,
+    Switch,
     Then,
     True,
     Try,
@@ -382,6 +383,7 @@ impl<'a> TokenLexer<'a> {
         check_keyword!("num4", Num4);
         check_keyword!("or", Or);
         check_keyword!("return", Return);
+        check_keyword!("switch", Switch);
         check_keyword!("then", Then);
         check_keyword!("true", True);
         check_keyword!("try", Try);

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -33,6 +33,7 @@ pub enum ExpectedIndentation {
     ExpectedLoopBody,
     ExpectedMatchArm,
     ExpectedRhsExpression,
+    ExpectedSwitchArm,
     ExpectedThenKeywordOrBlock,
     ExpectedTryBody,
     ExpectedUntilBody,
@@ -74,6 +75,8 @@ pub enum SyntaxError {
     ExpectedMatchExpression,
     ExpectedMatchPattern,
     ExpectedNegatableExpression,
+    ExpectedSwitchArmExpression,
+    ExpectedSwitchArmExpressionAfterThen,
     ExpectedThenExpression,
     ExpectedUntilCondition,
     ExpectedWhileCondition,
@@ -82,6 +85,7 @@ pub enum SyntaxError {
     MatchEllipsisOutsideOfNestedPatterns,
     MatchElseNotInLastArm,
     SelfArgNotInFirstPosition,
+    SwitchElseNotInLastArm,
     TooManyNum2Terms,
     TooManyNum4Terms,
     UnexpectedElseIndentation,
@@ -89,6 +93,7 @@ pub enum SyntaxError {
     UnexpectedEscapeInString,
     UnexpectedMatchElse,
     UnexpectedMatchIf,
+    UnexpectedSwitchElse,
     UnexpectedToken,
     UnexpectedTokenAfterExportId,
     UnexpectedTokenInImportExpression,
@@ -193,6 +198,7 @@ impl fmt::Display for ExpectedIndentation {
             ExpectedFunctionBody => f.write_str("Expected function body"),
             ExpectedLoopBody => f.write_str("Expected indented block in loop"),
             ExpectedMatchArm => f.write_str("Expected indented arm for match expression"),
+            ExpectedSwitchArm => f.write_str("Expected indented arm for switch expression"),
             ExpectedRhsExpression => f.write_str("Expected expression"),
             ExpectedThenKeywordOrBlock => f.write_str(
                 "Error parsing if expression, expected 'then' keyword or indented block.",
@@ -246,6 +252,10 @@ impl fmt::Display for SyntaxError {
             ExpectedMatchExpression => f.write_str("Expected expression after match"),
             ExpectedMatchPattern => f.write_str("Expected pattern for match arm"),
             ExpectedNegatableExpression => f.write_str("Expected negatable expression"),
+            ExpectedSwitchArmExpression => f.write_str("Expected expression in switch arm"),
+            ExpectedSwitchArmExpressionAfterThen => {
+                f.write_str("Expected expression after then in switch arm")
+            }
             ExpectedThenExpression => f.write_str("Expected 'then' expression."),
             ExpectedUntilCondition => f.write_str("Expected condition in until loop"),
             ExpectedWhileCondition => f.write_str("Expected condition in while loop"),
@@ -259,6 +269,9 @@ impl fmt::Display for SyntaxError {
             MatchElseNotInLastArm => {
                 f.write_str("else can only be used in the last arm in a match expression")
             }
+            SwitchElseNotInLastArm => {
+                f.write_str("else can only be used in the last arm in a switch expression")
+            }
             SelfArgNotInFirstPosition => f.write_str("self is only allowed as the first argument"),
             TooManyNum2Terms => f.write_str("num2 only supports up to 2 terms"),
             TooManyNum4Terms => f.write_str("num4 only supports up to 4 terms"),
@@ -267,6 +280,7 @@ impl fmt::Display for SyntaxError {
             UnexpectedEscapeInString => f.write_str("Unexpected escape pattern in string"),
             UnexpectedMatchElse => f.write_str("Unexpected else in match arm"),
             UnexpectedMatchIf => f.write_str("Unexpected if condition in match arm"),
+            UnexpectedSwitchElse => f.write_str("Unexpected else in switch arm"),
             UnexpectedToken => f.write_str("Unexpected token"),
             UnexpectedTokenAfterExportId => f.write_str("Unexpected token after export ID"),
             UnexpectedTokenInImportExpression => {

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -64,9 +64,10 @@ pub enum Node {
     },
     If(AstIf),
     Match {
-        expression: Option<AstIndex>,
+        expression: AstIndex,
         arms: Vec<MatchArm>,
     },
+    Switch(Vec<SwitchArm>),
     Wildcard,
     Ellipsis(Option<ConstantIndex>),
     For(AstFor),
@@ -135,6 +136,7 @@ impl fmt::Display for Node {
             BinaryOp { .. } => write!(f, "BinaryOp"),
             If(_) => write!(f, "If"),
             Match { .. } => write!(f, "Match"),
+            Switch { .. } => write!(f, "Switch"),
             Wildcard => write!(f, "Wildcard"),
             Ellipsis(_) => write!(f, "Ellipsis"),
             For(_) => write!(f, "For"),
@@ -239,6 +241,12 @@ pub struct AssignTarget {
 #[derive(Clone, Debug, PartialEq)]
 pub struct MatchArm {
     pub patterns: Vec<AstIndex>,
+    pub condition: Option<AstIndex>,
+    pub expression: AstIndex,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwitchArm {
     pub condition: Option<AstIndex>,
     pub expression: AstIndex,
 }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3221,7 +3221,7 @@ finally
         }
     }
 
-    mod match_expression {
+    mod match_and_switch {
         use super::*;
 
         #[test]
@@ -3242,7 +3242,7 @@ x = match y
                     Id(3), // 5
                     Int(4),
                     Match {
-                        expression: Some(1),
+                        expression: 1,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![2, 3],
@@ -3296,7 +3296,7 @@ match x
                     Str(4),
                     Break, // 5
                     Match {
-                        expression: Some(0),
+                        expression: 0,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![1],
@@ -3352,7 +3352,7 @@ match (x, y, z)
                     Tuple(vec![9, 12, 13]),
                     Number0, // 15
                     Match {
-                        expression: Some(3),
+                        expression: 3,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![7],
@@ -3401,7 +3401,7 @@ match x
                     Tuple(vec![5, 6]),
                     Number1,
                     Match {
-                        expression: Some(0),
+                        expression: 0,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![3],
@@ -3446,7 +3446,7 @@ match y
                     Tuple(vec![6, 7, 8]),
                     Number1, // 10
                     Match {
-                        expression: Some(0),
+                        expression: 0,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![4],
@@ -3508,7 +3508,7 @@ match x
                     Id(1),
                     Int(4),
                     Match {
-                        expression: Some(0),
+                        expression: 0,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![1],
@@ -3571,7 +3571,7 @@ match x, y
                     Id(5),
                     Number0, // 15
                     Match {
-                        expression: Some(2),
+                        expression: 2,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![5, 8],
@@ -3625,7 +3625,7 @@ match x.foo 42
                     Number0,
                     Number1,
                     Match {
-                        expression: Some(4),
+                        expression: 4,
                         arms: vec![
                             MatchArm {
                                 patterns: vec![5],
@@ -3663,7 +3663,7 @@ match x
                     Lookup((LookupNode::Root(1), Some(2))),
                     Number0,
                     Match {
-                        expression: Some(0),
+                        expression: 0,
                         arms: vec![MatchArm {
                             patterns: vec![3],
                             condition: None,
@@ -3676,6 +3676,57 @@ match x
                     },
                 ],
                 Some(&[Constant::Str("x"), Constant::Str("y"), Constant::Str("foo")]),
+            )
+        }
+
+        #[test]
+        fn switch_expression() {
+            let source = "
+switch
+  1 == 0 then 0
+  a > b then 1
+  else a
+";
+            check_ast(
+                source,
+                &[
+                    Number1,
+                    Number0,
+                    BinaryOp {
+                        op: AstOp::Equal,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                    Number0,
+                    Id(0),
+                    Id(1), // 5
+                    BinaryOp {
+                        op: AstOp::Greater,
+                        lhs: 4,
+                        rhs: 5,
+                    },
+                    Number1,
+                    Id(0),
+                    Switch(vec![
+                        SwitchArm {
+                            condition: Some(2),
+                            expression: 3,
+                        },
+                        SwitchArm {
+                            condition: Some(6),
+                            expression: 7,
+                        },
+                        SwitchArm {
+                            condition: None,
+                            expression: 8,
+                        },
+                    ]),
+                    MainBlock {
+                        body: vec![9],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("a"), Constant::Str("b")]),
             )
         }
     }

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -773,12 +773,16 @@ m.value_1 + m.value_2
 "#;
             test_script(script, Number(24.0.into()));
         }
+    }
+
+    mod switch_expressions {
+        use super::*;
 
         #[test]
         fn match_without_expression() {
             let script = r#"
 n = 42
-match
+switch
   n < 0 then -1
   n == 0 then 0
   n == 42 then 99


### PR DESCRIPTION
To avoid confusion about the two forms of 'matching', this PR renames `match`
when used without a value to `switch`.
