### PR TITLE
Wasm support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,16 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features
+
+  wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: jetli/wasm-pack-action@v0.3.0
+        with:
+          version: v0.9.1
+
+      - name: Build wasm example
+        run: cd examples/wasm && wasm-pack build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- Logging behaviour via print and debug logging can now be customized.
+- Koto can now be compiled to wasm.
+
+
 ### Changed
 - Captured values in functions are now immutable.
   - e.g.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,20 +1078,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+name = "wasm"
+version = "0.1.0"
 dependencies = [
- "cfg-if 0.1.10",
+ "koto",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+dependencies = [
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1104,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1114,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1127,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/examples/wasm/.gitignore
+++ b/examples/wasm/.gitignore
@@ -1,0 +1,7 @@
+.cache/
+dist/
+node_modules/
+pkg/
+
+package-lock.json
+yarn.lock

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "wasm"
+version = "0.1.0"
+authors = ["irh <ian.r.hobson@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+koto = { path = "../../src/koto" }
+wasm-bindgen = "0.2.71"
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,0 +1,24 @@
+# Koto + Wasm
+
+An example use of Koto in the browser via Wasm, providing an editor window and
+the output from running a script.
+
+## Usage
+
+[Parcel.js](https://parceljs.org) is used as bundler and takes care of building
+the Rust wasm library. To build and open the example site, `cd` to this folder
+and run either of the following:
+
+### npm
+
+```
+npm install
+npm run start
+```
+
+### yarn
+
+```
+yarn install
+yarn start
+```

--- a/examples/wasm/package.json
+++ b/examples/wasm/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "koto-wasm-example",
+  "version": "0.0.1",
+  "scripts": {
+    "start": "parcel public/index.html --open",
+    "build": "parcel build public/index.html"
+  },
+  "dependencies": {
+    "brace": "^0.11.1"
+  }
+  "devDependencies": {
+    "parcel-bundler": "1.12.3",
+    "parcel-plugin-wasm.rs": "^1.2.16"
+  },
+}

--- a/examples/wasm/public/index.html
+++ b/examples/wasm/public/index.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>Koto Test</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <div class="flex-container" id="wrapper">
+      <div class="flex-left" id="editor">"Hello, World!".print()</div>
+      <pre class="flex-right" id="output"></pre>
+    </div>
+
+    <script src="./main.js"></script>
+  </body>
+</html>

--- a/examples/wasm/public/main.css
+++ b/examples/wasm/public/main.css
@@ -1,0 +1,35 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+body {
+  background: white;
+}
+
+.flex-container {
+  display: flex;
+  flex-wrap: wrap;
+  height: 100%;
+}
+
+.flex-left {
+  flex: 50%;
+}
+
+.flex-right {
+  flex: 50%;
+}
+
+@media (max-width: 800px) {
+  .flex-left, .flex-right {
+    flex: 100%;
+  }
+}
+
+#editor {
+  flex-grow: 1;
+}

--- a/examples/wasm/public/main.js
+++ b/examples/wasm/public/main.js
@@ -1,0 +1,15 @@
+import koto from "../Cargo.toml";
+import * as ace from "brace";
+import "brace/theme/solarized_dark";
+import "./main.css";
+
+var editor = ace.edit("editor");
+editor.setTheme("ace/theme/solarized_dark");
+editor.session.on("change", compile_and_run);
+
+function compile_and_run() {
+  const result = koto.compile_and_run(editor.session.getValue());
+  document.getElementById("output").innerText = result;
+}
+
+compile_and_run();

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -1,0 +1,37 @@
+use {
+    koto::{runtime::KotoLogger, Koto, KotoSettings},
+    std::sync::{Arc, Mutex},
+    wasm_bindgen::prelude::*,
+};
+
+// A logger that captures output from Koto in a Vec of Strings
+struct CaptureLogger {
+    output: Arc<Mutex<Vec<String>>>,
+}
+
+impl KotoLogger for CaptureLogger {
+    fn writeln(&self, output: &str) {
+        self.output.lock().unwrap().push(output.to_string());
+    }
+}
+
+// Runs an input program and returns the output as a String
+#[wasm_bindgen]
+pub fn compile_and_run(input: &str) -> String {
+    let output = Arc::new(Mutex::new(Vec::new()));
+
+    let mut koto = Koto::with_settings(KotoSettings {
+        logger: Arc::new(CaptureLogger {
+            output: output.clone(),
+        }),
+        ..Default::default()
+    });
+
+    match koto.compile(input) {
+        Ok(_) => match koto.run() {
+            Ok(_) => output.lock().unwrap().join("\n"),
+            Err(e) => format!("Runtime error: {}", e),
+        },
+        Err(e) => format!("Compilation error: {}", e),
+    }
+}

--- a/justfile
+++ b/justfile
@@ -27,3 +27,6 @@ test_all:
 
 test_benches:
   cargo watch -x "test --benches"
+
+wasm:
+  cd examples/wasm && wasm-pack build

--- a/src/bytecode/src/lib.rs
+++ b/src/bytecode/src/lib.rs
@@ -9,7 +9,7 @@ mod loader;
 mod op;
 
 pub use {
-    chunk::{chunk_to_string, chunk_to_string_annotated, Chunk, DebugInfo},
+    chunk::{Chunk, DebugInfo},
     compiler::{Compiler, CompilerError, CompilerSettings},
     instruction_reader::{FunctionFlags, Instruction, InstructionReader, TypeId},
     loader::{Loader, LoaderError},

--- a/src/koto/Cargo.toml
+++ b/src/koto/Cargo.toml
@@ -18,7 +18,11 @@ koto_bytecode = { path = "../bytecode", version = "^0.6.0"}
 koto_parser = { path = "../parser", version = "^0.6.0"}
 koto_runtime = { path = "../runtime", version = "^0.6.0"}
 
+[target.'cfg(not(wasm32))'.dependencies]
 parking_lot = "0.11.1"
+
+[target.'cfg(wasm32)'.dependencies]
+parking_lot = { version = "0.11.1", features=["wasm-bindgen"] }
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -31,7 +31,8 @@ pub use {koto_bytecode as bytecode, koto_parser as parser, koto_runtime as runti
 use {
     koto_bytecode::{chunk_to_string, chunk_to_string_annotated, Chunk, LoaderError},
     koto_runtime::{
-        type_as_string, Loader, RuntimeError, Value, ValueList, ValueMap, ValueVec, Vm,
+        type_as_string, DefaultLogger, KotoLogger, Loader, RuntimeError, Value, ValueList,
+        ValueMap, ValueVec, Vm, VmSettings,
     },
     std::{error::Error, fmt, path::PathBuf, sync::Arc},
 };
@@ -74,35 +75,59 @@ impl From<RuntimeError> for KotoError {
 pub type KotoResult = Result<Value, KotoError>;
 
 /// Settings used to control the behaviour of the [Koto] runtime
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Clone)]
 pub struct KotoSettings {
     pub run_tests: bool,
     pub show_annotated: bool,
     pub show_bytecode: bool,
     pub repl_mode: bool,
+    pub logger: Arc<dyn KotoLogger>,
+}
+
+impl Default for KotoSettings {
+    fn default() -> Self {
+        Self {
+            run_tests: true,
+            show_annotated: false,
+            show_bytecode: false,
+            repl_mode: false,
+            logger: Arc::new(DefaultLogger {}),
+        }
+    }
 }
 
 /// The main interface for the Koto language.
 ///
 /// Example
-#[derive(Default)]
 pub struct Koto {
-    script_path: Option<PathBuf>,
     runtime: Vm,
-    pub settings: KotoSettings,
+    pub settings: KotoSettings, // TODO make private, needs enable / disable tests methods
+    script_path: Option<PathBuf>,
     loader: Loader,
     chunk: Option<Arc<Chunk>>,
 }
 
+impl Default for Koto {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Koto {
     pub fn new() -> Self {
-        Self::default()
+        Self::with_settings(KotoSettings::default())
     }
 
     pub fn with_settings(settings: KotoSettings) -> Self {
-        let mut result = Self::new();
-        result.settings = settings;
-        result
+        Self {
+            settings: settings.clone(),
+            runtime: Vm::with_settings(VmSettings {
+                logger: settings.logger,
+            }),
+            loader: Loader::default(),
+            chunk: None,
+            script_path: None,
+        }
     }
 
     pub fn compile(&mut self, script: &str) -> Result<Arc<Chunk>, LoaderError> {
@@ -116,15 +141,20 @@ impl Koto {
             Ok(chunk) => {
                 self.chunk = Some(chunk.clone());
                 if self.settings.show_annotated {
-                    println!("Constants\n---------\n{}\n", chunk.constants.to_string());
+                    self.runtime.logger().writeln(&format!(
+                        "Constants\n---------\n{}\n",
+                        chunk.constants.to_string()
+                    ));
 
                     let script_lines = script.lines().collect::<Vec<_>>();
-                    println!(
+                    self.runtime.logger().writeln(&format!(
                         "Instructions\n------------\n{}",
                         chunk_to_string_annotated(chunk.clone(), &script_lines)
-                    );
+                    ));
                 } else if self.settings.show_bytecode {
-                    println!("{}", chunk_to_string(chunk.clone()));
+                    self.runtime
+                        .logger()
+                        .writeln(&chunk_to_string(chunk.clone()));
                 }
                 Ok(chunk)
             }

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -29,7 +29,7 @@
 pub use {koto_bytecode as bytecode, koto_parser as parser, koto_runtime as runtime};
 
 use {
-    koto_bytecode::{chunk_to_string, chunk_to_string_annotated, Chunk, LoaderError},
+    koto_bytecode::{Chunk, LoaderError},
     koto_runtime::{
         type_as_string, DefaultLogger, KotoLogger, Loader, RuntimeError, Value, ValueList,
         ValueMap, ValueVec, Vm, VmSettings,
@@ -78,8 +78,6 @@ pub type KotoResult = Result<Value, KotoError>;
 #[derive(Clone)]
 pub struct KotoSettings {
     pub run_tests: bool,
-    pub show_annotated: bool,
-    pub show_bytecode: bool,
     pub repl_mode: bool,
     pub logger: Arc<dyn KotoLogger>,
 }
@@ -88,8 +86,6 @@ impl Default for KotoSettings {
     fn default() -> Self {
         Self {
             run_tests: true,
-            show_annotated: false,
-            show_bytecode: false,
             repl_mode: false,
             logger: Arc::new(DefaultLogger {}),
         }
@@ -140,22 +136,6 @@ impl Koto {
         match compile_result {
             Ok(chunk) => {
                 self.chunk = Some(chunk.clone());
-                if self.settings.show_annotated {
-                    self.runtime.logger().writeln(&format!(
-                        "Constants\n---------\n{}\n",
-                        chunk.constants.to_string()
-                    ));
-
-                    let script_lines = script.lines().collect::<Vec<_>>();
-                    self.runtime.logger().writeln(&format!(
-                        "Instructions\n------------\n{}",
-                        chunk_to_string_annotated(chunk.clone(), &script_lines)
-                    ));
-                } else if self.settings.show_bytecode {
-                    self.runtime
-                        .logger()
-                        .writeln(&chunk_to_string(chunk.clone()));
-                }
                 Ok(chunk)
             }
             Err(error) => Err(error),

--- a/src/runtime/src/core/string.rs
+++ b/src/runtime/src/core/string.rs
@@ -85,9 +85,9 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("print", |vm, args| {
         match vm.get_args(args) {
-            [Str(s)] => println!("{}", s.as_str()),
+            [Str(s)] => vm.logger().writeln(s.as_str()),
             [Str(format), format_args @ ..] => match format::format_string(format, format_args) {
-                Ok(result) => println!("{}", result.as_str()),
+                Ok(result) => vm.logger().writeln(&result),
                 Err(error) => return external_error!("string.print: {}", error),
             },
             _ => return external_error!("string.print: Expected a string as first argument"),

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -4,6 +4,7 @@ pub mod core;
 mod error;
 mod external;
 mod frame;
+mod logger;
 pub mod num2;
 pub mod num4;
 pub mod value;
@@ -20,6 +21,7 @@ pub use {
     external::{is_external_instance, visit_external_value, ExternalFunction, ExternalValue},
     koto_bytecode::{CompilerError, Loader, LoaderError},
     koto_parser::ParserError,
+    logger::{DefaultLogger, KotoLogger},
     num2::Num2,
     num4::Num4,
     value::{
@@ -31,5 +33,5 @@ pub use {
     value_number::ValueNumber,
     value_string::ValueString,
     value_tuple::ValueTuple,
-    vm::Vm,
+    vm::{Vm, VmSettings},
 };

--- a/src/runtime/src/logger.rs
+++ b/src/runtime/src/logger.rs
@@ -1,0 +1,11 @@
+pub trait KotoLogger: Send + Sync {
+    fn writeln(&self, output: &str);
+}
+
+pub struct DefaultLogger {}
+
+impl KotoLogger for DefaultLogger {
+    fn writeln(&self, output: &str) {
+        println!("{}", output);
+    }
+}

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -9,8 +9,8 @@ use {
             RuntimeFunction,
         },
         value_iterator::{IntRange, Iterable, ValueIterator, ValueIteratorOutput},
-        vm_error, Loader, RuntimeError, RuntimeResult, Value, ValueList, ValueMap, ValueNumber,
-        ValueString, ValueVec,
+        vm_error, DefaultLogger, KotoLogger, Loader, RuntimeError, RuntimeResult, Value, ValueList,
+        ValueMap, ValueNumber, ValueString, ValueVec,
     },
     koto_bytecode::{Chunk, Instruction, InstructionReader, TypeId},
     koto_parser::ConstantIndex,
@@ -40,10 +40,17 @@ pub type InstructionResult = Result<(), RuntimeError>;
 struct SharedContext {
     pub prelude: ValueMap,
     core_lib: CoreLib,
+    logger: Arc<dyn KotoLogger>,
 }
 
 impl Default for SharedContext {
     fn default() -> Self {
+        Self::with_logger(Arc::new(DefaultLogger {}))
+    }
+}
+
+impl SharedContext {
+    fn with_logger(logger: Arc<dyn KotoLogger>) -> Self {
         let core_lib = CoreLib::default();
 
         let mut prelude = ValueMap::default();
@@ -60,7 +67,11 @@ impl Default for SharedContext {
         prelude.add_map("thread", core_lib.thread.clone());
         prelude.add_map("tuple", core_lib.tuple.clone());
 
-        Self { prelude, core_lib }
+        Self {
+            prelude,
+            core_lib,
+            logger,
+        }
     }
 }
 
@@ -103,6 +114,18 @@ impl Drop for ModuleContext {
     }
 }
 
+pub struct VmSettings {
+    pub logger: Arc<dyn KotoLogger>,
+}
+
+impl Default for VmSettings {
+    fn default() -> Self {
+        Self {
+            logger: Arc::new(DefaultLogger {}),
+        }
+    }
+}
+
 pub struct Vm {
     context: Arc<RwLock<ModuleContext>>,
     context_shared: Arc<SharedContext>,
@@ -114,18 +137,22 @@ pub struct Vm {
 
 impl Default for Vm {
     fn default() -> Self {
+        Self::with_settings(VmSettings::default())
+    }
+}
+
+impl Vm {
+    pub fn with_settings(settings: VmSettings) -> Self {
         Self {
             context: Arc::new(RwLock::new(ModuleContext::default())),
-            context_shared: Arc::new(SharedContext::default()),
+            context_shared: Arc::new(SharedContext::with_logger(settings.logger)),
             reader: InstructionReader::default(),
             value_stack: Vec::with_capacity(32),
             call_stack: vec![],
             stop_flag: None,
         }
     }
-}
 
-impl Vm {
     pub fn spawn_new_vm(&mut self) -> Self {
         Self {
             context: Arc::new(RwLock::new(self.context().spawn_new_context())),
@@ -174,6 +201,10 @@ impl Vm {
 
     fn context_mut(&mut self) -> RwLockWriteGuard<ModuleContext> {
         self.context.write()
+    }
+
+    pub fn logger(&self) -> &Arc<dyn KotoLogger> {
+        &self.context_shared.logger
     }
 
     pub fn get_global_value(&self, id: &str) -> Option<Value> {
@@ -2186,7 +2217,12 @@ impl Vm {
             (None, None) => "[#ERR] ".to_string(),
         };
         let value = self.get_register(register);
-        println!("{}{}: {}", prefix, self.get_constant_str(constant), value);
+        self.logger().writeln(&format!(
+            "{}{}: {}",
+            prefix,
+            self.get_constant_str(constant),
+            value
+        ));
     }
 
     fn run_check_type(&self, register: u8, type_id: TypeId) -> Result<(), RuntimeError> {

--- a/src/runtime/tests/logger.rs
+++ b/src/runtime/tests/logger.rs
@@ -1,5 +1,5 @@
 use {
-    koto_bytecode::{chunk_to_string_annotated, Chunk},
+    koto_bytecode::Chunk,
     koto_runtime::{KotoLogger, Loader, Vm, VmSettings},
     parking_lot::Mutex,
     std::sync::Arc,
@@ -34,7 +34,7 @@ mod vm {
             println!("Constants\n---------\n{}\n", chunk.constants.to_string());
             println!(
                 "Instructions\n------------\n{}",
-                chunk_to_string_annotated(chunk, &script_lines)
+                Chunk::instructions_as_string(chunk, &script_lines)
             );
         };
 

--- a/src/runtime/tests/logger.rs
+++ b/src/runtime/tests/logger.rs
@@ -1,0 +1,85 @@
+use {
+    koto_bytecode::{chunk_to_string_annotated, Chunk},
+    koto_runtime::{KotoLogger, Loader, Vm, VmSettings},
+    parking_lot::Mutex,
+    std::sync::Arc,
+};
+
+struct TestLogger {
+    output: Arc<Mutex<Vec<String>>>,
+}
+
+impl KotoLogger for TestLogger {
+    fn writeln(&self, s: &str) {
+        self.output.lock().push(s.to_string());
+    }
+}
+
+mod vm {
+    use super::*;
+
+    fn check_logged_output(script: &str, expected_output: &[String]) {
+        let output = Arc::new(Mutex::new(Vec::new()));
+
+        let mut vm = Vm::with_settings(VmSettings {
+            logger: Arc::new(TestLogger {
+                output: output.clone(),
+            }),
+        });
+
+        let print_chunk = |script: &str, chunk: Arc<Chunk>| {
+            println!("{}\n", script);
+            let script_lines = script.lines().collect::<Vec<_>>();
+
+            println!("Constants\n---------\n{}\n", chunk.constants.to_string());
+            println!(
+                "Instructions\n------------\n{}",
+                chunk_to_string_annotated(chunk, &script_lines)
+            );
+        };
+
+        let mut loader = Loader::default();
+        let chunk = match loader.compile_script(script, &None) {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                print_chunk(script, vm.chunk());
+                panic!("Error while compiling script: {}", error);
+            }
+        };
+
+        match vm.run(chunk) {
+            Ok(_) => {
+                assert_eq!(output.lock().as_slice(), expected_output);
+            }
+            Err(e) => {
+                print_chunk(script, vm.chunk());
+                panic!(format!("Error while running script: {}", e.to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn print_loop() {
+        let script = r#"
+for i in 0..5
+  "foo {}".print i
+"#;
+        check_logged_output(
+            &script,
+            &[
+                "foo 0".to_string(),
+                "foo 1".to_string(),
+                "foo 2".to_string(),
+                "foo 3".to_string(),
+                "foo 4".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn debug() {
+        let script = "debug 2 + 2";
+
+        check_logged_output(&script, &["[1] 2 + 2: 4".to_string()]);
+    }
+}

--- a/src/runtime/tests/runtime_failures.rs
+++ b/src/runtime/tests/runtime_failures.rs
@@ -1,6 +1,6 @@
 mod runtime {
     use {
-        koto_bytecode::chunk_to_string_annotated,
+        koto_bytecode::Chunk,
         koto_runtime::{Loader, Vm},
     };
 
@@ -11,7 +11,7 @@ mod runtime {
             println!("{}\n", script);
             let script_lines = script.lines().collect::<Vec<_>>();
 
-            println!("{}", chunk_to_string_annotated(chunk, &script_lines));
+            println!("{}", Chunk::instructions_as_string(chunk, &script_lines));
         };
 
         let mut loader = Loader::default();

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1,6 +1,6 @@
 mod vm {
     use {
-        koto_bytecode::{chunk_to_string_annotated, Chunk},
+        koto_bytecode::Chunk,
         koto_runtime::{
             external_error, num2, num4, type_as_string, IntRange, Loader, Value, Value::*,
             ValueHashMap, ValueList, ValueMap, Vm,
@@ -39,7 +39,7 @@ mod vm {
             println!("Constants\n---------\n{}\n", chunk.constants.to_string());
             println!(
                 "Instructions\n------------\n{}",
-                chunk_to_string_annotated(chunk, &script_lines)
+                Chunk::instructions_as_string(chunk, &script_lines)
             );
         };
 


### PR DESCRIPTION
This PR adds initial support for compiling Koto to Wasm, and includes a basic
example of a simple Koto editor in a website.
