### PR TITLE
Add support for throw expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@
   - `number.shift_left`
   - `number.shift_right`
   - `number.xor`
+- `throw` can now be used for throwing errors.
+  - Strings can be used as an error message:
+    `throw "Was für ein Fehler!"`
+  - Maps that implement `@display` can also be thrown:
+    ```
+    throw
+      data: foo
+      @display: |self| "Che errore! - {}".format self.data
+    ```
+
 
 ### Changed
 - Captured values in functions are now immutable.

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -1,7 +1,7 @@
 use {
     crate::Poetry,
     koto::runtime::{
-        external_error, get_external_instance, is_external_instance, visit_external_value,
+        get_external_instance, is_external_instance, runtime_error, visit_external_value,
         ExternalValue, Value, ValueIterator, ValueIteratorOutput, ValueMap,
     },
     std::fmt,
@@ -19,11 +19,11 @@ pub fn make_module() -> ValueMap {
                 poetry.add_links(text);
                 Ok(Map(KotoPoetry::make_value_map(poetry)))
             }
-            [unexpected] => external_error!(
+            [unexpected] => runtime_error!(
                 "poetry.new: Expected a String as argument, found '{}'",
                 unexpected.type_as_string(),
             ),
-            _ => external_error!("poetry.new: Expected a String as argument"),
+            _ => runtime_error!("poetry.new: Expected a String as argument"),
         }
     });
 
@@ -47,7 +47,7 @@ impl KotoPoetry {
                         poetry.0.add_links(text);
                         Ok(Empty)
                     }
-                    _ => external_error!("poetry.add_links: Expected a String as argument"),
+                    _ => runtime_error!("poetry.add_links: Expected a String as argument"),
                 }
             })
         });
@@ -73,10 +73,10 @@ impl KotoPoetry {
 
                     Ok(Iterator(ValueIterator::make_external(iter)))
                 } else {
-                    external_error!("poetry.iter: Missing Poetry instance")
+                    runtime_error!("poetry.iter: Missing Poetry instance")
                 }
             }
-            _ => external_error!("poetry.iter: Expected Poetry instance as argument"),
+            _ => runtime_error!("poetry.iter: Expected Poetry instance as argument"),
         });
 
         result.add_instance_fn("next_word", |vm, args| {

--- a/libs/json/src/lib.rs
+++ b/libs/json/src/lib.rs
@@ -1,7 +1,7 @@
 //! A Koto language module for working with JSON data
 
 use {
-    koto_runtime::{external_error, Value, ValueList, ValueMap, ValueVec},
+    koto_runtime::{runtime_error, Value, ValueList, ValueMap, ValueVec},
     koto_serialize::SerializableValue,
     serde_json::Value as JsonValue,
 };
@@ -49,22 +49,22 @@ pub fn make_module() -> ValueMap {
         [Str(s)] => match serde_json::from_str(&s) {
             Ok(value) => match json_value_to_koto_value(&value) {
                 Ok(result) => Ok(result),
-                Err(e) => external_error!("json.from_string: Error while parsing input: {}", e),
+                Err(e) => runtime_error!("json.from_string: Error while parsing input: {}", e),
             },
-            Err(e) => external_error!(
+            Err(e) => runtime_error!(
                 "json.from_string: Error while parsing input: {}",
                 e.to_string()
             ),
         },
-        _ => external_error!("json.from_string expects a string as argument"),
+        _ => runtime_error!("json.from_string expects a string as argument"),
     });
 
     result.add_fn("to_string", |vm, args| match vm.get_args(args) {
         [value] => match serde_json::to_string_pretty(&SerializableValue(value)) {
             Ok(result) => Ok(Str(result.into())),
-            Err(e) => external_error!("json.to_string: {}", e),
+            Err(e) => runtime_error!("json.to_string: {}", e),
         },
-        _ => external_error!("json.to_string expects a single argument"),
+        _ => runtime_error!("json.to_string expects a single argument"),
     });
 
     result

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -2,7 +2,7 @@
 
 use {
     koto_runtime::{
-        external_error, get_external_instance, num2, num4, ExternalValue, Value, ValueMap,
+        get_external_instance, num2, num4, runtime_error, ExternalValue, Value, ValueMap,
     },
     rand::{Rng, SeedableRng},
     rand_chacha::ChaCha20Rng,
@@ -21,7 +21,7 @@ pub fn make_module() -> ValueMap {
         [Number(n)] => Ok(Map(ChaChaRng::make_value_map(ChaCha20Rng::seed_from_u64(
             n.to_bits(),
         )))),
-        _ => external_error!("random.generator - expected no arguments, or seed number"),
+        _ => runtime_error!("random.generator - expected no arguments, or seed number"),
     });
 
     result
@@ -89,7 +89,7 @@ impl ChaChaRng {
                         let index = rng.0.gen_range(0, size);
                         Ok(Number((start + index).into()))
                     }
-                    _ => external_error!("random.pick - expected list or range as argument"),
+                    _ => runtime_error!("random.pick - expected list or range as argument"),
                 }
             })
         });
@@ -102,7 +102,7 @@ impl ChaChaRng {
                         *rng = ChaChaRng(ChaCha20Rng::seed_from_u64(n.to_bits()));
                         Ok(Empty)
                     }
-                    _ => external_error!("random.seed - expected number as argument"),
+                    _ => runtime_error!("random.seed - expected number as argument"),
                 }
             })
         });

--- a/libs/tempfile/src/lib.rs
+++ b/libs/tempfile/src/lib.rs
@@ -2,7 +2,7 @@
 
 use koto_runtime::{
     core::io::{make_file_map, File},
-    external_error, Value, ValueMap,
+    runtime_error, Value, ValueMap,
 };
 
 pub fn make_module() -> ValueMap {
@@ -14,9 +14,9 @@ pub fn make_module() -> ValueMap {
         |_, _| match tempfile::NamedTempFile::new() {
             Ok(file) => match file.keep() {
                 Ok((_temp_file, path)) => Ok(Str(path.to_string_lossy().as_ref().into())),
-                Err(e) => external_error!("io.temp_file: Error while making temp path: {}", e),
+                Err(e) => runtime_error!("io.temp_file: Error while making temp path: {}", e),
             },
-            Err(e) => external_error!("io.temp_file: Error while making temp path: {}", e),
+            Err(e) => runtime_error!("io.temp_file: Error while making temp path: {}", e),
         }
     });
 
@@ -26,14 +26,14 @@ pub fn make_module() -> ValueMap {
                 Ok(file) => match file.keep() {
                     Ok((temp_file, path)) => (temp_file, path),
                     Err(e) => {
-                        return external_error!(
+                        return runtime_error!(
                             "io.temp_file: Error while creating temp file: {}",
                             e,
                         );
                     }
                 },
                 Err(e) => {
-                    return external_error!("io.temp_file: Error while creating temp file: {}", e);
+                    return runtime_error!("io.temp_file: Error while creating temp file: {}", e);
                 }
             };
 

--- a/libs/toml/src/lib.rs
+++ b/libs/toml/src/lib.rs
@@ -1,7 +1,7 @@
 //! A Koto language module for working with TOML data
 
 use {
-    koto_runtime::{external_error, Value, ValueList, ValueMap, ValueVec},
+    koto_runtime::{runtime_error, Value, ValueList, ValueMap, ValueVec},
     koto_serialize::SerializableValue,
     toml::Value as Toml,
 };
@@ -44,22 +44,22 @@ pub fn make_module() -> ValueMap {
         [Str(s)] => match toml::from_str(s) {
             Ok(toml) => match toml_to_koto_value(&toml) {
                 Ok(result) => Ok(result),
-                Err(e) => external_error!("toml.from_string: Error while parsing input: {}", e),
+                Err(e) => runtime_error!("toml.from_string: Error while parsing input: {}", e),
             },
-            Err(e) => external_error!(
+            Err(e) => runtime_error!(
                 "toml.from_string: Error while parsing input: {}",
                 e.to_string()
             ),
         },
-        _ => external_error!("toml.from_string expects a string as argument"),
+        _ => runtime_error!("toml.from_string expects a string as argument"),
     });
 
     result.add_fn("to_string", |vm, args| match vm.get_args(args) {
         [value] => match toml::to_string_pretty(&SerializableValue(value)) {
             Ok(result) => Ok(Str(result.into())),
-            Err(e) => external_error!("toml.to_string: {}", e),
+            Err(e) => runtime_error!("toml.to_string: {}", e),
         },
-        _ => external_error!("toml.to_string expects a single argument"),
+        _ => runtime_error!("toml.to_string expects a single argument"),
     });
 
     result

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -707,6 +707,19 @@ impl Compiler {
 
                 result
             }
+            Node::Throw(expression) => {
+                let expression_register = self
+                    .compile_node(ResultRegister::Any, ast.node(*expression), ast)?
+                    .unwrap();
+
+                self.push_op(Throw, &[expression_register.register]);
+
+                if expression_register.is_temporary {
+                    self.pop_register()?;
+                }
+
+                None
+            }
             Node::Try(try_expression) => {
                 self.compile_try_expression(result_register, try_expression, ast)?
             }

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -266,6 +266,9 @@ pub enum Instruction {
     Yield {
         register: u8,
     },
+    Throw {
+        register: u8,
+    },
     Size {
         register: u8,
         value: u8,
@@ -410,6 +413,7 @@ impl fmt::Display for Instruction {
             CallChild { .. } => write!(f, "CallChild"),
             Return { .. } => write!(f, "Return"),
             Yield { .. } => write!(f, "Yield"),
+            Throw { .. } => write!(f, "Throw"),
             Size { .. } => write!(f, "Size"),
             IterNext { .. } => write!(f, "IterNext"),
             IterNextTemp { .. } => write!(f, "IterNextTemp"),
@@ -677,6 +681,7 @@ impl fmt::Debug for Instruction {
             ),
             Return { register } => write!(f, "Return\t\tresult: {}", register),
             Yield { register } => write!(f, "Yield\t\tresult: {}", register),
+            Throw { register } => write!(f, "Throw\t\tresult: {}", register),
             Size { register, value } => write!(f, "Size\t\tresult: {}\tvalue: {}", register, value),
             IterNext {
                 register,
@@ -1143,6 +1148,9 @@ impl Iterator for InstructionReader {
                 register: get_byte!(),
             }),
             Op::Yield => Some(Yield {
+                register: get_byte!(),
+            }),
+            Op::Throw => Some(Throw {
                 register: get_byte!(),
             }),
             Op::Size => Some(Size {

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -61,6 +61,7 @@ pub enum Op {
     CallChild,        // result, function, arg register, arg count, parent
     Return,           // register
     Yield,            // register
+    Throw,            // register
     IterNext,         // output, iterator, jump offset[2]
     IterNextTemp,     // output, iterator, jump offset[2]
     IterNextQuiet,    // iterator, jump offset[2]
@@ -84,7 +85,6 @@ pub enum Op {
     Debug,            // register, constant[4]
     CheckType,        // register, type (see TypeId)
     CheckSize,        // register, size
-    Unused80,
     Unused81,
     Unused82,
     Unused83,

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -134,10 +134,10 @@ fn main() {
                 }
                 match koto.run_with_args(&args.script_args) {
                     Ok(_) => {}
-                    Err(e) => eprintln!("{}", e),
+                    Err(e) => eprintln!("Error: {}", e),
                 }
             }
-            Err(e) => eprintln!("{}", e),
+            Err(e) => eprintln!("Error: {}", e),
         }
     } else {
         let mut repl = Repl::with_settings(

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -80,6 +80,7 @@ pub enum Token {
     Return,
     Switch,
     Then,
+    Throw,
     True,
     Try,
     Until,
@@ -405,6 +406,7 @@ impl<'a> TokenLexer<'a> {
             check_keyword!("return", Return);
             check_keyword!("switch", Switch);
             check_keyword!("then", Then);
+            check_keyword!("throw", Throw);
             check_keyword!("true", True);
             check_keyword!("try", Try);
             check_keyword!("until", Until);

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -90,6 +90,7 @@ pub enum Node {
     ReturnExpression(AstIndex),
     Negate(AstIndex),
     Try(AstTry),
+    Throw(AstIndex),
     Yield(AstIndex),
     Debug {
         expression_string: ConstantIndex,
@@ -150,6 +151,7 @@ impl fmt::Display for Node {
             Return => write!(f, "Return"),
             ReturnExpression(_) => write!(f, "ReturnExpression"),
             Try { .. } => write!(f, "Try"),
+            Throw(_) => write!(f, "Throw"),
             Yield { .. } => write!(f, "Yield"),
             Debug { .. } => write!(f, "Debug"),
         }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3500,6 +3500,68 @@ finally
                 Some(&[Constant::Str("f"), Constant::Str("e")]),
             )
         }
+
+        #[test]
+        fn throw_value() {
+            let source = "throw x";
+            check_ast(
+                source,
+                &[
+                    Id(0),
+                    Throw(0),
+                    MainBlock {
+                        body: vec![1],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x")]),
+            )
+        }
+
+        #[test]
+        fn throw_string() {
+            let source = r#"throw "error!""#;
+            check_ast(
+                source,
+                &[
+                    Str(0),
+                    Throw(0),
+                    MainBlock {
+                        body: vec![1],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("error!")]),
+            )
+        }
+
+        #[test]
+        fn throw_map() {
+            let source = r#"
+throw
+  data: x
+  message: "error!"
+"#;
+            check_ast(
+                source,
+                &[
+                    Id(1),
+                    Str(3),
+                    Map(vec![(MapKey::Id(0), Some(0)), (MapKey::Id(2), Some(1))]),
+                    Throw(2),
+                    MainBlock {
+                        body: vec![3],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("data"),
+                    Constant::Str("x"),
+                    Constant::Str("message"),
+                    Constant::Str("error!"),
+                ]),
+            )
+        }
     }
 
     mod match_and_switch {

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    external_error,
+    runtime_error,
     value_iterator::{
         make_iterator, ValueIterator, ValueIteratorOutput as Output, ValueIteratorResult,
     },
@@ -26,7 +26,7 @@ pub fn make_module() -> ValueMap {
                             }
                         }
                         Ok(unexpected) => {
-                            return external_error!(
+                            return runtime_error!(
                                 "iterator.all: Predicate should return a bool, found '{}'",
                                 unexpected.type_as_string()
                             )
@@ -40,7 +40,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Bool(true))
         }
-        _ => external_error!("iterator.all: Expected iterable and function as arguments"),
+        _ => runtime_error!("iterator.all: Expected iterable and function as arguments"),
     });
 
     result.add_fn("any", |vm, args| match vm.get_args(args) {
@@ -58,7 +58,7 @@ pub fn make_module() -> ValueMap {
                             }
                         }
                         Ok(unexpected) => {
-                            return external_error!(
+                            return runtime_error!(
                                 "iterator.any: Predicate should return a bool, found '{}'",
                                 unexpected.type_as_string()
                             )
@@ -72,7 +72,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Bool(false))
         }
-        _ => external_error!("iterator.any: Expected iterable and function as arguments"),
+        _ => runtime_error!("iterator.any: Expected iterable and function as arguments"),
     });
 
     result.add_fn("chain", |vm, args| match vm.get_args(args) {
@@ -84,7 +84,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
-        _ => external_error!("iterator.chain: Expected two iterables as arguments"),
+        _ => runtime_error!("iterator.chain: Expected two iterables as arguments"),
     });
 
     result.add_fn("consume", |vm, args| match vm.get_args(args) {
@@ -97,7 +97,7 @@ pub fn make_module() -> ValueMap {
             }
             Ok(Empty)
         }
-        _ => external_error!("iterator.consume: Expected iterable as argument"),
+        _ => runtime_error!("iterator.consume: Expected iterable as argument"),
     });
 
     result.add_fn("count", |vm, args| match vm.get_args(args) {
@@ -112,7 +112,7 @@ pub fn make_module() -> ValueMap {
             }
             Ok(Number(result.into()))
         }
-        _ => external_error!("iterator.count: Expected iterable as argument"),
+        _ => runtime_error!("iterator.count: Expected iterable as argument"),
     });
 
     result.add_fn("each", |vm, args| match vm.get_args(args) {
@@ -132,7 +132,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
-        _ => external_error!("iterator.each: Expected iterable and function as arguments"),
+        _ => runtime_error!("iterator.each: Expected iterable and function as arguments"),
     });
 
     result.add_fn("enumerate", |vm, args| match vm.get_args(args) {
@@ -147,7 +147,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
-        _ => external_error!("iterator.enumerate: Expected iterable as argument"),
+        _ => runtime_error!("iterator.enumerate: Expected iterable as argument"),
     });
 
     result.add_fn("fold", |vm, args| {
@@ -186,7 +186,7 @@ pub fn make_module() -> ValueMap {
                     _ => unreachable!(),
                 }
             }
-            _ => external_error!(
+            _ => runtime_error!(
                 "iterator.fold: Expected iterable, initial value, and function as arguments"
             ),
         }
@@ -211,7 +211,7 @@ pub fn make_module() -> ValueMap {
                                     }
                                 }
                                 Ok(unexpected) => {
-                                    return Some(external_error!(
+                                    return Some(runtime_error!(
                                         "iterator.keep expects a Bool to be returned from the \
                                          predicate, found '{}'",
                                         unexpected.type_as_string(),
@@ -227,7 +227,7 @@ pub fn make_module() -> ValueMap {
                 None
             })))
         }
-        _ => external_error!("iterator.keep: Expected iterable and function as arguments"),
+        _ => runtime_error!("iterator.keep: Expected iterable and function as arguments"),
     });
 
     result.add_fn("max", |vm, args| match vm.get_args(args) {
@@ -248,7 +248,7 @@ pub fn make_module() -> ValueMap {
                                 Ok(Bool(true)) => value,
                                 Ok(Bool(false)) => result,
                                 Ok(unexpected) => {
-                                    return external_error!(
+                                    return runtime_error!(
                                         "iterator.max: \
                                          Expected Bool from < comparison, found '{}'",
                                         unexpected.type_as_string()
@@ -266,7 +266,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(result.unwrap_or(Empty))
         }
-        _ => external_error!("iterator.max: Expected iterable as argument"),
+        _ => runtime_error!("iterator.max: Expected iterable as argument"),
     });
 
     result.add_fn("min", |vm, args| match vm.get_args(args) {
@@ -287,7 +287,7 @@ pub fn make_module() -> ValueMap {
                                 Ok(Bool(true)) => result,
                                 Ok(Bool(false)) => value,
                                 Ok(unexpected) => {
-                                    return external_error!(
+                                    return runtime_error!(
                                         "iterator.min: \
                                          Expected Bool from < comparison, found '{}'",
                                         unexpected.type_as_string()
@@ -305,7 +305,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(result.unwrap_or(Empty))
         }
-        _ => external_error!("iterator.min: Expected iterable as argument"),
+        _ => runtime_error!("iterator.min: Expected iterable as argument"),
     });
 
     result.add_fn("min_max", |vm, args| match vm.get_args(args) {
@@ -319,7 +319,7 @@ pub fn make_module() -> ValueMap {
                     Ok(Bool(true)) => Ok(a),
                     Ok(Bool(false)) => Ok(b),
                     Ok(unexpected) => {
-                        return external_error!(
+                        return runtime_error!(
                             "iterator.min_max: \
                              Expected Bool from {} comparison, found '{}'",
                             op,
@@ -348,7 +348,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(result.map_or(Empty, |(min, max)| Tuple(vec![min, max].into())))
         }
-        _ => external_error!("iterator.min_max: Expected iterable as argument"),
+        _ => runtime_error!("iterator.min_max: Expected iterable as argument"),
     });
 
     result.add_fn("next", |vm, args| match vm.get_args(args) {
@@ -361,7 +361,7 @@ pub fn make_module() -> ValueMap {
             };
             Ok(result)
         }
-        _ => external_error!("iterator.next: Expected iterator as argument"),
+        _ => runtime_error!("iterator.next: Expected iterator as argument"),
     });
 
     result.add_fn("position", |vm, args| match vm.get_args(args) {
@@ -380,7 +380,7 @@ pub fn make_module() -> ValueMap {
                                 }
                             }
                             Ok(unexpected) => {
-                                return external_error!(
+                                return runtime_error!(
                                     "iterator.position expects a Bool to be returned from the \
                                      predicate, found '{}'",
                                     unexpected.type_as_string(),
@@ -396,7 +396,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Empty)
         }
-        _ => external_error!("iterator.position: Expected iterable and function as arguments"),
+        _ => runtime_error!("iterator.position: Expected iterable and function as arguments"),
     });
 
     result.add_fn("product", |vm, args| {
@@ -405,7 +405,7 @@ pub fn make_module() -> ValueMap {
             [iterable, initial_value] if iterable.is_iterable() => {
                 (iterable.clone(), initial_value.clone())
             }
-            _ => return external_error!("iterator.product: Expected iterable as argument"),
+            _ => return runtime_error!("iterator.product: Expected iterable as argument"),
         };
 
         fold_with_operator(vm, iterable, initial_value, BinaryOp::Multiply)
@@ -425,7 +425,7 @@ pub fn make_module() -> ValueMap {
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
         _ => {
-            external_error!("iterator.skip: Expected iterable and non-negative number as arguments")
+            runtime_error!("iterator.skip: Expected iterable and non-negative number as arguments")
         }
     });
 
@@ -435,7 +435,7 @@ pub fn make_module() -> ValueMap {
             [iterable, initial_value] if iterable.is_iterable() => {
                 (iterable.clone(), initial_value.clone())
             }
-            _ => return external_error!("iterator.sum: Expected iterable as argument"),
+            _ => return runtime_error!("iterator.sum: Expected iterable as argument"),
         };
 
         fold_with_operator(vm, iterable, initial_value, BinaryOp::Add)
@@ -449,7 +449,7 @@ pub fn make_module() -> ValueMap {
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
         _ => {
-            external_error!("iterator.take: Expected iterable and non-negative number as arguments")
+            runtime_error!("iterator.take: Expected iterable and non-negative number as arguments")
         }
     });
 
@@ -469,7 +469,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(List(ValueList::with_data(result)))
         }
-        _ => external_error!("iterator.to_list: Expected iterable as argument"),
+        _ => runtime_error!("iterator.to_list: Expected iterable as argument"),
     });
 
     result.add_fn("to_map", |vm, args| match vm.get_args(args) {
@@ -497,7 +497,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Map(ValueMap::with_data(result)))
         }
-        _ => external_error!("iterator.to_map: Expected iterator as argument"),
+        _ => runtime_error!("iterator.to_map: Expected iterator as argument"),
     });
 
     result.add_fn("to_tuple", |vm, args| match vm.get_args(args) {
@@ -516,7 +516,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Tuple(result.into()))
         }
-        _ => external_error!("iterator.to_tuple: Expected iterable as argument"),
+        _ => runtime_error!("iterator.to_tuple: Expected iterable as argument"),
     });
 
     result.add_fn("zip", |vm, args| match vm.get_args(args) {
@@ -534,7 +534,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
-        _ => external_error!("iterator.zip: Expected two iterables as arguments"),
+        _ => runtime_error!("iterator.zip: Expected two iterables as arguments"),
     });
 
     result

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -1,4 +1,4 @@
-use crate::{external_error, Value, ValueList, ValueMap};
+use crate::{runtime_error, Value, ValueList, ValueMap};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -24,7 +24,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("type", |vm, args| match vm.get_args(args) {
         [value] => Ok(Str(value.type_as_string().into())),
-        _ => external_error!("koto.type: Expected single argument"),
+        _ => runtime_error!("koto.type: Expected single argument"),
     });
 
     result

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        external_error,
+        runtime_error,
         value_sort::{compare_values, sort_values},
         BinaryOp, Value, ValueIterator, ValueList, ValueMap,
     },
@@ -18,7 +18,7 @@ pub fn make_module() -> ValueMap {
             l.data_mut().clear();
             Ok(Empty)
         }
-        _ => external_error!("list.clear: Expected list as argument"),
+        _ => runtime_error!("list.clear: Expected list as argument"),
     });
 
     result.add_fn("contains", |vm, args| match vm.get_args(args) {
@@ -31,7 +31,7 @@ pub fn make_module() -> ValueMap {
                     Ok(Bool(false)) => {}
                     Ok(Bool(true)) => return Ok(true.into()),
                     Ok(unexpected) => {
-                        return external_error!(
+                        return runtime_error!(
                             "list.contains: Expected Bool from comparison, found '{}'",
                             unexpected.type_as_string()
                         )
@@ -41,17 +41,17 @@ pub fn make_module() -> ValueMap {
             }
             Ok(false.into())
         }
-        _ => external_error!("list.contains: Expected list and value as arguments"),
+        _ => runtime_error!("list.contains: Expected list and value as arguments"),
     });
 
     result.add_fn("copy", |vm, args| match vm.get_args(args) {
         [List(l)] => Ok(List(ValueList::with_data(l.data().clone()))),
-        _ => external_error!("list.copy: Expected list as argument"),
+        _ => runtime_error!("list.copy: Expected list as argument"),
     });
 
     result.add_fn("deep_copy", |vm, args| match vm.get_args(args) {
         [value @ List(_)] => Ok(value.deep_copy()),
-        _ => external_error!("list.deep_copy: Expected list as argument"),
+        _ => runtime_error!("list.deep_copy: Expected list as argument"),
     });
 
     result.add_fn("fill", |vm, args| match vm.get_args(args) {
@@ -61,7 +61,7 @@ pub fn make_module() -> ValueMap {
             }
             Ok(Empty)
         }
-        _ => external_error!("list.fill: Expected list and value as arguments"),
+        _ => runtime_error!("list.fill: Expected list and value as arguments"),
     });
 
     result.add_fn("first", |vm, args| match vm.get_args(args) {
@@ -69,46 +69,46 @@ pub fn make_module() -> ValueMap {
             Some(value) => Ok(value.clone()),
             None => Ok(Empty),
         },
-        _ => external_error!("list.first: Expected list as argument"),
+        _ => runtime_error!("list.first: Expected list as argument"),
     });
 
     result.add_fn("get", |vm, args| match vm.get_args(args) {
         [List(l), Number(n)] => {
             if *n < 0.0 {
-                return external_error!("list.get: Negative indices aren't allowed");
+                return runtime_error!("list.get: Negative indices aren't allowed");
             }
             match l.data().get(usize::from(n)) {
                 Some(value) => Ok(value.clone()),
                 None => Ok(Value::Empty),
             }
         }
-        _ => external_error!("list.get: Expected list and number as arguments"),
+        _ => runtime_error!("list.get: Expected list and number as arguments"),
     });
 
     result.add_fn("insert", |vm, args| match vm.get_args(args) {
         [List(l), Number(n), value] => {
             if *n < 0.0 {
-                return external_error!("list.insert: Negative indices aren't allowed");
+                return runtime_error!("list.insert: Negative indices aren't allowed");
             }
             let index: usize = n.into();
             if index > l.data().len() {
-                return external_error!("list.insert: Index out of bounds");
+                return runtime_error!("list.insert: Index out of bounds");
             }
 
             l.data_mut().insert(index, value.clone());
             Ok(Empty)
         }
-        _ => external_error!("list.insert: Expected list, number, and value as arguments"),
+        _ => runtime_error!("list.insert: Expected list, number, and value as arguments"),
     });
 
     result.add_fn("is_empty", |vm, args| match vm.get_args(args) {
         [List(l)] => Ok(Bool(l.data().is_empty())),
-        _ => external_error!("list.is_empty: Expected list as argument"),
+        _ => runtime_error!("list.is_empty: Expected list as argument"),
     });
 
     result.add_fn("iter", |vm, args| match vm.get_args(args) {
         [List(l)] => Ok(Iterator(ValueIterator::with_list(l.clone()))),
-        _ => external_error!("list.iter: Expected list as argument"),
+        _ => runtime_error!("list.iter: Expected list as argument"),
     });
 
     result.add_fn("last", |vm, args| match vm.get_args(args) {
@@ -116,7 +116,7 @@ pub fn make_module() -> ValueMap {
             Some(value) => Ok(value.clone()),
             None => Ok(Empty),
         },
-        _ => external_error!("list.last: Expected list as argument"),
+        _ => runtime_error!("list.last: Expected list as argument"),
     });
 
     result.add_fn("pop", |vm, args| match vm.get_args(args) {
@@ -124,7 +124,7 @@ pub fn make_module() -> ValueMap {
             Some(value) => Ok(value),
             None => Ok(Empty),
         },
-        _ => external_error!("list.pop: Expected list as argument"),
+        _ => runtime_error!("list.pop: Expected list as argument"),
     });
 
     result.add_fn("push", |vm, args| match vm.get_args(args) {
@@ -132,17 +132,17 @@ pub fn make_module() -> ValueMap {
             l.data_mut().push(value.clone());
             Ok(Empty)
         }
-        _ => external_error!("list.push: Expected list and value as arguments"),
+        _ => runtime_error!("list.push: Expected list and value as arguments"),
     });
 
     result.add_fn("remove", |vm, args| match vm.get_args(args) {
         [List(l), Number(n)] => {
             if *n < 0.0 {
-                return external_error!("list.remove: Negative indices aren't allowed");
+                return runtime_error!("list.remove: Negative indices aren't allowed");
             }
             let index: usize = n.into();
             if index >= l.data().len() {
-                return external_error!(
+                return runtime_error!(
                     "list.remove: Index out of bounds - \
                      the index is {} but the List only has {} elements",
                     index,
@@ -152,18 +152,18 @@ pub fn make_module() -> ValueMap {
 
             Ok(l.data_mut().remove(index))
         }
-        _ => external_error!("list.remove: Expected list and index as arguments"),
+        _ => runtime_error!("list.remove: Expected list and index as arguments"),
     });
 
     result.add_fn("resize", |vm, args| match vm.get_args(args) {
         [List(l), Number(n), value] => {
             if *n < 0.0 {
-                return external_error!("list.resize: Negative sizes aren't allowed");
+                return runtime_error!("list.resize: Negative sizes aren't allowed");
             }
             l.data_mut().resize(n.into(), value.clone());
             Ok(Empty)
         }
-        _ => external_error!("list.resize: Expected list, number, and value as arguments"),
+        _ => runtime_error!("list.resize: Expected list, number, and value as arguments"),
     });
 
     result.add_fn("retain", |vm, args| {
@@ -184,7 +184,7 @@ pub fn make_module() -> ValueMap {
                             }
                         }
                         Ok(unexpected) => {
-                            return external_error!(
+                            return runtime_error!(
                                 "list.retain expects a Bool to be returned from the \
                                  predicate, found '{}'",
                                 unexpected.type_as_string(),
@@ -209,7 +209,7 @@ pub fn make_module() -> ValueMap {
                         Ok(Bool(true)) => true,
                         Ok(Bool(false)) => false,
                         Ok(unexpected) => {
-                            error = Some(external_error!(
+                            error = Some(runtime_error!(
                                 "list.retain:: Expected Bool from == comparison, found '{}'",
                                 unexpected.type_as_string()
                             ));
@@ -226,7 +226,7 @@ pub fn make_module() -> ValueMap {
                 }
             }
             _ => {
-                return external_error!(
+                return runtime_error!(
                     "list.retain: Expected list and function or value as arguments"
                 )
             }
@@ -240,12 +240,12 @@ pub fn make_module() -> ValueMap {
             l.data_mut().reverse();
             Ok(Empty)
         }
-        _ => external_error!("list.reverse: Expected list as argument"),
+        _ => runtime_error!("list.reverse: Expected list as argument"),
     });
 
     result.add_fn("size", |vm, args| match vm.get_args(args) {
         [List(l)] => Ok(Number(l.len().into())),
-        _ => external_error!("list.size: Expected list as argument"),
+        _ => runtime_error!("list.size: Expected list as argument"),
     });
 
     result.add_fn("sort", |vm, args| match vm.get_args(args) {
@@ -300,7 +300,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Empty)
         }
-        _ => external_error!("list.sort: Expected list as argument"),
+        _ => runtime_error!("list.sort: Expected list as argument"),
     });
 
     result.add_fn("sort_copy", |vm, args| match vm.get_args(args) {
@@ -310,7 +310,7 @@ pub fn make_module() -> ValueMap {
             sort_values(vm, &mut result)?;
             Ok(List(ValueList::with_data(result)))
         }
-        _ => external_error!("list.sort_copy: Expected list as argument"),
+        _ => runtime_error!("list.sort_copy: Expected list as argument"),
     });
 
     result.add_fn("swap", |vm, args| match vm.get_args(args) {
@@ -319,12 +319,12 @@ pub fn make_module() -> ValueMap {
 
             Ok(Empty)
         }
-        _ => external_error!("list.swap: Expected two lists as arguments"),
+        _ => runtime_error!("list.swap: Expected two lists as arguments"),
     });
 
     result.add_fn("to_tuple", |vm, args| match vm.get_args(args) {
         [List(l)] => Ok(Value::Tuple(l.data().as_slice().into())),
-        _ => external_error!("list.to_tuple expects a list as argument"),
+        _ => runtime_error!("list.to_tuple expects a list as argument"),
     });
 
     result.add_fn("transform", |vm, args| match vm.get_args(args) {
@@ -342,19 +342,19 @@ pub fn make_module() -> ValueMap {
 
             Ok(Empty)
         }
-        _ => external_error!("list.transform expects a list and function as arguments"),
+        _ => runtime_error!("list.transform expects a list and function as arguments"),
     });
 
     result.add_fn("with_size", |vm, args| match vm.get_args(args) {
         [Number(n), value] => {
             if *n < 0.0 {
-                return external_error!("list.with_size: Negative sizes aren't allowed");
+                return runtime_error!("list.with_size: Negative sizes aren't allowed");
             }
 
             let result = smallvec::smallvec![value.clone(); n.into()];
             Ok(List(ValueList::with_data(result)))
         }
-        _ => external_error!("list.with_size: Expected number and value as arguments"),
+        _ => runtime_error!("list.with_size: Expected number and value as arguments"),
     });
 
     result

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        external_error, value_iterator::ValueIteratorOutput as Output, value_sort::compare_values,
+        runtime_error, value_iterator::ValueIteratorOutput as Output, value_sort::compare_values,
         RuntimeResult, Value, ValueHashMap, ValueIterator, ValueKey, ValueMap, Vm,
     },
     std::{cmp::Ordering, ops::Deref},
@@ -16,29 +16,29 @@ pub fn make_module() -> ValueMap {
             m.contents_mut().data.clear();
             Ok(Empty)
         }
-        _ => external_error!("map.clear: Expected map as argument"),
+        _ => runtime_error!("map.clear: Expected map as argument"),
     });
 
     result.add_fn("contains_key", |vm, args| match vm.get_args(args) {
         [Map(m), key] if key.is_immutable() => Ok(Bool(
             m.contents().data.contains_key(&ValueKey::from(key.clone())),
         )),
-        [other_a, other_b, ..] => external_error!(
+        [other_a, other_b, ..] => runtime_error!(
             "map.contains_key: Expected map and key as arguments, found '{}' and '{}'",
             other_a.type_as_string(),
             other_b.type_as_string()
         ),
-        _ => external_error!("map.contains_key: Expected map and key as arguments"),
+        _ => runtime_error!("map.contains_key: Expected map and key as arguments"),
     });
 
     result.add_fn("copy", |vm, args| match vm.get_args(args) {
         [Map(m)] => Ok(Map(ValueMap::with_data(m.contents().data.clone()))),
-        _ => external_error!("map.copy: Expected map as argument"),
+        _ => runtime_error!("map.copy: Expected map as argument"),
     });
 
     result.add_fn("deep_copy", |vm, args| match vm.get_args(args) {
         [value @ Map(_)] => Ok(value.deep_copy()),
-        _ => external_error!("map.deep_copy: Expected map as argument"),
+        _ => runtime_error!("map.deep_copy: Expected map as argument"),
     });
 
     result.add_fn("get", |vm, args| match vm.get_args(args) {
@@ -46,25 +46,25 @@ pub fn make_module() -> ValueMap {
             Some(value) => Ok(value.clone()),
             None => Ok(Empty),
         },
-        [other_a, other_b, ..] => external_error!(
+        [other_a, other_b, ..] => runtime_error!(
             "map.get: Expected map and key as arguments, found '{}' and '{}'",
             other_a.type_as_string(),
             other_b.type_as_string()
         ),
-        _ => external_error!("map.get: Expected map and key as arguments"),
+        _ => runtime_error!("map.get: Expected map and key as arguments"),
     });
 
     result.add_fn("get_index", |vm, args| match vm.get_args(args) {
         [Map(m), Number(n)] => {
             if *n < 0.0 {
-                return external_error!("map.get_index: Negative indices aren't allowed");
+                return runtime_error!("map.get_index: Negative indices aren't allowed");
             }
             match m.contents().data.get_index(n.into()) {
                 Some((key, value)) => Ok(Tuple(vec![key.deref().clone(), value.clone()].into())),
                 None => Ok(Empty),
             }
         }
-        _ => external_error!("map.get_index: Expected map and index as arguments"),
+        _ => runtime_error!("map.get_index: Expected map and index as arguments"),
     });
 
     result.add_fn("insert", |vm, args| match vm.get_args(args) {
@@ -84,30 +84,30 @@ pub fn make_module() -> ValueMap {
                 None => Ok(Empty),
             }
         }
-        [other_a, other_b, ..] => external_error!(
+        [other_a, other_b, ..] => runtime_error!(
             "map.insert: Expected map and key as arguments, found '{}' and '{}'",
             other_a.type_as_string(),
             other_b.type_as_string()
         ),
-        _ => external_error!("map.insert: Expected map and key as arguments"),
+        _ => runtime_error!("map.insert: Expected map and key as arguments"),
     });
 
     result.add_fn("is_empty", |vm, args| match vm.get_args(args) {
         [Map(m)] => Ok(Bool(m.contents().data.is_empty())),
-        [other, ..] => external_error!(
+        [other, ..] => runtime_error!(
             "map.is_empty: Expected map as argument, found '{}'",
             other.type_as_string(),
         ),
-        _ => external_error!("map.contains_key: Expected map and key as arguments"),
+        _ => runtime_error!("map.contains_key: Expected map and key as arguments"),
     });
 
     result.add_fn("iter", |vm, args| match vm.get_args(args) {
         [Map(m)] => Ok(Iterator(ValueIterator::with_map(m.clone()))),
-        [other, ..] => external_error!(
+        [other, ..] => runtime_error!(
             "map.iter: Expected map as argument, found '{}'",
             other.type_as_string(),
         ),
-        _ => external_error!("map.iter: Expected map as argument"),
+        _ => runtime_error!("map.iter: Expected map as argument"),
     });
 
     result.add_fn("keys", |vm, args| match vm.get_args(args) {
@@ -120,11 +120,11 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
-        [other, ..] => external_error!(
+        [other, ..] => runtime_error!(
             "map.keys: Expected map as argument, found '{}'",
             other.type_as_string(),
         ),
-        _ => external_error!("map.keys: Expected map as argument"),
+        _ => runtime_error!("map.keys: Expected map as argument"),
     });
 
     result.add_fn("remove", |vm, args| match vm.get_args(args) {
@@ -138,12 +138,12 @@ pub fn make_module() -> ValueMap {
                 None => Ok(Empty),
             }
         }
-        [other_a, other_b, ..] => external_error!(
+        [other_a, other_b, ..] => runtime_error!(
             "map.remove: Expected map and key as arguments, found '{}' and '{}'",
             other_a.type_as_string(),
             other_b.type_as_string()
         ),
-        _ => external_error!("map.remove: Expected map and key as arguments"),
+        _ => runtime_error!("map.remove: Expected map and key as arguments"),
     });
 
     result.add_fn("sort", |vm, args| match vm.get_args(args) {
@@ -211,16 +211,16 @@ pub fn make_module() -> ValueMap {
                 Ok(Empty)
             }
         }
-        _ => external_error!("map.sort: Expected map as argument"),
+        _ => runtime_error!("map.sort: Expected map as argument"),
     });
 
     result.add_fn("size", |vm, args| match vm.get_args(args) {
         [Map(m)] => Ok(Number(m.len().into())),
-        [other, ..] => external_error!(
+        [other, ..] => runtime_error!(
             "map.size: Expected map as argument, found '{}'",
             other.type_as_string(),
         ),
-        _ => external_error!("map.contains_key: Expected map and key as arguments"),
+        _ => runtime_error!("map.contains_key: Expected map and key as arguments"),
     });
 
     result.add_fn("update", |vm, args| match vm.get_args(args) {
@@ -238,7 +238,7 @@ pub fn make_module() -> ValueMap {
             f.clone(),
             vm.child_vm(),
         ),
-        _ => external_error!("map.update: Expected map, key, and function as arguments"),
+        _ => runtime_error!("map.update: Expected map, key, and function as arguments"),
     });
 
     result.add_fn("values", |vm, args| match vm.get_args(args) {
@@ -251,11 +251,11 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(ValueIterator::make_external(move || iter.next())))
         }
-        [other, ..] => external_error!(
+        [other, ..] => runtime_error!(
             "map.values: Expected map as argument, found '{}'",
             other.type_as_string(),
         ),
-        _ => external_error!("map.values: Expected map as argument"),
+        _ => runtime_error!("map.values: Expected map as argument"),
     });
 
     result

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -1,4 +1,4 @@
-use crate::{external_error, Value, ValueMap};
+use crate::{runtime_error, Value, ValueMap};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -7,11 +7,11 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("sum", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Number((n[0] + n[1]).into())),
-        [unexpected] => external_error!(
+        [unexpected] => runtime_error!(
             "num2.sum: Expected Num2, found '{}'",
             unexpected.type_as_string()
         ),
-        _ => external_error!("num2.sum: Expected a Num2 as argument"),
+        _ => runtime_error!("num2.sum: Expected a Num2 as argument"),
     });
 
     result

--- a/src/runtime/src/core/num4.rs
+++ b/src/runtime/src/core/num4.rs
@@ -1,4 +1,4 @@
-use crate::{external_error, Value, ValueMap};
+use crate::{runtime_error, Value, ValueMap};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -9,11 +9,11 @@ pub fn make_module() -> ValueMap {
         [Num4(n)] => Ok(Number(
             (n[0] as f64 + n[1] as f64 + n[2] as f64 + n[3] as f64).into(),
         )),
-        [unexpected] => external_error!(
+        [unexpected] => runtime_error!(
             "num4.sum: Expected Num4, found '{}'",
             unexpected.type_as_string()
         ),
-        _ => external_error!("num4.sum: Expected a Num4 as argument"),
+        _ => runtime_error!("num4.sum: Expected a Num4 as argument"),
     });
 
     result

--- a/src/runtime/src/core/number.rs
+++ b/src/runtime/src/core/number.rs
@@ -1,4 +1,4 @@
-use crate::{external_error, Value, ValueMap, ValueNumber};
+use crate::{runtime_error, Value, ValueMap, ValueNumber};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -12,12 +12,12 @@ pub fn make_module() -> ValueMap {
         ($name:expr, $fn:ident) => {
             result.add_fn($name, |vm, args| match vm.get_args(args) {
                 [Number(n)] => Ok(Number(n.$fn())),
-                [other] => external_error!(
+                [other] => runtime_error!(
                     "number.{}: Expected Number as argument, found '{}'",
                     $name,
                     other.type_as_string()
                 ),
-                _ => external_error!("number.{} expects a Number as argument", $name),
+                _ => runtime_error!("number.{} expects a Number as argument", $name),
             });
         };
     }
@@ -29,12 +29,12 @@ pub fn make_module() -> ValueMap {
         ($name:expr, $fn:ident) => {
             result.add_fn($name, |vm, args| match vm.get_args(args) {
                 [Number(n)] => Ok(Number(f64::from(n).$fn().into())),
-                [other] => external_error!(
+                [other] => runtime_error!(
                     "number.{} expects a Number as argument, found {}",
                     $name,
                     other.type_as_string(),
                 ),
-                _ => external_error!("number.{} expects a Number as argument", $name),
+                _ => runtime_error!("number.{} expects a Number as argument", $name),
             })
         };
     }
@@ -45,7 +45,7 @@ pub fn make_module() -> ValueMap {
                 use ValueNumber::I64;
                 match vm.get_args(args) {
                     [Number(I64(a)), Number(I64(b))] => Ok(Number((a $op b).into())),
-                    _ => external_error!(
+                    _ => runtime_error!(
                         "number.{} expects two Integers as arguments",
                         stringify!($name)
                     ),
@@ -60,7 +60,7 @@ pub fn make_module() -> ValueMap {
                 use ValueNumber::I64;
                 match vm.get_args(args) {
                     [Number(I64(a)), Number(I64(b))] if *b >= 0 => Ok(Number((a $op b).into())),
-                    _ => external_error!(
+                    _ => runtime_error!(
                         "number.{} expects two Integers as arguments,
                          with a non-negative second argument",
                         stringify!($name)
@@ -79,7 +79,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("clamp", |vm, args| match vm.get_args(args) {
         [Number(x), Number(a), Number(b)] => Ok(Number(*a.max(b.min(x)))),
-        _ => external_error!("number.clamp: Expected three numbers as arguments"),
+        _ => runtime_error!("number.clamp: Expected three numbers as arguments"),
     });
 
     number_f64_fn!(cos);
@@ -96,7 +96,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("is_nan", |vm, args| match vm.get_args(args) {
         [Number(n)] => Ok(Bool(n.is_nan())),
-        _ => external_error!("number.is_nan: Expected Number as argument"),
+        _ => runtime_error!("number.is_nan: Expected Number as argument"),
     });
 
     number_f64_fn!(ln);
@@ -105,12 +105,12 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("max", |vm, args| match vm.get_args(args) {
         [Number(a), Number(b)] => Ok(Number(*a.max(b))),
-        _ => external_error!("number.max: Expected two numbers as arguments"),
+        _ => runtime_error!("number.max: Expected two numbers as arguments"),
     });
 
     result.add_fn("min", |vm, args| match vm.get_args(args) {
         [Number(a), Number(b)] => Ok(Number(*a.min(b))),
-        _ => external_error!("number.min: Expected two numbers as arguments"),
+        _ => runtime_error!("number.min: Expected two numbers as arguments"),
     });
 
     result.add_value("nan", Number(std::f64::NAN.into()));
@@ -118,7 +118,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("flip_bits", |vm, args| match vm.get_args(args) {
         [Number(ValueNumber::I64(n))] => Ok(Number((!n).into())),
-        _ => external_error!("number.flip_bits: Expected integer as argument"),
+        _ => runtime_error!("number.flip_bits: Expected integer as argument"),
     });
     bitwise_fn!(or, |);
 
@@ -126,7 +126,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("pow", |vm, args| match vm.get_args(args) {
         [Number(a), Number(b)] => Ok(Number(a.pow(*b))),
-        _ => external_error!("number.pow: Expected two numbers as arguments"),
+        _ => runtime_error!("number.pow: Expected two numbers as arguments"),
     });
 
     number_f64_fn!("radians", to_radians);
@@ -143,12 +143,12 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("to_float", |vm, args| match vm.get_args(args) {
         [Number(n)] => Ok(Number(f64::from(n).into())),
-        _ => external_error!("number.to_float: Expected Number as argument"),
+        _ => runtime_error!("number.to_float: Expected Number as argument"),
     });
 
     result.add_fn("to_int", |vm, args| match vm.get_args(args) {
         [Number(n)] => Ok(Number(i64::from(n).into())),
-        _ => external_error!("number.to_int: Expected Number as argument"),
+        _ => runtime_error!("number.to_int: Expected Number as argument"),
     });
 
     result.add_value("tau", Number(std::f64::consts::TAU.into()));

--- a/src/runtime/src/core/range.rs
+++ b/src/runtime/src/core/range.rs
@@ -1,4 +1,4 @@
-use crate::{external_error, IntRange, Value, ValueIterator, ValueMap};
+use crate::{runtime_error, IntRange, Value, ValueIterator, ValueMap};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -7,12 +7,12 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("contains", |vm, args| match vm.get_args(args) {
         [Range(r), Number(n)] => Ok(Bool(*n >= r.start && n.ceil() < r.end)),
-        _ => external_error!("range.contains: Expected range and number as arguments"),
+        _ => runtime_error!("range.contains: Expected range and number as arguments"),
     });
 
     result.add_fn("end", |vm, args| match vm.get_args(args) {
         [Range(r)] => Ok(Number(r.end.into())),
-        _ => external_error!("range.end: Expected range as argument"),
+        _ => runtime_error!("range.end: Expected range as argument"),
     });
 
     result.add_fn("expanded", |vm, args| match vm.get_args(args) {
@@ -30,22 +30,22 @@ pub fn make_module() -> ValueMap {
                 }))
             }
         }
-        _ => external_error!("range.expanded: Expected range and number as arguments"),
+        _ => runtime_error!("range.expanded: Expected range and number as arguments"),
     });
 
     result.add_fn("iter", |vm, args| match vm.get_args(args) {
         [Range(r)] => Ok(Iterator(ValueIterator::with_range(*r))),
-        _ => external_error!("range.iter: Expected range as argument"),
+        _ => runtime_error!("range.iter: Expected range as argument"),
     });
 
     result.add_fn("size", |vm, args| match vm.get_args(args) {
         [Range(r)] => Ok(Number((r.end - r.start).into())),
-        _ => external_error!("range.size: Expected range as argument"),
+        _ => runtime_error!("range.size: Expected range as argument"),
     });
 
     result.add_fn("start", |vm, args| match vm.get_args(args) {
         [Range(r)] => Ok(Number(r.start.into())),
-        _ => external_error!("range.start: Expected range as argument"),
+        _ => runtime_error!("range.start: Expected range as argument"),
     });
 
     result.add_fn("union", |vm, args| match vm.get_args(args) {
@@ -85,7 +85,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(result)
         }
-        _ => external_error!("range.union: Expected range and number/range as arguments"),
+        _ => runtime_error!("range.union: Expected range and number/range as arguments"),
     });
 
     result

--- a/src/runtime/src/core/string.rs
+++ b/src/runtime/src/core/string.rs
@@ -2,7 +2,7 @@ mod format;
 
 use {
     crate::{
-        external_error,
+        runtime_error,
         value_iterator::{ValueIterator, ValueIteratorOutput},
         Value, ValueMap,
     },
@@ -16,22 +16,22 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("chars", |vm, args| match vm.get_args(args) {
         [Str(s)] => Ok(Iterator(ValueIterator::with_string(s.clone()))),
-        _ => external_error!("string.chars: Expected a string as argument"),
+        _ => runtime_error!("string.chars: Expected a string as argument"),
     });
 
     result.add_fn("contains", |vm, args| match vm.get_args(args) {
         [Str(s1), Str(s2)] => Ok(Bool(s1.contains(s2.as_str()))),
-        _ => external_error!("string.contains: Expected two strings as arguments"),
+        _ => runtime_error!("string.contains: Expected two strings as arguments"),
     });
 
     result.add_fn("escape", |vm, args| match vm.get_args(args) {
         [Str(s)] => Ok(Str(s.escape_default().to_string().into())),
-        _ => external_error!("string.escape: Expected string as argument"),
+        _ => runtime_error!("string.escape: Expected string as argument"),
     });
 
     result.add_fn("is_empty", |vm, args| match vm.get_args(args) {
         [Str(s)] => Ok(Bool(s.is_empty())),
-        _ => external_error!("string.is_empty: Expected string as argument"),
+        _ => runtime_error!("string.is_empty: Expected string as argument"),
     });
 
     result.add_fn("ends_with", |vm, args| match vm.get_args(args) {
@@ -39,7 +39,7 @@ pub fn make_module() -> ValueMap {
             let result = s.as_str().ends_with(pattern.as_str());
             Ok(Bool(result))
         }
-        _ => external_error!("string.ends_with: Expected two strings as arguments"),
+        _ => runtime_error!("string.ends_with: Expected two strings as arguments"),
     });
 
     result.add_fn("format", |vm, args| match vm.get_args(args) {
@@ -53,7 +53,7 @@ pub fn make_module() -> ValueMap {
                 Err(error) => Err(error.with_prefix("string.format")),
             }
         }
-        _ => external_error!("string.format: Expected a string as first argument"),
+        _ => runtime_error!("string.format: Expected a string as first argument"),
     });
 
     result.add_fn("lines", |vm, args| match vm.get_args(args) {
@@ -85,7 +85,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(iterator))
         }
-        _ => external_error!("string.lines: Expected string as argument"),
+        _ => runtime_error!("string.lines: Expected string as argument"),
     });
 
     result.add_fn("print", |vm, args| {
@@ -100,14 +100,14 @@ pub fn make_module() -> ValueMap {
                     Err(error) => return Err(error.with_prefix("string.print")),
                 }
             }
-            _ => return external_error!("string.print: Expected a string as first argument"),
+            _ => return runtime_error!("string.print: Expected a string as first argument"),
         }
         Ok(Empty)
     });
 
     result.add_fn("size", |vm, args| match vm.get_args(args) {
         [Str(s)] => Ok(Number(s.graphemes(true).count().into())),
-        _ => external_error!("string.size: Expected string as argument"),
+        _ => runtime_error!("string.size: Expected string as argument"),
     });
 
     result.add_fn("slice", |vm, args| match vm.get_args(args) {
@@ -127,7 +127,7 @@ pub fn make_module() -> ValueMap {
             };
             Ok(result)
         }
-        _ => external_error!("string.slice: Expected a string and slice index as arguments"),
+        _ => runtime_error!("string.slice: Expected a string and slice index as arguments"),
     });
 
     result.add_fn("split", |vm, args| match vm.get_args(args) {
@@ -154,7 +154,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Iterator(iterator))
         }
-        _ => external_error!("string.split: Expected two strings as arguments"),
+        _ => runtime_error!("string.split: Expected two strings as arguments"),
     });
 
     result.add_fn("starts_with", |vm, args| match vm.get_args(args) {
@@ -162,7 +162,7 @@ pub fn make_module() -> ValueMap {
             let result = s.as_str().starts_with(pattern.as_str());
             Ok(Bool(result))
         }
-        _ => external_error!("string.starts_with: Expected two strings as arguments"),
+        _ => runtime_error!("string.starts_with: Expected two strings as arguments"),
     });
 
     result.add_fn("to_lowercase", |vm, args| match vm.get_args(args) {
@@ -170,7 +170,7 @@ pub fn make_module() -> ValueMap {
             let result = s.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
             Ok(Str(result.into()))
         }
-        _ => external_error!("string.to_lowercase: Expected string as argument"),
+        _ => runtime_error!("string.to_lowercase: Expected string as argument"),
     });
 
     result.add_fn("to_number", |vm, args| match vm.get_args(args) {
@@ -179,11 +179,11 @@ pub fn make_module() -> ValueMap {
             Err(_) => match s.parse::<f64>() {
                 Ok(n) => Ok(Number(n.into())),
                 Err(_) => {
-                    external_error!("string.to_number: Failed to convert '{}'", s)
+                    runtime_error!("string.to_number: Failed to convert '{}'", s)
                 }
             },
         },
-        _ => external_error!("string.to_number: Expected string as argument"),
+        _ => runtime_error!("string.to_number: Expected string as argument"),
     });
 
     result.add_fn("to_uppercase", |vm, args| match vm.get_args(args) {
@@ -191,7 +191,7 @@ pub fn make_module() -> ValueMap {
             let result = s.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
             Ok(Str(result.into()))
         }
-        _ => external_error!("string.to_uppercase: Expected string as argument"),
+        _ => runtime_error!("string.to_uppercase: Expected string as argument"),
     });
 
     result.add_fn("trim", |vm, args| match vm.get_args(args) {
@@ -206,7 +206,7 @@ pub fn make_module() -> ValueMap {
 
             Ok(Str(result))
         }
-        _ => external_error!("string.trim: Expected string as argument"),
+        _ => runtime_error!("string.trim: Expected string as argument"),
     });
 
     result

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{external_error, RuntimeError, UnaryOp, Value, Vm},
+    crate::{runtime_error, RuntimeError, UnaryOp, Value, Vm},
     koto_lexer::{is_id_continue, is_id_start},
 };
 
@@ -160,26 +160,26 @@ pub fn format_string(
             FormatToken::String(s) => result.push_str(s),
             FormatToken::Placeholder => match arg_iter.next() {
                 Some(arg) => result.push_str(&value_to_string(vm, arg)?),
-                None => return external_error!("Not enough arguments for format string"),
+                None => return runtime_error!("Not enough arguments for format string"),
             },
             FormatToken::Positional(n) => match format_args.get(n as usize) {
                 Some(arg) => result.push_str(&value_to_string(vm, arg)?),
-                None => return external_error!("Missing argument for index {}", n),
+                None => return runtime_error!("Missing argument for index {}", n),
             },
             FormatToken::Identifier(id) => match format_args.first() {
                 Some(Value::Map(map)) => match map.contents().data.get_with_string(id) {
                     Some(value) => result.push_str(&value_to_string(vm, value)?),
-                    None => return external_error!("Key '{}' not found in map", id),
+                    None => return runtime_error!("Key '{}' not found in map", id),
                 },
                 Some(other) => {
-                    return external_error!(
+                    return runtime_error!(
                         "Expected map as first argument, found '{}'",
                         other.type_as_string()
                     )
                 }
-                None => return external_error!("Expected map as first argument"),
+                None => return runtime_error!("Expected map as first argument"),
             },
-            FormatToken::Error => return external_error!("Error while parsing format string"),
+            FormatToken::Error => return runtime_error!("Error while parsing format string"),
         }
     }
 
@@ -189,7 +189,7 @@ pub fn format_string(
 fn value_to_string(vm: &mut Vm, value: &Value) -> Result<String, RuntimeError> {
     match vm.run_unary_op(UnaryOp::Display, value.clone())? {
         Value::Str(result) => Ok(result.to_string()),
-        other => external_error!(
+        other => runtime_error!(
             "Expected string from value display, found '{}'",
             other.type_as_string()
         ),

--- a/src/runtime/src/core/test.rs
+++ b/src/runtime/src/core/test.rs
@@ -1,4 +1,4 @@
-use crate::{external_error, BinaryOp, Value, ValueMap, ValueNumber};
+use crate::{runtime_error, BinaryOp, Value, ValueMap, ValueNumber};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -10,11 +10,11 @@ pub fn make_module() -> ValueMap {
             match value {
                 Bool(b) => {
                     if !b {
-                        return external_error!("Assertion failed");
+                        return runtime_error!("Assertion failed");
                     }
                 }
                 unexpected => {
-                    return external_error!(
+                    return runtime_error!(
                         "assert expects booleans as arguments, found '{}'",
                         unexpected.type_as_string(),
                     )
@@ -34,16 +34,16 @@ pub fn make_module() -> ValueMap {
             match result {
                 Ok(Bool(true)) => Ok(Empty),
                 Ok(Bool(false)) => {
-                    external_error!("Assertion failed, '{}' is not equal to '{}'", a, b)
+                    runtime_error!("Assertion failed, '{}' is not equal to '{}'", a, b)
                 }
-                Ok(unexpected) => external_error!(
+                Ok(unexpected) => runtime_error!(
                     "assert_eq: expected Bool from comparison, found '{}'",
                     unexpected.type_as_string()
                 ),
                 Err(e) => Err(e.with_prefix("assert_eq")),
             }
         }
-        _ => external_error!("assert_eq expects two arguments"),
+        _ => runtime_error!("assert_eq expects two arguments"),
     });
 
     result.add_fn("assert_ne", |vm, args| match vm.get_args(args) {
@@ -56,16 +56,16 @@ pub fn make_module() -> ValueMap {
             match result {
                 Ok(Bool(true)) => Ok(Empty),
                 Ok(Bool(false)) => {
-                    external_error!("Assertion failed, '{}' should not be equal to '{}'", a, b)
+                    runtime_error!("Assertion failed, '{}' should not be equal to '{}'", a, b)
                 }
-                Ok(unexpected) => external_error!(
+                Ok(unexpected) => runtime_error!(
                     "assert_ne: expected Bool from comparison, found '{}'",
                     unexpected.type_as_string()
                 ),
                 Err(e) => Err(e.with_prefix("assert_ne")),
             }
         }
-        _ => external_error!("assert_ne expects two arguments"),
+        _ => runtime_error!("assert_ne expects two arguments"),
     });
 
     result.add_fn("assert_near", |vm, args| match vm.get_args(args) {
@@ -73,7 +73,7 @@ pub fn make_module() -> ValueMap {
             if number_near(*a, *b, *allowed_diff) {
                 Ok(Empty)
             } else {
-                external_error!(
+                runtime_error!(
                     "Assertion failed, '{}' and '{}' are not within {} of each other",
                     a,
                     b,
@@ -86,7 +86,7 @@ pub fn make_module() -> ValueMap {
             if f64_near(a.0, b.0, allowed_diff) && f64_near(a.1, b.1, allowed_diff) {
                 Ok(Empty)
             } else {
-                external_error!(
+                runtime_error!(
                     "Assertion failed, '{}' and '{}' are not within {} of each other",
                     a,
                     b,
@@ -103,7 +103,7 @@ pub fn make_module() -> ValueMap {
             {
                 Ok(Empty)
             } else {
-                external_error!(
+                runtime_error!(
                     "Assertion failed, '{}' and '{}' are not within {} of each other",
                     a,
                     b,
@@ -111,13 +111,13 @@ pub fn make_module() -> ValueMap {
                 )
             }
         }
-        [a, b, c] => external_error!(
+        [a, b, c] => runtime_error!(
             "assert_near expects Numbers as arguments, found '{}', '{}', and '{}'",
             a.type_as_string(),
             b.type_as_string(),
             c.type_as_string(),
         ),
-        _ => external_error!("assert_eq expects three arguments"),
+        _ => runtime_error!("assert_eq expects three arguments"),
     });
 
     result.add_fn("run_tests", |vm, args| match vm.get_args(args) {
@@ -125,7 +125,7 @@ pub fn make_module() -> ValueMap {
             let tests = tests.clone();
             vm.run_tests(tests)
         }
-        _ => external_error!("run_tests expects a map as argument"),
+        _ => runtime_error!("run_tests expects a map as argument"),
     });
 
     result

--- a/src/runtime/src/core/thread.rs
+++ b/src/runtime/src/core/thread.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{external_error, ExternalValue, RuntimeError, Value, ValueMap},
+    crate::{runtime_error, ExternalValue, RuntimeError, Value, ValueMap},
     std::{fmt, thread, thread::JoinHandle, time::Duration},
 };
 
@@ -25,29 +25,29 @@ pub fn make_module() -> ValueMap {
 
             Ok(Thread::make_thread_map(join_handle))
         }
-        [unexpected] => external_error!(
+        [unexpected] => runtime_error!(
             "thread.create: Expected callable value as argument, found '{}'",
             unexpected.type_as_string(),
         ),
-        _ => external_error!("thread.create: Expected callable value as argument"),
+        _ => runtime_error!("thread.create: Expected callable value as argument"),
     });
 
     #[cfg(target_arch = "wasm32")]
     result.add_fn("create", |_, _| {
-        external_error!("thread.create: Not supported on this platform")
+        runtime_error!("thread.create: Not supported on this platform")
     });
 
     result.add_fn("sleep", |vm, args| match vm.get_args(args) {
         [Number(seconds)] => {
             if *seconds < 0.0 {
-                return external_error!("thread.sleep: negative durations aren't supported");
+                return runtime_error!("thread.sleep: negative durations aren't supported");
             }
 
             thread::sleep(Duration::from_millis((f64::from(seconds) * 1000.0) as u64));
 
             Ok(Empty)
         }
-        _ => external_error!("thread.sleep: Expected number as argument"),
+        _ => runtime_error!("thread.sleep: Expected number as argument"),
     });
 
     result
@@ -70,7 +70,7 @@ impl Thread {
                 match result {
                     Ok(Ok(result)) => Ok(result),
                     Ok(Err(koto_error)) => Err(koto_error),
-                    Err(_) => external_error!("thread.join: thread panicked"),
+                    Err(_) => runtime_error!("thread.join: thread panicked"),
                 }
             })
         });

--- a/src/runtime/src/core/tuple.rs
+++ b/src/runtime/src/core/tuple.rs
@@ -1,5 +1,5 @@
 use crate::{
-    external_error, value_iterator::ValueIterator, value_sort::sort_values, BinaryOp, Value,
+    runtime_error, value_iterator::ValueIterator, value_sort::sort_values, BinaryOp, Value,
     ValueList, ValueMap,
 };
 
@@ -18,7 +18,7 @@ pub fn make_module() -> ValueMap {
                     Ok(Bool(false)) => {}
                     Ok(Bool(true)) => return Ok(true.into()),
                     Ok(unexpected) => {
-                        return external_error!(
+                        return runtime_error!(
                             "tuple.contains: Expected Bool from comparison, found '{}'",
                             unexpected.type_as_string()
                         )
@@ -28,12 +28,12 @@ pub fn make_module() -> ValueMap {
             }
             Ok(false.into())
         }
-        _ => external_error!("tuple.contains: Expected tuple and value as arguments"),
+        _ => runtime_error!("tuple.contains: Expected tuple and value as arguments"),
     });
 
     result.add_fn("deep_copy", |vm, args| match vm.get_args(args) {
         [value @ Tuple(_)] => Ok(value.deep_copy()),
-        _ => external_error!("tuple.deep_copy: Expected tuple as argument"),
+        _ => runtime_error!("tuple.deep_copy: Expected tuple as argument"),
     });
 
     result.add_fn("first", |vm, args| match vm.get_args(args) {
@@ -41,13 +41,13 @@ pub fn make_module() -> ValueMap {
             Some(value) => Ok(value.clone()),
             None => Ok(Value::Empty),
         },
-        _ => external_error!("tuple.first: Expected tuple as argument"),
+        _ => runtime_error!("tuple.first: Expected tuple as argument"),
     });
 
     result.add_fn("get", |vm, args| match vm.get_args(args) {
         [Tuple(t), Number(n)] => {
             if *n < 0.0 {
-                return external_error!("tuple.get: Negative indices aren't allowed");
+                return runtime_error!("tuple.get: Negative indices aren't allowed");
             }
             let index: usize = n.into();
             match t.data().get(index) {
@@ -55,12 +55,12 @@ pub fn make_module() -> ValueMap {
                 None => Ok(Value::Empty),
             }
         }
-        _ => external_error!("tuple.get: Expected tuple and number as arguments"),
+        _ => runtime_error!("tuple.get: Expected tuple and number as arguments"),
     });
 
     result.add_fn("iter", |vm, args| match vm.get_args(args) {
         [Tuple(t)] => Ok(Iterator(ValueIterator::with_tuple(t.clone()))),
-        _ => external_error!("tuple.iter: Expected tuple as argument"),
+        _ => runtime_error!("tuple.iter: Expected tuple as argument"),
     });
 
     result.add_fn("last", |vm, args| match vm.get_args(args) {
@@ -68,12 +68,12 @@ pub fn make_module() -> ValueMap {
             Some(value) => Ok(value.clone()),
             None => Ok(Value::Empty),
         },
-        _ => external_error!("tuple.last: Expected tuple as argument"),
+        _ => runtime_error!("tuple.last: Expected tuple as argument"),
     });
 
     result.add_fn("size", |vm, args| match vm.get_args(args) {
         [Tuple(t)] => Ok(Number(t.data().len().into())),
-        _ => external_error!("tuple.size: Expected tuple as argument"),
+        _ => runtime_error!("tuple.size: Expected tuple as argument"),
     });
 
     result.add_fn("sort_copy", |vm, args| match vm.get_args(args) {
@@ -85,12 +85,12 @@ pub fn make_module() -> ValueMap {
 
             Ok(Tuple(result.into()))
         }
-        _ => external_error!("tuple.sort_copy: Expected tuple as argument"),
+        _ => runtime_error!("tuple.sort_copy: Expected tuple as argument"),
     });
 
     result.add_fn("to_list", |vm, args| match vm.get_args(args) {
         [Tuple(t)] => Ok(List(ValueList::from_slice(t.data()))),
-        _ => external_error!("tuple.to_list: Expected tuple as argument"),
+        _ => runtime_error!("tuple.to_list: Expected tuple as argument"),
     });
 
     result

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{external_error, RuntimeResult, Value, ValueKey, ValueMap, Vm},
+    crate::{runtime_error, RuntimeResult, Value, ValueKey, ValueMap, Vm},
     downcast_rs::impl_downcast,
     std::{
         fmt,
@@ -88,13 +88,13 @@ where
             let mut value = maybe_external.as_ref().write();
             match value.downcast_mut::<T>() {
                 Some(external) => f(external),
-                None => external_error!(
+                None => runtime_error!(
                     "Invalid type for external value, found '{}'",
                     value.value_type(),
                 ),
             }
         }
-        _ => external_error!("External value not found"),
+        _ => runtime_error!("External value not found"),
     }
 }
 
@@ -124,7 +124,7 @@ macro_rules! get_external_instance {
             [Value::Map(instance), ..] => {
                 $crate::visit_external_value(instance, |$match_name: &mut $external_type| $body)
             }
-            _ => $crate::external_error!(
+            _ => $crate::runtime_error!(
                 "{0}.{1}: Expected {0} instance as first argument",
                 $external_name,
                 $fn_name,

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -1,7 +1,5 @@
 use {
-    crate::{
-        external_error, RuntimeError, Value, ValueList, ValueMap, ValueString, ValueTuple, Vm,
-    },
+    crate::{runtime_error, RuntimeError, Value, ValueList, ValueMap, ValueString, ValueTuple, Vm},
     std::{
         fmt,
         sync::{Arc, Mutex},
@@ -197,7 +195,7 @@ impl ValueIterator {
     ) -> Option<ValueIteratorResult> {
         match self.0.lock() {
             Ok(mut internals) => f(&mut internals),
-            Err(_) => Some(external_error!("Failed to access iterator internals")),
+            Err(_) => Some(runtime_error!("Failed to access iterator internals")),
         }
     }
 }
@@ -208,7 +206,7 @@ impl Iterator for ValueIterator {
     fn next(&mut self) -> Option<Self::Item> {
         match self.0.lock() {
             Ok(mut internals) => internals.next(),
-            Err(_) => Some(external_error!("Failed to access iterator internals")),
+            Err(_) => Some(runtime_error!("Failed to access iterator internals")),
         }
     }
 }

--- a/src/runtime/src/value_sort.rs
+++ b/src/runtime/src/value_sort.rs
@@ -4,7 +4,7 @@
 
 use std::cmp::Ordering;
 
-use crate::{external_error, BinaryOp, RuntimeError, Value, Vm};
+use crate::{runtime_error, BinaryOp, RuntimeError, Value, Vm};
 
 /// Sorts values in a slice using Koto operators for comparison.
 pub fn sort_values(vm: &mut Vm, arr: &mut [Value]) -> Result<(), RuntimeError> {
@@ -38,13 +38,13 @@ pub fn compare_values(vm: &mut Vm, a: &Value, b: &Value) -> Result<Ordering, Run
         Value::Bool(false) => match vm.run_binary_op(BinaryOp::Greater, a.clone(), b.clone())? {
             Value::Bool(true) => Ok(Ordering::Greater),
             Value::Bool(false) => Ok(Ordering::Equal),
-            unexpected => external_error!(
+            unexpected => runtime_error!(
                 "Expected Bool from > comparison, found '{}'",
                 unexpected.type_as_string()
             ),
         },
         unexpected => {
-            external_error!(
+            runtime_error!(
                 "Expected Bool from < comparison, found '{}'",
                 unexpected.type_as_string()
             )

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -3,12 +3,11 @@ use {
         core::CoreLib,
         external::{self, Args, ExternalFunction},
         frame::Frame,
-        num2, num4,
+        num2, num4, runtime_error,
         value::{self, RegisterSlice, RuntimeFunction},
         value_iterator::{IntRange, Iterable, ValueIterator, ValueIteratorOutput},
-        vm_error, BinaryOp, DefaultLogger, KotoLogger, Loader, MetaKey, RuntimeError,
-        RuntimeErrorType, RuntimeResult, UnaryOp, Value, ValueList, ValueMap, ValueNumber,
-        ValueString, ValueVec,
+        BinaryOp, DefaultLogger, KotoLogger, Loader, MetaKey, RuntimeError, RuntimeErrorType,
+        RuntimeResult, UnaryOp, Value, ValueList, ValueMap, ValueNumber, ValueString, ValueVec,
     },
     koto_bytecode::{Chunk, Instruction, InstructionReader, TypeId},
     koto_parser::{ConstantIndex, MetaId},
@@ -273,14 +272,14 @@ impl Vm {
         args: &[Value],
     ) -> RuntimeResult {
         if !self.call_stack.is_empty() {
-            return vm_error!(
+            return runtime_error!(
                 "run_function: the call stack must be empty,
                  are you calling run_function on an active VM?"
             );
         }
 
         if !function.is_callable() {
-            return vm_error!("run_function: the provided value isn't a function");
+            return runtime_error!("run_function: the provided value isn't a function");
         }
 
         let result_register = 0;
@@ -310,7 +309,7 @@ impl Vm {
             // should be in the frame base.
             match self.value_stack.first() {
                 Some(value) => Ok(value.clone()),
-                None => vm_error!("run_function: missing return register"),
+                None => runtime_error!("run_function: missing return register"),
             }
         } else {
             self.frame_mut().catch_barrier = true;
@@ -324,7 +323,7 @@ impl Vm {
 
     pub fn run_unary_op(&mut self, op: UnaryOp, value: Value) -> RuntimeResult {
         if !self.call_stack.is_empty() {
-            return vm_error!(
+            return runtime_error!(
                 "run_unary_op: the call stack must be empty,
                  are you calling run_unary_op on an active VM?"
             );
@@ -350,7 +349,7 @@ impl Vm {
 
     pub fn run_binary_op(&mut self, op: BinaryOp, lhs: Value, rhs: Value) -> RuntimeResult {
         if !self.call_stack.is_empty() {
-            return vm_error!(
+            return runtime_error!(
                 "run_binary_op: the call stack must be empty,
                  are you calling run_binary_op on an active VM?"
             );
@@ -533,7 +532,7 @@ impl Vm {
 
         match instruction {
             Instruction::Error { message } => {
-                vm_error!("{}", message)
+                runtime_error!("{}", message)
             }
             Instruction::Copy { target, source } => {
                 self.run_copy(target, source);
@@ -727,10 +726,10 @@ impl Vm {
                         vm: None,
                     })),
                     Map(m) if m.contents().meta.contains_key(&display_op) => Err(
-                        RuntimeError::make_koto_error(thrown_value, self.spawn_shared_vm()),
+                        RuntimeError::from_koto_value(thrown_value, self.spawn_shared_vm()),
                     ),
                     other => {
-                        vm_error!(
+                        runtime_error!(
                             "throw: expected string or map with @display function, found '{}'",
                             other.type_as_string()
                         )
@@ -863,7 +862,7 @@ impl Vm {
                 self.set_register(register, value);
                 Ok(())
             }
-            None => vm_error!("'{}' not found", export_name),
+            None => runtime_error!("'{}' not found", export_name),
         }
     }
 
@@ -918,7 +917,10 @@ impl Vm {
             }
             (None, Some(Number(end))) => {
                 if *end < 0.0 {
-                    return vm_error!("RangeTo: negative numbers not allowed, found '{}'", end);
+                    return runtime_error!(
+                        "RangeTo: negative numbers not allowed, found '{}'",
+                        end
+                    );
                 }
                 let end = if inclusive {
                     usize::from(end) + 1
@@ -932,7 +934,10 @@ impl Vm {
             }
             (Some(Number(start)), None) => {
                 if *start < 0.0 {
-                    return vm_error!("RangeFrom: negative numbers not allowed, found '{}'", start);
+                    return runtime_error!(
+                        "RangeFrom: negative numbers not allowed, found '{}'",
+                        start
+                    );
                 }
                 IndexRange(value::IndexRange {
                     start: usize::from(start),
@@ -998,7 +1003,10 @@ impl Vm {
         let result = match self.get_register_mut(iterator) {
             Iterator(iterator) => iterator.next(),
             unexpected => {
-                return vm_error!("Expected Iterator, found '{}'", unexpected.type_as_string());
+                return runtime_error!(
+                    "Expected Iterator, found '{}'",
+                    unexpected.type_as_string()
+                );
             }
         };
 
@@ -1022,7 +1030,7 @@ impl Vm {
                     self.set_register(register, Tuple(vec![first, second].into()));
                 }
             }
-            (Some(Err(error)), _) => return vm_error!(error.to_string()),
+            (Some(Err(error)), _) => return runtime_error!(error.to_string()),
             (None, _) => self.jump_ip(jump_offset),
         };
 
@@ -1185,7 +1193,7 @@ impl Vm {
             Some(capture_list) => {
                 capture_list.data_mut()[capture_index as usize] = self.clone_register(value)
             }
-            None => return vm_error!("Capture: missing capture list for function"),
+            None => return runtime_error!("Capture: missing capture list for function"),
         }
 
         Ok(())
@@ -1624,7 +1632,7 @@ impl Vm {
                 Value::Bool(true) => {}
                 Value::Bool(false) => return Ok(false),
                 other => {
-                    return vm_error!(
+                    return runtime_error!(
                         "Expected Bool from equality comparison, found '{}'",
                         other.type_as_string()
                     );
@@ -1658,7 +1666,7 @@ impl Vm {
                 Value::Bool(true) => {}
                 Value::Bool(false) => return Ok(false),
                 other => {
-                    return vm_error!(
+                    return runtime_error!(
                         "Expected Bool from equality comparison, found '{}'",
                         other.type_as_string()
                     );
@@ -1678,7 +1686,7 @@ impl Vm {
     ) -> InstructionResult {
         let op = match map.contents().meta.get(&MetaKey::UnaryOp(op)) {
             Some(op) => op.clone(),
-            None => return vm_error!("Missing overloaded {:?} key", op),
+            None => return runtime_error!("Missing overloaded {:?} key", op),
         };
 
         // Set up the call registers at the end of the stack
@@ -1706,7 +1714,7 @@ impl Vm {
     ) -> InstructionResult {
         let op = match map.contents().meta.get(&MetaKey::BinaryOp(op)) {
             Some(op) => op.clone(),
-            None => return vm_error!("Missing overloaded {:?} operation", op),
+            None => return runtime_error!("Missing overloaded {:?} operation", op),
         };
 
         // Set up the call registers at the end of the stack
@@ -1802,12 +1810,14 @@ impl Vm {
                     .compile_module(&import_name, source_path);
                 let (module_chunk, module_path) = match compile_result {
                     Ok(chunk) => chunk,
-                    Err(e) => return vm_error!("Failed to import '{}': {}", import_name, e),
+                    Err(e) => return runtime_error!("Failed to import '{}': {}", import_name, e),
                 };
                 let maybe_module = self.context().modules.get(&module_path).cloned();
                 match maybe_module {
                     Some(Some(module)) => self.set_register(result_register, Value::Map(module)),
-                    Some(None) => return vm_error!("Recursive import of module '{}'", import_name),
+                    Some(None) => {
+                        return runtime_error!("Recursive import of module '{}'", import_name)
+                    }
                     None => {
                         // Insert a placeholder for the new module, preventing recursive imports
                         self.context_mut().modules.insert(module_path.clone(), None);
@@ -1966,7 +1976,7 @@ impl Vm {
                 _ => list.data_mut().push(value),
             },
             unexpected => {
-                return vm_error!("Expected List, found '{}'", unexpected,);
+                return runtime_error!("Expected List, found '{}'", unexpected,);
             }
         };
         Ok(())
@@ -1992,7 +2002,7 @@ impl Vm {
                         if index >= 0.0 && u_index < list_len {
                             list.data_mut()[u_index] = value;
                         } else {
-                            return vm_error!("Index '{}' not in List", index);
+                            return runtime_error!("Index '{}' not in List", index);
                         }
                     }
                     Range(IntRange { start, end }) => {
@@ -2000,21 +2010,21 @@ impl Vm {
                         let uend = end as usize;
 
                         if start < 0 || end < 0 {
-                            return vm_error!(
+                            return runtime_error!(
                                 "Indexing with negative indices isn't supported, \
                                                 start: {}, end: {}",
                                 start,
                                 end
                             );
                         } else if start > end {
-                            return vm_error!(
+                            return runtime_error!(
                                 "Indexing with a descending range isn't supported, \
                                                 start: {}, end: {}",
                                 start,
                                 end
                             );
                         } else if ustart > list_len || uend > list_len {
-                            return vm_error!(
+                            return runtime_error!(
                                 "Index out of bounds, \
                                                 List has a length of {} - start: {}, end: {}",
                                 list_len,
@@ -2031,14 +2041,14 @@ impl Vm {
                     IndexRange(value::IndexRange { start, end }) => {
                         let end = end.unwrap_or(list_len);
                         if start > end {
-                            return vm_error!(
+                            return runtime_error!(
                                 "Indexing with a descending range isn't supported, \
                                                 start: {}, end: {}",
                                 start,
                                 end
                             );
                         } else if start > list_len || end > list_len {
-                            return vm_error!(
+                            return runtime_error!(
                                 "Index out of bounds, \
                                                 List has a length of {} - start: {}, end: {}",
                                 list_len,
@@ -2058,7 +2068,7 @@ impl Vm {
                 }
             }
             unexpected => {
-                return vm_error!("Expected List, found '{}'", unexpected);
+                return runtime_error!("Expected List, found '{}'", unexpected);
             }
         };
 
@@ -2069,9 +2079,9 @@ impl Vm {
         let index = usize::from(n);
 
         if n < 0.0 {
-            vm_error!("Negative indices aren't allowed ('{}')", n)
+            runtime_error!("Negative indices aren't allowed ('{}')", n)
         } else if index >= size {
-            vm_error!("Index out of bounds - index: {}, size: {}", n, size)
+            runtime_error!("Index out of bounds - index: {}, size: {}", n, size)
         } else {
             Ok(index)
         }
@@ -2082,19 +2092,19 @@ impl Vm {
         let uend = end as usize;
 
         if start < 0 || end < 0 {
-            vm_error!(
+            runtime_error!(
                 "Indexing with negative indices isn't supported, start: {}, end: {}",
                 start,
                 end
             )
         } else if start > end {
-            vm_error!(
+            runtime_error!(
                 "Indexing with a descending range isn't supported, start: {}, end: {}",
                 start,
                 end
             )
         } else if ustart > size || uend > size {
-            vm_error!(
+            runtime_error!(
                 "Index out of bounds, size of {} - start: {}, end: {}",
                 size,
                 start,
@@ -2107,13 +2117,13 @@ impl Vm {
 
     fn validate_index_range(&self, start: usize, end: usize, size: usize) -> InstructionResult {
         if start > end {
-            vm_error!(
+            runtime_error!(
                 "Indexing with a descending range isn't supported, start: {}, end: {}",
                 start,
                 end
             )
         } else if start > size || end > size {
-            vm_error!(
+            runtime_error!(
                 "Index out of bounds, size of {} - start: {}, end: {}",
                 size,
                 start,
@@ -2179,14 +2189,14 @@ impl Vm {
                 let i = usize::from(i);
                 match i {
                     0 | 1 => self.set_register(result_register, Number(n[i].into())),
-                    other => return vm_error!("Index out of bounds for Num2, {}", other),
+                    other => return runtime_error!("Index out of bounds for Num2, {}", other),
                 }
             }
             (Num4(n), Number(i)) => {
                 let i = usize::from(i);
                 match i {
                     0 | 1 | 2 | 3 => self.set_register(result_register, Number(n[i].into())),
-                    other => return vm_error!("Index out of bounds for Num4, {}", other),
+                    other => return runtime_error!("Index out of bounds for Num4, {}", other),
                 }
             }
             (Map(map), index) if map.contents().meta.contains_key(&MetaKey::BinaryOp(Index)) => {
@@ -2199,7 +2209,7 @@ impl Vm {
                 );
             }
             (unexpected_value, unexpected_index) => {
-                return vm_error!(
+                return runtime_error!(
                     "Unable to index '{}' with '{}'",
                     unexpected_value.type_as_string(),
                     unexpected_index.type_as_string(),
@@ -2224,7 +2234,7 @@ impl Vm {
                 map.contents_mut().data.insert(key_string.into(), value);
                 Ok(())
             }
-            unexpected => vm_error!(
+            unexpected => runtime_error!(
                 "MapInsert: Expected Map, found '{}'",
                 unexpected.type_as_string()
             ),
@@ -2244,7 +2254,7 @@ impl Vm {
                 map.contents_mut().meta.insert(meta_id.into(), value);
                 Ok(())
             }
-            unexpected => vm_error!(
+            unexpected => runtime_error!(
                 "MetaInsert: Expected Map, found '{}'",
                 unexpected.type_as_string()
             ),
@@ -2353,7 +2363,7 @@ impl Vm {
                 }
                 other => other,
             },
-            None => return vm_error!("'{}' not found in module '{}'", key, module_name),
+            None => return runtime_error!("'{}' not found in module '{}'", key, module_name),
         };
 
         Ok(result)
@@ -2380,7 +2390,7 @@ impl Vm {
                 call_arg_count += 1;
                 frame_base
             } else {
-                return vm_error!("Expected self for external instance function");
+                return runtime_error!("Expected self for external instance function");
             }
         } else {
             frame_base + 1
@@ -2447,7 +2457,7 @@ impl Vm {
                 generator_vm.set_register(0, instance);
                 1
             } else {
-                return vm_error!("Missing instance for call to instance function");
+                return runtime_error!("Missing instance for call to instance function");
             }
         } else {
             0
@@ -2464,14 +2474,14 @@ impl Vm {
                     Value::Tuple(self.register_slice(varargs_start, varargs_count).into());
                 generator_vm.set_register(expected_arg_count + arg_offset, varargs);
             } else {
-                return vm_error!(
+                return runtime_error!(
                     "Insufficient arguments for function call, expected {}, found {}",
                     expected_arg_count,
                     call_arg_count,
                 );
             }
         } else if call_arg_count != expected_arg_count {
-            return vm_error!(
+            return runtime_error!(
                 "Incorrect argument count, expected {}, found {}",
                 expected_arg_count,
                 call_arg_count,
@@ -2553,7 +2563,7 @@ impl Vm {
                         }
                         frame_base
                     } else {
-                        return vm_error!("Missing instance for call to instance function");
+                        return runtime_error!("Missing instance for call to instance function");
                     }
                 } else {
                     // If there's no self arg, then the frame's instance register is unused,
@@ -2574,14 +2584,14 @@ impl Vm {
                         self.set_register(varargs_start, varargs);
                         self.truncate_registers(varargs_start + 1);
                     } else {
-                        return vm_error!(
+                        return runtime_error!(
                             "Insufficient arguments for function call, expected {}, found {}",
                             expected_arg_count,
                             call_arg_count,
                         );
                     }
                 } else if call_arg_count != expected_arg_count {
-                    return vm_error!(
+                    return runtime_error!(
                         "Incorrect argument count, expected {}, found {}",
                         expected_arg_count,
                         call_arg_count,
@@ -2628,7 +2638,7 @@ impl Vm {
         let value_string = match vm.run_unary_op(UnaryOp::Display, value)? {
             result @ Value::Str(_) => result,
             other => {
-                return vm_error!(
+                return runtime_error!(
                     "debug: Expected string to display, found '{}'",
                     other.type_as_string()
                 )
@@ -2678,7 +2688,7 @@ impl Vm {
         if value_size == expected_size {
             Ok(())
         } else {
-            vm_error!(
+            runtime_error!(
                 "Value has a size of '{}', expected '{}'",
                 value_size,
                 expected_size
@@ -2735,7 +2745,7 @@ impl Vm {
         self.truncate_registers(0);
 
         if self.call_stack.pop().is_none() {
-            return vm_error!("pop_frame: Empty call stack");
+            return runtime_error!("pop_frame: Empty call stack");
         };
 
         if !self.call_stack.is_empty() && self.frame().return_register_and_ip.is_some() {
@@ -2824,11 +2834,11 @@ impl Vm {
     }
 
     fn unexpected_type_error<T>(&self, message: &str, value: &Value) -> Result<T, RuntimeError> {
-        vm_error!("{}, found '{}'", message, value.type_as_string())
+        runtime_error!("{}, found '{}'", message, value.type_as_string())
     }
 
     fn binary_op_error(&self, lhs: &Value, rhs: &Value, op: &str) -> InstructionResult {
-        vm_error!(
+        runtime_error!(
             "Unable to perform operation '{}' with '{}' and '{}'",
             op,
             lhs.type_as_string(),

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2,7 +2,7 @@ mod vm {
     use {
         koto_bytecode::Chunk,
         koto_runtime::{
-            external_error, num2, num4, BinaryOp, IntRange, Loader, Value, Value::*, ValueHashMap,
+            num2, num4, runtime_error, BinaryOp, IntRange, Loader, Value, Value::*, ValueHashMap,
             ValueList, ValueMap, Vm,
         },
         std::sync::Arc,
@@ -18,11 +18,11 @@ mod vm {
                 match value {
                     Bool(b) => {
                         if !b {
-                            return external_error!("Assertion failed");
+                            return runtime_error!("Assertion failed");
                         }
                     }
                     unexpected => {
-                        return external_error!(
+                        return runtime_error!(
                             "assert expects booleans as arguments, found '{}'",
                             unexpected.type_as_string(),
                         )

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1966,6 +1966,34 @@ catch _
         }
 
         #[test]
+        fn try_catch_with_throw_string() {
+            let script = r#"
+x = 1
+try
+  x += 1
+  throw "{}".format x
+catch error
+  error
+"#;
+            test_script(script, Str("2".into()));
+        }
+
+        #[test]
+        fn try_catch_with_throw_map() {
+            let script = r#"
+x = 1
+try
+  x += 1
+  throw
+    data: x
+    @display: |self| "error!"
+catch error
+  error.data
+"#;
+            test_script(script, Number(2.0.into()));
+        }
+
+        #[test]
         fn try_catch_finally() {
             let script = "
 try


### PR DESCRIPTION
This PR adds support for `throw` expressions, allowing errors to be created directly.

Strings or Maps that implement `@display` can be used as the value that gets thrown.

Closes #56.