### PR TITLE
Arithmetic parsing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - The `Koto` struct now returns a concrete error type instead of a `String`.
 - It's no longer necessary to call helper functions to get formatted source
   extracts for errors.
+- Whitespace is no longer required after operators,
+  e.g. `1+1==2` would previously trigger a parsing error.
 
 ### Fixed
 - Error messages produced in the functor passed to `iterator.fold` were reported

--- a/koto/tests/arithmetic.koto
+++ b/koto/tests/arithmetic.koto
@@ -4,7 +4,7 @@ export tests =
   test_operators: ||
     assert_eq 1 + 1, 2
     assert_eq 2 - 2, 0
-    assert_eq 1 + 2 * 3 + 4, 11
+    assert_eq 1+2*3+4, 11 # whitespace around operators is conventional but optional
     assert_eq 1.5 * 4.0, 6.0
     assert_eq 1.5 * 4.0, 6.0
     assert_eq 9 / 3 + 1, 4

--- a/koto/tests/loops.koto
+++ b/koto/tests/loops.koto
@@ -4,11 +4,12 @@ export tests =
   test_for_block: ||
     count = 0
     for x in 0..10
-      for y in -5..5 if x == y and x < 3
-        assert_eq x, y
+      for y in -5..5
+        if x == y and x < 3
+          assert_eq x, y
 
-        # loop bodies share scope of statement
-        count += 1
+          # loop bodies share scope of statement
+          count += 1
 
     assert_eq count, 3
 

--- a/libs/lib_tests/tests/lib_tests.rs
+++ b/libs/lib_tests/tests/lib_tests.rs
@@ -25,12 +25,12 @@ fn run_script(script: &str, path: Option<PathBuf>, should_fail_at_runtime: bool)
             }
             Err(error) => {
                 if !should_fail_at_runtime {
-                    panic!(error);
+                    panic!("{}", error);
                 }
             }
         },
         Err(error) => {
-            panic!(error);
+            panic!("{}", error);
         }
     }
 }

--- a/src/bytecode/src/loader.rs
+++ b/src/bytecode/src/loader.rs
@@ -129,7 +129,7 @@ impl Loader {
                     debug_info,
                 )))
             }
-            Err(e) => return Err(LoaderError::from_parser_error(e, script, script_path)),
+            Err(e) => Err(LoaderError::from_parser_error(e, script, script_path)),
         }
     }
 

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -19,12 +19,12 @@ fn run_script(script: &str, path: Option<PathBuf>, should_fail_at_runtime: bool)
             }
             Err(error) => {
                 if !should_fail_at_runtime {
-                    panic!(error);
+                    panic!("{}", error);
                 }
             }
         },
         Err(error) => {
-            panic!(error);
+            panic!("{}", error);
         }
     }
 }

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -261,77 +261,53 @@ impl<'a> TokenLexer<'a> {
         Some(Error)
     }
 
-    fn consume_number_or_subtract(&mut self, mut chars: Peekable<Chars>) -> Option<Token> {
+    fn consume_number(&mut self, mut chars: Peekable<Chars>) -> Option<Token> {
         use Token::*;
 
-        let mut char_bytes = 0;
+        let mut char_bytes = consume_and_count(&mut chars, is_digit);
 
-        if chars.peek() == Some(&'-') {
+        if chars.peek() == Some(&'.') {
             chars.next();
-            char_bytes += 1;
 
-            if chars.peek() == Some(&'=') {
-                self.advance_line(2);
-                return Some(AssignSubtract);
-            }
-        }
-
-        match chars.peek() {
-            Some(c) if is_digit(*c) => {
-                char_bytes += consume_and_count(&mut chars, is_digit);
-
-                if chars.peek() == Some(&'.') {
-                    chars.next();
-
-                    match chars.peek() {
+            match chars.peek() {
+                Some(c) if is_digit(*c) => {}
+                Some(&'e') => {
+                    // lookahead to check that this isn't a function call starting with 'e'
+                    // e.g. 1.exp()
+                    let mut lookahead = chars.clone();
+                    lookahead.next();
+                    match lookahead.peek() {
                         Some(c) if is_digit(*c) => {}
-                        Some(&'e') => {
-                            // lookahead to check that this isn't a function call starting with 'e'
-                            // e.g. 1.exp()
-                            let mut lookahead = chars.clone();
-                            lookahead.next();
-                            match lookahead.peek() {
-                                Some(c) if is_digit(*c) => {}
-                                Some(&'+') | Some(&'-') => {}
-                                _ => {
-                                    self.advance_line(char_bytes);
-                                    return Some(Number);
-                                }
-                            }
-                        }
+                        Some(&'+') | Some(&'-') => {}
                         _ => {
                             self.advance_line(char_bytes);
                             return Some(Number);
                         }
                     }
-
-                    char_bytes += 1 + consume_and_count(&mut chars, is_digit);
                 }
-
-                if chars.peek() == Some(&'e') {
-                    chars.next();
-                    char_bytes += 1;
-
-                    if matches!(chars.peek(), Some(&'+') | Some(&'-')) {
-                        chars.next();
-                        char_bytes += 1;
-                    }
-
-                    char_bytes += consume_and_count(&mut chars, is_digit);
-                }
-
-                self.advance_line(char_bytes);
-                Some(Number)
-            }
-            _ => {
-                if char_bytes == 1 {
-                    self.advance_line(1);
-                    Some(Subtract)
-                } else {
-                    Some(Error)
+                _ => {
+                    self.advance_line(char_bytes);
+                    return Some(Number);
                 }
             }
+
+            char_bytes += 1 + consume_and_count(&mut chars, is_digit);
         }
+
+        if chars.peek() == Some(&'e') {
+            chars.next();
+            char_bytes += 1;
+
+            if matches!(chars.peek(), Some(&'+') | Some(&'-')) {
+                chars.next();
+                char_bytes += 1;
+            }
+
+            char_bytes += consume_and_count(&mut chars, is_digit);
+        }
+
+        self.advance_line(char_bytes);
+        Some(Number)
     }
 
     fn consume_id_or_keyword(&mut self, mut chars: Peekable<Chars>) -> Option<Token> {
@@ -423,17 +399,17 @@ impl<'a> TokenLexer<'a> {
         check_symbol!("<", Less);
 
         check_symbol!("+=", AssignAdd);
+        check_symbol!("-=", AssignSubtract);
         check_symbol!("*=", AssignMultiply);
         check_symbol!("/=", AssignDivide);
         check_symbol!("%=", AssignModulo);
         check_symbol!("=", Assign);
 
         check_symbol!("+", Add);
+        check_symbol!("-", Subtract);
         check_symbol!("*", Multiply);
         check_symbol!("/", Divide);
         check_symbol!("%", Modulo);
-
-        // Subtract and AssignSubtract are checked separately to allow for negative numbers
 
         check_symbol!(":", Colon);
         check_symbol!(",", Comma);
@@ -470,7 +446,7 @@ impl<'a> Iterator for TokenLexer<'a> {
                     Some('\n') => self.consume_newline(chars),
                     Some('#') => self.consume_comment(chars),
                     Some('"') => self.consume_string(chars),
-                    Some('0'..='9') | Some('-') => self.consume_number_or_subtract(chars),
+                    Some('0'..='9') => self.consume_number(chars),
                     Some(c) if is_id_start(*c) => self.consume_id_or_keyword(chars),
                     Some(_) => {
                         if let Some(id) = self.consume_symbol(remaining) {
@@ -844,11 +820,13 @@ true"#;
                 (NewLine, None, 2),
                 (Number, Some("55.5"), 2),
                 (NewLine, None, 3),
-                (Number, Some("-1e-3"), 3),
+                (Subtract, None, 3),
+                (Number, Some("1e-3"), 3),
                 (NewLine, None, 4),
                 (Number, Some("0.5e+9"), 4),
                 (NewLine, None, 5),
-                (Number, Some("-8e8"), 5),
+                (Subtract, None, 5),
+                (Number, Some("8e8"), 5),
             ],
         );
     }
@@ -869,7 +847,8 @@ true"#;
                 (ParenOpen, None, 1),
                 (ParenClose, None, 1),
                 (NewLine, None, 2),
-                (Number, Some("-1e-3"), 2),
+                (Subtract, None, 2),
+                (Number, Some("1e-3"), 2),
                 (Dot, None, 2),
                 (Id, Some("abs"), 2),
                 (ParenOpen, None, 2),

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -86,6 +86,18 @@ pub enum Token {
     Yield,
 }
 
+impl Token {
+    pub fn is_whitespace(&self) -> bool {
+        use Token::*;
+        matches!(self, Whitespace | CommentMulti | CommentSingle)
+    }
+
+    pub fn is_newline(&self) -> bool {
+        use Token::*;
+        matches!(self, NewLine | NewLineIndented)
+    }
+}
+
 #[derive(Clone)]
 struct TokenLexer<'a> {
     source: &'a str,

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -855,6 +855,7 @@ impl<'source> Parser<'source> {
                 .increment_expression_access_for_id(constant_index);
 
             let id_index = self.push_node(Node::Id(constant_index))?;
+
             let result = match self.peek_token() {
                 Some(Token::Whitespace) if context.allow_space_separated_call => {
                     let start_span = self.lexer.span();
@@ -1232,8 +1233,6 @@ impl<'source> Parser<'source> {
     ) -> Result<Option<AstIndex>, ParserError> {
         use Node::*;
 
-        // let current_indent = self.lexer.current_indent();
-
         if let Some((token, peek_count)) = self.peek_next_token(context) {
             let result = match token {
                 Token::True => {
@@ -1245,36 +1244,7 @@ impl<'source> Parser<'source> {
                     Some(self.push_node(BoolFalse)?)
                 }
                 Token::ParenOpen => self.parse_nested_expressions(context)?,
-                Token::Number => {
-                    self.consume_next_token(context);
-                    let slice = self.lexer.slice();
-                    let number_node = match i64::from_str(slice) {
-                        Ok(n) => {
-                            if n == 0 {
-                                self.push_node(Number0)?
-                            } else if n == 1 {
-                                self.push_node(Number1)?
-                            } else {
-                                let constant_index = self.constants.add_i64(n) as u32;
-                                self.push_node(Int(constant_index))?
-                            }
-                        }
-                        Err(_) => match f64::from_str(slice) {
-                            Ok(n) => {
-                                let constant_index = self.constants.add_f64(n) as u32;
-                                self.push_node(Float(constant_index))?
-                            }
-                            Err(_) => {
-                                return internal_error!(NumberParseFailure, self);
-                            }
-                        },
-                    };
-                    if self.next_token_is_lookup_start(context) {
-                        Some(self.parse_lookup(number_node, context)?)
-                    } else {
-                        Some(number_node)
-                    }
-                }
+                Token::Number => self.parse_number(false, context)?,
                 Token::String => {
                     self.consume_next_token(context);
                     let s = self.parse_string(self.lexer.slice())?;
@@ -1333,24 +1303,22 @@ impl<'source> Parser<'source> {
                 Token::Match => self.parse_match_expression(context)?,
                 Token::Switch => self.parse_switch_expression(context)?,
                 Token::Function => self.parse_function(context)?,
-                Token::Subtract => {
-                    if let Some(token_after_subtract) = self.peek_token_n(peek_count + 1) {
-                        if !token_is_whitespace(token_after_subtract) {
-                            self.consume_next_token(context);
-                            if let Some(term) =
-                                self.parse_term(&mut ExpressionContext::restricted())?
-                            {
-                                Some(self.push_node(Node::Negate(term))?)
-                            } else {
-                                return syntax_error!(ExpectedExpression, self);
-                            }
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
+                Token::Subtract => match self.peek_token_n(peek_count + 1) {
+                    Some(Token::Whitespace) => None,
+                    Some(Token::Number) => {
+                        self.consume_next_token(context);
+                        self.parse_number(true, context)?
                     }
-                }
+                    Some(_) => {
+                        self.consume_next_token(context);
+                        if let Some(term) = self.parse_term(&mut ExpressionContext::restricted())? {
+                            Some(self.push_node(Node::Negate(term))?)
+                        } else {
+                            return syntax_error!(ExpectedExpression, self);
+                        }
+                    }
+                    None => None,
+                },
                 Token::Not => {
                     self.consume_next_token(context);
                     if let Some(expression) = self.parse_expression(&mut ExpressionContext {
@@ -1405,6 +1373,47 @@ impl<'source> Parser<'source> {
         } else {
             Ok(None)
         }
+    }
+
+    fn parse_number(
+        &mut self,
+        negate: bool,
+        context: &mut ExpressionContext,
+    ) -> Result<Option<AstIndex>, ParserError> {
+        use Node::*;
+
+        self.consume_next_token(context);
+
+        let slice = self.lexer.slice();
+        let number_node = match i64::from_str(slice) {
+            Ok(n) => {
+                if n == 0 {
+                    self.push_node(Number0)?
+                } else if n == 1 && !negate {
+                    self.push_node(Number1)?
+                } else {
+                    let n = if negate { -n } else { n };
+                    let constant_index = self.constants.add_i64(n) as u32;
+                    self.push_node(Int(constant_index))?
+                }
+            }
+            Err(_) => match f64::from_str(slice) {
+                Ok(n) => {
+                    let n = if negate { -n } else { n };
+                    let constant_index = self.constants.add_f64(n) as u32;
+                    self.push_node(Float(constant_index))?
+                }
+                Err(_) => {
+                    return internal_error!(NumberParseFailure, self);
+                }
+            },
+        };
+
+        Ok(if self.next_token_is_lookup_start(context) {
+            Some(self.parse_lookup(number_node, context)?)
+        } else {
+            Some(number_node)
+        })
     }
 
     fn parse_list(
@@ -2080,7 +2089,9 @@ impl<'source> Parser<'source> {
 
         let result = match self.peek_next_token(&pattern_context) {
             Some((token, _)) => match token {
-                True | False | Number | String => return self.parse_term(&mut pattern_context),
+                True | False | Number | String | Subtract => {
+                    return self.parse_term(&mut pattern_context)
+                }
                 Id => match self.parse_id(&mut pattern_context) {
                     Some(id) => {
                         let result = if self.peek_token() == Some(Ellipsis) {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -158,6 +158,29 @@ a
         }
 
         #[test]
+        fn list_nested() {
+            let source = r#"
+[0, [1, -1], 2]
+"#;
+            check_ast(
+                source,
+                &[
+                    Number0,
+                    Number1,
+                    Int(0),
+                    List(vec![1, 2]),
+                    Int(1),
+                    List(vec![0, 3, 4]), // 5
+                    MainBlock {
+                        body: vec![5],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::I64(-1), Constant::I64(2)]),
+            )
+        }
+
+        #[test]
         fn list_with_line_breaks() {
             let source = "\
 x = [
@@ -1839,6 +1862,33 @@ f 42";
         }
 
         #[test]
+        fn call_arithmetic_arg() {
+            let source = "f x - 1";
+            check_ast(
+                source,
+                &[
+                    Id(0),
+                    Id(1),
+                    Number1,
+                    BinaryOp {
+                        op: AstOp::Subtract,
+                        lhs: 1,
+                        rhs: 2,
+                    },
+                    Call {
+                        function: 0,
+                        args: vec![3],
+                    },
+                    MainBlock {
+                        body: vec![4],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("f"), Constant::Str("x")]),
+            )
+        }
+
+        #[test]
         fn call_with_parentheses() {
             let source = "f(x, -x)";
             check_ast(
@@ -2673,6 +2723,31 @@ y z";
                     Lookup((LookupNode::Root(0), Some(2))),
                     MainBlock {
                         body: vec![3],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x"), Constant::Str("bar")]),
+            )
+        }
+
+        #[test]
+        fn lookup_call_arithmetic_arg() {
+            let source = "x.bar() - 1";
+            check_ast(
+                source,
+                &[
+                    Id(0),
+                    Lookup((LookupNode::Call(vec![]), None)),
+                    Lookup((LookupNode::Id(1), Some(1))),
+                    Lookup((LookupNode::Root(0), Some(2))),
+                    Number1,
+                    BinaryOp {
+                        op: AstOp::Subtract,
+                        lhs: 3,
+                        rhs: 4,
+                    }, // 5
+                    MainBlock {
+                        body: vec![5],
                         local_count: 0,
                     },
                 ],

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -148,6 +148,11 @@ mod vm {
         }
 
         #[test]
+        fn add_multiply_compressed_whitespace() {
+            test_script("1+ 2 *3+4", Number(11.0.into()));
+        }
+
+        #[test]
         fn subtract_divide_modulo() {
             test_script("(20 - 2) / 3 % 4", Number(2.0.into()));
         }
@@ -465,7 +470,7 @@ b";
         fn swap_values_with_expressions() {
             let script = "
 a, b = 10, 7
-a, b = a + b, a % b
+a, b = a+b, a%b
 b";
             test_script(script, Number(3.0.into()));
         }


### PR DESCRIPTION
This PR improves arithmetic parsing so that whitespace isn't required after
operators.

e.g. `1+2+3` would previously have to be written as `1 + 2 + 3`.

I think it's good style to have whitespace surrounding operators,
but find that it's too restrictive to require it while writing.
