### PR TITLE
Don't print map values in the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@
       @display: |self| "Che errore! - {}".format self.data
     ```
 
-
 ### Changed
+
 - Captured values in functions are now immutable.
   - e.g.
     ```
@@ -65,15 +65,16 @@
 - Keywords can now be used as identifiers in lookups, e.g. `foo.and()` was
   previously disallowed.
 
-
 ## [0.6.0] 2021.01.21
 
 ### Added
+
 - Core Ops
   - `range.expanded`
   - `range.union`
 
 ### Changed
+
 - Function calls without parentheses now require commas to separate arguments.
   - e.g. `f a b c` now needs to be written as `f a, b, c`.
   - Care needs to be taken when adapting programs to this change.
@@ -96,21 +97,21 @@
   e.g. `1+1==2` would previously trigger a parsing error.
 
 ### Fixed
+
 - Error messages produced in the functor passed to `iterator.fold` were reported
   as coming from `iterator.each`.
 - Error messages associated with accessed IDs now have the correct spans.
   - e.g.
     ```
     x = (1..10).fold 42
-
     ```
-    Previously the error (wrong arguments for `.fold`) would be connected with
-    the range rather than the function call.
-
+    - Previously the error (wrong arguments for `.fold`) would be connected with
+      the range rather than the function call.
 
 ## [0.5.0] 2020.12.17
 
 ### Added
+
 - Core Ops
   - `iterator.chain`
   - `iterator.product`
@@ -147,7 +148,7 @@
         n == 1 then "one"
         else "???"
       ```
-    - *Note* (20.12.2020): After v0.5.0 this form of expression was renamed to
+    - _Note_ (20.12.2020): After v0.5.0 this form of expression was renamed to
       `switch`.
   - The results of list/map accesses or function calls can be used as match
     patterns.
@@ -176,6 +177,7 @@
     ```
 
 ### Changed
+
 - `thread.join` now returns the result of the thread's function.
 - Numbers now can either be integers or floats.
   - The integer representation is `i64`.
@@ -194,8 +196,8 @@
   sorting behaviour.
 - The ordering of entries is now preserved when calling `map.remove`.
 
-
 ### Fixed
+
 - `else` and `else if` blocks with unexpected indentation will now trigger a
   parser error.
 - Multi-assignment of values where the values are used in the expressions now
@@ -212,11 +214,10 @@
   rather than `1.e` followed by `xp()`.
 - `string.split` now works correctly when used with multi-character patterns.
 
-
-
 ## [0.4.0] 2020.12.10
 
 ### Added
+
 - Core Ops
   - `iterator.min_max`
   - `list.copy`
@@ -237,18 +238,20 @@
     ```
 
 ### Fixed
+
 - iterator.consume and iterator.count now propagate errors correctly.
 - Wildcard function args that weren't in last position would cause arguments to
   be assigned to the wrong IDs.
 
 ### Removed
+
 - The copy expression has been removed in favour of copy / deep_copy operations
   on container types.
-
 
 ## [0.3.0] - 2020.12.06
 
 ### Added
+
 - Core Ops
   - `iterator.all`
   - `iterator.any`
@@ -260,6 +263,7 @@
 - Strings can now be used with the ordered comparison operators.
 
 ### Changed
+
 - Map blocks can now be used in return and yield expressions.
 - `iterator.each` and `iterator.keep` now collect iterator pairs into tuples.
 - Space-separated function calls are allowed in function args when the arg is on
@@ -268,30 +272,34 @@
   - e.g. `(1 + 1)..(2 + 2)` can now be written as `1 + 1..2 + 2`.
 
 ### Removed
+
 - Vim support has been moved to [its own repo][vim].
 
 ### Fixed
+
 - `iterator.fold`, `list.retain`, and `list.transform` could cause runtime
   errors or stack overflows when being called after other functions.
   - [Bug report](https://github.com/koto-lang/koto/issues/6)
 
 [vim]: https://github.com/koto-lang/koto.vim
 
-
 ## [0.2.0] - 2020.12.02
 
 ### Added
+
 - `iterator.count`
 - `string.chars`
 - `tuple.contains`
 
 ### Changed
+
 - `koto.script_dir` is now canonicalized and includes a trailing slash.
 - `koto.script_path` is now canonicalized.
 
 ### Fixed
+
 - Multiline strings broke following spans.
 
-
 ## [0.1.0] - 2020.12.01
+
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Runtime errors now provide a full backtrace.
 - Keywords can now be used as identifiers in lookups, e.g. `foo.and()` was
   previously disallowed.
+- Maps are now printed in the REPL with keys only.
 
 ## [0.6.0] 2021.01.21
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,15 @@ Koto is versatile enough to be useful in a variety of applications, although
 there has been a focus during development on interactive systems, such as rapid
 iteration during game development, or experimentation in creative coding.
 
-
-* [Current State](#current-state)
-* [Getting Started](#getting-started)
-  * [A Quick Tour](#a-quick-tour)
-  * [Learning the Language](#learning-the-language)
-  * [Installation](#installation)
-  * [REPL](#repl)
-* [Language Goals](#language-goals)
-* [Editor Support](#editor-support)
-  * [Vim / Neovim](#vim--neovim)
-
+- [Current State](#current-state)
+- [Getting Started](#getting-started)
+  - [A Quick Tour](#a-quick-tour)
+  - [Learning the Language](#learning-the-language)
+  - [Installation](#installation)
+  - [REPL](#repl)
+- [Language Goals](#language-goals)
+- [Editor Support](#editor-support)
+  - [Vim / Neovim](#vim--neovim)
 
 ## Current State
 
@@ -34,7 +32,6 @@ more real-world contexts. We're some distance away from a stable 1.0 release.
 
 That said, if you're curious and feeling adventurous then please give Koto
 a try, your early feedback will be invaluable.
-
 
 ## Getting Started
 
@@ -76,17 +73,14 @@ x = {foo: 42, bar: "bar"}
 assert_eq x.keys().to_tuple(), ("foo", "bar")
 ```
 
-
 ### Learning the Language
 
 While there's not yet a complete guide to Koto, there are some code examples
 that are a good starting point for getting to know the language.
 
-* [Koto test scripts, organized by feature](./koto/tests/)
-* [Koto benchmark scripts](./koto/benches/)
-* [Example Rust application with Koto bindings](./examples/poetry/)
-
-
+- [Koto test scripts, organized by feature](./koto/tests/)
+- [Koto benchmark scripts](./koto/benches/)
+- [Example Rust application with Koto bindings](./examples/poetry/)
 
 ### Installation
 
@@ -96,7 +90,6 @@ The most recent release of the Koto CLI can be installed with
 ```
 cargo install koto_cli
 ```
-
 
 ### REPL
 
@@ -113,31 +106,28 @@ Hello, World!
 ()
 ```
 
-
 ## Language Goals
 
-* A clean, minimal syntax designed for coding in creative contexts.
-* Fast compilation.
-  * The lexer, parser, and compiler are all written with speed in mind,
+- A clean, minimal syntax designed for coding in creative contexts.
+- Fast compilation.
+  - The lexer, parser, and compiler are all written with speed in mind,
     enabling as-fast-as-possible iteration when working on an idea.
-* Fast and predictable runtime performance.
-  * Memory allocations are reference counted.
-  * Currently there's no tracing garbage collector (and no plan to add one)
+- Fast and predictable runtime performance.
+  - Memory allocations are reference counted.
+  - Currently there's no tracing garbage collector (and no plan to add one)
     so memory leaks are possible if cyclic references are created.
-* Lightweight integration into host applications.
-  * One of the primary use cases for Koto is for it to be embedded as a library
+- Lightweight integration into host applications.
+  - One of the primary use cases for Koto is for it to be embedded as a library
     in other applications, so it should be a good citizen and not introduce too
     much overhead.
-
 
 [crates]: https://crates.io/crates/koto
 [ci]: https://github.com/koto-lang/koto/actions
 [docs]: https://docs.rs/koto
 [repl]: https://en.wikipedia.org/wiki/Read–eval–print_loop
 
-
 ## Editor Support
 
-* [Visual Studio Code](https://github.com/koto-lang/koto-vscode)
-* [Vim / Neovim](https://github.com/koto-lang/koto.vim)
-* [Sublime Text](https://github.com/koto-lang/koto-sublime)
+- [Visual Studio Code](https://github.com/koto-lang/koto-vscode)
+- [Vim / Neovim](https://github.com/koto-lang/koto.vim)
+- [Sublime Text](https://github.com/koto-lang/koto-sublime)

--- a/src/cli/src/repl.rs
+++ b/src/cli/src/repl.rs
@@ -258,7 +258,7 @@ impl Repl {
                         );
                     }
                     match self.koto.run() {
-                        Ok(result) => writeln!(stdout, "{}", result).unwrap(),
+                        Ok(result) => writeln!(stdout, "{:#}", result).unwrap(),
                         Err(error) => self.print_error(stdout, tty, &error),
                     }
                     self.continued_lines.clear();

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -209,26 +209,32 @@ impl fmt::Display for Value {
         use Value::*;
         match self {
             Empty => f.write_str("()"),
-            Bool(b) => f.write_str(&b.to_string()),
-            Number(n) => f.write_str(&n.to_string()),
-            Num2(n) => f.write_str(&n.to_string()),
-            Num4(n) => f.write_str(&n.to_string()),
+            Bool(b) => write!(f, "{}", b),
+            Number(n) => write!(f, "{}", n),
+            Num2(n) => write!(f, "{}", n),
+            Num4(n) => write!(f, "{}", n),
             Str(s) => {
                 if f.alternate() {
-                    write!(f, "\"{}\"", s)
+                    write!(f, "{:#}", s)
                 } else {
-                    f.write_str(s)
+                    write!(f, "{}", s)
                 }
             }
-            List(l) => f.write_str(&l.to_string()),
-            Tuple(t) => f.write_str(&t.to_string()),
-            Map(m) => f.write_str(&m.to_string()),
+            List(l) => write!(f, "{}", l),
+            Tuple(t) => write!(f, "{}", t),
+            Map(m) => {
+                if f.alternate() {
+                    write!(f, "{:#}", m)
+                } else {
+                    write!(f, "{}", m)
+                }
+            }
             Range(IntRange { start, end }) => write!(f, "{}..{}", start, end),
             Function(_) => write!(f, "||"),
             Generator(_) => write!(f, "Generator"),
             Iterator(_) => write!(f, "Iterator"),
             ExternalFunction(_) => write!(f, "||"),
-            ExternalValue(ref value) => f.write_str(&value.read().to_string()),
+            ExternalValue(ref value) => write!(f, "{}", value.read()),
             IndexRange(self::IndexRange { .. }) => f.write_str("IndexRange"),
             TemporaryTuple(RegisterSlice { start, count }) => {
                 write!(f, "TemporaryTuple [{}..{}]", start, start + count)

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -352,12 +352,22 @@ impl fmt::Display for ValueMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         let mut first = true;
-        for (key, value) in self.contents().data.iter() {
-            if !first {
-                write!(f, ", ")?;
+        if f.alternate() {
+            for key in self.contents().data.keys() {
+                if !first {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}", key.value())?;
+                first = false;
             }
-            write!(f, "{}: {:#}", key.value(), value)?;
-            first = false;
+        } else {
+            for (key, value) in self.contents().data.iter() {
+                if !first {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}: {:#}", key.value(), value)?;
+                first = false;
+            }
         }
         write!(f, "}}")
     }

--- a/src/runtime/src/value_string.rs
+++ b/src/runtime/src/value_string.rs
@@ -91,6 +91,10 @@ impl fmt::Debug for ValueString {
 
 impl fmt::Display for ValueString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self)
+        if f.alternate() {
+            write!(f, "\"{}\"", self.as_str())
+        } else {
+            write!(f, "{}", self.as_str())
+        }
     }
 }


### PR DESCRIPTION
This PR adds alternate formatted output for `ValueMap`s, so that formatting with
`"{:#}"` will avoid printing out the values of map entries.

This is a good default when working in the REPL, in particular when importing
modules.
