### PR TITLE
Some more parser fixes

### DIFF
--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -229,7 +229,7 @@ impl<'a> TokenLexer<'a> {
         // The '"' character has already been matched
         chars.next();
 
-        let mut string_bytes = 1;
+        let mut string_bytes = 1; // 1 for '"'
         let mut position = self.position;
 
         while let Some(c) = chars.next() {
@@ -249,6 +249,8 @@ impl<'a> TokenLexer<'a> {
                     position.column = 1;
                 }
                 '"' => {
+                    // +1 to get the column 1 past the end of the string
+                    position.column += 1;
                     self.advance_to_position(string_bytes, position);
                     return Some(String);
                 }

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1035,8 +1035,9 @@ impl<'source> Parser<'source> {
                     }
                 }
                 Token::Whitespace if node_context.allow_space_separated_call => {
-                    let args = self.parse_call_args(context)?;
+                    node_context.allow_space_separated_call = false;
 
+                    let args = self.parse_call_args(context)?;
                     if args.is_empty() {
                         break;
                     } else {

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -280,7 +280,10 @@ impl<'source> Parser<'source> {
                 match self.peek_next_token_on_same_line() {
                     Some(Token::NewLine) | Some(Token::NewLineIndented) => continue,
                     None => break,
-                    _ => return syntax_error!(UnexpectedToken, self),
+                    _ => {
+                        self.consume_next_token_on_same_line();
+                        return syntax_error!(UnexpectedToken, self);
+                    }
                 }
             } else {
                 self.lexer.next();
@@ -2337,7 +2340,10 @@ impl<'source> Parser<'source> {
             match self.peek_next_token_on_same_line() {
                 None => break,
                 Some(Token::NewLine) | Some(Token::NewLineIndented) => {}
-                _ => return syntax_error!(UnexpectedToken, self),
+                _ => {
+                    self.consume_next_token_on_same_line();
+                    return syntax_error!(UnexpectedToken, self);
+                }
             }
 
             // Peek ahead to see if the indented block continues after this line

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -176,6 +176,11 @@ f = ||
 ";
                 check_parsing_fails(source);
             }
+
+            #[test]
+            fn missing_commas_in_lookup_call() {
+                check_parsing_fails("f.bar 1 2 3");
+            }
         }
 
         mod lookups {


### PR DESCRIPTION
- Fix spans created for strings
- Fix spans for unexpected token error messages
- Ensure that commas are used in space-separated lookup calls
