### PR TITLE
Core library improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     modules can be accessed in scripts without them being imported first.
     - e.g. `number.pi` is now a valid script, whereas previously
       `import number` would be required for `number` to be available.
+- `koto.args` is now a Tuple instead of a List.
 
 ## [0.7.0] 2021.03.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 - The REPL now contains a help system that provides reference documentation for
   the core library.
 
+### Changed
+
+- Items from the prelude now don't have to be imported for them to available
+  in a script.
+  - The core library is made available in the prelude by default, so core
+    modules can be accessed in scripts without them being imported first.
+    - e.g. `number.pi` is now a valid script, whereas previously
+      `import number` would be required for `number` to be available.
+
 ## [0.7.0] 2021.03.27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     - e.g. `number.pi` is now a valid script, whereas previously
       `import number` would be required for `number` to be available.
 - `koto.args` is now a Tuple instead of a List.
+- `koto.script_dir` and `koto.script_path` are now empty by default.
 
 ## [0.7.0] 2021.03.27
 

--- a/docs/reference/core_lib/koto.md
+++ b/docs/reference/core_lib/koto.md
@@ -13,7 +13,7 @@ A collection of utilities for working with the Koto runtime.
 
 ## args
 
-`List`
+`Tuple`
 
 Provides access to the arguments that were passed into the script when running
 the `koto` CLI application.

--- a/docs/reference/core_lib/koto.md
+++ b/docs/reference/core_lib/koto.md
@@ -51,15 +51,17 @@ it can be useful to export items programatically.
 
 ## script_dir
 
-`String`
+`String or Empty`
 
-Provides the directory that the current script is contained in as a String.
+If a script is being executed then `script_dir` provides the directory that the
+current script is contained in as a String, otherwise `script_dir` is Empty.
 
 ## script_path
 
-`String`
+`String or Empty`
 
-Provides the path of the current script as a String.
+If a script is being executed then `script_path` provides the path of the
+current script as a String, otherwise `script_path` is Empty.
 
 ## type
 

--- a/examples/wasm/package.json
+++ b/examples/wasm/package.json
@@ -7,9 +7,9 @@
   },
   "dependencies": {
     "brace": "^0.11.1"
-  }
+  },
   "devDependencies": {
     "parcel-bundler": "1.12.3",
     "parcel-plugin-wasm.rs": "^1.2.16"
-  },
+  }
 }

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -1,4 +1,4 @@
-import koto, test.assert_eq
+import test.assert_eq
 
 export main = ||
   n = match koto.args.get 0

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -6,7 +6,6 @@ Based on the Ruby implementation:
 https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fannkuchredux-yarv-1.html
 -#
 
-import koto
 from test import assert, assert_eq
 
 fannkuch = |n|

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -1,4 +1,4 @@
-import koto, test.assert_eq
+import test.assert_eq
 
 fib = |n|
   switch

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -8,7 +8,7 @@ https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-lua-4.
 
 # TODO Using num4 for pos/vel reduces precision compared to the original
 
-import koto, number.pi, test.assert_near
+import number.pi, test.assert_near
 
 solar_mass = 4 * pi * pi
 days_per_year = 365.24

--- a/koto/benches/num4.koto
+++ b/koto/benches/num4.koto
@@ -1,4 +1,4 @@
-import koto, test.assert_eq
+import test.assert_eq
 
 export main = ||
   n = match koto.args.get 0

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -6,7 +6,7 @@ Adapted from the Lua implementation by Mike Pall
 https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/spectralnorm-lua-1.html
 -#
 
-import koto, list, test.assert_near
+import test.assert_near
 
 A = |i, j|
   ij = i + j - 1

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -1,6 +1,3 @@
-from test import assert_eq
-import koto
-
 digits = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
   "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
   "eighteen", "nineteen"]
@@ -46,6 +43,8 @@ export main = ||
 
 export tests =
   test_number_to_english: ||
+    import test.assert_eq
+
     assert_eq (number_to_english 0), "zero"
     assert_eq (number_to_english -42), "minus forty-two"
     assert_eq (number_to_english 217), "two hundred and seventeen"

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -1,4 +1,4 @@
-import koto.type, test.assert_eq
+import test.assert_eq
 
 export tests =
   test_import_module: ||
@@ -6,7 +6,7 @@ export tests =
     # The test_module module is defined in the test_module directory,
     # with test_module/main.koto as its entry point.
     import test_module
-    assert_eq (type test_module), "Map"
+    assert_eq (koto.type test_module), "Map"
     assert_eq test_module.foo, 42
     assert_eq (test_module.square 9), 81
 
@@ -30,7 +30,6 @@ export tests =
     assert_eq y, -1
 
   test_access_export: ||
-    import koto
     x = "value_x"
     koto.exports().insert x, 99
     assert_eq value_x, 99

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -1,4 +1,3 @@
-import koto, io
 from test import assert, assert_eq, assert_ne
 
 

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -1,4 +1,3 @@
-import iterator
 from test import assert, assert_eq
 
 make_foo = |x|

--- a/koto/tests/libs/json.koto
+++ b/koto/tests/libs/json.koto
@@ -1,4 +1,3 @@
-import koto, io, json
 from test import assert, assert_eq
 
 export tests =

--- a/koto/tests/libs/random.koto
+++ b/koto/tests/libs/random.koto
@@ -1,4 +1,3 @@
-import random
 from test import assert, assert_eq, assert_ne, assert_near
 
 export tests =

--- a/koto/tests/libs/tempfile.koto
+++ b/koto/tests/libs/tempfile.koto
@@ -1,4 +1,3 @@
-import io, tempfile
 from test import assert, assert_eq
 
 

--- a/koto/tests/libs/toml.koto
+++ b/koto/tests/libs/toml.koto
@@ -1,4 +1,4 @@
-import koto, io, test.assert_eq, toml,
+import test.assert_eq
 
 export tests =
   test_serialize_and_deserialize_toml: ||

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -1,4 +1,3 @@
-import list
 from test import assert, assert_ne, assert_eq
 
 make_foo = |x|

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -1,4 +1,3 @@
-import map
 from test import assert, assert_eq
 
 make_foo = |x|
@@ -100,7 +99,7 @@ export tests =
     m.sort |key, value| value
     assert_eq m.keys().to_tuple(), ("foo", "bar")
 
-    m = 
+    m =
       foo: make_foo(27)
       bar: make_foo(42)
       baz: make_foo(-1)

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -1,4 +1,3 @@
-import map
 from test import assert, assert_eq, assert_ne
 
 export tests =

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -1,5 +1,4 @@
 from test import assert, assert_eq
-import koto
 
 locals = {}
 

--- a/koto/tests/number_ops.koto
+++ b/koto/tests/number_ops.koto
@@ -1,4 +1,4 @@
-import koto.type, number
+import koto.type
 from number import e, infinity, negative_infinity, pi, tau,
 from test import assert, assert_eq, assert_near
 

--- a/koto/tests/os.koto
+++ b/koto/tests/os.koto
@@ -1,4 +1,4 @@
-import os, test.assert
+import test.assert
 
 export tests =
   test_cpu_count: ||

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -1,4 +1,4 @@
-import koto.type, string
+import koto.type
 from test import assert, assert_eq, assert_ne
 
 export tests =

--- a/koto/tests/threads.koto
+++ b/koto/tests/threads.koto
@@ -1,4 +1,4 @@
-import list, thread, test.assert_eq
+import test.assert_eq
 
 export tests =
   test_spawn_4_threads_and_join: ||

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -570,7 +570,7 @@ impl Compiler {
                             };
 
                             let function_register = self.push_register()?;
-                            self.compile_load_export(function_register, *id);
+                            self.compile_load_non_local(function_register, *id);
 
                             self.compile_call(
                                 call_result_register,
@@ -1194,7 +1194,7 @@ impl Compiler {
         } else {
             match self.get_result_register(result_register)? {
                 Some(result) => {
-                    self.compile_load_export(result.register, id);
+                    self.compile_load_non_local(result.register, id);
                     Some(result)
                 }
                 None => None,
@@ -1213,13 +1213,13 @@ impl Compiler {
         }
     }
 
-    fn compile_load_export(&mut self, result_register: u8, id: ConstantIndex) {
+    fn compile_load_non_local(&mut self, result_register: u8, id: ConstantIndex) {
         use Op::*;
 
         if id <= u8::MAX as u32 {
-            self.push_op(LoadExport, &[result_register, id as u8]);
+            self.push_op(LoadNonLocal, &[result_register, id as u8]);
         } else {
-            self.push_op(LoadExportLong, &[result_register]);
+            self.push_op(LoadNonLocalLong, &[result_register]);
             self.push_bytes(&id.to_le_bytes());
         }
     }
@@ -1904,7 +1904,7 @@ impl Compiler {
                                 Some(register) => CompileResult::with_assigned(register),
                                 None => {
                                     let register = self.push_register()?;
-                                    self.compile_load_export(register, *id);
+                                    self.compile_load_non_local(register, *id);
                                     CompileResult::with_temporary(register)
                                 }
                             }
@@ -2037,7 +2037,7 @@ impl Compiler {
                     self.push_op(Op::Capture, &[result.register, i as u8, local_register]);
                 } else {
                     let capture_register = self.push_register()?;
-                    self.compile_load_export(capture_register, *capture);
+                    self.compile_load_non_local(capture_register, *capture);
                     self.push_op(Op::Capture, &[result.register, i as u8, capture_register]);
                     self.pop_register()?;
                 }

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -89,7 +89,7 @@ pub enum Instruction {
         register: u8,
         constant: ConstantIndex,
     },
-    LoadExport {
+    LoadNonLocal {
         register: u8,
         constant: ConstantIndex,
     },
@@ -375,7 +375,7 @@ impl fmt::Display for Instruction {
             LoadFloat { .. } => write!(f, "LoadFloat"),
             LoadInt { .. } => write!(f, "LoadInt"),
             LoadString { .. } => write!(f, "LoadString"),
-            LoadExport { .. } => write!(f, "LoadExport"),
+            LoadNonLocal { .. } => write!(f, "LoadNonLocal"),
             SetExport { .. } => write!(f, "SetExport"),
             Import { .. } => write!(f, "Import"),
             MakeTuple { .. } => write!(f, "MakeTuple"),
@@ -463,9 +463,9 @@ impl fmt::Debug for Instruction {
                 "LoadString\tresult: {}\tconstant: {}",
                 register, constant
             ),
-            LoadExport { register, constant } => write!(
+            LoadNonLocal { register, constant } => write!(
                 f,
-                "LoadExport\tresult: {}\tconstant: {}",
+                "LoadNonLocal\tresult: {}\tconstant: {}",
                 register, constant
             ),
             SetExport { export, source } => {
@@ -940,11 +940,11 @@ impl Iterator for InstructionReader {
                 register: get_byte!(),
                 constant: get_u32!() as ConstantIndex,
             }),
-            Op::LoadExport => Some(LoadExport {
+            Op::LoadNonLocal => Some(LoadNonLocal {
                 register: get_byte!(),
                 constant: get_byte!() as ConstantIndex,
             }),
-            Op::LoadExportLong => Some(LoadExport {
+            Op::LoadNonLocalLong => Some(LoadNonLocal {
                 register: get_byte!(),
                 constant: get_u32!() as ConstantIndex,
             }),

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -17,8 +17,8 @@ pub enum Op {
     LoadIntLong,      // register, constant[4]
     LoadString,       // register, constant
     LoadStringLong,   // register, constant[4]
-    LoadExport,       // register, constant
-    LoadExportLong,   // register, constant[4]
+    LoadNonLocal,     // register, constant
+    LoadNonLocalLong, // register, constant[4]
     SetExport,        // export, source
     SetExportLong,    // export[4], source
     Import,           // register, constant

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -31,8 +31,7 @@ pub use {koto_bytecode as bytecode, koto_parser as parser, koto_runtime as runti
 use {
     koto_bytecode::{Chunk, LoaderError},
     koto_runtime::{
-        DefaultLogger, KotoLogger, Loader, RuntimeError, Value, ValueList, ValueMap, ValueVec, Vm,
-        VmSettings,
+        DefaultLogger, KotoLogger, Loader, RuntimeError, Value, ValueMap, Vm, VmSettings,
     },
     std::{error::Error, fmt, path::PathBuf, sync::Arc},
 };
@@ -184,12 +183,12 @@ impl Koto {
     }
 
     pub fn set_args(&mut self, args: &[String]) {
-        use Value::{Map, Str};
+        use Value::{Map, Str, Tuple};
 
         let koto_args = args
             .iter()
             .map(|arg| Str(arg.as_str().into()))
-            .collect::<ValueVec>();
+            .collect::<Vec<_>>();
 
         match self
             .runtime
@@ -199,10 +198,11 @@ impl Koto {
             .get_with_string_mut("koto")
             .unwrap()
         {
-            Map(map) => map
-                .contents_mut()
-                .data
-                .add_list("args", ValueList::with_data(koto_args)),
+            Map(map) => {
+                map.contents_mut()
+                    .data
+                    .add_value("args", Tuple(koto_args.into()));
+            }
             _ => unreachable!(),
         }
     }

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -1,11 +1,11 @@
-use crate::{runtime_error, Value, ValueList, ValueMap};
+use crate::{runtime_error, Value, ValueMap, ValueTuple};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
 
     let mut result = ValueMap::new();
 
-    result.add_value("args", List(ValueList::default()));
+    result.add_value("args", Tuple(ValueTuple::default()));
 
     result.add_fn("current_dir", |_, _| {
         let result = match std::env::current_dir() {

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -19,8 +19,8 @@ pub fn make_module() -> ValueMap {
         Ok(Value::Map(vm.context_mut().exports.clone()))
     });
 
-    result.add_value("script_dir", Str("".into()));
-    result.add_value("script_path", Str("".into()));
+    result.add_value("script_dir", Empty);
+    result.add_value("script_path", Empty);
 
     result.add_fn("type", |vm, args| match vm.get_args(args) {
         [value] => Ok(Str(value.type_as_string().into())),

--- a/src/runtime/src/value_tuple.rs
+++ b/src/runtime/src/value_tuple.rs
@@ -13,6 +13,12 @@ impl ValueTuple {
     }
 }
 
+impl Default for ValueTuple {
+    fn default() -> Self {
+        Vec::default().into()
+    }
+}
+
 impl fmt::Display for ValueTuple {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;


### PR DESCRIPTION
- The prelude is now searched when looking for a non-local value.
  - This makes the core library modules available by default without having to be imported first.
- `koto.args` is now a Tuple instead of a List (closes #61).
- `koto.script_dir` and `koto.script_path` are now Empty by default.