### PR TITLE
Add bitwise operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
     debug state.x # 142
     ```
 - Runtime errors now provide a full backtrace.
+- Keywords can now be used as identifiers in lookups, e.g. `foo.and()` was
+  previously disallowed.
 
 
 ## [0.6.0] 2021.01.21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
     assert_eq 0o1000, 512
     assert_eq 0x1000, 4096
     ```
+- Bitwise operations are now available for integers.
+  - `number.and`
+  - `number.flip_bits`
+  - `number.or`
+  - `number.shift_left`
+  - `number.shift_right`
+  - `number.xor`
 
 ### Changed
 - Captured values in functions are now immutable.

--- a/koto/tests/number_ops.koto
+++ b/koto/tests/number_ops.koto
@@ -15,6 +15,10 @@ export tests =
     assert_eq 0.acos(), pi / 2
     assert_eq 1.acos(), 0
 
+  test_and: ||
+    assert_eq (0b10101.and 0b00111), 0b00101
+    assert_eq (-1.and 1), 1
+
   test_asin: ||
     assert_eq 0.asin(), 0
     assert_eq 1.asin(), pi / 2
@@ -54,6 +58,11 @@ export tests =
     assert_eq 0.exp2(), 1
     assert_eq 2.exp2(), 4
 
+  test_flip_bits: ||
+    assert_eq -1.flip_bits(), 0
+    assert_eq 0.flip_bits(), -1
+    assert_eq 8.flip_bits(), -9
+
   test_floor: ||
     assert_eq 1.5.floor(), 1
     assert_eq -1.2.floor(), -2
@@ -82,6 +91,10 @@ export tests =
   test_min: ||
     assert_eq (1.min 2), 1
 
+  test_or: ||
+    assert_eq (0b10101.or 0b01010), 0b11111
+    assert_eq (-1.or 1), -1
+
   test_pow: ||
     assert_eq (2.pow 8), 256
     assert_eq (4.pow 1.5), 8
@@ -96,6 +109,14 @@ export tests =
     assert_eq 0.recip(), infinity
     assert_eq 2.recip(), 0.5
     assert_eq 4.recip(), 0.25
+
+  test_shift_left: ||
+    assert_eq 0b10101.shift_left(1), 0b101010
+    assert_eq 2.shift_left(3), 16
+
+  test_shift_right: ||
+    assert_eq 0b10101.shift_right(1), 0b1010
+    assert_eq 256.shift_right(3), 32
 
   test_sin: ||
     assert_near 0.sin(), 0, epsilon
@@ -129,3 +150,7 @@ export tests =
     assert_eq type(x), "Float"
     assert_eq type(x.to_int()), "Int"
     assert_eq x.to_int(), x
+
+  test_xor: ||
+    assert_eq (0b10101.xor 0b01011), 0b11110
+    assert_eq (-1.xor 1), -2


### PR DESCRIPTION
This PR adds bitwise operations to the `number` module.

  - `number.and`
  - `number.flip_bits`
  - `number.or`
  - `number.shift_left`
  - `number.shift_right`
  - `number.xor`

```coffee
assert_eq (0b10101.and 0b00111), 0b00101
assert_eq (0b10101.shift_left 1), 0b101010
```

Closes #37, see the issue for some discussion regarding why these operations are being exposed as module functions rather than via operators.