### PR TITLE
Some parser cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
     assert_eq x [[1], [1, 2], [1, 2, 3]]
     ```
 
+### Fixed
+- Error messages produced in the functor passed to `iterator.fold` were reported
+  as coming from `iterator.each`.
+
 
 ## [0.5.0] 2020.12.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
 ### Fixed
 - Error messages produced in the functor passed to `iterator.fold` were reported
   as coming from `iterator.each`.
+- Error messages associated with accessed IDs now have the correct spans.
+  - e.g.
+    ```
+    x = (1..10).fold 42
+
+    ```
+    Previously the error (wrong arguments for `.fold`) would be connected with
+    the range rather than the function call.
 
 
 ## [0.5.0] 2020.12.17

--- a/koto/tests/line_breaks.koto
+++ b/koto/tests/line_breaks.koto
@@ -1,11 +1,11 @@
 import test.assert_eq
 
 a = num4
-  0 1 2 3
+  0, 1, 2, 3
 b = num4
-  0 1
-  2 3
-assert_eq a b
+  0, 1,
+  2, 3
+assert_eq a, b
 
 a = num4(1,
   2, 3,
@@ -16,19 +16,19 @@ b = num4(
   2, 3, # Comments can be included in the num4 construction
   4
 )
-assert_eq a b
+assert_eq a, b
 
 x = (1, 2, 3).fold(
   0,
   |a, b| a + b
 )
-assert_eq x 6
+assert_eq x, 6
 
 x = (1, 2, 3)
   .each |n| n
   # This comment shouldn't interrupt the chain
-  .fold 0 |a, b| a + b
-assert_eq x 6
+  .fold 0, |a, b| a + b
+assert_eq x, 6
 
 assert_equal = |
   long_arg, # This is an argument that needs an explanation
@@ -40,7 +40,7 @@ assert_equal = |
     long_arg_2
 
 assert_equal
-  1234
+  1234,
   1234
 
 m = {
@@ -49,17 +49,17 @@ m = {
   bar:
     -1,
 }
-assert_eq m.bar -1
+assert_eq m.bar, -1
 
 x = [
   42,
   99,
 ]
-assert_eq x[1] 99
+assert_eq x[1], 99
 
 
 a = 1 +
     2 + #- inline comment -# 3 +
     # Another comment
     4
-assert_eq a 10
+assert_eq a, 10

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -68,7 +68,7 @@ test.assert false
     fn check_assert_eq() {
         let script = "
 import test.assert_eq
-assert_eq 0 1
+assert_eq 0, 1
 ";
         run_script(script, None, true);
     }
@@ -77,7 +77,7 @@ assert_eq 0 1
     fn check_assert_ne() {
         let script = "
 import test.assert_ne
-assert_ne 1 1
+assert_ne 1, 1
 ";
         run_script(script, None, true);
     }
@@ -86,7 +86,7 @@ assert_ne 1 1
     fn check_assert_near() {
         let script = "
 import test.assert_near
-assert_near 1 2 0.1
+assert_near 1, 2, 0.1
 ";
         run_script(script, None, true);
     }

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -276,6 +276,12 @@ impl<'source> Parser<'source> {
 
             if let Some(expression) = self.parse_line()? {
                 body.push(expression);
+
+                match self.peek_next_token_on_same_line() {
+                    Some(Token::NewLine) | Some(Token::NewLineIndented) => continue,
+                    None => break,
+                    _ => return syntax_error!(UnexpectedToken, self),
+                }
             } else {
                 self.lexer.next();
                 return syntax_error!(ExpectedExpressionInMainBlock, self);
@@ -524,21 +530,8 @@ impl<'source> Parser<'source> {
         context: &mut ExpressionContext,
         temp_result: bool,
     ) -> Result<Option<AstIndex>, ParserError> {
-        let current_indent = self.lexer.current_indent();
-
-        if context.allow_initial_indentation
-            && self.peek_next_token_on_same_line() == Some(Token::NewLineIndented)
-        {
-            self.consume_until_next_token(context);
-
-            let indent = self.lexer.current_indent();
-            if indent <= current_indent {
-                return Ok(None);
-            }
-
-            if let Some(map_block) = self.parse_map_block(context)? {
-                return Ok(Some(map_block));
-            }
+        if let Some(map_block) = self.parse_map_block(context)? {
+            return Ok(Some(map_block));
         }
 
         let mut expression_context = ExpressionContext {
@@ -549,14 +542,10 @@ impl<'source> Parser<'source> {
         if let Some(first) = self.parse_expression(&mut expression_context)? {
             let mut expressions = vec![first];
             let mut encountered_comma = false;
+
             while let Some(Token::Comma) = self.peek_next_token_on_same_line() {
                 self.consume_next_token_on_same_line();
                 encountered_comma = true;
-
-                if self.peek_next_token(context).is_none() {
-                    break;
-                }
-                self.consume_until_next_token(context);
 
                 if let Some(next_expression) =
                     self.parse_expression_with_lhs(Some(&expressions), &mut expression_context)?
@@ -581,6 +570,7 @@ impl<'source> Parser<'source> {
                     expressions.push(next_expression);
                 }
             }
+
             if expressions.len() == 1 && !encountered_comma {
                 Ok(Some(first))
             } else {
@@ -2343,6 +2333,13 @@ impl<'source> Parser<'source> {
         while let Some(expression) = self.parse_line()? {
             body.push(expression);
 
+            match self.peek_next_token_on_same_line() {
+                None => break,
+                Some(Token::NewLine) | Some(Token::NewLineIndented) => {}
+                _ => return syntax_error!(UnexpectedToken, self),
+            }
+
+            // Peek ahead to see if the indented block continues after this line
             if self.peek_next_token(context).is_none() {
                 break;
             }
@@ -2648,7 +2645,7 @@ impl<'source> Parser<'source> {
 
         while let Some(peeked) = self.peek_token_n(peek_count) {
             match peeked {
-                Whitespace | CommentMulti => {}
+                Whitespace | CommentMulti | CommentSingle => {}
                 token => return Some(token),
             }
 
@@ -2664,7 +2661,7 @@ impl<'source> Parser<'source> {
 
         while let Some(peeked) = self.peek_token() {
             match peeked {
-                Whitespace | CommentMulti => {}
+                Whitespace | CommentMulti | CommentSingle => {}
                 _ => return,
             }
 
@@ -2678,7 +2675,7 @@ impl<'source> Parser<'source> {
 
         while let Some(peeked) = self.peek_token() {
             match peeked {
-                Whitespace | CommentMulti => {}
+                Whitespace | CommentMulti | CommentSingle => {}
                 _ => return self.lexer.next(),
             }
 

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1022,9 +1022,10 @@ impl<'source> Parser<'source> {
                     if !matches!(self.peek_token(), Some(Token::Id) | Some(Token::String)) {
                         return syntax_error!(ExpectedMapKey, self);
                     } else if let Some(id_index) = self.parse_id_or_string()? {
+                        node_start_span = self.lexer.span();
                         lookup.push((
                             LookupNode::Id(id_index),
-                            self.span_with_start(self.lexer.span()),
+                            self.span_with_start(node_start_span),
                         ));
                     } else {
                         return syntax_error!(ExpectedMapKey, self);

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -1356,6 +1356,46 @@ a";
                 Some(&[Constant::Str("a"), Constant::Str("b")]),
             )
         }
+
+        #[test]
+        fn if_block_in_function_followed_by_id() {
+            let source = "
+||
+  if true
+    return
+  x
+";
+
+            check_ast(
+                source,
+                &[
+                    BoolTrue,
+                    Return,
+                    If(AstIf {
+                        condition: 0,
+                        then_node: 1,
+                        else_if_blocks: vec![],
+                        else_node: None,
+                    }),
+                    Id(0),
+                    Block(vec![2, 3]),
+                    Function(koto_parser::Function {
+                        args: vec![],
+                        local_count: 0,
+                        accessed_non_locals: vec![0],
+                        body: 4,
+                        is_instance_function: false,
+                        is_variadic: false,
+                        is_generator: false,
+                    }), // 5
+                    MainBlock {
+                        body: vec![5],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x")]),
+            )
+        }
     }
 
     mod loops {

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -162,6 +162,20 @@ for x in y if f x
             fn missing_terminator_for_list_arg() {
                 check_parsing_fails("f = |a, [b, c, d| a");
             }
+
+            #[test]
+            fn missing_commas_in_call() {
+                check_parsing_fails("f 1 2 3");
+            }
+
+            #[test]
+            fn missing_commas_in_call_in_indented_block() {
+                let source = "
+f = ||
+  f 1 2 3
+";
+                check_parsing_fails(source);
+            }
         }
 
         mod lookups {

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -173,7 +173,7 @@ pub fn make_module() -> ValueMap {
                                     match vm.run_function(f.clone(), &[fold_result, value]) {
                                         Ok(result) => fold_result = result,
                                         Err(error) => {
-                                            return Some(Err(error.with_prefix("iterator.each")))
+                                            return Some(Err(error.with_prefix("iterator.fold")))
                                         }
                                     }
                                 }


### PR DESCRIPTION
- Fix wrong error prefix in iterator.fold
- Trigger a parser error when unparsed tokens are remaining on a line
- Fix span placement for ID lookup nodes
