### PR TITLE
Allow access to the export map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Direct access to the module's export map is now allowed via `koto.exports()`.
 - Captured values in functions are now immutable.
   - e.g.
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Added
 
+- Direct access to the module's export map is now allowed via `koto.exports()`.
 - Logging behaviour via print and debug logging can now be customized.
 - Koto can now be compiled to wasm.
 
 
 ### Changed
-- Direct access to the module's export map is now allowed via `koto.exports()`.
 - Captured values in functions are now immutable.
   - e.g.
     ```

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -28,3 +28,8 @@ export tests =
     assert_eq x, 42
     assert_eq y, -1
 
+  test_access_export: ||
+    import koto
+    x = "value_x"
+    koto.exports().insert x, 99
+    assert_eq value_x, 99

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -19,6 +19,9 @@ pub fn make_module() -> ValueMap {
         Ok(Value::Map(vm.context_mut().global.clone()))
     });
 
+    result.add_value("script_dir", Str("".into()));
+    result.add_value("script_path", Str("".into()));
+
     result.add_fn("type", |vm, args| match vm.get_args(args) {
         [value] => Ok(Str(type_as_string(value).into())),
         _ => external_error!("koto.type: Expected single argument"),

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -15,8 +15,9 @@ pub fn make_module() -> ValueMap {
         Ok(result)
     });
 
-    result.add_value("script_dir", Str("".into()));
-    result.add_value("script_path", Str("".into()));
+    result.add_fn("exports", |vm, _| {
+        Ok(Value::Map(vm.context_mut().global.clone()))
+    });
 
     result.add_fn("type", |vm, args| match vm.get_args(args) {
         [value] => Ok(Str(type_as_string(value).into())),

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -67,7 +67,8 @@ impl Default for SharedContext {
 /// VM Context shared by VMs running in the same module
 #[derive(Default)]
 pub struct ModuleContext {
-    global: ValueMap,
+    /// Global context.
+    pub global: ValueMap,
     loader: Loader,
     modules: HashMap<PathBuf, Option<ValueMap>>,
     spawned_stop_flags: Vec<Arc<AtomicBool>>,
@@ -172,7 +173,8 @@ impl Vm {
         self.context.read()
     }
 
-    fn context_mut(&mut self) -> RwLockWriteGuard<ModuleContext> {
+    /// Access module context.
+    pub fn context_mut(&mut self) -> RwLockWriteGuard<ModuleContext> {
         self.context.write()
     }
 


### PR DESCRIPTION
Closes #46 

Adds a function `exports` to the koto module. The function returns `ValueMap`, which represents the module's context. So now it's possible to modify the module's exports programmatically.

The PR changes `Vm::context_mut` to public method. It also makes `ModuleContext::global` a public field.