### PR TITLE
Modified captured values shouldn't persist between function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Changed
+- Captured values in functions are now immutable.
+  - e.g.
+    ```
+    x = 100
+    f = |n|
+      x = x + n # Assigning to x here now only affects the local copy of x
+    debug f 42  # 142
+    debug x     # 100 - The value of x in this scope is unchanged
+    ```
+  - Captured values can now be thought of as 'hidden arguments' for a function
+    rather than 'hidden mutable state', which simplifies things quite a bit.
+  - If mutable state is required then you can use a list or map, e.g.
+    ```
+    state = {x: 100}
+    f = |n|
+      state.x = state.x + n # The function has a local copy of the state,
+                            # which shares its data with the outer scope's copy.
+    debug f 42    # 142
+    debug state.x # 142
+    ```
+
 
 ## [0.6.0] 2021.01.21
 

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -13,22 +13,20 @@ A = |i, j|
   1.0 / (ij * (ij - 1) * 0.5 + i)
 
 Av = |x, y, n|
-  i = 0
-  y.transform |n|
-    i += 1
-    j = 0
-    x.fold 0, |result, n|
-      j += 1
-      result + n * (A i, j)
+  for i in 0..y.size()
+    i2 = i + 1
+    y[i] = x
+      .enumerate()
+      .each |(j, n)| n * (A i2, (j + 1))
+      .sum()
 
 Atv = |x, y, n|
-  i = 0
-  y.transform |n|
-    i += 1
-    j = 0
-    x.fold 0, |result, n|
-      j += 1
-      result + n * (A j, i)
+  for i in 0..y.size()
+    i2 = i + 1
+    y[i] = x
+      .enumerate()
+      .each |(j, n)| n * (A (j + 1), i2)
+      .sum()
 
 AtAv = |x, y, t, n|
   Av x, t, n

--- a/koto/tests/function_closures.koto
+++ b/koto/tests/function_closures.koto
@@ -21,17 +21,3 @@ export tests =
       b, c = (), () # inner and inner2 have captured their own copies of b and c
       inner()
     assert_eq (capture_test 1, 2, 3), 6
-
-  test_mutable_captured_values: ||
-    counter = ||
-      # make a counter functor with count initialized to 0
-      count = 0
-      return || count += 1
-
-    c = counter()
-    c2 = counter()
-    assert_eq c(), 1
-    assert_eq c(), 2
-    assert_eq c2(), 1
-    assert_eq c(), 3
-    assert_eq c2(), 2

--- a/koto/tests/logic.koto
+++ b/koto/tests/logic.koto
@@ -39,10 +39,11 @@ export tests =
   test_single_evaluation_of_chained_token: ||
     make_counter = ||
       count = 0
-      || count += 1
+      loop
+        yield count += 1
     f = make_counter()
-    assert 0 < f() < 2
-    assert_eq f(), 2
+    assert 0 < f.next() < 2
+    assert_eq f.next(), 2
 
   test_fiddly_chained_comparison: ||
     f = |x, y, z| if x < y < z > y > x then 0 else 1

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -172,14 +172,6 @@ pub enum Instruction {
         target: u8,
         source: u8,
     },
-    LoadCapture {
-        register: u8,
-        capture: u8,
-    },
-    SetCapture {
-        capture: u8,
-        source: u8,
-    },
     Negate {
         register: u8,
         source: u8,
@@ -393,8 +385,6 @@ impl fmt::Display for Instruction {
             MakeIterator { .. } => write!(f, "MakeIterator"),
             Function { .. } => write!(f, "Function"),
             Capture { .. } => write!(f, "Capture"),
-            LoadCapture { .. } => write!(f, "LoadCapture"),
-            SetCapture { .. } => write!(f, "SetCapture"),
             Negate { .. } => write!(f, "Negate"),
             Add { .. } => write!(f, "Add"),
             Subtract { .. } => write!(f, "Subtract"),
@@ -580,12 +570,6 @@ impl fmt::Debug for Instruction {
                 "Capture\t\tfunction: {}\ttarget: {}\tsource: {}",
                 function, target, source
             ),
-            LoadCapture { register, capture } => {
-                write!(f, "LoadCapture\tresult: {}\tcapture: {}", register, capture)
-            }
-            SetCapture { capture, source } => {
-                write!(f, "SetCapture\tcapture: {}\tsource {}", capture, source)
-            }
             Negate { register, source } => {
                 write!(f, "Negate\t\tresult: {}\tsource: {}", register, source)
             }
@@ -1045,14 +1029,6 @@ impl Iterator for InstructionReader {
             Op::Capture => Some(Capture {
                 function: get_byte!(),
                 target: get_byte!(),
-                source: get_byte!(),
-            }),
-            Op::LoadCapture => Some(LoadCapture {
-                register: get_byte!(),
-                capture: get_byte!(),
-            }),
-            Op::SetCapture => Some(SetCapture {
-                capture: get_byte!(),
                 source: get_byte!(),
             }),
             Op::Negate => Some(Negate {

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -34,8 +34,6 @@ pub enum Op {
     MakeIterator,     // register, range
     Function,         // register, arg count, capture count, flags, size[2]
     Capture,          // function, target, source
-    LoadCapture,      // register, capture
-    SetCapture,       // capture, source
     Range,            // register, start, end
     RangeInclusive,   // register, start, end
     RangeTo,          // register, end
@@ -85,6 +83,8 @@ pub enum Op {
     Debug,            // register, constant[4]
     CheckType,        // register, type (see TypeId)
     CheckSize,        // register, size
+    Unused79,
+    Unused80,
     Unused81,
     Unused82,
     Unused83,

--- a/src/runtime/src/frame.rs
+++ b/src/runtime/src/frame.rs
@@ -1,8 +1,4 @@
-use {
-    crate::{Value, ValueList},
-    koto_bytecode::Chunk,
-    std::sync::Arc,
-};
+use {koto_bytecode::Chunk, std::sync::Arc};
 
 #[derive(Debug)]
 pub(crate) struct Frame {
@@ -18,37 +14,16 @@ pub(crate) struct Frame {
     // True if the frame should prevent errors from being caught further down the stack,
     // e.g. when an external function is calling back into the VM with a functor
     pub catch_barrier: bool,
-    // The captures that are available in this frame
-    captures: Option<ValueList>,
 }
 
 impl Frame {
-    pub fn new(chunk: Arc<Chunk>, register_base: usize, captures: Option<ValueList>) -> Self {
+    pub fn new(chunk: Arc<Chunk>, register_base: usize) -> Self {
         Self {
             chunk,
             register_base,
-            captures,
             return_register_and_ip: None,
             catch_stack: vec![],
             catch_barrier: false,
         }
-    }
-
-    pub fn get_capture(&self, capture: u8) -> Option<Value> {
-        if let Some(captures) = &self.captures {
-            captures.data().get(capture as usize).cloned()
-        } else {
-            None
-        }
-    }
-
-    pub fn set_capture(&self, capture_index: u8, value: Value) -> bool {
-        if let Some(captures) = &self.captures {
-            if let Some(capture) = captures.data_mut().get_mut(capture_index as usize) {
-                *capture = value;
-                return true;
-            }
-        }
-        false
     }
 }

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -957,6 +957,16 @@ f 1, (2, [3, 4]), 5
         }
 
         #[test]
+        fn function_arg_unpacking_with_capture() {
+            let script = "
+x = 10
+f = |a, (b, c)| a + b + c + x
+f 1, (2, 3)
+";
+            test_script(script, Number(16.0.into()));
+        }
+
+        #[test]
         fn variadic_function() {
             let script = "
 f = |a, b...|
@@ -1067,10 +1077,9 @@ f().bar";
         #[test]
         fn captured_value() {
             let script = "
-f = |x|
-  inner = || x * x
-  inner()
-f 3";
+x = 3
+f = || x * x
+f()";
             test_script(script, Number(9.0.into()));
         }
 
@@ -1080,7 +1089,7 @@ f 3";
 data = [1, 2, 3]
 f = ||
   data[1] = 99
-  data = () # reassignment doesn't affect the original copy of data
+  data = () # shadowed assignment doesn't affect the original copy of data
 f()
 data[1]";
             test_script(script, Number(99.0.into()));

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1101,24 +1101,34 @@ capture_test 1, 2, 3";
         }
 
         #[test]
-        fn modifying_a_captured_value() {
+        fn local_copy_of_captured_value() {
             let script = "
-import assert
-make_counter = ||
-  count = 0
-  return || count += 1
-c = make_counter()
-c2 = make_counter()
-assert c() == 1
-assert c() == 2
-assert c2() == 1
-assert c() == 3
-c2()";
-            test_script(script, Number(2.0.into()));
+x = 99
+f = ||
+  x = x + 1
+  x
+if f() == 100
+  x
+else
+  -1
+";
+            test_script(script, Number(99.0.into()));
         }
 
         #[test]
-        fn multi_assignment_of_captured_values() {
+        fn mutation_of_captured_map() {
+            let script = "
+f = |x|
+  inner = ||
+    x.foo = 123
+  inner()
+  x.foo
+f {foo: 42, bar: 99}";
+            test_script(script, Number(123.0.into()));
+        }
+
+        #[test]
+        fn multi_assignment_to_captured_list() {
             let script = "
 f = |x|
   inner = ||


### PR DESCRIPTION
This PR changes the behaviour of captured function values so that modifications of them don't persist between function calls.

Mutable captures seemed to have some value in the past, but now that generators are in the language it's hard to think of scenarios where they're the best solution, whereas it's easier to think of scenarios where they're confusing.

This also allows for a simpler bytecode implementation: when functions are called, all captures are immediately copied into the register stack where they can be accessed like any other value, allowing for the removal of the `LoadCapture` / `SetCapture` ops.