### PR TITLE
Add commas to function calls without parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   - `range.union`
 
 ### Changed
+- Function calls without parentheses now require commas to separate arguments.
+  - e.g. `f a b c` now needs to be written as `f a, b, c`.
+  - Care needs to be taken when adapting programs to this change.
+    - e.g. `f a, b c` was parsed as two separate expressions
+      (i.e. `(f a), (b c)`), and it's now parsed as `f(a, (b c))`.
 - `match` when used without a value to match against has been renamed to
   `switch`.
 - Error messages in core ops that call functors have been made a bit clearer.

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -12,4 +12,4 @@ export main = ||
 export tests =
   test_it_works: ||
     x = (1..=3).enumerate().to_tuple()
-    assert_eq x ((0, 1), (1, 2), (2, 3))
+    assert_eq x, ((0, 1), (1, 2), (2, 3))

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -60,7 +60,7 @@ fannkuch = |n|
         s[i] = i
         # Rotate 1<-...<-i+1.
         t = p.remove 1
-        p.insert (i + 1) t
+        p.insert (i + 1), t
 
 export main = ||
   n = match koto.args.get 0
@@ -76,5 +76,5 @@ export main = ||
 export tests =
   test_5: ||
     sum, flips = fannkuch 5
-    assert_eq sum 11
-    assert_eq flips 7
+    assert_eq sum, 11
+    assert_eq flips, 7

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -15,5 +15,5 @@ export main = ||
 
 export tests =
   test_fib: ||
-    assert_eq (fib 4) 3
-    assert_eq (fib 5) 5
+    assert_eq (fib 4), 3
+    assert_eq (fib 5), 5

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -22,42 +22,42 @@ init_bodies = ||
   sun.mass = solar_mass
 
   jupiter.pos =
-    num4 4.84143144246472090e+00
-         -1.16032004402742839e+00
+    num4 4.84143144246472090e+00,
+         -1.16032004402742839e+00,
          -1.03622044471123109e-01
   jupiter.vel =
-    num4 (1.66007664274403694e-03 * days_per_year)
-         (7.69901118419740425e-03 * days_per_year)
+    num4 (1.66007664274403694e-03 * days_per_year),
+         (7.69901118419740425e-03 * days_per_year),
          (-6.90460016972063023e-05 * days_per_year)
   jupiter.mass = 9.54791938424326609e-04 * solar_mass
 
   saturn.pos =
-    num4 8.34336671824457987e+00
-         4.12479856412430479e+00
+    num4 8.34336671824457987e+00,
+         4.12479856412430479e+00,
          -4.03523417114321381e-01
   saturn.vel =
-    num4 (-2.76742510726862411e-03 * days_per_year)
-         (4.99852801234917238e-03 * days_per_year)
+    num4 (-2.76742510726862411e-03 * days_per_year),
+         (4.99852801234917238e-03 * days_per_year),
          (2.30417297573763929e-05 * days_per_year)
   saturn.mass = 2.85885980666130812e-04 * solar_mass
 
   uranus.pos =
-    num4 1.28943695621391310e+01
-         -1.51111514016986312e+01
+    num4 1.28943695621391310e+01,
+         -1.51111514016986312e+01,
          -2.23307578892655734e-01
   uranus.vel =
-    num4 (2.96460137564761618e-03 * days_per_year)
-         (2.37847173959480950e-03 * days_per_year)
+    num4 (2.96460137564761618e-03 * days_per_year),
+         (2.37847173959480950e-03 * days_per_year),
          (-2.96589568540237556e-05 * days_per_year)
   uranus.mass = 4.36624404335156298e-05 * solar_mass
 
   neptune.pos =
-    num4 1.53796971148509165e+01
-         -2.59193146099879641e+01
+    num4 1.53796971148509165e+01,
+         -2.59193146099879641e+01,
          1.79258772950371181e-01
   neptune.vel =
-    num4 (2.68067772490389322e-03 * days_per_year)
-         (1.62824170038242295e-03 * days_per_year)
+    num4 (2.68067772490389322e-03 * days_per_year),
+         (1.62824170038242295e-03 * days_per_year),
          (-9.51592254519715870e-05 * days_per_year)
   neptune.mass = 5.15138902046611451e-05 * solar_mass
 
@@ -106,11 +106,11 @@ offset_momentum = |bodies, nbody|
 run_nbody = |n|
   init_bodies()
   nbody = bodies.size()
-  offset_momentum bodies nbody
-  initial_energy = get_energy bodies nbody
+  offset_momentum bodies, nbody
+  initial_energy = get_energy bodies, nbody
   for _ in 0..n
-    advance bodies nbody 0.01
-  end_energy = get_energy bodies nbody
+    advance bodies, nbody, 0.01
+  end_energy = get_energy bodies, nbody
   initial_energy, end_energy
 
 
@@ -130,5 +130,5 @@ export main = ||
 export tests =
   test_100: ||
     initial_energy, end_energy = run_nbody 100
-    assert_near initial_energy -0.16907514 1.0e-8
-    assert_near end_energy -0.16904989 1.0e-8
+    assert_near initial_energy, -0.16907514, 1.0e-8
+    assert_near end_energy, -0.16904989, 1.0e-8

--- a/koto/benches/num4.koto
+++ b/koto/benches/num4.koto
@@ -6,18 +6,18 @@ export main = ||
     arg then arg.to_number()
 
   for _ in 0..n
-    assert_eq (num4 0) (num4 0 0 0 0)
-    assert_eq (num4 1) (num4 1 1 1 1)
-    assert_eq (num4 1 1) (num4 1 1 0 0)
-    assert_eq (num4 1 1 1) (num4 1 1 1 0)
-    assert_eq (num4 1 1 1 1) (num4 1 1 1 1)
+    assert_eq (num4 0), (num4 0, 0, 0, 0)
+    assert_eq (num4 1), (num4 1, 1, 1, 1)
+    assert_eq (num4 1, 1), (num4 1, 1, 0, 0)
+    assert_eq (num4 1, 1, 1), (num4 1, 1, 1, 0)
+    assert_eq (num4 1, 1, 1, 1), (num4 1, 1, 1, 1)
 
-    assert_eq (num4 [-1, 1]) (num4 -1 1 0 0)
-    assert_eq (num4 num4 1) (num4 1)
+    assert_eq (num4 [-1, 1]), (num4 -1, 1, 0, 0)
+    assert_eq (num4 num4 1), (num4 1)
 
-    assert_eq ((num4 1) + (num4 0.5)) (num4 1.5)
-    assert_eq ((num4 2 4 6 8) - 1) (num4 1 3 5 7)
+    assert_eq ((num4 1) + (num4 0.5)), (num4 1.5)
+    assert_eq ((num4 2, 4, 6, 8) - 1), (num4 1, 3, 5, 7)
 
-    assert_eq ((num4 2) * (num4 0.5)) (num4 1)
-    assert_eq ((num4 2 4 6 8) * 0.5) (num4 1 2 3 4)
-    assert_eq (8 / (num4 2 4 8 16)) (num4 4 2 1 0.5)
+    assert_eq ((num4 2) * (num4 0.5)), (num4 1)
+    assert_eq ((num4 2, 4, 6, 8) * 0.5), (num4 1, 2, 3, 4)
+    assert_eq (8 / (num4 2, 4, 8, 16)), (num4 4, 2, 1, 0.5)

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -17,31 +17,31 @@ Av = |x, y, n|
   y.transform |n|
     i += 1
     j = 0
-    x.fold 0 |result, n|
+    x.fold 0, |result, n|
       j += 1
-      result + n * (A i j)
+      result + n * (A i, j)
 
 Atv = |x, y, n|
   i = 0
   y.transform |n|
     i += 1
     j = 0
-    x.fold 0 |result, n|
+    x.fold 0, |result, n|
       j += 1
-      result + n * (A j i)
+      result + n * (A j, i)
 
 AtAv = |x, y, t, n|
-  Av x t n
-  Atv t y n
+  Av x, t, n
+  Atv t, y, n
 
 spectral_norm = |n|
-  u = list.with_size n 1
-  v = list.with_size n 0
-  t = list.with_size n 0
+  u = list.with_size n, 1
+  v = list.with_size n, 0
+  t = list.with_size n, 0
 
   for _ in 0..10
-    AtAv u v t n
-    AtAv v u t n
+    AtAv u, v, t, n
+    AtAv v, u, t, n
   vBv, vv = 0, 0
   for ui, vi in u.zip v
     vBv = vBv + ui * vi
@@ -62,4 +62,4 @@ export main = ||
 
 export tests =
   test_5: ||
-    assert_near (spectral_norm 5) 1.261218 1e-6
+    assert_near (spectral_norm 5), 1.261218, 1e-6

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -11,7 +11,7 @@ tens = ["", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eight
 number_to_english = |n|
   n = n.floor()
   if n < 0
-    "minus {}".format (number_to_english n.abs())
+    "minus {}".format number_to_english n.abs()
   else if n < 20
     digits[n]
   else if n < 100
@@ -20,15 +20,15 @@ number_to_english = |n|
     if y == 0
       tens[x]
     else
-      "{}-{}".format tens[x] digits[y]
+      "{}-{}".format tens[x], digits[y]
   else if n < 1000
     x = (n / 100).floor()
-    x_string = (number_to_english x)
+    x_string = number_to_english x
     y = n % 100
     if y == 0
       "{} hundred".format x_string
     else
-      "{} hundred and {}".format x_string (number_to_english y)
+      "{} hundred and {}".format x_string, number_to_english y
   else
     "???"
 
@@ -46,7 +46,7 @@ export main = ||
 
 export tests =
   test_number_to_english: ||
-    assert_eq (number_to_english 0) "zero"
-    assert_eq (number_to_english -42) "minus forty-two"
-    assert_eq (number_to_english 217) "two hundred and seventeen"
-    assert_eq (number_to_english 999) "nine hundred and ninety-nine"
+    assert_eq (number_to_english 0), "zero"
+    assert_eq (number_to_english -42), "minus forty-two"
+    assert_eq (number_to_english 217), "two hundred and seventeen"
+    assert_eq (number_to_english 999), "nine hundred and ninety-nine"

--- a/koto/tests/arithmetic.koto
+++ b/koto/tests/arithmetic.koto
@@ -2,14 +2,14 @@ import test.assert_eq
 
 export tests =
   test_operators: ||
-    assert_eq (1 + 1) 2
-    assert_eq (2 - 2) 0
-    assert_eq (1 + 2 * 3 + 4) 11
-    assert_eq (1.5 * 4.0) 6.0
-    assert_eq (1.5 * 4.0) 6.0
-    assert_eq (9 / 3 + 1) 4
-    assert_eq ((3 - 2) / (4 - 2)) 0.5
-    assert_eq (2 + 5 % 3) 4
+    assert_eq 1 + 1, 2
+    assert_eq 2 - 2, 0
+    assert_eq 1 + 2 * 3 + 4, 11
+    assert_eq 1.5 * 4.0, 6.0
+    assert_eq 1.5 * 4.0, 6.0
+    assert_eq 9 / 3 + 1, 4
+    assert_eq (3 - 2) / (4 - 2), 0.5
+    assert_eq 2 + 5 % 3, 4
 
   test_long_expression: ||
     # Long expressions can be broken before and after operators
@@ -18,17 +18,17 @@ export tests =
             # Comments don't interrupt the expression
         + 5 + 5
         + 9 / 3
-    assert_eq a 20
+    assert_eq a, 20
 
   test_assignment_operators: ||
     x = 0
     x += 2
-    assert_eq x 2
+    assert_eq x, 2
     x *= 4
-    assert_eq x 8
+    assert_eq x, 8
     x -= 2
-    assert_eq x 6
+    assert_eq x, 6
     x /= 2
-    assert_eq x 3
+    assert_eq x, 3
     x %= 2
-    assert_eq x 1
+    assert_eq x, 1

--- a/koto/tests/assignment.koto
+++ b/koto/tests/assignment.koto
@@ -4,57 +4,57 @@ export tests =
   test_basic_assignment: ||
     a = 1
     b = -a
-    assert_eq a -b
+    assert_eq a, -b
 
   test_multi_assignment: ||
     a, b, c, d, e = 1, 2, 3, 4, 5, 6, 7, 8,
-    assert_eq c 3
-    assert_eq e 5
+    assert_eq c, 3
+    assert_eq e, 5
 
   test_chained_assignment: ||
     a = b = "foo"
-    assert_eq a "foo"
-    assert_eq b "foo"
+    assert_eq a, "foo"
+    assert_eq b, "foo"
 
   test_unicode_identifiers: ||
     やあ = héllø = 99
-    assert_eq héllø 99
-    assert_eq やあ 99
+    assert_eq héllø, 99
+    assert_eq やあ, 99
 
   test_assignment_returns_value: ||
-    assert_eq (a = 42) 42
-    assert_eq (x = 99) 99
-    assert_eq a 42
-    assert_eq x 99
+    assert_eq (a = 42), 42
+    assert_eq (x = 99), 99
+    assert_eq a, 42
+    assert_eq x, 99
 
   test_export_assignment: ||
     f = ||
       export x = 42
     f()
-    assert_eq x 42
+    assert_eq x, 42
 
     f2 = ||
       export x = x * 2
     f2()
-    assert_eq x 84
+    assert_eq x, 84
 
     f3 = ||
       x = x + 15 # assigning x in local scope
-      assert_eq x 99
+      assert_eq x, 99
     f3()
-    assert_eq x 84 # exported x remains the same
+    assert_eq x, 84 # exported x remains the same
 
   test_multiline_assignment: ||
     f = |n| n
     a, b, c =
       1,
-      f 2,
-      f 3,
-    assert_eq a 1
-    assert_eq b 2
-    assert_eq c 3
+      (f 2),
+      (f 3),
+    assert_eq a, 1
+    assert_eq b, 2
+    assert_eq c, 3
 
   test_assign_empty: ||
     a = ()
-    assert_eq a ()
-    assert_ne 1 ()
+    assert_eq a, ()
+    assert_ne 1, ()

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -3,25 +3,25 @@ from test import assert, assert_eq
 export tests =
   test_inline_if: ||
     x = if true then 10 else 20
-    assert_eq x 10
+    assert_eq x, 10
 
   test_inline_if_function_call: ||
     is_zero = |x| x == 0
     x = 0
     x = if is_zero 0 then 42
-    assert_eq x 42
+    assert_eq x, 42
     assert if is_zero 0 then true else false
 
   test_inline_if_multi_assignment: ||
     a, b = if true then 10, 20 else 30, 40
-    assert_eq b 20
+    assert_eq b, 20
 
   test_if_block: ||
     x = true
     a = 0
     if x
       a = 42
-    assert_eq a 42
+    assert_eq a, 42
 
   test_if_else_if: ||
     x = true
@@ -44,7 +44,7 @@ export tests =
         n == 1 then 1
         else (fib n - 1) + (fib n - 2)
 
-    assert_eq 13 (fib 7)
+    assert_eq 13, fib 7
 
   test_match: ||
     inspect = |n|
@@ -57,7 +57,7 @@ export tests =
           "odd"
         else
           ">= 10"
-    assert_eq (inspect 7) "odd"
+    assert_eq (inspect 7), "odd"
 
   test_match_against_lookups: ||
     m = {foo: 42, bar: 99}
@@ -66,7 +66,7 @@ export tests =
       m.foo then "foo"
       m.bar then "bar"
       other then "{}".format other
-    assert_eq z "bar"
+    assert_eq z, "bar"
 
   test_match_multiple_values: ||
     fizz_buzz = |n|
@@ -79,7 +79,7 @@ export tests =
     x = (10..=15)
       .each |n| fizz_buzz n
       .to_tuple()
-    assert_eq x ("Buzz", 11, "Fizz", 13, 14, "Fizz Buzz")
+    assert_eq x, ("Buzz", 11, "Fizz", 13, 14, "Fizz Buzz")
 
   test_match_lists_and_tuples: ||
     z = [1, 2, (3, 4), (5, [6, 7, 8])]
@@ -93,4 +93,4 @@ export tests =
       # Matched lists and tuples can be nested
       [a, b, (3, 4), (c, [6, rest...])]
         a + b + c + rest.size()
-    assert_eq a 10
+    assert_eq a, 10

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -9,35 +9,35 @@ make_enum = |entries...|
 make_bidirectional_enum = |entries...|
   entries
     .enumerate()
-    .fold {} |enum, (index, id)|
-      enum.insert id index
-      enum.insert index id
+    .fold {}, |enum, (index, id)|
+      enum.insert id, index
+      enum.insert index, id
       enum
 
 export tests =
   test_make_enum: ||
-    enum = make_enum "foo" "bar" "baz"
-    assert_eq enum.foo 0
-    assert_eq enum.bar 1
-    assert_eq enum.baz 2
-    assert_eq (enum.get_index 0)[0] "foo"
-    assert_eq (enum.get_index 1)[0] "bar"
-    assert_eq (enum.get_index 2)[0] "baz"
+    enum = make_enum "foo", "bar", "baz"
+    assert_eq enum.foo, 0
+    assert_eq enum.bar, 1
+    assert_eq enum.baz, 2
+    assert_eq enum.get_index(0)[0], "foo"
+    assert_eq enum.get_index(1)[0], "bar"
+    assert_eq enum.get_index(2)[0], "baz"
 
   test_make_bidirectional_enum: ||
-    enum = make_bidirectional_enum "foo" "bar" "baz"
-    assert_eq enum.foo 0
-    assert_eq enum.bar 1
-    assert_eq enum.baz 2
-    assert_eq (enum.get 0) "foo"
-    assert_eq (enum.get 1) "bar"
-    assert_eq (enum.get 2) "baz"
+    enum = make_bidirectional_enum "foo", "bar", "baz"
+    assert_eq enum.foo, 0
+    assert_eq enum.bar, 1
+    assert_eq enum.baz, 2
+    assert_eq enum.get(0), "foo"
+    assert_eq enum.get(1), "bar"
+    assert_eq enum.get(2), "baz"
 
   test_match_against_enum_values: ||
-    enum = make_enum "a" "b" "c"
+    enum = make_enum "a", "b", "c"
     x = enum.b
     y = match x
       enum.a then 1
       enum.b then 2
       enum.c then 3
-    assert_eq y 2
+    assert_eq y, 2

--- a/koto/tests/error_handling.koto
+++ b/koto/tests/error_handling.koto
@@ -7,7 +7,7 @@ export tests =
       42
     catch error
       assert false
-    assert_eq x 42
+    assert_eq x, 42
 
   test_catch: ||
     x = try
@@ -16,7 +16,7 @@ export tests =
       99
     catch error
       -1
-    assert_eq x -1
+    assert_eq x, -1
 
   test_finally: ||
     error_caught = false
@@ -29,7 +29,7 @@ export tests =
     finally
       x = 42
     assert error_caught
-    assert_eq x 42
+    assert_eq x, 42
 
   test_error_in_other_module: ||
     x = 0
@@ -37,4 +37,4 @@ export tests =
       error_handling_module.error_function()
     catch error
       x = 99
-    assert_eq x 99
+    assert_eq x, 99

--- a/koto/tests/function_closures.koto
+++ b/koto/tests/function_closures.koto
@@ -9,7 +9,7 @@ export tests =
     assert_eq
       multipliers
         .each |multiplier| multiplier 2
-        .to_tuple()
+        .to_tuple(),
       (2, 4, 6, 8)
 
   test_outer_value_captured_in_nested_function: ||
@@ -20,7 +20,7 @@ export tests =
         inner2 a
       b, c = (), () # inner and inner2 have captured their own copies of b and c
       inner()
-    assert_eq (capture_test 1 2 3) 6
+    assert_eq (capture_test 1, 2, 3), 6
 
   test_mutable_captured_values: ||
     counter = ||
@@ -30,8 +30,8 @@ export tests =
 
     c = counter()
     c2 = counter()
-    assert_eq c() 1
-    assert_eq c() 2
-    assert_eq c2() 1
-    assert_eq c() 3
-    assert_eq c2() 2
+    assert_eq c(), 1
+    assert_eq c(), 2
+    assert_eq c2(), 1
+    assert_eq c(), 3
+    assert_eq c2(), 2

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -3,34 +3,36 @@ from test import assert, assert_eq
 export tests =
   test_square: ||
     square = |x| x * x
-    assert_eq (square 7) 49
-    assert_eq (square -10) 100
+    assert_eq (square 7), 49
+    assert_eq (square -10), 100
 
   test_sum: ||
     sum = |x, y| x + y
-    # Space-separated arguments
-    assert_eq (sum 10 11) 21
-    # Comma-separated arguments in parentheses
-    assert_eq sum(10, 11) 21
+    # Call with parentheses
+    result = sum(10, 11)
+    assert_eq result, 21
+    # Call without parentheses
+    result = sum 12, 18
+    assert_eq result, 30
 
   test_sum_variadic: ||
     sum = |x, y, z...|
       x + y + z.fold(0, |a, b| a + b)
-    assert_eq (sum 1 2) 3
-    assert_eq (sum 3 4 5) 12
-    assert_eq (sum 6 7 8 9) 30
+    assert_eq (sum 1, 2), 3
+    assert_eq (sum 3, 4, 5), 12
+    assert_eq (sum 6, 7, 8, 9), 30
 
   test_wildcard_arg: ||
     foo = |a, _, c| a + c
-    assert_eq (foo 1 2 3) 4
+    assert_eq (foo 1, 2, 3), 4
 
   test_list_unpacking: ||
     foo = |a, [b, [c, d]], e| a * b * c * d * e
-    assert_eq (foo 1 [2, [3, 4]] 5) 120
+    assert_eq (foo 1, [2, [3, 4]], 5), 120
 
   test_tuple_unpacking: ||
     foo = |a, (b, (c, d)), e| a + b + c + d + e
-    assert_eq (foo 1 (2, (3, 4)) 5) 15
+    assert_eq (foo 1, (2, (3, 4)), 5), 15
 
   test_nested_function: ||
     add = |x, y|
@@ -38,26 +40,26 @@ export tests =
       do_add = |x, y|
         x = x + y # Nested trailing comment
         x # implicit return of last expression
-      result = do_add x y
+      result = do_add x, y
       # function arguments are locally scoped
-      assert_eq x x2
+      assert_eq x, x2
       result # implicit return
-    assert_eq (add 1 2) 3
+    assert_eq (add 1, 2), 3
 
   test_captured_function: ||
     add = |x, y| x + y
-    add2 = |x, y| add x y
-    assert_eq (add2 90 9) 99
+    add2 = |x, y| add x, y
+    assert_eq (add2 90, 9), 99
 
   test_nested_calls: ||
     add = |x, y| x + y
-    assert_eq (add (add 1 1) (add -1 -1)) 0
+    assert_eq (add (add 1, 1), (add -1, -1)), 0
 
   test_function_returning_multiple_values: ||
     f = |x| x - 1, x + 1
     a, b = f 0
-    assert_eq a -1
-    assert_eq b 1
+    assert_eq a, -1
+    assert_eq b, 1
 
   test_early_return: ||
     match_digit = |n|
@@ -73,15 +75,15 @@ export tests =
     assert_eq
       (0..3)
         .each |i| match_digit i
-        .to_tuple()
+        .to_tuple(),
       (0, 1, 2)
 
   test_return_multiple_values: ||
     f = ||
       return -1, 1
     a, b = f()
-    assert_eq a -1
-    assert_eq b 1
+    assert_eq a, -1
+    assert_eq b, 1
 
   test_return_no_value: ||
     f = ||

--- a/koto/tests/functions_in_lookups.koto
+++ b/koto/tests/functions_in_lookups.koto
@@ -12,18 +12,18 @@ maps = [test_map(), test_map()]
 export tests =
   test_call_setter_in_child_map_in_list: ||
     # set the first map's child foo
-    assert_eq maps[0].get_child_map().foo 42
+    assert_eq maps[0].get_child_map().foo, 42
     maps[0].get_child_map().set_foo -1
-    assert_eq maps[0].get_child_map().foo -1
-    assert_eq maps[0].child_map.foo -1
+    assert_eq maps[0].get_child_map().foo, -1
+    assert_eq maps[0].child_map.foo, -1
     # the second map's child foo hasn't been modified
-    assert_eq maps[1].get_child_map().foo 42
+    assert_eq maps[1].get_child_map().foo, 42
 
   test_negation_of_lookup: ||
-    assert_eq -maps[1].get_child_map().foo -42
+    assert_eq -maps[1].get_child_map().foo, -42
 
   test_chained_function_call: ||
     f = ||
       # Calling f() returns the following function
       |x| x * x
-    assert_eq f()(8) 64
+    assert_eq f()(8), 64

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -5,26 +5,26 @@ export tests =
     # importing a module brings the module's global map into scope by assignment
     # test_module is defined in the test_module directory, with main.koto as its entry point
     import test_module
-    assert_eq (type test_module) "Map"
-    assert_eq test_module.foo 42
-    assert_eq (test_module.square 9) 81
+    assert_eq (type test_module), "Map"
+    assert_eq test_module.foo, 42
+    assert_eq (test_module.square 9), 81
 
   test_assign_import_item: ||
     x = import test_module.bar
-    assert_eq bar -1
-    assert_eq x bar
+    assert_eq bar, -1
+    assert_eq x, bar
 
   test_import_nested_item: ||
     import test_module.baz.qux
-    assert_eq qux "O_o"
+    assert_eq qux, "O_o"
 
   test_import_multiple_items: ||
     a, b = import test_module.foo, test_module.bar
-    assert_eq a 42
-    assert_eq b -1
+    assert_eq a, 42
+    assert_eq b, -1
 
   test_import_multiple_items_with_from: ||
     x, y = from test_module import foo, bar
-    assert_eq x 42
-    assert_eq y -1
+    assert_eq x, 42
+    assert_eq y, -1
 

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -5,13 +5,13 @@ from test import assert, assert_eq, assert_ne
 export tests =
   test_reading_a_file: ||
     path = koto.script_dir + "/data/test.txt"
-    assert (io.exists path)
+    assert io.exists path
 
     contents = io.read_to_string path
-    assert_eq contents.lines().to_tuple() ("aaa", "bbb", "ccc")
+    assert_eq contents.lines().to_tuple(), ("aaa", "bbb", "ccc")
 
     file = io.open path
-    assert_eq contents file.read_to_string()
+    assert_eq contents, file.read_to_string()
 
   test_current_dir: ||
-    assert_ne koto.current_dir() ""
+    assert_ne koto.current_dir(), ""

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -4,48 +4,48 @@ from test import assert, assert_eq
 export tests =
   test_next: ||
     i = (1..=3).iter()
-    assert_eq i.next() 1
-    assert_eq i.next() 2
-    assert_eq i.next() 3
-    assert_eq i.next() ()
+    assert_eq i.next(), 1
+    assert_eq i.next(), 2
+    assert_eq i.next(), 3
+    assert_eq i.next(), ()
 
   test_to_list: ||
-    assert_eq (1..=3).to_list() [1, 2, 3]
-    assert_eq [2, 4, 6].to_list() [2, 4, 6]
+    assert_eq (1..=3).to_list(), [1, 2, 3]
+    assert_eq [2,, 4, 6].to_list(), [2, 4, 6]
     assert_eq
-      {foo: 42, bar: 99}.to_list()
+      {foo: 42, bar: 99}.to_list(),
       [("foo", 42), ("bar", 99)]
 
     doubler = |xs|
       for x in xs
         yield x * 2
-    assert_eq (doubler 1..=5).to_list() [2, 4, 6, 8, 10]
+    assert_eq (doubler 1..=5).to_list(), [2, 4, 6, 8, 10]
 
   test_to_map: ||
     # An iterator that returns a single value produces a Map,
     # with the input values as keys, and with Empty as their values.
     assert_eq
-      ("1", "2", "3").to_map()
+      ("1", "2", "3").to_map(),
       {"1": (), "2": (), "3": ()}
 
     # An iterator that provides a pair of values produces key/value entries for each pair
     assert_eq
       (1..=3)
-        .each |n| return "{}".format n, n
-        .to_map()
+        .each |n| "{}".format(n), n
+        .to_map(),
       {"1": 1, "2": 2, "3": 3}
 
   test_to_tuple: ||
-    assert_eq (1..=3).iter().to_tuple() (1, 2, 3)
-    assert_eq [2, 4, 6].iter().to_tuple() (2, 4, 6)
+    assert_eq (1..=3).iter().to_tuple(), (1, 2, 3)
+    assert_eq [2, 4, 6].iter().to_tuple(), (2, 4, 6)
     assert_eq
-      {foo: 42, bar: 99}.iter().to_tuple()
+      {foo: 42, bar: 99}.iter().to_tuple(),
       (("foo", 42), ("bar", 99))
 
   test_all: ||
     assert (1..10).all(|n| n < 10)
     assert not (1..10).all(|n| n < 5)
-    assert "xyz".all(|c| "zyx".contains c)
+    assert "xyz".all |c| "zyx".contains c
 
   test_any: ||
     assert (1..10).any(|n| n == 5)
@@ -54,106 +54,106 @@ export tests =
 
   test_chain: ||
     assert_eq
-      (1..10).chain(10..15).chain(15..20).to_tuple()
+      (1..10).chain(10..15).chain(15..20).to_tuple(),
       (1..20).to_tuple()
 
   test_consume: ||
     x = []
     (1..=5).each(|n| x.push n).consume()
-    assert_eq x [1, 2, 3, 4, 5]
+    assert_eq x, [1, 2, 3, 4, 5]
 
   test_count: ||
     result = (0..10)
       .keep |n| n % 2 == 0
       .count()
-    assert_eq result 5
+    assert_eq result, 5
 
   test_each: ||
     assert_eq
-      ("1", "2").each(|x| x.to_number()).to_tuple()
+      ("1", "2").each(|x| x.to_number()).to_tuple(),
       (1, 2)
 
     assert_eq
       {foo: 42, bar: 99}
-        .each |key_value| key, value = key_value # TODO tuple unpacking in args
-        .to_tuple()
+        .each |(key, value)| key, value
+        .to_tuple(),
       (("foo", 42), ("bar", 99))
 
   test_enumerate: ||
     assert_eq
-      (10..=12).enumerate().to_tuple()
+      (10..=12).enumerate().to_tuple(),
       ((0, 10), (1, 11), (2, 12))
 
   test_keep: ||
     assert_eq
       (0..10)
         .keep |x| x % 2 == 1
-        .to_tuple()
+        .to_tuple(),
       (1, 3, 5, 7, 9)
 
   test_fold: ||
     assert_eq
-      (1..=5).fold 0 |sum, x| sum + x
+      (1..=5).fold(0, |sum, x| sum + x),
       15
 
   test_max: ||
-    assert_eq (2, -1, 9).max() 9
-    assert_eq ("hello", "goodbye").max() "hello"
+    assert_eq (2, -1, 9).max(), 9
+    assert_eq ("hello", "goodbye").max(), "hello"
 
   test_min: ||
-    assert_eq (2, -1, 9).min() -1
-    assert_eq ("hello", "goodbye").min() "goodbye"
+    assert_eq (2, -1, 9).min(), -1
+    assert_eq ("hello", "goodbye").min(), "goodbye"
 
   test_min_max: ||
-    assert_eq (2, -1, 9).min_max() (-1, 9)
-    assert_eq ("hello", "to the", "world").min_max() ("hello", "world")
+    assert_eq (2, -1, 9).min_max(), (-1, 9)
+    assert_eq ("hello", "to the", "world").min_max(), ("hello", "world")
 
   test_position: ||
     assert_eq
-      (100..1000).position |x| x >= 110
+      (100..1000).position(|x| x >= 110),
       10
     assert_eq
-      "hey now".position |c| c == " "
+      "hey now".position(|c| c == " "),
       3
 
   test_product: ||
-    assert_eq (1..=5).product() 120
+    assert_eq (1..=5).product(), 120
     # An initial value can be provided to override the default initial value of 0
-    assert_eq (2, 3, 4).product(num2 1 2) (num2 24 48)
+    assert_eq (2, 3, 4).product(num2 1, 2), (num2 24, 48)
 
   test_skip: ||
     assert_eq
-      (0..10).skip(5).to_tuple()
+      (0..10).skip(5).to_tuple(),
       (5, 6, 7, 8, 9)
 
   test_sum: ||
-    assert_eq (1..=5).sum() 15
+    assert_eq (1..=5).sum(), 15
     # An initial value can be provided to override the default initial value of 0
-    assert_eq ([1], [2], [3]).sum([]) [1, 2, 3]
+    assert_eq ([1], [2], [3]).sum([]), [1, 2, 3]
 
   test_take: ||
     assert_eq
-      (1..100).take(5).to_tuple()
+      (1..100).take(5).to_tuple(),
       (1, 2, 3, 4, 5)
 
     ones = ||
       loop
         yield 1
     assert_eq
-      ones().take(3).to_tuple()
+      ones().take(3).to_tuple(),
       (1, 1, 1)
 
   test_zip: ||
     assert_eq
       (1..=3)
         .zip 11..100
-        .to_tuple()
+        .to_tuple(),
       ((1, 11), (2, 12), (3, 13))
 
     assert_eq
       {foo: 42, bar: 99}
         .zip 100..200
-        .to_tuple()
+        .to_tuple(),
       ((("foo", 42), 100), (("bar", 99), 101))
 
   test_custom_iterator_adaptor: ||
@@ -170,10 +170,10 @@ export tests =
       (10..15).each |x| "{}".format x
 
     assert_eq
-      make_iter().every_other().to_tuple()
+      make_iter().every_other().to_tuple(),
       ("10", "12", "14")
 
     # The every_other adaptor can also be called via iterator.every_other
     assert_eq
-      iterator.every_other(make_iter()).to_tuple()
+      iterator.every_other(make_iter()).to_tuple(),
       ("10", "12", "14")

--- a/koto/tests/libs/json.koto
+++ b/koto/tests/libs/json.koto
@@ -15,16 +15,16 @@ export tests =
       "Error reading decoding json data: {}".print error
       assert false
 
-    assert_eq data.empty ()
-    assert_eq data.number 99
-    assert_eq data.bool true
-    assert_eq data.string "O_o"
-    assert_eq data.nested.number_float -1.2
-    assert_eq data.nested.number_int 123
-    assert_eq data.nested.string "hello"
-    assert_eq data.entries[0].foo "bar"
-    assert_eq data.entries[1].foo "baz"
+    assert_eq data.empty, ()
+    assert_eq data.number, 99
+    assert_eq data.bool, true
+    assert_eq data.string, "O_o"
+    assert_eq data.nested.number_float, -1.2
+    assert_eq data.nested.number_int, 123
+    assert_eq data.nested.string, "hello"
+    assert_eq data.entries[0].foo, "bar"
+    assert_eq data.entries[1].foo, "baz"
 
     serialized = json.to_string data
     data_2 = json.from_string serialized
-    assert_eq data data_2
+    assert_eq data, data_2

--- a/koto/tests/libs/random.koto
+++ b/koto/tests/libs/random.koto
@@ -11,12 +11,12 @@ export tests =
     assert not random.bool()
 
   test_number: ||
-    assert_near random.number() 0.024 0.001
-    assert_near random.number() 0.982 0.001
+    assert_near random.number(), 0.024, 0.001
+    assert_near random.number(), 0.982, 0.001
 
   test_num2_num4: ||
-    assert_near random.number2() (num2 0.024 0.982) 0.001
-    assert_near random.number4() (num4 0.006 0.861 0.823 0.186) 0.001
+    assert_near random.number2(), (num2 0.024, 0.982), 0.001
+    assert_near random.number4(), (num4 0.006, 0.861, 0.823, 0.186), 0.001
 
   test_pick: ||
     x = ["foo", "bar", "baz"]
@@ -36,9 +36,9 @@ export tests =
 
     output1 = get_rng_output rng1
 
-    assert_eq output1 (get_rng_output rng2)
-    assert_ne output1 (get_rng_output rng3)
+    assert_eq output1, (get_rng_output rng2)
+    assert_ne output1, (get_rng_output rng3)
 
     # seed can be used to reseed the unique generator
     rng3.seed 0
-    assert_eq output1 (get_rng_output rng3)
+    assert_eq output1, (get_rng_output rng3)

--- a/koto/tests/libs/tempfile.koto
+++ b/koto/tests/libs/tempfile.koto
@@ -8,7 +8,7 @@ export tests =
     file = io.create path
     contents = "<(^_^)<"
     file.write contents
-    assert_eq (io.read_to_string path) contents
+    assert_eq (io.read_to_string path), contents
     io.remove_file path
     assert not io.exists path
 
@@ -18,7 +18,7 @@ export tests =
     temp.write_line "hello"
     temp.write_line 42
     assert (io.exists temp_path)
-    assert_eq (io.read_to_string temp_path) temp.read_to_string()
+    assert_eq (io.read_to_string temp_path), temp.read_to_string()
 
     # Temp files are deleted when they're no longer used
     temp = ()

--- a/koto/tests/libs/toml.koto
+++ b/koto/tests/libs/toml.koto
@@ -1,19 +1,19 @@
-import koto, io, test.assert_eq, toml
+import koto, io, test.assert_eq, toml,
 
 export tests =
   test_serialize_and_deserialize_toml: ||
     file_data = io.read_to_string koto.script_dir + "/data/test.toml"
     data = toml.from_string file_data
 
-    assert_eq data.number 99
-    assert_eq data.bool true
-    assert_eq data.string "O_o"
-    assert_eq data.nested.number_float -1.2
-    assert_eq data.nested.number_int 123
-    assert_eq data.nested.string "hello"
-    assert_eq data.entries[0].foo "bar"
-    assert_eq data.entries[1].foo "baz"
+    assert_eq data.number, 99
+    assert_eq data.bool, true
+    assert_eq data.string, "O_o"
+    assert_eq data.nested.number_float, -1.2
+    assert_eq data.nested.number_int, 123
+    assert_eq data.nested.string, "hello"
+    assert_eq data.entries[0].foo, "bar"
+    assert_eq data.entries[1].foo, "baz"
 
     serialized = toml.to_string data
     data_2 = toml.from_string serialized
-    assert_eq data data_2
+    assert_eq data, data_2

--- a/koto/tests/line_breaks.koto
+++ b/koto/tests/line_breaks.koto
@@ -36,7 +36,7 @@ assert_equal = |
 |
   # The body must be indented
   assert_eq
-    long_arg # call args can be indented
+    long_arg, # call args can be indented
     long_arg_2
 
 assert_equal

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -6,53 +6,53 @@ export tests =
   test_clear: ||
     x = [1, 2, 3, 4, 5]
     x.clear()
-    assert_eq x []
+    assert_eq x, []
 
   test_contains: ||
-    assert ([0..10].contains 5)
-    assert not ([0..10].contains 15)
+    assert [0..10].contains 5
+    assert not [0..10].contains 15
 
   test_copy: ||
     x = [1, 2, 3]
     x2 = x
     x3 = x.copy()
     x[0] = 99
-    assert_eq x2[0] 99
-    assert_eq x3[0] 1
+    assert_eq x2[0], 99
+    assert_eq x3[0], 1
 
   test_deep_copy: ||
     x = [1, [2, 3]]
     x2 = x.deep_copy()
     x[1][0] = 99
-    assert_eq x2[1][0] 2
+    assert_eq x2[1][0], 2
 
   test_push_pop: ||
     z = [1]
     z.push 2
-    assert_eq z [1, 2]
+    assert_eq z, [1, 2]
     # list ops are also available in the list module
-    list.push z 3
-    assert_eq z [1, 2, 3]
-    assert_eq z.pop() 3
-    assert_eq z [1, 2]
+    list.push z, 3
+    assert_eq z, [1, 2, 3]
+    assert_eq z.pop(), 3
+    assert_eq z, [1, 2]
     z.pop()
     z.pop()
-    assert_eq z []
+    assert_eq z, []
     list.pop z
-    assert_eq z []
+    assert_eq z, []
 
   test_first_last: ||
     z = []
-    assert_eq z.first() ()
-    assert_eq z.last() ()
+    assert_eq z.first(), ()
+    assert_eq z.last(), ()
 
     z = [99]
-    assert_eq z.first() 99
-    assert_eq z.last() 99
+    assert_eq z.first(), 99
+    assert_eq z.last(), 99
 
     z = [1, 2, 3]
-    assert_eq z.first() 1
-    assert_eq z.last() 3
+    assert_eq z.first(), 1
+    assert_eq z.last(), 3
 
   test_is_empty: ||
     assert [].is_empty()
@@ -60,66 +60,66 @@ export tests =
 
   test_remove_insert: ||
     z = [1, 2, 3]
-    assert_eq (z.remove 1) 2
-    assert_eq z [1, 3]
-    z.insert 1 42
-    assert_eq z [1, 42, 3]
-    z.insert 3 -1
-    assert_eq z [1, 42, 3, -1]
+    assert_eq (z.remove 1), 2
+    assert_eq z, [1, 3]
+    z.insert 1, 42
+    assert_eq z, [1, 42, 3]
+    z.insert 3, -1
+    assert_eq z, [1, 42, 3, -1]
 
   test_get: ||
-    assert_eq ([0..10].get 5) 5
-    assert_eq ([0..10].get 15) ()
+    assert_eq ([0..10].get 5), 5
+    assert_eq ([0..10].get 15), ()
 
   test_fill: ||
     a = [1, 2, 3]
     a.fill 42
-    assert_eq a [42, 42, 42]
+    assert_eq a, [42, 42, 42]
 
   test_resize: ||
     z = [42]
-    z.resize 4 99
-    assert_eq z [42, 99, 99, 99]
+    z.resize 4, 99
+    assert_eq z, [42, 99, 99, 99]
 
-    z.resize 2 -1
-    assert_eq z [42, 99]
+    z.resize 2, -1
+    assert_eq z, [42, 99]
 
   test_retain_value: ||
-    z = ["hello", 42, num4 0, "hello"]
+    z = ["hello", 42, (num4 0), "hello"]
     z.retain "hello"
-    assert_eq z ["hello", "hello"]
+    assert_eq z, ["hello", "hello"]
 
   test_retain_predicate: ||
     z = [0..10]
     z.retain |n| n % 2 == 0
-    assert_eq z [0, 2, 4, 6, 8]
+    assert_eq z, [0, 2, 4, 6, 8]
 
   test_reverse: ||
     a = [1, 2, 3]
     a.reverse()
-    assert_eq a [3, 2, 1]
+    assert_eq a, [3, 2, 1]
 
   test_size: ||
-    assert_eq [].size() 0
-    assert_eq [1, 2, 3].size() 3
+    assert_eq [].size(), 0
+    assert_eq [1, 2, 3].size(), 3
 
   test_sort: ||
     z = [3, 2, 1]
     z.sort()
-    assert_eq z [1, 2, 3]
+    assert_eq z, [1, 2, 3]
 
     # Sorting with a key function
     z = [3, 2, 1, 2]
     z.sort |n| -n # reverse sorting
-    assert_eq z [3, 2, 2, 1]
+    assert_eq z, [3, 2, 2, 1]
 
     # Sorting with a core op
     z = [[4, 5, 6], [1], [2, 3]]
     z.sort list.size
-    assert_eq z [[1], [2, 3], [4, 5, 6]]
+    assert_eq z, [[1], [2, 3], [4, 5, 6]]
 
   test_sort_copy: ||
-    assert_eq [42, 10, 9].sort_copy() [9, 10, 42]
+    assert_eq [42, 10, 9].sort_copy(), [9, 10, 42]
 
   test_swap: ||
     a = [1, 2, 3]
@@ -127,22 +127,22 @@ export tests =
 
     a.swap b
 
-    assert_eq a [7, 8, 9]
-    assert_eq b [1, 2, 3]
+    assert_eq a, [7, 8, 9]
+    assert_eq b, [1, 2, 3]
 
   test_to_tuple: ||
-    assert_eq [1, 2, 3].to_tuple() (1, 2, 3)
+    assert_eq [1, 2, 3].to_tuple(), (1, 2, 3)
 
   test_transform: ||
     z = ["1", "2", "3"]
     z.transform |x| x.to_number()
-    assert_eq z [1, 2, 3]
+    assert_eq z, [1, 2, 3]
 
   test_with_size: ||
     assert_eq
-      (list.with_size 3 "x")
+      (list.with_size 3, "x"),
       ["x", "x", "x"]
 
     assert_eq
-      (list.with_size 5 42)
+      (list.with_size 5, 42),
       [42, 42, 42, 42, 42]

--- a/koto/tests/lists.koto
+++ b/koto/tests/lists.koto
@@ -3,57 +3,57 @@ from test import assert, assert_eq, assert_ne
 export tests =
   test_list_indexing: ||
     z = [10, 10 + 10, 30]
-    assert_eq z[0] 10
-    assert_eq z[0 + 1] 20
+    assert_eq z[0], 10
+    assert_eq z[0 + 1], 20
 
   test_list_equality: ||
     z = [1, 2, 3]
-    assert_eq z z
-    assert_ne z []
+    assert_eq z, z
+    assert_ne z, []
 
   test_list_addition: ||
     x = [0]
     x = x + [1]
-    assert_eq x [0, 1]
+    assert_eq x, [0, 1]
     x += [2, 3]
-    assert_eq x [0, 1, 2, 3]
+    assert_eq x, [0, 1, 2, 3]
     # Tuples can also be added to lists
     x += (4, 5)
-    assert_eq x [0, 1, 2, 3, 4, 5]
+    assert_eq x, [0, 1, 2, 3, 4, 5]
 
   test_list_unpacking: ||
     a, b, c = [10, 20, 30, 40]
-    assert_eq a 10
-    assert_eq b 20
-    assert_eq c 30
+    assert_eq a, 10
+    assert_eq b, 20
+    assert_eq c, 30
 
   test_list_multiple_assignment: ||
     a, b, c = [10, 20], [30, 40]
-    assert_eq a [10, 20]
-    assert_eq b [30, 40]
-    assert_eq c ()
+    assert_eq a, [10, 20]
+    assert_eq b, [30, 40]
+    assert_eq c, ()
 
   test_list_shared_data: ||
     a = [0, 1, 2]
     b = a # Assigning a list makes a new reference to the same data
     a[0] = 42
-    assert_eq a [42, 1, 2]
+    assert_eq a, [42, 1, 2]
     a[1], a[2] = -42, 99
-    assert_eq a [42, -42, 99]
+    assert_eq a, [42, -42, 99]
     a[1..] = 0
-    assert_eq a [42, 0, 0]
+    assert_eq a, [42, 0, 0]
     a[1] += 2
-    assert_eq a [42, 2, 0]
+    assert_eq a, [42, 2, 0]
     # b still refers to the same underlying data
-    assert_eq a b
+    assert_eq a, b
     # assigning a new list to a doesn't affect b's binding
     a = [1, 2, 3]
-    assert_eq a [1, 2, 3]
-    assert_eq b [42, 2, 0]
+    assert_eq a, [1, 2, 3]
+    assert_eq b, [42, 2, 0]
 
   test_lists_in_lists: ||
     b = [42, 42]
     a = [b, b, b]
-    assert_eq a[1][1] 42
+    assert_eq a[1][1], 42
     a[1][1] = -1
-    assert_eq a[1][1] -1
+    assert_eq a[1][1], -1

--- a/koto/tests/logic.koto
+++ b/koto/tests/logic.koto
@@ -42,8 +42,8 @@ export tests =
       || count += 1
     f = make_counter()
     assert 0 < f() < 2
-    assert_eq f() 2
+    assert_eq f(), 2
 
   test_fiddly_chained_comparison: ||
     f = |x, y, z| if x < y < z > y > x then 0 else 1
-    assert (f 1 2 3) < (f 3 2 1) <= (f 5 4 3) < 2 > (f 1 2 3)
+    assert (f 1, 2, 3) < (f 3, 2, 1) <= (f 5, 4, 3) < 2 > (f 1, 2, 3)

--- a/koto/tests/loops.koto
+++ b/koto/tests/loops.koto
@@ -5,12 +5,12 @@ export tests =
     count = 0
     for x in 0..10
       for y in -5..5 if x == y and x < 3
-        assert_eq x y
+        assert_eq x, y
 
         # loop bodies share scope of statement
         count += 1
 
-    assert_eq count 3
+    assert_eq count, 3
 
   test_for_break_continue: ||
     count = 0
@@ -21,7 +21,7 @@ export tests =
         break
       else
         count += 1
-    assert_eq count 2 # 2 odd numbers less than 5
+    assert_eq count, 2 # 2 odd numbers less than 5
 
   test_while_block: ||
     count = 0
@@ -38,14 +38,14 @@ export tests =
       else
         break
       assert false
-    assert_eq count 10
+    assert_eq count, 10
 
   test_until_block: ||
     count = 5
     until count == 0
       count -= 1
       assert count < 5
-    assert_eq count 0
+    assert_eq count, 0
 
   test_loop_break: ||
     count = 0
@@ -53,4 +53,4 @@ export tests =
       count += 1
       if count == 5
         break
-    assert_eq count 5
+    assert_eq count, 5

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -5,42 +5,44 @@ export tests =
   test_clear: ||
     m = {foo: 42, bar: 99}
     m.clear()
-    assert_eq m {}
+    assert_eq m, {}
 
   test_contains_key: ||
     m = {foo: 42, bar: 99}
-    assert (m.contains_key "foo")
-    assert (m.contains_key "bar")
-    assert not (m.contains_key "baz")
+    assert m.contains_key "foo"
+    assert m.contains_key "bar"
+    assert not m.contains_key "baz"
 
   test_deep_copy: ||
     m = {foo: 42, bar: {baz: 99}}
     m2 = m.deep_copy()
     m.bar.baz = 123
-    assert_eq m2.bar.baz 99
+    assert_eq m2.bar.baz, 99
 
   test_insert: ||
     m = {foo: 42}
-    old_value = m.insert "foo" 99
-    assert_eq m.foo 99
-    assert_eq old_value 42
+    old_value = m.insert "foo", 99
+    assert_eq m.foo, 99
+    assert_eq old_value, 42
 
   test_insert_via_map_module: ||
     # map ops are also available in the map module,
     # which allows access to ops when a key might have a matching name.
     m = {foo: 42}
-    map.insert m "foo" -1
-    assert_eq m.foo -1
+    map.insert m, "foo", -1
+    assert_eq m.foo, -1
 
   test_insert_without_value: ||
     m = {foo: 42}
     m.insert "foo"
-    assert_eq m.foo ()
+    assert_eq m.foo, ()
 
   test_insert_non_string_key: ||
     m = {}
-    m.insert 1 "one"
-    m.insert 2 "two"
+    m.insert 1, "one"
+    m.insert 2, "two"
+    assert_eq m.get(1), "one"
+    assert_eq m.get(2), "two"
 
   test_is_empty: ||
     assert {}.is_empty()
@@ -48,64 +50,64 @@ export tests =
 
   test_get: ||
     m = {foo: 42}
-    assert_eq (m.get "foo") 42
-    assert_eq (m.get "bar") ()
+    assert_eq (m.get "foo"), 42
+    assert_eq (m.get "bar"), ()
 
   test_get_non_string_key: ||
     m = {}
-    m.insert 1 "O_o"
-    assert_eq (m.get 1) "O_o"
-    assert_eq (m.get (num2 1 2)) ()
+    m.insert 1, "O_o"
+    assert_eq (m.get 1), "O_o"
+    assert_eq (m.get num2 1, 2), ()
 
   test_get_index: ||
     m = {foo: 42, bar: 99, baz: 123}
-    assert_eq (m.get_index 1) ("bar", 99)
-    assert_eq (m.get_index 2) ("baz", 123)
+    assert_eq (m.get_index 1), ("bar", 99)
+    assert_eq (m.get_index 2), ("baz", 123)
 
   test_keys: ||
     m = {foo: 42}
-    assert_eq m.keys().to_tuple() ("foo",)
-    m.insert 0 "zero"
-    assert_eq m.keys().to_tuple() ("foo", 0)
+    assert_eq m.keys().to_tuple(), ("foo",)
+    m.insert 0, "zero"
+    assert_eq m.keys().to_tuple(), ("foo", 0)
 
   test_remove: ||
     m = {foo: 42, bar: 99, baz: -1}
-    assert_eq (m.remove "foo") 42
-    assert_eq m.keys().to_tuple() ("bar", "baz")
-    assert_eq (m.remove "bar") 99
-    assert_eq (m.remove "foo") ()
+    assert_eq (m.remove "foo"), 42
+    assert_eq m.keys().to_tuple(), ("bar", "baz")
+    assert_eq (m.remove "bar"), 99
+    assert_eq (m.remove "foo"), ()
 
   test_size: ||
-    assert_eq {}.size() 0
-    assert_eq {foo: 42}.size() 1
+    assert_eq {}.size(), 0
+    assert_eq {foo: 42}.size(), 1
 
   test_sort: ||
     m = {foo: 42, bar: 99}
-    assert_eq m.keys().to_tuple() ("foo", "bar")
+    assert_eq m.keys().to_tuple(), ("foo", "bar")
 
     m.sort()
-    assert_eq m.keys().to_tuple() ("bar", "foo")
+    assert_eq m.keys().to_tuple(), ("bar", "foo")
 
     # A sort function can be optionally provided
     # which takes the key and value of a map entry,
     # and returns a value which is then used for sorting.
     m.sort |key, value| value
-    assert_eq m.keys().to_tuple() ("foo", "bar")
+    assert_eq m.keys().to_tuple(), ("foo", "bar")
 
   test_update: ||
     m = {foo: 42}
 
     # update takes a function that receives the entry's current value,
     # which is then replaced with the function's result.
-    m.update "foo" |x| x * 2
-    assert_eq m.foo 84
+    m.update "foo", |x| x * 2
+    assert_eq m.foo, 84
 
     # update optionally takes a default value for missing entries,
     # an entry will be inserted with the default value before the function is called.
     assert not m.contains_key "xyz"
-    m.update "xyz" 100 |x| x / 2
-    assert_eq m.xyz 50
+    m.update "xyz", 100, |x| x / 2
+    assert_eq m.xyz, 50
 
   test_values: ||
     m = {foo: 42, bar: "O_o"}
-    assert_eq m.values().to_tuple() (42, "O_o")
+    assert_eq m.values().to_tuple(), (42, "O_o")

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -4,38 +4,38 @@ from test import assert, assert_eq, assert_ne
 export tests =
   test_access_by_key: ||
     m = {key: "value", another_key: "another_value"}
-    assert_eq m.key "value"
-    assert_eq m.another_key "another_value"
+    assert_eq m.key, "value"
+    assert_eq m.another_key, "another_value"
 
   test_assign_by_key: ||
     m = {key: -1}
     m.key = 42
-    assert_eq m.key 42
+    assert_eq m.key, 42
 
   test_implict_key_values: ||
     foo, baz = 42, -1
     m = {foo, bar: 99, baz}
-    assert_eq m.foo 42
-    assert_eq m.bar 99
-    assert_eq m.baz -1
+    assert_eq m.foo, 42
+    assert_eq m.bar, 99
+    assert_eq m.baz, -1
 
   test_map_iteration: ||
     m = {foo: 42, bar: -1}
     for key, value in m
-      assert_ne key ()
-      assert_ne value ()
+      assert_ne key, ()
+      assert_ne value, ()
 
   test_map_quoted_keys: ||
     # Quoted strings can be used for keys that would otherwise be disallowed
     x = {"for": -1, "while": 99, "20": "twenty"}
-    assert_eq x."for" -1
-    assert_eq x."while" 99
-    assert_eq x."20" "twenty"
+    assert_eq x."for", -1
+    assert_eq x."while", 99
+    assert_eq x."20", "twenty"
 
   test_unicode_keys: ||
     x = {}
     x.ƒöó = 123
-    assert_eq x.ƒöó 123
+    assert_eq x.ƒöó, 123
 
   test_function_value: ||
     o = {}
@@ -44,17 +44,17 @@ export tests =
     sum = 0
     for i in o.min()..o.max()
       sum += i
-    assert_eq sum 861
+    assert_eq sum, 861
 
   test_equality_and_shared_data: ||
     m = {foo: 42, bar: -1}
     m2 = m
-    assert_eq m m2
+    assert_eq m, m2
     m2.foo = -1
-    assert_eq m m2
+    assert_eq m, m2
     m3 = m.copy()
     m3.foo = 99
-    assert_ne m m3
+    assert_ne m, m3
 
   test_map_block: ||
     m =
@@ -62,22 +62,22 @@ export tests =
       square: |x| x * x
       baz:
         child_foo: 99
-    assert_eq m.foo 42
-    assert_eq (m.square 9) 81
-    assert_eq m.baz.child_foo 99
+    assert_eq m.foo, 42
+    assert_eq (m.square 9), 81
+    assert_eq m.baz.child_foo, 99
 
   test_addition: ||
     m = {foo: 42}
     m2 = m + {bar: -1}
-    assert_eq m2.bar -1
+    assert_eq m2.bar, -1
     m2 += {extra: 99}
-    assert_eq m2.extra 99
+    assert_eq m2.extra, 99
 
   test_value_mutation: ||
     m = {}
     m.foo = 42
     m.foo /= 2
-    assert_eq m.foo 21
+    assert_eq m.foo, 21
 
   test_instance_functions: ||
     make_map = ||
@@ -88,7 +88,7 @@ export tests =
         self.foo
 
     m = make_map()
-    assert_eq 42 m.get_foo() # m is implicitly passed to get_foo as an argument
+    assert_eq 42, m.get_foo() # m is implicitly passed to get_foo as an argument
 
     make_map_2 = ||
       make_map() +
@@ -98,21 +98,21 @@ export tests =
         sum_foo: |self| self.foo + self.foo_2
 
     m2 = make_map_2()
-    assert_eq m2.foo 42 # .foo takes no arguments
-    assert_eq m2.get_foo_2() 57 # .get_foo_2 receives m2 as first argument
+    assert_eq m2.foo, 42 # .foo takes no arguments
+    assert_eq m2.get_foo_2(), 57 # .get_foo_2 receives m2 as first argument
     m2.set_foo_2 58 # .set_foo_2 receives m2 as first argument, 58 as second argument
-    assert_eq m2.sum_foo() 100
+    assert_eq m2.sum_foo(), 100
 
   test_instance_function_outside_of_map: ||
     m =
       foo: 42
       get_foo: |self| self.foo
     getter = m.get_foo
-    assert_eq (getter m) 42
+    assert_eq (getter m), 42
 
   test_map_in_list_comprehension: ||
     a = [{foo, bar} for foo, bar in 1..=3, 4..=6]
-    assert_eq a [{foo: 1, bar: 4}, {foo: 2, bar: 5}, {foo: 3, bar: 6}]
+    assert_eq a, [{foo: 1, bar: 4}, {foo: 2, bar: 5}, {foo: 3, bar: 6}]
 
   test_map_blocks_in_if_expression: ||
     make_map = |n|
@@ -124,15 +124,15 @@ export tests =
         n: n
 
     p = make_map 100
-    assert_eq p.sign "positive"
+    assert_eq p.sign, "positive"
     n = make_map -100
-    assert_eq n.sign "negative"
+    assert_eq n.sign, "negative"
 
   test_nested_inline: ||
     deep = {a: {b: {c: {d: {e: {f: 42}}}}}}
-    assert_eq deep.a.b.c.d.e.f 42
+    assert_eq deep.a.b.c.d.e.f, 42
     deep.a.b.c.d.e.f = 99
-    assert_eq deep.a.b.c.d.e.f 99
+    assert_eq deep.a.b.c.d.e.f, 99
 
   test_nested_block: ||
     deep =
@@ -142,6 +142,6 @@ export tests =
             d:
               foo: -1
               set_foo: |self x| self.foo = x
-    assert_eq deep.a.b.c.d.foo -1
+    assert_eq deep.a.b.c.d.foo, -1
     deep.a.b.c.d.set_foo(42)
-    assert_eq deep.a.b.c.d.foo 42
+    assert_eq deep.a.b.c.d.foo, 42

--- a/koto/tests/maps_and_lists.koto
+++ b/koto/tests/maps_and_lists.koto
@@ -7,15 +7,15 @@ export tests =
       bar:
         baz: [-1, -2, -3]
 
-    assert_eq x.foo[2] 12
+    assert_eq x.foo[2], 12
     x.foo[2] = 42
-    assert_eq x.foo[2] 42
-    assert_eq x.bar.baz[1] -2
+    assert_eq x.foo[2], 42
+    assert_eq x.bar.baz[1], -2
     x.bar.baz[1] = 99
-    assert_eq x.bar.baz[1] 99
+    assert_eq x.bar.baz[1], 99
 
     # Nested mutation doesn't affect parent nodes
-    assert_eq x.foo[2] 42
+    assert_eq x.foo[2], 42
 
   test_maps_in_lists: ||
     make_foo = |x|
@@ -24,15 +24,15 @@ export tests =
 
     # Getting a value
     foos = [(make_foo 42), (make_foo 99)]
-    assert_eq foos[0].foo 42
-    assert_eq foos[1].foo 99
+    assert_eq foos[0].foo, 42
+    assert_eq foos[1].foo, 99
 
     # Setting a value directly
     foos[0].foo = -1
-    assert_eq foos[0].foo -1
+    assert_eq foos[0].foo, -1
 
     # Calling a function
     foos[0].set_foo -42
     foos[1].set_foo -123
-    assert_eq foos[0].foo -42
-    assert_eq foos[1].foo -123
+    assert_eq foos[0].foo, -42
+    assert_eq foos[1].foo, -123

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -2,54 +2,54 @@ import test.assert_eq
 
 export tests =
   test_creating: ||
-    assert_eq (num4 0) (num4 0 0 0 0)
-    assert_eq (num2 1) (num2 1 1)
-    assert_eq (num4 (num2 1)) (num4 1 1 0 0)
+    assert_eq (num4 0), (num4 0, 0, 0, 0)
+    assert_eq (num2 1), (num2 1, 1)
+    assert_eq (num4 (num2 1)), (num4 1, 1, 0, 0)
 
   test_mutation_num2: ||
-    x = num2 10 11
+    x = num2 10, 11
     x *= 2
-    assert_eq x (num2 20 22)
+    assert_eq x, (num2 20, 22)
     x %= 5
-    assert_eq x (num2 0 2)
+    assert_eq x, (num2 0, 2)
     x += num2 10
-    assert_eq x (num2 10 12)
+    assert_eq x, (num2 10, 12)
 
   test_mutation_num4: ||
-    x = num4 5 6 7 8
+    x = num4 5, 6, 7, 8
     x *= 2
-    assert_eq x (num4 10 12 14 16)
+    assert_eq x, (num4 10, 12, 14, 16)
     x %= 5
-    assert_eq x (num4 0 2 4 1)
+    assert_eq x, (num4 0, 2, 4, 1)
     x += num4 10
-    assert_eq x (num4 10 12 14 11)
+    assert_eq x, (num4 10, 12, 14, 11)
 
   test_sum: ||
-    assert_eq (num2 1 2).sum() 3
-    assert_eq (num4 1 2 3 4).sum() 10
+    assert_eq (num2 1, 2).sum(), 3
+    assert_eq (num4 1, 2, 3, 4).sum(), 10
 
   test_element_access_num2: ||
-    x = num2 10 20
-    assert_eq x[0] 10
-    assert_eq x[1] 20
+    x = num2 10, 20
+    assert_eq x[0], 10
+    assert_eq x[1], 20
 
   test_element_access_num4: ||
-    x = num4 2 3 4 5
-    assert_eq x[0] 2
-    assert_eq x[3] 5
+    x = num4 2, 3, 4, 5
+    assert_eq x[0], 2
+    assert_eq x[3], 5
 
   test_element_unpacking_num2: ||
-    x = num2 1 2
+    x = num2 1, 2
     a, b, c = x
-    assert_eq a 1
-    assert_eq b 2
-    assert_eq c ()
+    assert_eq a, 1
+    assert_eq b, 2
+    assert_eq c, ()
 
   test_element_unpacking_num4: ||
-    x = num4 5 6 7 8
+    x = num4 5, 6, 7, 8
     a, b, c, d, e = x
-    assert_eq a 5
-    assert_eq b 6
-    assert_eq c 7
-    assert_eq d 8
-    assert_eq e ()
+    assert_eq a, 5
+    assert_eq b, 6
+    assert_eq c, 7
+    assert_eq d, 8
+    assert_eq e, ()

--- a/koto/tests/numbers.koto
+++ b/koto/tests/numbers.koto
@@ -6,126 +6,126 @@ epsilon = 1.0e-15
 
 export tests =
   test_abs: ||
-    assert_eq -1.abs() 1
-    assert_eq 3.abs() 3
-    assert_eq -1.5.abs() 1.5
-    assert_eq 9.1.abs() 9.1
+    assert_eq -1.abs(), 1
+    assert_eq 3.abs(), 3
+    assert_eq -1.5.abs(), 1.5
+    assert_eq 9.1.abs(), 9.1
 
   test_acos: ||
-    assert_eq 0.acos() pi / 2
-    assert_eq 1.acos() 0
+    assert_eq 0.acos(), pi / 2
+    assert_eq 1.acos(), 0
 
   test_asin: ||
-    assert_eq 0.asin() 0
-    assert_eq 1.asin() pi / 2
+    assert_eq 0.asin(), 0
+    assert_eq 1.asin(), pi / 2
 
   test_atan: ||
-    assert_eq 0.atan() 0
-    assert_eq 1.atan() pi / 4
+    assert_eq 0.atan(), 0
+    assert_eq 1.atan(), pi / 4
 
   test_ceil: ||
-    assert_eq 0.ceil() 0
-    assert_eq 0.5.ceil() 1
-    assert_eq 1.ceil() 1
+    assert_eq 0.ceil(), 0
+    assert_eq 0.5.ceil(), 1
+    assert_eq 1.ceil(), 1
 
   test_clamp: ||
-    assert_eq (0.clamp 1 2) 1
-    assert_eq (1.5.clamp 1 2) 1.5
-    assert_eq (3.clamp 1 2) 2
+    assert_eq (0.clamp 1, 2), 1
+    assert_eq (1.5.clamp 1, 2), 1.5
+    assert_eq (3.clamp 1, 2), 2
 
   test_cos: ||
-    assert_eq 0.cos() 1
-    assert_near (pi / 2).cos() 0 epsilon
+    assert_eq 0.cos(), 1
+    assert_near (pi / 2).cos(), 0, epsilon
 
   test_cosh: ||
-    assert_eq 0.cosh() 1
-    assert_near 1.cosh() ((1 + e.pow(2)) / (2 * e)) epsilon
+    assert_eq 0.cosh(), 1
+    assert_near 1.cosh(), ((1 + e.pow(2)) / (2 * e)), epsilon
 
   test_degrees: ||
-    assert_eq 0.degrees() 0
-    assert_eq pi.degrees() 180
-    assert_eq tau.degrees() 360
+    assert_eq 0.degrees(), 0
+    assert_eq pi.degrees(), 180
+    assert_eq tau.degrees(), 360
 
   test_exp: ||
-    assert_eq 0.exp() 1
-    assert_eq 1.exp() e
+    assert_eq 0.exp(), 1
+    assert_eq 1.exp(), e
 
   test_exp2: ||
-    assert_eq 0.exp2() 1
-    assert_eq 2.exp2() 4
+    assert_eq 0.exp2(), 1
+    assert_eq 2.exp2(), 4
 
   test_floor: ||
-    assert_eq 1.5.floor() 1
-    assert_eq -1.2.floor() -2
-    assert_eq type(1.1.floor()) "Int"
+    assert_eq 1.5.floor(), 1
+    assert_eq -1.2.floor(), -2
+    assert_eq type(1.1.floor()), "Int"
 
   test_is_nan: ||
     assert not 0.is_nan()
     assert (0 / 0).is_nan()
 
   test_ln: ||
-    assert_eq 0.ln() negative_infinity
-    assert_eq 1.ln() 0
-    assert_eq e.ln() 1
+    assert_eq 0.ln(), negative_infinity
+    assert_eq 1.ln(), 0
+    assert_eq e.ln(), 1
 
   test_log2: ||
-    assert_eq 0.log2() negative_infinity
-    assert_eq 256.log2() 8
+    assert_eq 0.log2(), negative_infinity
+    assert_eq 256.log2(), 8
 
   test_log10: ||
-    assert_eq 0.log10() negative_infinity
-    assert_eq 100.log10() 2
+    assert_eq 0.log10(), negative_infinity
+    assert_eq 100.log10(), 2
 
   test_max: ||
-    assert_eq (1.5.max 2) 2
+    assert_eq (1.5.max 2), 2
 
   test_min: ||
-    assert_eq (1.min 2) 1
+    assert_eq (1.min 2), 1
 
   test_pow: ||
-    assert_eq (2.pow 8) 256
-    assert_eq (4.pow 1.5) 8
+    assert_eq (2.pow 8), 256
+    assert_eq (4.pow 1.5), 8
 
   test_radians: ||
-    assert_eq 0.radians() 0
-    assert_eq 180.radians() pi
-    assert_eq 360.radians() tau
+    assert_eq 0.radians(), 0
+    assert_eq 180.radians(), pi
+    assert_eq 360.radians(), tau
 
   test_recip: ||
-    assert_eq -2.recip() -0.5
-    assert_eq 0.recip() infinity
-    assert_eq 2.recip() 0.5
-    assert_eq 4.recip() 0.25
+    assert_eq -2.recip(), -0.5
+    assert_eq 0.recip(), infinity
+    assert_eq 2.recip(), 0.5
+    assert_eq 4.recip(), 0.25
 
   test_sin: ||
-    assert_near 0.sin() 0 epsilon
-    assert_eq (pi / 2).sin() 1
+    assert_near 0.sin(), 0, epsilon
+    assert_eq (pi / 2).sin(), 1
 
   test_sinh: ||
-    assert_near 0.sinh() 0 epsilon
-    assert_near 1.sinh() ((e.pow(2) - 1) / (2 * e)) epsilon
+    assert_near 0.sinh(), 0, epsilon
+    assert_near 1.sinh(), ((e.pow(2) - 1) / (2 * e)), epsilon
 
   test_sqrt: ||
-    assert_eq 64.sqrt() 8
+    assert_eq 64.sqrt(), 8
     assert -1.sqrt().is_nan()
 
   test_tan: ||
-    assert_near (pi / 4).tan() 1 epsilon
-    assert_eq 0.tan() 0
-    assert_near 1.tan() (1.sin() / 1.cos()) epsilon
+    assert_near (pi / 4).tan(), 1, epsilon
+    assert_eq 0.tan(), 0
+    assert_near 1.tan(), (1.sin() / 1.cos()), epsilon
 
   test_tanh: ||
-    assert_eq 0.tanh() 0
-    assert_eq 1.tanh() (1.sinh() / 1.cosh())
+    assert_eq 0.tanh(), 0
+    assert_eq 1.tanh(), (1.sinh() / 1.cosh())
 
   test_to_float: ||
     x = 1
-    assert_eq type(x) "Int"
-    assert_eq type(x.to_float()) "Float"
-    assert_eq x.to_float() x
+    assert_eq type(x), "Int"
+    assert_eq type(x.to_float()), "Float"
+    assert_eq x.to_float(), x
 
   test_to_int: ||
     x = 1.0
-    assert_eq type(x) "Float"
-    assert_eq type(x.to_int()) "Int"
-    assert_eq x.to_int() x
+    assert_eq type(x), "Float"
+    assert_eq type(x.to_int()), "Int"
+    assert_eq x.to_int(), x

--- a/koto/tests/primes.koto
+++ b/koto/tests/primes.koto
@@ -5,7 +5,7 @@ get_primes = |n|
     return
 
   sieve = []
-  sieve.resize (n + 1) true
+  sieve.resize (n + 1), true
 
   for x in 2..=n.sqrt() if sieve[x]
     i = x * x
@@ -15,4 +15,4 @@ get_primes = |n|
 
   (2..=n).keep |x| sieve[x]
 
-assert_eq (get_primes 20).to_tuple() (2, 3, 5, 7, 11, 13, 17, 19)
+assert_eq (get_primes 20).to_tuple(), (2, 3, 5, 7, 11, 13, 17, 19)

--- a/koto/tests/primes.koto
+++ b/koto/tests/primes.koto
@@ -7,11 +7,12 @@ get_primes = |n|
   sieve = []
   sieve.resize (n + 1), true
 
-  for x in 2..=n.sqrt() if sieve[x]
-    i = x * x
-    while i <= n
-      sieve[i] = false
-      i += x
+  for x in 2..=n.sqrt()
+    if sieve[x]
+      i = x * x
+      while i <= n
+        sieve[i] = false
+        i += x
 
   (2..=n).keep |x| sieve[x]
 

--- a/koto/tests/ranges.koto
+++ b/koto/tests/ranges.koto
@@ -5,37 +5,37 @@ export tests =
     # Assigning a range to a value
     r = 0..2
     # Ranges can be compared
-    assert_eq r 0..2
+    assert_eq r, 0..2
 
     # Ranges are exclusive by default, ..= creates an inclusive range
     r = 0..=2
-    assert_eq [r] [0, 1, 2]
+    assert_eq [r], [0, 1, 2]
 
   test_indexing: ||
     # Indexing lists with ranges produces sub-lists
     n = [0..10]
-    assert_eq n[2..5] [2, 3, 4]
-    assert_eq n[2..=4] [2, 3, 4]
+    assert_eq n[2..5], [2, 3, 4]
+    assert_eq n[2..=4], [2, 3, 4]
 
   test_evaluated_boundaries: ||
     z = |n| n
     x = [(z 10)..=(z 20)]
     y = x[1 + 1..x.size() / 2]
-    assert_eq y[0] 12
+    assert_eq y[0], 12
 
   test_from_and_to_ranges: ||
     n = [0..=10]
-    assert_eq n[..=2] [0, 1, 2]
-    assert_eq n[8..] [8, 9, 10]
+    assert_eq n[..=2], [0, 1, 2]
+    assert_eq n[8..], [8, 9, 10]
 
   test_empty_range: ||
     n = [0..10]
-    assert_eq n[10..10] []
+    assert_eq n[10..10], []
 
   test_descending_range: ||
     r = 2..0
-    assert_eq [r] [2, 1]
-    assert_eq [2..=0] [2, 1, 0]
+    assert_eq [r], [2, 1]
+    assert_eq [2..=0], [2, 1, 0]
 
   test_range_contains: ||
     assert (0..10).contains(5)
@@ -46,45 +46,45 @@ export tests =
 
   test_range_expanded: ||
     x = 10..20
-    assert_eq x.expanded(5) 5..25
-    assert_eq x.expanded(-1) 11..19
+    assert_eq x.expanded(5), 5..25
+    assert_eq x.expanded(-1), 11..19
 
   test_range_expanded_descending: ||
     x = 10..0
-    assert_eq x.expanded(5) 15..-5
-    assert_eq x.expanded(-5) 5..5
+    assert_eq x.expanded(5), 15..-5
+    assert_eq x.expanded(-5), 5..5
 
   test_range_size: ||
-    assert_eq (0..10).size() 10
-    assert_eq (0..=10).size() 11
+    assert_eq (0..10).size(), 10
+    assert_eq (0..=10).size(), 11
 
   test_range_start_end: ||
     x = 10..20
-    assert_eq x.start() 10
-    assert_eq x.end() 20
+    assert_eq x.start(), 10
+    assert_eq x.end(), 20
 
-    assert_eq (10..=20).end() 21
+    assert_eq (10..=20).end(), 21
 
   test_range_union: ||
     x = 10..20
 
-    assert_eq x.union(5) 5..20
-    assert_eq x.union(15) 10..20
-    assert_eq x.union(25) 10..=25
+    assert_eq x.union(5), 5..20
+    assert_eq x.union(15), 10..20
+    assert_eq x.union(25), 10..=25
 
-    assert_eq x.union(1..15) 1..20
-    assert_eq x.union(12..100) 10..100
-    assert_eq x.union(5..=25) 5..=25
-    assert_eq x.union(25..=5) 5..=25
+    assert_eq x.union(1..15), 1..20
+    assert_eq x.union(12..100), 10..100
+    assert_eq x.union(5..=25), 5..=25
+    assert_eq x.union(25..=5), 5..=25
 
   test_range_union_descending: ||
     x = 10..0
 
-    assert_eq x.union(-5) 10..=-5
-    assert_eq x.union(5) 10..0
-    assert_eq x.union(15) 15..0
+    assert_eq x.union(-5), 10..=-5
+    assert_eq x.union(5), 10..0
+    assert_eq x.union(15), 15..0
 
-    assert_eq x.union(1..=15) 15..0
-    assert_eq x.union(5..=100) 100..0
-    assert_eq x.union(-5..=25) 25..-5
-    assert_eq x.union(99..0) 99..0
+    assert_eq x.union(1..=15), 15..0
+    assert_eq x.union(5..=100), 100..0
+    assert_eq x.union(-5..=25), 25..-5
+    assert_eq x.union(99..0), 99..0

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -3,29 +3,29 @@ from test import assert, assert_eq, assert_ne
 
 export tests =
   test_comparisons: ||
-    assert_eq "Hello" "Hello"
-    assert_ne "Hello" "Héllö"
-    assert_eq ("Hello" + ", " + "World!") "Hello, World!"
+    assert_eq "Hello", "Hello"
+    assert_ne "Hello", "Héllö"
+    assert_eq ("Hello" + ", " + "World!"), "Hello, World!"
     assert "Hello" < "Hiyaa" and "World" <= "World!"
     assert "Hiyaa" > "Hello" and "World!" >= "World"
 
   test_addition: ||
     x = "^"
     x += "_" + "^"
-    assert_eq x "^_^"
+    assert_eq x, "^_^"
 
   test_chars: ||
     hello = "Héllö"
     assert_eq
-      hello.chars().to_tuple()
+      hello.chars().to_tuple(),
       ("H", "é", "l", "l", "ö")
 
     # chars() is the default iterator for strings
     hello_chars = []
     for c in hello
       hello_chars.push c
-    assert_eq hello_chars hello.to_list()
-    assert_eq hello_chars.size() 5
+    assert_eq hello_chars, hello.to_list()
+    assert_eq hello_chars.size(), 5
 
   test_contains: ||
     assert "O_o".contains("_")
@@ -39,7 +39,7 @@ export tests =
   test_escape: ||
     x = "
 "
-    assert_eq x.escape() "\\n"
+    assert_eq x.escape(), "\\n"
 
   test_is_empty: ||
     assert "".is_empty()
@@ -49,7 +49,7 @@ export tests =
     x = "aaa
 bbb
 ccc"
-    assert_eq x.lines().to_tuple() ("aaa", "bbb", "ccc")
+    assert_eq x.lines().to_tuple(), ("aaa", "bbb", "ccc")
 
     x2 = "
 xxx
@@ -57,36 +57,36 @@ yyy
 zzz
 
 "
-    assert_eq x2.lines().to_tuple() ("", "xxx", "yyy", "zzz", "")
+    assert_eq x2.lines().to_tuple(), ("", "xxx", "yyy", "zzz", "")
 
     x3 = "foo\nbar\nbaz"
-    assert_eq x3.lines().to_tuple() ("foo", "bar", "baz")
+    assert_eq x3.lines().to_tuple(), ("foo", "bar", "baz")
 
   test_escaped_newlines: ||
     x = "foo \
          bar \
          baz"
-    assert_eq x "foo bar baz"
+    assert_eq x, "foo bar baz"
 
   test_size: ||
     # size returns the number of unicode graphemes in the string,
     # rather than the number of bytes
-    assert_eq "".size() 0
-    assert_eq "ø".size() 1
-    assert_eq "abcdef".size() 6
-    assert_eq "äbcdéf".size() 6
+    assert_eq "".size(), 0
+    assert_eq "ø".size(), 1
+    assert_eq "abcdef".size(), 6
+    assert_eq "äbcdéf".size(), 6
 
   test_slice: ||
-    assert_eq ("abcdef".slice 2 5) "cde"
+    assert_eq ("abcdef".slice 2, 5), "cde"
     x = "abcdef".slice 2 # end index is optional
-    assert_eq x "cdef"
-    assert_eq (x.slice 1 3) "de"
-    assert_eq (x.slice 10 13) ()
+    assert_eq x, "cdef"
+    assert_eq (x.slice 1, 3), "de"
+    assert_eq (x.slice 10, 13), ()
 
   test_split: ||
-    assert_eq "a,b,c".split(",").to_tuple() ("a", "b", "c")
-    assert_eq "O_O".split("O").to_tuple() ("", "_", "")
-    assert_eq "a - b - c".split(" - ").to_tuple() ("a", "b", "c")
+    assert_eq "a,b,c".split(",").to_tuple(), ("a", "b", "c")
+    assert_eq "O_O".split("O").to_tuple(), ("", "_", "")
+    assert_eq "a - b - c".split(" - ").to_tuple(), ("a", "b", "c")
 
   test_starts_with: ||
     assert "a,b,c".starts_with("")
@@ -94,43 +94,43 @@ zzz
     assert not "a,b,c".starts_with(",b")
 
   test_to_lowercase: ||
-    assert_eq (string.to_lowercase "ABC 123") "abc 123"
-    assert_eq (string.to_lowercase "HÉLLÖ") "héllö"
+    assert_eq (string.to_lowercase "ABC 123"), "abc 123"
+    assert_eq (string.to_lowercase "HÉLLÖ"), "héllö"
 
   test_to_number: ||
     x = string.to_number "42"
-    assert_eq x 42
-    assert_eq type(x) "Int"
+    assert_eq x, 42
+    assert_eq type(x), "Int"
 
     x = string.to_number "-1.5"
-    assert_eq x -1.5
-    assert_eq type(x) "Float"
+    assert_eq x, -1.5
+    assert_eq type(x), "Float"
 
   test_to_uppercase: ||
-    assert_eq (string.to_uppercase "xyz 890") "XYZ 890"
-    assert_eq (string.to_uppercase "Görlitzer Straße") "GÖRLITZER STRASSE"
+    assert_eq (string.to_uppercase "xyz 890"), "XYZ 890"
+    assert_eq (string.to_uppercase "Görlitzer Straße"), "GÖRLITZER STRASSE"
 
   test_trim: ||
-    assert_eq (string.trim "   x    ") "x"
-    assert_eq "foo    ".trim() "foo"
-    assert_eq "     bar".trim() "bar"
-    assert_eq "     ".trim() ""
+    assert_eq (string.trim "   x    "), "x"
+    assert_eq "foo    ".trim(), "foo"
+    assert_eq "     bar".trim(), "bar"
+    assert_eq "     ".trim(), ""
 
   test_format: ||
     hello = "Hello"
     world = "World"
 
     # A string literal is expected as first argument
-    assert_eq "Hello, World!" (string.format "Hello, World!")
+    assert_eq "Hello, World!", (string.format "Hello, World!")
 
     # {} is a placeholder for an argument to be included in the string
-    assert_eq "Hello, World!" ("{}, {}!".format hello world)
+    assert_eq "Hello, World!", ("{}, {}!".format hello, world)
 
     # Curly braces can be included in the output by escaping them with another curly brace
-    assert_eq "{Hello}, World!" ("{{{}}}, {}!".format hello world)
+    assert_eq "{Hello}, World!", ("{{{}}}, {}!".format hello, world)
 
     # Positional placeholders can be used to reference arguments by index
-    assert_eq "Hello World, Hello World!" ("{0} {1}, {0} {1}!".format hello world)
+    assert_eq "Hello World, Hello World!", ("{0} {1}, {0} {1}!".format hello, world)
 
     # Identifier placeholders are looked up in a map argument
-    assert_eq "O_o" ("{first}_{second}".format {first: "O", second: "o"})
+    assert_eq "O_o", ("{first}_{second}".format {first: "O", second: "o"})

--- a/koto/tests/test_module/baz.koto
+++ b/koto/tests/test_module/baz.koto
@@ -2,7 +2,7 @@
 
 # std modules should be available to import
 import number.pi, test.assert_eq
-assert_eq pi pi
+assert_eq pi, pi
 
 export qux = ()
 # main functions should be run when loading a module

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -14,9 +14,9 @@ export tests =
   # Functions with a name starting with 'test_' will be automatically run as tests
   test_size: |self|
     # assert_eq checks that its two arguments are equal
-    assert_eq self.test_data.size() 3
+    assert_eq self.test_data.size(), 3
     # assert_ne checks that its two arguments are not equal
-    assert_ne self.test_data.size() 1
+    assert_ne self.test_data.size(), 1
 
   # Test functions don't have to be instance functions
   test_extra: ||
@@ -24,4 +24,4 @@ export tests =
     assert 1 > 0
     # assert_near checks that its arguments are equal, within a specied margin
     allowed_error = 0.1
-    assert_near 1.3 1.301 allowed_error
+    assert_near 1.3, 1.301, allowed_error

--- a/koto/tests/threads.koto
+++ b/koto/tests/threads.koto
@@ -2,7 +2,7 @@ import list, thread, test.assert_eq
 
 export tests =
   test_spawn_4_threads_and_join: ||
-    data = list.with_size 8 0
+    data = list.with_size 8, 0
 
     worker_count = 4
     worker_indices = (0..worker_count).to_tuple()
@@ -20,5 +20,5 @@ export tests =
       .each |t| t.join()
       .to_tuple()
 
-    assert_eq thread_results worker_indices
-    assert_eq data [10..18]
+    assert_eq thread_results, worker_indices
+    assert_eq data, [10..18]

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -6,7 +6,7 @@ export tests =
     z = []
     for x in a
       z.push x
-    assert_eq z [1, 2, 3]
+    assert_eq z, [1, 2, 3]
 
   test_contains: ||
     x = 1, 2, 3
@@ -21,51 +21,51 @@ export tests =
     x2 = x.deep_copy()
     # modifying a is reflected in x, but not x2
     a[0] = 99
-    assert_eq x[1][0] 99
-    assert_eq x2[0][0] 1
+    assert_eq x[1][0], 99
+    assert_eq x2[0][0], 1
     # modifying one list in x2 doesn't affect the others
     x2[1][0] = 42
-    assert_eq x2[0][0] 1
+    assert_eq x2[0][0], 1
 
   test_first: ||
-    assert_eq (1, 2, 3).first() 1
-    assert_eq [].to_tuple().first() ()
+    assert_eq (1, 2, 3).first(), 1
+    assert_eq [].to_tuple().first(), ()
 
   test_get: ||
     x = 1, 2, 3
-    assert_eq (x.get 0) 1
-    assert_eq (x.get 2) 3
-    assert_eq (x.get 4) ()
+    assert_eq (x.get 0), 1
+    assert_eq (x.get 2), 3
+    assert_eq (x.get 4), ()
 
   test_indexing: ||
     x = 1, 2, 3
-    assert_eq x[0] 1
-    assert_eq x[2] 3
-    assert_eq x[..] x
-    assert_eq x[0..2] (1, 2)
-    assert_eq x[1..] (2, 3)
-    assert_eq x[..=1] (1, 2)
+    assert_eq x[0], 1
+    assert_eq x[2], 3
+    assert_eq x[..], x
+    assert_eq x[0..2], (1, 2)
+    assert_eq x[1..], (2, 3)
+    assert_eq x[..=1], (1, 2)
 
   test_iter: ||
     assert_eq
       (1, 2, 3)
         .each |n| "{}".format n
-        .to_tuple()
+        .to_tuple(),
       ("1", "2", "3")
 
   test_last: ||
-    assert_eq (1, 2, 3).last() 3
-    assert_eq [].to_tuple().last() ()
+    assert_eq (1, 2, 3).last(), 3
+    assert_eq [].to_tuple().last(), ()
 
   test_size: ||
-    assert_eq (1, 2).size() 2
-    assert_eq (1, 2, 3).size() 3
-    assert_eq ((1, 2), (3, 4)).size() 2
+    assert_eq (1, 2).size(), 2
+    assert_eq (1, 2, 3).size(), 3
+    assert_eq ((1, 2), (3, 4)).size(), 2
 
   test_sort_copy: ||
-    assert_eq (3, 1, 2).sort_copy() (1, 2, 3)
-    assert_eq ("tuple", "sort", "copy").sort_copy() ("copy", "sort", "tuple")
+    assert_eq (3, 1, 2).sort_copy(), (1, 2, 3)
+    assert_eq ("tuple", "sort", "copy").sort_copy(), ("copy", "sort", "tuple")
 
   test_to_list: ||
-    assert_eq (1, 2).to_list() [1, 2]
-    assert_eq ((1, 2), (3, 4)).to_list() [(1, 2), (3, 4)]
+    assert_eq (1, 2).to_list(), [1, 2]
+    assert_eq ((1, 2), (3, 4)).to_list(), [(1, 2), (3, 4)]

--- a/koto/tests/types.koto
+++ b/koto/tests/types.koto
@@ -2,19 +2,19 @@ import koto.type, test.assert_eq
 
 export tests =
   test_type_returns_type_name: ||
-    assert_eq (type true) "Bool"
-    assert_eq (type |x| x * x) "Function"
-    assert_eq (type [1, 2, 3]) "List"
-    assert_eq (type {foo: 42}) "Map"
-    assert_eq (type 0) "Int"
-    assert_eq (type 0.0) "Float"
-    assert_eq (type (num2 0)) "Num2"
-    assert_eq (type (num4 0)) "Num4"
-    assert_eq (type 0..10) "Range"
-    assert_eq (type "foo") "String"
+    assert_eq (type true), "Bool"
+    assert_eq (type |x| x * x), "Function"
+    assert_eq (type [1, 2, 3]), "List"
+    assert_eq (type {foo: 42}), "Map"
+    assert_eq (type 0), "Int"
+    assert_eq (type 0.0), "Float"
+    assert_eq (type (num2 0)), "Num2"
+    assert_eq (type (num4 0)), "Num4"
+    assert_eq (type 0..10), "Range"
+    assert_eq (type "foo"), "String"
 
     x = 1
-    assert_eq (type x) "Int"
+    assert_eq (type x), "Int"
 
     x = "bar"
-    assert_eq (type x) "String"
+    assert_eq (type x), "String"

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -80,6 +80,7 @@ pub enum SyntaxError {
     ExpectedThenExpression,
     ExpectedUntilCondition,
     ExpectedWhileCondition,
+    IfBlockNotAllowedInThisContext,
     ImportFromExpressionHasTooManyItems,
     LexerError,
     MatchEllipsisOutsideOfNestedPatterns,
@@ -259,6 +260,9 @@ impl fmt::Display for SyntaxError {
             ExpectedThenExpression => f.write_str("Expected 'then' expression."),
             ExpectedUntilCondition => f.write_str("Expected condition in until loop"),
             ExpectedWhileCondition => f.write_str("Expected condition in while loop"),
+            IfBlockNotAllowedInThisContext => {
+                f.write_str("Non-inline if expression isn't allowed in this context.")
+            }
             ImportFromExpressionHasTooManyItems => {
                 f.write_str("Too many items listed after 'from' in import expression")
             }

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -141,16 +141,19 @@ impl Frame {
 
 #[derive(Clone, Copy, Debug)]
 struct ExpressionContext {
-    // e.g. a = f x y
-    // `x` and `y` are `f`'s arguments, and while parsing them this flag is set to false,
-    // preventing further function calls from being started.
+    // e.g.
+    //
+    // match x
+    //   foo.bar if x == 0 then...
+    //
+    // Without the flag, `if f == 0...` would be parsed as being an argument for a call to foo.bar.
     allow_space_separated_call: bool,
     // e.g. f = |x|
     //        x + x
     // This function can have an indented body.
     //
     // foo
-    //   bar
+    //   bar,
     //   baz
     // This function call can be broken over lines.
     //
@@ -817,6 +820,11 @@ impl<'source> Parser<'source> {
         let mut last_arg_line = self.lexer.line_number();
         let mut args = Vec::new();
 
+        let mut arg_context = ExpressionContext {
+            expected_indentation: None,
+            ..*context
+        };
+
         while let Some((_, peek_count)) = self.peek_next_token(&context) {
             let peeked_line = self.lexer.peek_line_number(peek_count);
             let new_line = peeked_line > last_arg_line;
@@ -828,13 +836,6 @@ impl<'source> Parser<'source> {
             } else {
                 break;
             }
-
-            let mut arg_context = ExpressionContext {
-                allow_space_separated_call: new_line,
-                allow_linebreaks: true,
-                allow_initial_indentation: false,
-                expected_indentation: None,
-            };
 
             if let Some(expression) = self.parse_expression(&mut arg_context)? {
                 args.push(expression);
@@ -1046,11 +1047,6 @@ impl<'source> Parser<'source> {
                         break;
                     } else {
                         lookup.push((LookupNode::Call(args), node_start_span));
-
-                        node_context = ExpressionContext {
-                            allow_space_separated_call: false,
-                            ..node_context
-                        };
                     }
                 }
                 _ if matches!(self.peek_next_token(&node_context), Some((Token::Dot, _))) => {
@@ -1338,9 +1334,7 @@ impl<'source> Parser<'source> {
 
                     Some(self.push_node_with_start_span(Num4(args), start_span)?)
                 }
-                Token::If if context.allow_space_separated_call => {
-                    self.parse_if_expression(context)?
-                }
+                Token::If => self.parse_if_expression(context)?,
                 Token::Match => self.parse_match_expression(context)?,
                 Token::Switch => self.parse_switch_expression(context)?,
                 Token::Function => self.parse_function(context)?,
@@ -1406,9 +1400,7 @@ impl<'source> Parser<'source> {
                     Some(result)
                 }
                 Token::From | Token::Import => self.parse_import_expression(context)?,
-                Token::Try if context.allow_space_separated_call => {
-                    self.parse_try_expression(context)?
-                }
+                Token::Try => self.parse_try_expression(context)?,
                 // Token::NewLineIndented => self.parse_map_block(current_indent, None)?,
                 Token::Error => return syntax_error!(LexerError, self),
                 _ => None,
@@ -1776,53 +1768,59 @@ impl<'source> Parser<'source> {
                 else_if_blocks: vec![],
                 else_node,
             }))?
-        } else if let Some(then_node) = self.parse_indented_map_or_block()? {
-            let mut else_if_blocks = Vec::new();
-
-            while let Some((Token::ElseIf, _)) = self.peek_next_token(context) {
-                self.consume_next_token(context);
-
-                if self.lexer.current_indent() != expected_indentation {
-                    return syntax_error!(UnexpectedElseIfIndentation, self);
-                }
-
-                if let Some(else_if_condition) =
-                    self.parse_expression(&mut ExpressionContext::inline())?
-                {
-                    if let Some(else_if_block) = self.parse_indented_map_or_block()? {
-                        else_if_blocks.push((else_if_condition, else_if_block));
-                    } else {
-                        return indentation_error!(ExpectedElseIfBlock, self);
-                    }
-                } else {
-                    return syntax_error!(ExpectedElseIfCondition, self);
-                }
+        } else {
+            if !context.allow_linebreaks {
+                return syntax_error!(IfBlockNotAllowedInThisContext, self);
             }
 
-            let else_node = if let Some((Token::Else, _)) = self.peek_next_token(context) {
-                self.consume_next_token(context);
+            if let Some(then_node) = self.parse_indented_map_or_block()? {
+                let mut else_if_blocks = Vec::new();
 
-                if self.lexer.current_indent() != expected_indentation {
-                    return syntax_error!(UnexpectedElseIndentation, self);
+                while let Some((Token::ElseIf, _)) = self.peek_next_token(context) {
+                    self.consume_next_token(context);
+
+                    if self.lexer.current_indent() != expected_indentation {
+                        return syntax_error!(UnexpectedElseIfIndentation, self);
+                    }
+
+                    if let Some(else_if_condition) =
+                        self.parse_expression(&mut ExpressionContext::inline())?
+                    {
+                        if let Some(else_if_block) = self.parse_indented_map_or_block()? {
+                            else_if_blocks.push((else_if_condition, else_if_block));
+                        } else {
+                            return indentation_error!(ExpectedElseIfBlock, self);
+                        }
+                    } else {
+                        return syntax_error!(ExpectedElseIfCondition, self);
+                    }
                 }
 
-                if let Some(else_block) = self.parse_indented_map_or_block()? {
-                    Some(else_block)
+                let else_node = if let Some((Token::Else, _)) = self.peek_next_token(context) {
+                    self.consume_next_token(context);
+
+                    if self.lexer.current_indent() != expected_indentation {
+                        return syntax_error!(UnexpectedElseIndentation, self);
+                    }
+
+                    if let Some(else_block) = self.parse_indented_map_or_block()? {
+                        Some(else_block)
+                    } else {
+                        return indentation_error!(ExpectedElseBlock, self);
+                    }
                 } else {
-                    return indentation_error!(ExpectedElseBlock, self);
-                }
-            } else {
-                None
-            };
+                    None
+                };
 
-            self.push_node(Node::If(AstIf {
-                condition,
-                then_node,
-                else_if_blocks,
-                else_node,
-            }))?
-        } else {
-            return indentation_error!(ExpectedThenKeywordOrBlock, self);
+                self.push_node(Node::If(AstIf {
+                    condition,
+                    then_node,
+                    else_if_blocks,
+                    else_node,
+                }))?
+            } else {
+                return indentation_error!(ExpectedThenKeywordOrBlock, self);
+            }
         };
 
         Ok(Some(result))

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -810,7 +810,7 @@ impl<'source> Parser<'source> {
         Ok(result)
     }
 
-    fn parse_space_separated_call_args(
+    fn parse_call_args(
         &mut self,
         context: &mut ExpressionContext,
     ) -> Result<Vec<AstIndex>, ParserError> {
@@ -841,6 +841,12 @@ impl<'source> Parser<'source> {
             } else {
                 break;
             }
+
+            if self.peek_next_token_on_same_line() == Some(Token::Comma) {
+                self.consume_next_token_on_same_line();
+            } else {
+                break;
+            }
         }
 
         Ok(args)
@@ -858,7 +864,7 @@ impl<'source> Parser<'source> {
             let result = match self.peek_token() {
                 Some(Token::Whitespace) if context.allow_space_separated_call => {
                     let start_span = self.lexer.span();
-                    let args = self.parse_space_separated_call_args(context)?;
+                    let args = self.parse_call_args(context)?;
 
                     if args.is_empty() {
                         id_index
@@ -877,7 +883,7 @@ impl<'source> Parser<'source> {
                 }
                 Some(_) if context.allow_space_separated_call && context.allow_linebreaks => {
                     let start_span = self.lexer.span();
-                    let args = self.parse_space_separated_call_args(context)?;
+                    let args = self.parse_call_args(context)?;
 
                     if args.is_empty() {
                         id_index
@@ -1034,7 +1040,7 @@ impl<'source> Parser<'source> {
                     }
                 }
                 Token::Whitespace if node_context.allow_space_separated_call => {
-                    let args = self.parse_space_separated_call_args(context)?;
+                    let args = self.parse_call_args(context)?;
 
                     if args.is_empty() {
                         break;
@@ -1303,7 +1309,7 @@ impl<'source> Parser<'source> {
                     let args = if self.peek_token() == Some(Token::ParenOpen) {
                         self.parse_parenthesized_args()?
                     } else {
-                        self.parse_space_separated_call_args(&mut ExpressionContext::permissive())?
+                        self.parse_call_args(&mut ExpressionContext::permissive())?
                     };
 
                     if args.is_empty() {
@@ -1321,7 +1327,7 @@ impl<'source> Parser<'source> {
                     let args = if self.peek_token() == Some(Token::ParenOpen) {
                         self.parse_parenthesized_args()?
                     } else {
-                        self.parse_space_separated_call_args(&mut ExpressionContext::permissive())?
+                        self.parse_call_args(&mut ExpressionContext::permissive())?
                     };
 
                     if args.is_empty() {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -1485,6 +1485,40 @@ for x in y
                 Some(&[Constant::Str("x"), Constant::Str("y")]),
             )
         }
+
+        #[test]
+        fn for_with_range_from_lookup_call() {
+            let source = "\
+for a in x.zip y
+  a
+";
+            check_ast(
+                source,
+                &[
+                    Id(1),
+                    Id(3),
+                    Lookup((LookupNode::Call(vec![1]), None)),
+                    Lookup((LookupNode::Id(2), Some(2))),
+                    Lookup((LookupNode::Root(0), Some(3))),
+                    Id(0),
+                    For(AstFor {
+                        args: vec![Some(0)], // constant 0
+                        range: 4,            // ast 1
+                        body: 5,
+                    }),
+                    MainBlock {
+                        body: vec![6],
+                        local_count: 1,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("a"),
+                    Constant::Str("x"),
+                    Constant::Str("zip"),
+                    Constant::Str("y"),
+                ]),
+            )
+        }
     }
 
     mod functions {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -483,7 +483,7 @@ min..max
             let source = "\
 num2 0
 num2
-  1
+  1,
   x";
             check_ast(
                 source,
@@ -506,7 +506,7 @@ num2
         fn num4() {
             let source = "\
 num4 0
-num4 1 x
+num4 1, x
 num4(
   x, 0,
   1, x,
@@ -1743,7 +1743,7 @@ f 42";
 
         #[test]
         fn call_negative_arg() {
-            let source = "f x -x";
+            let source = "f x, -x";
             check_ast(
                 source,
                 &[
@@ -1789,7 +1789,7 @@ f 42";
         fn call_over_lines() {
             let source = "
 foo
-  x
+  x,
   y";
             check_ast(
                 source,
@@ -2240,7 +2240,7 @@ f = |n|
         #[test]
         fn call_with_function() {
             let source = "\
-z = y [0..20] |x| x > 1
+z = y [0..20], |x| x > 1
 y z";
             check_ast(
                 source,
@@ -2933,7 +2933,7 @@ return 1";
             let source = r#"
 not true
 debug x + x
-assert_eq x "hello"
+assert_eq x, "hello"
 "#;
             check_ast(
                 source,

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -122,6 +122,19 @@ if f x
             }
         }
 
+        mod loops {
+            use super::*;
+
+            #[test]
+            fn if_following_for() {
+                let source = "
+for x in y if f x
+  debug x
+";
+                check_parsing_fails(source);
+            }
+        }
+
         mod functions {
             use super::*;
 

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -606,6 +606,19 @@ match x
         }
 
         #[test]
+        fn match_with_condition_after_lookup() {
+            let script = r#"
+foo = {bar: 0, baz: 1}
+x = 42
+match 0
+  foo.bar if x == -1 then 0
+  foo.bar if x == 42 then 42
+  else -1
+"#;
+            test_script(script, Number(42.0.into()));
+        }
+
+        #[test]
         fn match_on_alternative() {
             let script = "
 match 42
@@ -855,6 +868,15 @@ add = |a, b|
   a + b
 add(5, 6)";
             test_script(script, Number(11.0.into()));
+        }
+
+        #[test]
+        fn nested_call_without_parens() {
+            let script = "
+add = |a, b|
+  a + b
+add 2, add 3, 4";
+            test_script(script, Number(9.0.into()));
         }
 
         #[test]


### PR DESCRIPTION
This PR changes the form of function calls without parentheses so that arguments
need to be separated with commas.

The fact that paren-free calls _didn't_ require commas was a hangover from the
early days of Koto when commas were absent from most expressions. Now though,
calls-without-commas stick out as an exception, and so for consistency's sake
it's worth adding them back in.

The rule now is that 'Parentheses may be removed from calls' (rather
than 'Parentheses _and commas_ may be removed from calls'), which is the rule in
Coffeescript and several other scripting languages.

Adapting to this change in existing scripts is reasonably straight forward in
most cases, but some care needs to be taken, e.g. `f a, b c` was previously
parsed as two separate expressions (`(f a), (b c)`),
and it's now parsed as `f(a, (b c))`.

I'm sorry if this causes you trouble, but it's less painful to make this change
now rather than later on.
