### PR TITLE
MetaMap improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@
     modules can be accessed in scripts without them being imported first.
     - e.g. `number.pi` is now a valid script, whereas previously
       `import number` would be required for `number` to be available.
+- Tests are now defined using the meta map.
+  - e.g. instead of `test_check_it_works: ...`,
+    you now write `@test check_it_works: ...`.
+  - Similarly, `pre_test:` and `post_test` are now defined as
+    `@pre_test` and `@post_test`.
+
 - `koto.args` is now a Tuple instead of a List.
 - `koto.script_dir` and `koto.script_path` are now empty by default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@
       assert_eq ('{:6.2}'.format 1 / 3), '  0.33'
       assert_eq ('{:-^8}'.format "ab"), '---ab---'
       ```
+- Meta maps can now have user-defined entries defined, using the `@meta` tag.
+  - e.g.
+    ```koto
+    make_foo = |x, y|
+      x: x
+      y: y
+      @meta get_x_plus_y: |self| self.x + self.y
+    foo = make_foo 1, 2
+    assert_eq foo.get_x_plus_y(), 3
+    assert_eq foo.keys().to_tuple(), ("x", "y")
+    ```
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@
     you now write `@test check_it_works: ...`.
   - Similarly, `pre_test:` and `post_test` are now defined as
     `@pre_test` and `@post_test`.
+  - To define a tests map, export the map as `@tests` rather than `tests`.
+  - e.g.
+    ```koto
+    export @tests =
+        @pre_test: |self|
+            self.test_data = 1, 2, 3
+        @post_test: |self|
+            self.test_data = ()
+        @test data_size: |self|
+            assert_eq self.test_data.size(), 3
+    ```
 
 - `koto.args` is now a Tuple instead of a List.
 - `koto.script_dir` and `koto.script_path` are now empty by default.

--- a/docs/reference/core_lib/map.md
+++ b/docs/reference/core_lib/map.md
@@ -152,6 +152,29 @@ Additionally, the following meta functions can customize object behaviour:
   - Provides a String that's used when checking the map's type:
     - `@type: "X"`
 
+#### Meta entries
+
+`@meta` can be used as a prefix on a map entry to add it to the meta map.
+The entry will be accessible on value lookups but won't show up in the regular
+map data:
+
+```koto
+make_x = |n|
+  data: n
+  # Overloading the addition operator
+  @meta get_data: |self| self.data
+
+x = make_x 42
+x.keys().to_list()
+# ["data"]
+x.get_data()
+# 42
+```
+
+#### Tests
+
+Tests are also stored in the meta map, see [test.md](test.md) for info.
+
 # Reference
 
 - [clear](#clear)

--- a/docs/reference/core_lib/test.md
+++ b/docs/reference/core_lib/test.md
@@ -5,10 +5,10 @@ A collection of utilities for writing tests.
 ## Writing tests
 
 To add tests to a Koto script, `export` a Map named `tests`, and then any
-functions in the Map with names starting with `test_` will be run as tests.
+functions in the Map tagged with `@test` will be run as tests.
 
-If a function named `pre_test` is in the `tests` Map, then it will be run before
-each test. Similarly, if a function named `post_test` is present then it will be
+If a function named `@pre_test` is in the `tests` Map, then it will be run before
+each test. Similarly, if a function named `@post_test` is present then it will be
 run after each test.
 
 These functions are useful if some setup work is needed before each test, and
@@ -22,16 +22,16 @@ first argument, then the `tests` Map itself will be passed in as `self`.
 ```koto
 # Tests are exported from a module as a map named `tests`
 export tests =
-  # 'pre_test' will be run before each test
-  pre_test: |self|
+  # '@pre_test' will be run before each test
+  @pre_test: |self|
     self.test_data = 1, 2, 3
 
-  # 'post_test' will be run after each test
-  post_test: |self|
+  # '@post_test' will be run after each test
+  @post_test: |self|
     self.test_data = ()
 
-  # Functions with a name starting with 'test_' are automatically run as tests
-  test_basic_assertions: ||
+  # Functions that are tagged with @test are automatically run as tests
+  @test basic_assertions: ||
     # assert checks that its argument is true
     assert 1 > 0
     # assert_near checks that its arguments are equal, within a specied margin
@@ -39,7 +39,7 @@ export tests =
     assert_near 1.3, 1.301, allowed_error
 
   # Instance test functions receive the tests map as `self`
-  test_data_size: |self|
+  @test data_size: |self|
     # assert_eq checks that its two arguments are equal
     assert_eq self.test_data.size(), 3
     # assert_ne checks that its two arguments are not equal
@@ -159,11 +159,11 @@ Runs the tests contained in the map.
 
 ```koto
 my_tests =
-  pre_test: |self| self.test_data = 1, 2, 3
-  post_test: |self| self.test_data = ()
+  @pre_test: |self| self.test_data = 1, 2, 3
+  @post_test: |self| self.test_data = ()
 
-  test_data_size: |self| assert_eq self.test_data.size(), 3
-  test_failure: |self| assert not self.test_data.is_empty()
+  @test data_size: |self| assert_eq self.test_data.size(), 3
+  @test failure: |self| assert not self.test_data.is_empty()
 
 try
   run_tests my_tests

--- a/docs/reference/core_lib/test.md
+++ b/docs/reference/core_lib/test.md
@@ -4,24 +4,24 @@ A collection of utilities for writing tests.
 
 ## Writing tests
 
-To add tests to a Koto script, `export` a Map named `tests`, and then any
+To add tests to a Koto script, `export` a Map named `@tests`, and then any
 functions in the Map tagged with `@test` will be run as tests.
 
-If a function named `@pre_test` is in the `tests` Map, then it will be run before
-each test. Similarly, if a function named `@post_test` is present then it will be
-run after each test.
+If a function named `@pre_test` is in the `@tests` Map, then it will be run
+before each test. Similarly, if a function named `@post_test` is present then it
+will be run after each test.
 
 These functions are useful if some setup work is needed before each test, and
 then maybe there's some cleanup work to do after the test has finished.
 
 To access the result of the setup work, if the test function takes `self` as its
-first argument, then the `tests` Map itself will be passed in as `self`.
+first argument, then the `@tests` Map itself will be passed in as `self`.
 
 ### Example
 
 ```koto
-# Tests are exported from a module as a map named `tests`
-export tests =
+# Tests are exported from a module as a map named `@tests`
+export @tests =
   # '@pre_test' will be run before each test
   @pre_test: |self|
     self.test_data = 1, 2, 3

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -9,7 +9,7 @@ export main = ||
   for i in 0..n
     a = (10..20).enumerate().to_tuple()
 
-export tests =
+export @tests =
   @test it_works: ||
     x = (1..=3).enumerate().to_tuple()
     assert_eq x, ((0, 1), (1, 2), (2, 3))

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -10,6 +10,6 @@ export main = ||
     a = (10..20).enumerate().to_tuple()
 
 export tests =
-  test_it_works: ||
+  @test it_works: ||
     x = (1..=3).enumerate().to_tuple()
     assert_eq x, ((0, 1), (1, 2), (2, 3))

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -73,7 +73,7 @@ export main = ||
     "Pfannkuchen({}) = {}".print n flips
 
 export tests =
-  test_5: ||
+  @test fannkuch_5: ||
     sum, flips = fannkuch 5
     assert_eq sum, 11
     assert_eq flips, 7

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -72,7 +72,7 @@ export main = ||
     "{}".print sum
     "Pfannkuchen({}) = {}".print n flips
 
-export tests =
+export @tests =
   @test fannkuch_5: ||
     sum, flips = fannkuch 5
     assert_eq sum, 11

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -14,6 +14,6 @@ export main = ||
   fib n
 
 export tests =
-  test_fib: ||
+  @test fib: ||
     assert_eq (fib 4), 3
     assert_eq (fib 5), 5

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -13,7 +13,7 @@ export main = ||
 
   fib n
 
-export tests =
+export @tests =
   @test fib: ||
     assert_eq (fib 4), 3
     assert_eq (fib 5), 5

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -128,7 +128,7 @@ export main = ||
     "{}".print end_energy # TODO format to 9dp
 
 export tests =
-  test_100: ||
+  @test nbody_100: ||
     initial_energy, end_energy = run_nbody 100
     assert_near initial_energy, -0.16907514, 1.0e-8
     assert_near end_energy, -0.16904989, 1.0e-8

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -127,7 +127,7 @@ export main = ||
     "{}".print initial_energy # TODO format to 9dp
     "{}".print end_energy # TODO format to 9dp
 
-export tests =
+export @tests =
   @test nbody_100: ||
     initial_energy, end_energy = run_nbody 100
     assert_near initial_energy, -0.16907514, 1.0e-8

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -58,6 +58,6 @@ export main = ||
     "{}".print result
 
 
-export tests =
+export @tests =
   @test spectral_norm_5: ||
     assert_near (spectral_norm 5), 1.261218, 1e-6

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -59,5 +59,5 @@ export main = ||
 
 
 export tests =
-  test_5: ||
+  @test spectral_norm_5: ||
     assert_near (spectral_norm 5), 1.261218, 1e-6

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -42,7 +42,7 @@ export main = ||
     "{}".print result
 
 export tests =
-  test_number_to_english: ||
+  @test number_to_english: ||
     import test.assert_eq
 
     assert_eq (number_to_english 0), "zero"

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -41,7 +41,7 @@ export main = ||
   if not (koto.args.get 1) == "quiet"
     "{}".print result
 
-export tests =
+export @tests =
   @test number_to_english: ||
     import test.assert_eq
 

--- a/koto/tests/assignment.koto
+++ b/koto/tests/assignment.koto
@@ -1,33 +1,33 @@
 from test import assert_eq, assert_ne
 
 export tests =
-  test_basic_assignment: ||
+  @test basic_assignment: ||
     a = 1
     b = -a
     assert_eq a, -b
 
-  test_multi_assignment: ||
+  @test multi_assignment: ||
     a, b, c, d, e = 1, 2, 3, 4, 5, 6, 7, 8,
     assert_eq c, 3
     assert_eq e, 5
 
-  test_chained_assignment: ||
+  @test chained_assignment: ||
     a = b = "foo"
     assert_eq a, "foo"
     assert_eq b, "foo"
 
-  test_unicode_identifiers: ||
+  @test unicode_identifiers: ||
     やあ = héllø = 99
     assert_eq héllø, 99
     assert_eq やあ, 99
 
-  test_assignment_returns_value: ||
+  @test assignment_returns_value: ||
     assert_eq (a = 42), 42
     assert_eq (x = 99), 99
     assert_eq a, 42
     assert_eq x, 99
 
-  test_export_assignment: ||
+  @test export_assignment: ||
     f = ||
       export x = 42
     f()
@@ -44,7 +44,7 @@ export tests =
     f3()
     assert_eq x, 84 # exported x remains the same
 
-  test_multiline_assignment: ||
+  @test multiline_assignment: ||
     f = |n| n
     a, b, c =
       1,
@@ -54,7 +54,7 @@ export tests =
     assert_eq b, 2
     assert_eq c, 3
 
-  test_assign_empty: ||
+  @test assign_empty: ||
     a = ()
     assert_eq a, ()
     assert_ne 1, ()

--- a/koto/tests/assignment.koto
+++ b/koto/tests/assignment.koto
@@ -1,6 +1,6 @@
 from test import assert_eq, assert_ne
 
-export tests =
+export @tests =
   @test basic_assignment: ||
     a = 1
     b = -a

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export tests =
+export @tests =
   @test inline_if: ||
     x = if true then 10 else 20
     assert_eq x, 10

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -1,29 +1,29 @@
 from test import assert, assert_eq
 
 export tests =
-  test_inline_if: ||
+  @test inline_if: ||
     x = if true then 10 else 20
     assert_eq x, 10
 
-  test_inline_if_function_call: ||
+  @test inline_if_function_call: ||
     is_zero = |x| x == 0
     x = 0
     x = if is_zero 0 then 42
     assert_eq x, 42
     assert if is_zero 0 then true else false
 
-  test_inline_if_multi_assignment: ||
+  @test inline_if_multi_assignment: ||
     a, b = if true then 10, 20 else 30, 40
     assert_eq b, 20
 
-  test_if_block: ||
+  @test if_block: ||
     x = true
     a = 0
     if x
       a = 42
     assert_eq a, 42
 
-  test_if_else_if: ||
+  @test if_else_if: ||
     x = true
     if x == false
       # This comment shouldn't break parsing
@@ -37,7 +37,7 @@ export tests =
           # or this one
         assert true
 
-  test_switch: ||
+  @test switch_expression: ||
     fib = |n|
       switch
         n <= 0 then 0
@@ -46,7 +46,7 @@ export tests =
 
     assert_eq 13, fib 7
 
-  test_match: ||
+  @test match_expression: ||
     inspect = |n|
       match n
         x if x < 0 then # 'then' is optional in a match arm when the body is indented
@@ -59,7 +59,7 @@ export tests =
           ">= 10"
     assert_eq (inspect 7), "odd"
 
-  test_match_against_lookups: ||
+  @test match_against_lookups: ||
     m = {foo: 42, bar: 99}
     z = match 99
       # Lookups (map/list accesses, function calls) match if their results are equal
@@ -68,7 +68,7 @@ export tests =
       other then "{}".format other
     assert_eq z, "bar"
 
-  test_match_multiple_values: ||
+  @test match_multiple_values: ||
     fizz_buzz = |n|
       match n % 3, n % 5
         0, 0 then "Fizz Buzz"
@@ -81,7 +81,7 @@ export tests =
       .to_tuple()
     assert_eq x, ("Buzz", 11, "Fizz", 13, 14, "Fizz Buzz")
 
-  test_match_lists_and_tuples: ||
+  @test match_lists_and_tuples: ||
     z = [1, 2, (3, 4), (5, [6, 7, 8])]
 
     a = match z

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -15,7 +15,7 @@ make_bidirectional_enum = |entries...|
       enum
 
 export tests =
-  test_make_enum: ||
+  @test make_enum: ||
     enum = make_enum "foo", "bar", "baz"
     assert_eq enum.foo, 0
     assert_eq enum.bar, 1
@@ -24,7 +24,7 @@ export tests =
     assert_eq enum.get_index(1)[0], "bar"
     assert_eq enum.get_index(2)[0], "baz"
 
-  test_make_bidirectional_enum: ||
+  @test make_bidirectional_enum: ||
     enum = make_bidirectional_enum "foo", "bar", "baz"
     assert_eq enum.foo, 0
     assert_eq enum.bar, 1
@@ -33,7 +33,7 @@ export tests =
     assert_eq enum.get(1), "bar"
     assert_eq enum.get(2), "baz"
 
-  test_match_against_enum_values: ||
+  @test match_against_enum_values: ||
     enum = make_enum "a", "b", "c"
     x = enum.b
     y = match x

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -14,7 +14,7 @@ make_bidirectional_enum = |entries...|
       enum.insert index, id
       enum
 
-export tests =
+export @tests =
   @test make_enum: ||
     enum = make_enum "foo", "bar", "baz"
     assert_eq enum.foo, 0

--- a/koto/tests/error_handling.koto
+++ b/koto/tests/error_handling.koto
@@ -1,7 +1,7 @@
 import error_handling_module
 from test import assert, assert_eq
 
-export tests =
+export @tests =
   @test try_expression: ||
     x = try
       42

--- a/koto/tests/error_handling.koto
+++ b/koto/tests/error_handling.koto
@@ -2,14 +2,14 @@ import error_handling_module
 from test import assert, assert_eq
 
 export tests =
-  test_try: ||
+  @test try_expression: ||
     x = try
       42
     catch _
       throw "error!" # This expression shouldn't be reached
     assert_eq x, 42
 
-  test_catch: ||
+  @test catch_expression: ||
     x = try
       # Error: List passed to function expecting a map
       [0, 1, 2].keys()
@@ -18,7 +18,7 @@ export tests =
       -1 # catch catches general runtime errors, not only thrown errors
     assert_eq x, -1
 
-  test_finally_following_try: ||
+  @test finally_following_try: ||
     x = 0
     try
       x = 1
@@ -28,7 +28,7 @@ export tests =
       x = 42 # finally is executed following both try and catch blocks
     assert_eq x, 42
 
-  test_finally_following_catch: ||
+  @test finally_following_catch: ||
     error_caught = false
     x = 0
     try
@@ -41,7 +41,7 @@ export tests =
     assert error_caught
     assert_eq x, 42
 
-  test_error_in_other_module: ||
+  @test error_in_other_module: ||
     x = 0
     try
       error_handling_module.error_function()

--- a/koto/tests/function_closures.koto
+++ b/koto/tests/function_closures.koto
@@ -1,7 +1,7 @@
 import test.assert_eq
 
 export tests =
-  test_value_capture_on_function_creation: ||
+  @test value_capture_on_function_creation: ||
     multipliers = (1..=4)
       .each |i| return |n| n * i
       .to_tuple()
@@ -12,7 +12,7 @@ export tests =
         .to_tuple(),
       (2, 4, 6, 8)
 
-  test_outer_value_captured_in_nested_function: ||
+  @test outer_value_captured_in_nested_function: ||
     capture_test = |a, b, c|
       inner = ||
         inner2 = |x|

--- a/koto/tests/function_closures.koto
+++ b/koto/tests/function_closures.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export tests =
+export @tests =
   @test value_capture_on_function_creation: ||
     multipliers = (1..=4)
       .each |i| return |n| n * i

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -1,12 +1,12 @@
 from test import assert, assert_eq
 
 export tests =
-  test_square: ||
+  @test square: ||
     square = |x| x * x
     assert_eq (square 7), 49
     assert_eq (square -10), 100
 
-  test_sum: ||
+  @test sum: ||
     sum = |x, y| x + y
     # Call with parentheses
     result = sum(10, 11)
@@ -15,26 +15,26 @@ export tests =
     result = sum 12, 18
     assert_eq result, 30
 
-  test_sum_variadic: ||
+  @test sum_variadic: ||
     sum = |x, y, z...|
       x + y + z.fold(0, |a, b| a + b)
     assert_eq (sum 1, 2), 3
     assert_eq (sum 3, 4, 5), 12
     assert_eq (sum 6, 7, 8, 9), 30
 
-  test_wildcard_arg: ||
+  @test wildcard_arg: ||
     foo = |a, _, c| a + c
     assert_eq (foo 1, 2, 3), 4
 
-  test_list_unpacking: ||
+  @test list_unpacking: ||
     foo = |a, [b, [c, d]], e| a * b * c * d * e
     assert_eq (foo 1, [2, [3, 4]], 5), 120
 
-  test_tuple_unpacking: ||
+  @test tuple_unpacking: ||
     foo = |a, (b, (c, d)), e| a + b + c + d + e
     assert_eq (foo 1, (2, (3, 4)), 5), 15
 
-  test_nested_function: ||
+  @test nested_function: ||
     add = |x, y|
       x2 = x
       do_add = |x, y|
@@ -46,22 +46,22 @@ export tests =
       result # implicit return
     assert_eq (add 1, 2), 3
 
-  test_captured_function: ||
+  @test captured_function: ||
     add = |x, y| x + y
     add2 = |x, y| add x, y
     assert_eq (add2 90, 9), 99
 
-  test_nested_calls: ||
+  @test nested_calls: ||
     add = |x, y| x + y
     assert_eq (add (add 1, 1), (add -1, -1)), 0
 
-  test_function_returning_multiple_values: ||
+  @test function_returning_multiple_values: ||
     f = |x| x - 1, x + 1
     a, b = f 0
     assert_eq a, -1
     assert_eq b, 1
 
-  test_early_return: ||
+  @test early_return: ||
     match_digit = |n|
       match_digit_nested = |n|
         for i in 0..10
@@ -78,14 +78,14 @@ export tests =
         .to_tuple(),
       (0, 1, 2)
 
-  test_return_multiple_values: ||
+  @test return_multiple_values: ||
     f = ||
       return -1, 1
     a, b = f()
     assert_eq a, -1
     assert_eq b, 1
 
-  test_return_no_value: ||
+  @test return_no_value: ||
     f = ||
       if true
         return

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export tests =
+export @tests =
   @test square: ||
     square = |x| x * x
     assert_eq (square 7), 49

--- a/koto/tests/functions_in_lookups.koto
+++ b/koto/tests/functions_in_lookups.koto
@@ -10,7 +10,7 @@ test_map = ||
 maps = [test_map(), test_map()]
 
 export tests =
-  test_call_setter_in_child_map_in_list: ||
+  @test call_setter_in_child_map_in_list: ||
     # set the first map's child foo
     assert_eq maps[0].get_child_map().foo, 42
     maps[0].get_child_map().set_foo -1
@@ -19,10 +19,10 @@ export tests =
     # the second map's child foo hasn't been modified
     assert_eq maps[1].get_child_map().foo, 42
 
-  test_negation_of_lookup: ||
+  @test negation_of_lookup: ||
     assert_eq -maps[1].get_child_map().foo, -42
 
-  test_chained_function_call: ||
+  @test chained_function_call: ||
     f = ||
       # Calling f() returns the following function
       |x| x * x

--- a/koto/tests/functions_in_lookups.koto
+++ b/koto/tests/functions_in_lookups.koto
@@ -9,7 +9,7 @@ test_map = ||
 # Make a list of two test maps
 maps = [test_map(), test_map()]
 
-export tests =
+export @tests =
   @test call_setter_in_child_map_in_list: ||
     # set the first map's child foo
     assert_eq maps[0].get_child_map().foo, 42

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export tests =
+export @tests =
   @test import_module: ||
     # Importing a module brings the module's exports map into scope by assignment.
     # The test_module module is defined in the test_module directory,

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -1,7 +1,7 @@
 import test.assert_eq
 
 export tests =
-  test_import_module: ||
+  @test import_module: ||
     # Importing a module brings the module's exports map into scope by assignment.
     # The test_module module is defined in the test_module directory,
     # with test_module/main.koto as its entry point.
@@ -10,26 +10,26 @@ export tests =
     assert_eq test_module.foo, 42
     assert_eq (test_module.square 9), 81
 
-  test_assign_import_item: ||
+  @test assign_import_item: ||
     x = import test_module.bar
     assert_eq bar, -1
     assert_eq x, bar
 
-  test_import_nested_item: ||
+  @test import_nested_item: ||
     import test_module.baz.qux
     assert_eq qux, "O_o"
 
-  test_import_multiple_items: ||
+  @test import_multiple_items: ||
     a, b = import test_module.foo, test_module.bar
     assert_eq a, 42
     assert_eq b, -1
 
-  test_import_multiple_items_with_from: ||
+  @test import_multiple_items_with_from: ||
     x, y = from test_module import foo, bar
     assert_eq x, 42
     assert_eq y, -1
 
-  test_access_export: ||
+  @test access_export: ||
     x = "value_x"
     koto.exports().insert x, 99
     assert_eq value_x, 99

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -2,7 +2,7 @@ from test import assert, assert_eq, assert_ne
 
 
 export tests =
-  test_reading_a_file: ||
+  @test reading_a_file: ||
     path = koto.script_dir + "/data/test.txt"
     assert io.exists path
 
@@ -12,5 +12,5 @@ export tests =
     file = io.open path
     assert_eq contents, file.read_to_string()
 
-  test_current_dir: ||
+  @test current_dir: ||
     assert_ne koto.current_dir(), ""

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -1,7 +1,7 @@
 from test import assert, assert_eq, assert_ne
 
 
-export tests =
+export @tests =
   @test reading_a_file: ||
     path = koto.script_dir + "/data/test.txt"
     assert io.exists path

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -7,14 +7,14 @@ make_foo = |x|
   @==: |self, other| self.x == other.x
 
 export tests =
-  test_next: ||
+  @test next: ||
     i = (1..=3).iter()
     assert_eq i.next(), 1
     assert_eq i.next(), 2
     assert_eq i.next(), 3
     assert_eq i.next(), ()
 
-  test_to_list: ||
+  @test to_list: ||
     assert_eq (1..=3).to_list(), [1, 2, 3]
     assert_eq [2,, 4, 6].to_list(), [2, 4, 6]
     assert_eq
@@ -26,7 +26,7 @@ export tests =
         yield x * 2
     assert_eq (doubler 1..=5).to_list(), [2, 4, 6, 8, 10]
 
-  test_to_map: ||
+  @test to_map: ||
     # An iterator that returns a single value produces a Map,
     # with the input values as keys, and with Empty as their values.
     assert_eq
@@ -40,40 +40,40 @@ export tests =
         .to_map(),
       {"1": 1, "2": 2, "3": 3}
 
-  test_to_tuple: ||
+  @test to_tuple: ||
     assert_eq (1..=3).iter().to_tuple(), (1, 2, 3)
     assert_eq [2, 4, 6].iter().to_tuple(), (2, 4, 6)
     assert_eq
       {foo: 42, bar: 99}.iter().to_tuple(),
       (("foo", 42), ("bar", 99))
 
-  test_all: ||
+  @test all: ||
     assert (1..10).all(|n| n < 10)
     assert not (1..10).all(|n| n < 5)
     assert "xyz".all |c| "zyx".contains c
 
-  test_any: ||
+  @test any: ||
     assert (1..10).any(|n| n == 5)
     assert not (1..10).any(|n| n == 15)
     assert "xyz".any(|c| c == "z")
 
-  test_chain: ||
+  @test chain: ||
     assert_eq
       (1..10).chain(10..15).chain(15..20).to_tuple(),
       (1..20).to_tuple()
 
-  test_consume: ||
+  @test consume: ||
     x = []
     (1..=5).each(|n| x.push n).consume()
     assert_eq x, [1, 2, 3, 4, 5]
 
-  test_count: ||
+  @test count: ||
     result = (0..10)
       .keep |n| n % 2 == 0
       .count()
     assert_eq result, 5
 
-  test_each: ||
+  @test each: ||
     assert_eq
       ("1", "2").each(|x| x.to_number()).to_tuple(),
       (1, 2)
@@ -84,40 +84,40 @@ export tests =
         .to_tuple(),
       (("foo", 42), ("bar", 99))
 
-  test_enumerate: ||
+  @test enumerate: ||
     assert_eq
       (10..=12).enumerate().to_tuple(),
       ((0, 10), (1, 11), (2, 12))
 
-  test_keep: ||
+  @test keep: ||
     assert_eq
       (0..10)
         .keep |x| x % 2 == 1
         .to_tuple(),
       (1, 3, 5, 7, 9)
 
-  test_fold: ||
+  @test fold: ||
     assert_eq
       (1..=5).fold(0, |sum, x| sum + x),
       15
 
-  test_max: ||
+  @test max: ||
     assert_eq (2, -1, 9).max(), 9
     assert_eq (make_foo(2), make_foo(-1), make_foo(9)).max().x, 9
     assert_eq ("hello", "goodbye").max(), "hello"
 
-  test_min: ||
+  @test min: ||
     assert_eq (2, -1, 9).min(), -1
     assert_eq (make_foo(2), make_foo(-1), make_foo(9)).min().x, -1
     assert_eq ("hello", "goodbye").min(), "goodbye"
 
-  test_min_max: ||
+  @test min_max: ||
     assert_eq (2, -1, 9).min_max(), (-1, 9)
     assert_eq ("hello", "to the", "world").min_max(), ("hello", "world")
     min_max = (make_foo(2), make_foo(-1), make_foo(9)).min_max()
     assert_eq (min_max[0].x, min_max[1].x), (-1, 9)
 
-  test_position: ||
+  @test position: ||
     assert_eq
       (100..1000).position(|x| x >= 110),
       10
@@ -125,36 +125,36 @@ export tests =
       "hey now".position(|c| c == " "),
       3
 
-  test_product: ||
+  @test product: ||
     assert_eq (1..=5).product(), 120
     # An initial value can be provided to override the default initial value of 0
     assert_eq (2, 3, 4).product(num2 1, 2), (num2 24, 48)
 
-  test_product_with_overloaded_multiply_operator: ||
+  @test product_with_overloaded_multiply_operator: ||
     foo = |x|
       x: x
       @*: |self, other| foo self.x * other.x
     foos = (foo 2), (foo 3), (foo 4)
     assert_eq foos.product(foo 1), (foo 24)
 
-  test_skip: ||
+  @test skip: ||
     assert_eq
       (0..10).skip(5).to_tuple(),
       (5, 6, 7, 8, 9)
 
-  test_sum: ||
+  @test sum: ||
     assert_eq (1..=5).sum(), 15
     # An initial value can be provided to override the default initial value of 0
     assert_eq ([1], [2], [3]).sum([]), [1, 2, 3]
 
-  test_sum_with_overloaded_add_operator: ||
+  @test sum_with_overloaded_add_operator: ||
     foo = |x|
       x: x
       @+: |self, other| foo self.x + other.x
     foos = (foo 10), (foo 20), (foo 30)
     assert_eq foos.sum(foo 0), (foo 60)
 
-  test_take: ||
+  @test take: ||
     assert_eq
       (1..100).take(5).to_tuple(),
       (1, 2, 3, 4, 5)
@@ -166,7 +166,7 @@ export tests =
       ones().take(3).to_tuple(),
       (1, 1, 1)
 
-  test_zip: ||
+  @test zip: ||
     assert_eq
       (1..=3)
         .zip 11..100
@@ -179,7 +179,7 @@ export tests =
         .to_tuple(),
       ((("foo", 42), 100), (("bar", 99), 101))
 
-  test_custom_iterator_adaptor: ||
+  @test custom_iterator_adaptor: ||
     # Inserting a function into the iterator map makes it available as an iterator adaptor
     iterator.every_other = |iter|
       n = 0

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export tests =
+export @tests =
   @test next: ||
     i = (1..=3).iter()
     assert_eq i.next(), 1

--- a/koto/tests/libs/json.koto
+++ b/koto/tests/libs/json.koto
@@ -1,7 +1,7 @@
 from test import assert, assert_eq
 
 export tests =
-  test_serialize_and_deserialize_json: ||
+  @test serialize_and_deserialize_json: ||
     file_data = try
       io.read_to_string koto.script_dir + "/data/test.json"
     catch error

--- a/koto/tests/libs/json.koto
+++ b/koto/tests/libs/json.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export tests =
+export @tests =
   @test serialize_and_deserialize_json: ||
     file_data = try
       io.read_to_string koto.script_dir + "/data/test.json"

--- a/koto/tests/libs/random.koto
+++ b/koto/tests/libs/random.koto
@@ -1,29 +1,29 @@
 from test import assert, assert_eq, assert_ne, assert_near
 
 export tests =
-  pre_test: ||
+  @pre_test: ||
     # random.seed seeds the default generator
     random.seed 0
 
-  test_bool: ||
+  @test bool: ||
     assert random.bool()
     assert not random.bool()
 
-  test_number: ||
+  @test number: ||
     assert_near random.number(), 0.024, 0.001
     assert_near random.number(), 0.982, 0.001
 
-  test_num2_num4: ||
+  @test num2_num4: ||
     assert_near random.number2(), (num2 0.024, 0.982), 0.001
     assert_near random.number4(), (num4 0.006, 0.861, 0.823, 0.186), 0.001
 
-  test_pick: ||
+  @test pick: ||
     x = ["foo", "bar", "baz"]
     assert (x.contains (random.pick x))
     x = 0..10
     assert (x.contains (random.pick x))
 
-  test_generator: ||
+  @test generator: ||
     get_rng_output = |rng|
       (0..10)
         .each |_| rng.pick 0..5

--- a/koto/tests/libs/random.koto
+++ b/koto/tests/libs/random.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq, assert_ne, assert_near
 
-export tests =
+export @tests =
   @pre_test: ||
     # random.seed seeds the default generator
     random.seed 0

--- a/koto/tests/libs/tempfile.koto
+++ b/koto/tests/libs/tempfile.koto
@@ -2,7 +2,7 @@ from test import assert, assert_eq
 
 
 export tests =
-  test_temp_dir: ||
+  @test temp_dir: ||
     path = tempfile.temp_path()
     file = io.create path
     contents = "<(^_^)<"
@@ -11,7 +11,7 @@ export tests =
     io.remove_file path
     assert not io.exists path
 
-  test_temp_file: ||
+  @test temp_file: ||
     temp = tempfile.temp_file()
     temp_path = temp.path()
     temp.write_line "hello"

--- a/koto/tests/libs/tempfile.koto
+++ b/koto/tests/libs/tempfile.koto
@@ -1,7 +1,6 @@
 from test import assert, assert_eq
 
-
-export tests =
+export @tests =
   @test temp_dir: ||
     path = tempfile.temp_path()
     file = io.create path

--- a/koto/tests/libs/toml.koto
+++ b/koto/tests/libs/toml.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export tests =
+export @tests =
   @test serialize_and_deserialize_toml: ||
     file_data = io.read_to_string koto.script_dir + "/data/test.toml"
     data = toml.from_string file_data

--- a/koto/tests/libs/toml.koto
+++ b/koto/tests/libs/toml.koto
@@ -1,7 +1,7 @@
 import test.assert_eq
 
 export tests =
-  test_serialize_and_deserialize_toml: ||
+  @test serialize_and_deserialize_toml: ||
     file_data = io.read_to_string koto.script_dir + "/data/test.toml"
     data = toml.from_string file_data
 

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export tests =
+export @tests =
   @test clear: ||
     x = [1, 2, 3, 4, 5]
     x.clear()

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -7,23 +7,23 @@ make_foo = |x|
   @==: |self, other| self.x == other.x
 
 export tests =
-  test_clear: ||
+  @test clear: ||
     x = [1, 2, 3, 4, 5]
     x.clear()
     assert_eq x, []
 
-  test_contains: ||
+  @test contains: ||
     assert [0..10].contains 5
     assert not [0..10].contains 15
 
-  test_contains_with_overloaded_equality_op: ||
+  @test contains_with_overloaded_equality_op: ||
     bar = |x|
       x: x
       @==: |self, other| self.x != other.x # This inverts the usual behaviour of ==
 
     assert not [(bar 1)].contains (bar 1)
 
-  test_copy: ||
+  @test copy: ||
     x = [1, 2, 3]
     x2 = x
     x3 = x.copy()
@@ -31,13 +31,13 @@ export tests =
     assert_eq x2[0], 99
     assert_eq x3[0], 1
 
-  test_deep_copy: ||
+  @test deep_copy: ||
     x = [1, [2, 3]]
     x2 = x.deep_copy()
     x[1][0] = 99
     assert_eq x2[1][0], 2
 
-  test_push_pop: ||
+  @test push_pop: ||
     z = [1]
     z.push 2
     assert_eq z, [1, 2]
@@ -46,13 +46,13 @@ export tests =
     assert_eq z, [1, 2, 3]
     assert_eq z.pop(), 3
     assert_eq z, [1, 2]
-    z.pop()
+   z.pop()
     z.pop()
     assert_eq z, []
     list.pop z
     assert_eq z, []
 
-  test_first_last: ||
+  @test first_last: ||
     z = []
     assert_eq z.first(), ()
     assert_eq z.last(), ()
@@ -65,11 +65,11 @@ export tests =
     assert_eq z.first(), 1
     assert_eq z.last(), 3
 
-  test_is_empty: ||
+  @test is_empty: ||
     assert [].is_empty()
     assert not [1, 2, 3].is_empty()
 
-  test_remove_insert: ||
+  @test remove_insert: ||
     z = [1, 2, 3]
     assert_eq (z.remove 1), 2
     assert_eq z, [1, 3]
@@ -78,16 +78,16 @@ export tests =
     z.insert 3, -1
     assert_eq z, [1, 42, 3, -1]
 
-  test_get: ||
+  @test get: ||
     assert_eq ([0..10].get 5), 5
     assert_eq ([0..10].get 15), ()
 
-  test_fill: ||
+  @test fill: ||
     a = [1, 2, 3]
     a.fill 42
     assert_eq a, [42, 42, 42]
 
-  test_resize: ||
+  @test resize: ||
     z = [42]
     z.resize 4, 99
     assert_eq z, [42, 99, 99, 99]
@@ -95,17 +95,17 @@ export tests =
     z.resize 2, -1
     assert_eq z, [42, 99]
 
-  test_retain_value: ||
+  @test retain_value: ||
     z = ["hello", 42, (num4 0), "hello"]
     z.retain "hello"
     assert_eq z, ["hello", "hello"]
 
-  test_retain_predicate: ||
+  @test retain_predicate: ||
     z = [0..10]
     z.retain |n| n % 2 == 0
     assert_eq z, [0, 2, 4, 6, 8]
 
-  test_retain_with_overloaded_equality_op: ||
+  @test retain_with_overloaded_equality_op: ||
     bar = |x|
       x: x
       @==: |self, other| self.x != other.x # This inverts the usual behaviour of ==
@@ -114,16 +114,16 @@ export tests =
     z.retain bar(1) # The inverted == operator causes the 'bar 1's to be dropped
     assert_eq z.size(), 2
 
-  test_reverse: ||
+  @test reverse: ||
     a = [1, 2, 3]
     a.reverse()
     assert_eq a, [3, 2, 1]
 
-  test_size: ||
+  @test size: ||
     assert_eq [].size(), 0
     assert_eq [1, 2, 3].size(), 3
 
-  test_sort: ||
+  @test sort: ||
     z = [3, 2, 1]
     z.sort()
     assert_eq z, [1, 2, 3]
@@ -151,7 +151,7 @@ export tests =
     for n in 0..z.size()
       assert_eq z[n].x, a[a.size() - 1 - n].x
 
-  test_sort_copy: ||
+  @test sort_copy: ||
     assert_eq [42, 10, 9].sort_copy(), [9, 10, 42]
 
     # values with overloaded operators
@@ -162,7 +162,7 @@ export tests =
     assert_ne r, z
     assert_eq r, a
 
-  test_swap: ||
+  @test swap: ||
     a = [1, 2, 3]
     b = [7, 8, 9]
 
@@ -171,15 +171,15 @@ export tests =
     assert_eq a, [7, 8, 9]
     assert_eq b, [1, 2, 3]
 
-  test_to_tuple: ||
+  @test to_tuple: ||
     assert_eq [1, 2, 3].to_tuple(), (1, 2, 3)
 
-  test_transform: ||
+  @test transform: ||
     z = ["1", "2", "3"]
     z.transform |x| x.to_number()
     assert_eq z, [1, 2, 3]
 
-  test_with_size: ||
+  @test with_size: ||
     assert_eq
       (list.with_size 3, "x"),
       ["x", "x", "x"]

--- a/koto/tests/lists.koto
+++ b/koto/tests/lists.koto
@@ -1,17 +1,17 @@
 from test import assert, assert_eq, assert_ne
 
 export tests =
-  test_list_indexing: ||
+  @test list_indexing: ||
     z = [10, 10 + 10, 30]
     assert_eq z[0], 10
     assert_eq z[0 + 1], 20
 
-  test_list_equality: ||
+  @test list_equality: ||
     z = [1, 2, 3]
     assert_eq z, z
     assert_ne z, []
 
-  test_list_addition: ||
+  @test list_addition: ||
     x = [0]
     x = x + [1]
     assert_eq x, [0, 1]
@@ -21,19 +21,19 @@ export tests =
     x += (4, 5)
     assert_eq x, [0, 1, 2, 3, 4, 5]
 
-  test_list_unpacking: ||
+  @test list_unpacking: ||
     a, b, c = [10, 20, 30, 40]
     assert_eq a, 10
     assert_eq b, 20
     assert_eq c, 30
 
-  test_list_multiple_assignment: ||
+  @test list_multiple_assignment: ||
     a, b, c = [10, 20], [30, 40]
     assert_eq a, [10, 20]
     assert_eq b, [30, 40]
     assert_eq c, ()
 
-  test_list_shared_data: ||
+  @test list_shared_data: ||
     a = [0, 1, 2]
     b = a # Assigning a list makes a new reference to the same data
     a[0] = 42
@@ -51,7 +51,7 @@ export tests =
     assert_eq a, [1, 2, 3]
     assert_eq b, [42, 2, 0]
 
-  test_lists_in_lists: ||
+  @test lists_in_lists: ||
     b = [42, 42]
     a = [b, b, b]
     assert_eq a[1][1], 42

--- a/koto/tests/lists.koto
+++ b/koto/tests/lists.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq, assert_ne
 
-export tests =
+export @tests =
   @test list_indexing: ||
     z = [10, 10 + 10, 30]
     assert_eq z[0], 10

--- a/koto/tests/logic.koto
+++ b/koto/tests/logic.koto
@@ -1,21 +1,21 @@
 from test import assert, assert_eq
 
 export tests =
-  test_and_not_or: ||
+  @test and_not_or: ||
     assert true and true
     assert not true and false
     assert not false and true
     assert true or false
     assert false or true
 
-  test_short_circuiting: ||
+  @test short_circuiting: ||
     a = false and assert false
     assert not a
 
     a = true or assert false
     assert a
 
-  test_comparison_operators: ||
+  @test comparison_operators: ||
     assert 1 < 2
     assert 0 > -1
     assert (1 + 1) <= 2
@@ -23,20 +23,20 @@ export tests =
     assert (2 * 2) >= 4
     assert not (2 * 2) > 4
 
-  test_chained_comparisons: ||
+  @test chained_comparisons: ||
     a = 5
     assert 1 < a < 10
     assert not 1 < a > 10
 
-  test_chained_equality: ||
+  @test chained_equality: ||
     a = 1
     assert 1 == a == 1
 
-  test_chained_comparison_short_circuiting: ||
+  @test chained_comparison_short_circuiting: ||
     a = 1
     assert not 1 > a < assert false
 
-  test_single_evaluation_of_chained_token: ||
+  @test single_evaluation_of_chained_token: ||
     make_counter = ||
       count = 0
       loop
@@ -45,6 +45,6 @@ export tests =
     assert 0 < f.next() < 2
     assert_eq f.next(), 2
 
-  test_fiddly_chained_comparison: ||
+  @test fiddly_chained_comparison: ||
     f = |x, y, z| if x < y < z > y > x then 0 else 1
     assert (f 1, 2, 3) < (f 3, 2, 1) <= (f 5, 4, 3) < 2 > (f 1, 2, 3)

--- a/koto/tests/logic.koto
+++ b/koto/tests/logic.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export tests =
+export @tests =
   @test and_not_or: ||
     assert true and true
     assert not true and false

--- a/koto/tests/loops.koto
+++ b/koto/tests/loops.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export tests =
+export @tests =
   @test for_block: ||
     count = 0
     for x in 0..10

--- a/koto/tests/loops.koto
+++ b/koto/tests/loops.koto
@@ -1,7 +1,7 @@
 from test import assert, assert_eq
 
 export tests =
-  test_for_block: ||
+  @test for_block: ||
     count = 0
     for x in 0..10
       for y in -5..5
@@ -13,7 +13,7 @@ export tests =
 
     assert_eq count, 3
 
-  test_for_break_continue: ||
+  @test for_break_continue: ||
     count = 0
     for i in 0..100
       if i % 2 == 0
@@ -24,13 +24,13 @@ export tests =
         count += 1
     assert_eq count, 2 # 2 odd numbers less than 5
 
-  test_while_block: ||
+  @test while_block: ||
     count = 0
     while count < 5
       count += 1
       assert not count > 5
 
-  test_while_break_continue: ||
+  @test while_break_continue: ||
     count = 0
     while true
       count += 1
@@ -41,14 +41,14 @@ export tests =
       assert false
     assert_eq count, 10
 
-  test_until_block: ||
+  @test until_block: ||
     count = 5
     until count == 0
       count -= 1
       assert count < 5
     assert_eq count, 0
 
-  test_loop_break: ||
+  @test loop_break: ||
     count = 0
     loop
       count += 1

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export tests =
+export @tests =
   @test clear: ||
     m = {foo: 42, bar: 99}
     m.clear()

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -7,86 +7,86 @@ make_foo = |x|
   @==: |self, other| self.x == other.x
 
 export tests =
-  test_clear: ||
+  @test clear: ||
     m = {foo: 42, bar: 99}
     m.clear()
     assert_eq m, {}
 
-  test_contains_key: ||
+  @test contains_key: ||
     m = {foo: 42, bar: 99}
     assert m.contains_key "foo"
     assert m.contains_key "bar"
     assert not m.contains_key "baz"
 
-  test_deep_copy: ||
+  @test deep_copy: ||
     m = {foo: 42, bar: {baz: 99}}
     m2 = m.deep_copy()
     m.bar.baz = 123
     assert_eq m2.bar.baz, 99
 
-  test_insert: ||
+  @test insert: ||
     m = {foo: 42}
     old_value = m.insert "foo", 99
     assert_eq m.foo, 99
     assert_eq old_value, 42
 
-  test_insert_via_map_module: ||
+  @test insert_via_map_module: ||
     # map ops are also available in the map module,
     # which allows access to ops when a key might have a matching name.
     m = {foo: 42}
     map.insert m, "foo", -1
     assert_eq m.foo, -1
 
-  test_insert_without_value: ||
+  @test insert_without_value: ||
     m = {foo: 42}
     m.insert "foo"
     assert_eq m.foo, ()
 
-  test_insert_non_string_key: ||
+  @test insert_non_string_key: ||
     m = {}
     m.insert 1, "one"
     m.insert 2, "two"
     assert_eq m.get(1), "one"
     assert_eq m.get(2), "two"
 
-  test_is_empty: ||
+  @test is_empty: ||
     assert {}.is_empty()
     assert not {foo: 42}.is_empty()
 
-  test_get: ||
+  @test get: ||
     m = {foo: 42}
     assert_eq (m.get "foo"), 42
     assert_eq (m.get "bar"), ()
 
-  test_get_non_string_key: ||
+  @test get_non_string_key: ||
     m = {}
     m.insert 1, "O_o"
     assert_eq (m.get 1), "O_o"
     assert_eq (m.get num2 1, 2), ()
 
-  test_get_index: ||
+  @test get_index: ||
     m = {foo: 42, bar: 99, baz: 123}
     assert_eq (m.get_index 1), ("bar", 99)
     assert_eq (m.get_index 2), ("baz", 123)
 
-  test_keys: ||
+  @test keys: ||
     m = {foo: 42}
     assert_eq m.keys().to_tuple(), ("foo",)
     m.insert 0, "zero"
     assert_eq m.keys().to_tuple(), ("foo", 0)
 
-  test_remove: ||
+  @test remove: ||
     m = {foo: 42, bar: 99, baz: -1}
     assert_eq (m.remove "foo"), 42
     assert_eq m.keys().to_tuple(), ("bar", "baz")
     assert_eq (m.remove "bar"), 99
     assert_eq (m.remove "foo"), ()
 
-  test_size: ||
+  @test size: ||
     assert_eq {}.size(), 0
     assert_eq {foo: 42}.size(), 1
 
-  test_sort: ||
+  @test sort: ||
     m = {foo: 42, bar: 99}
     assert_eq m.keys().to_tuple(), ("foo", "bar")
 
@@ -107,7 +107,7 @@ export tests =
     m.sort |key, value| value
     assert_eq m.keys().to_tuple(), ("baz", "foo", "bar")
 
-  test_update: ||
+  @test update: ||
     m = {foo: 42}
 
     # update takes a function that receives the entry's current value,
@@ -121,6 +121,6 @@ export tests =
     m.update "xyz", 100, |x| x / 2
     assert_eq m.xyz, 50
 
-  test_values: ||
+  @test values: ||
     m = {foo: 42, bar: "O_o"}
     assert_eq m.values().to_tuple(), (42, "O_o")

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq, assert_ne
 
-export tests =
+export @tests =
   @test access_by_key: ||
     m = {key: "value", another_key: "another_value"}
     assert_eq m.key, "value"

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -1,42 +1,42 @@
 from test import assert, assert_eq, assert_ne
 
 export tests =
-  test_access_by_key: ||
+  @test access_by_key: ||
     m = {key: "value", another_key: "another_value"}
     assert_eq m.key, "value"
     assert_eq m.another_key, "another_value"
 
-  test_assign_by_key: ||
+  @test assign_by_key: ||
     m = {key: -1}
     m.key = 42
     assert_eq m.key, 42
 
-  test_implict_key_values: ||
+  @test implict_key_values: ||
     foo, baz = 42, -1
     m = {foo, bar: 99, baz}
     assert_eq m.foo, 42
     assert_eq m.bar, 99
     assert_eq m.baz, -1
 
-  test_map_iteration: ||
+  @test map_iteration: ||
     m = {foo: 42, bar: -1}
     for key, value in m
       assert_ne key, ()
       assert_ne value, ()
 
-  test_map_quoted_keys: ||
+  @test map_quoted_keys: ||
     # Quoted strings can be used for keys that would otherwise be disallowed
     x = {"for": -1, "while": 99, "20": "twenty"}
     assert_eq x."for", -1
     assert_eq x."while", 99
     assert_eq x."20", "twenty"
 
-  test_unicode_keys: ||
+  @test unicode_keys: ||
     x = {}
     x.ƒöó = 123
     assert_eq x.ƒöó, 123
 
-  test_function_value: ||
+  @test function_value: ||
     o = {}
     o.min = || 0
     o.max = || 42
@@ -45,7 +45,7 @@ export tests =
       sum += i
     assert_eq sum, 861
 
-  test_equality_and_shared_data: ||
+  @test equality_and_shared_data: ||
     m = {foo: 42, bar: -1}
     m2 = m
     assert_eq m, m2
@@ -55,7 +55,7 @@ export tests =
     m3.foo = 99
     assert_ne m, m3
 
-  test_map_block: ||
+  @test map_block: ||
     m =
       foo: 42
       square: |x| x * x
@@ -65,20 +65,20 @@ export tests =
     assert_eq (m.square 9), 81
     assert_eq m.baz.child_foo, 99
 
-  test_addition: ||
+  @test addition: ||
     m = {foo: 42}
     m2 = m + {bar: -1}
     assert_eq m2.bar, -1
     m2 += {extra: 99}
     assert_eq m2.extra, 99
 
-  test_value_mutation: ||
+  @test value_mutation: ||
     m = {}
     m.foo = 42
     m.foo /= 2
     assert_eq m.foo, 21
 
-  test_instance_functions: ||
+  @test instance_functions: ||
     make_map = ||
       foo: 42
       get_foo: |self|
@@ -102,18 +102,18 @@ export tests =
     m2.set_foo_2 58 # .set_foo_2 receives m2 as first argument, 58 as second argument
     assert_eq m2.sum_foo(), 100
 
-  test_instance_function_outside_of_map: ||
+  @test instance_function_outside_of_map: ||
     m =
       foo: 42
       get_foo: |self| self.foo
     getter = m.get_foo
     assert_eq (getter m), 42
 
-  test_map_in_list_comprehension: ||
+  @test map_in_list_comprehension: ||
     a = [{foo, bar} for foo, bar in 1..=3, 4..=6]
     assert_eq a, [{foo: 1, bar: 4}, {foo: 2, bar: 5}, {foo: 3, bar: 6}]
 
-  test_map_blocks_in_if_expression: ||
+  @test map_blocks_in_if_expression: ||
     make_map = |n|
       if n >= 0
         sign: "positive"
@@ -127,13 +127,13 @@ export tests =
     n = make_map -100
     assert_eq n.sign, "negative"
 
-  test_nested_inline: ||
+  @test nested_inline: ||
     deep = {a: {b: {c: {d: {e: {f: 42}}}}}}
     assert_eq deep.a.b.c.d.e.f, 42
     deep.a.b.c.d.e.f = 99
     assert_eq deep.a.b.c.d.e.f, 99
 
-  test_nested_block: ||
+  @test nested_block: ||
     deep =
       a:
         b:

--- a/koto/tests/maps_and_lists.koto
+++ b/koto/tests/maps_and_lists.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export tests =
+export @tests =
   @test lists_in_maps: ||
     x =
       foo: [10, 11, 12]

--- a/koto/tests/maps_and_lists.koto
+++ b/koto/tests/maps_and_lists.koto
@@ -1,7 +1,7 @@
 import test.assert_eq
 
 export tests =
-  test_lists_in_maps: ||
+  @test lists_in_maps: ||
     x =
       foo: [10, 11, 12]
       bar:
@@ -17,7 +17,7 @@ export tests =
     # Nested mutation doesn't affect parent nodes
     assert_eq x.foo[2], 42
 
-  test_maps_in_lists: ||
+  @test maps_in_lists: ||
     make_foo = |x|
       foo: x
       set_foo: |self, x| self.foo = x

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -37,6 +37,9 @@ locals.foo_meta =
   # Type
   @type: "Foo"
 
+  # Named meta entries are accessible on the value but don't appear as map entries
+  @meta hello: "Hello"
+  @meta say_hello: |self, name| "{}, {}!".format(self.hello, name)
 
 export @tests =
   @test add: ||
@@ -99,3 +102,10 @@ export @tests =
 
   @test type: ||
     assert_eq (koto.type (foo 0)), "Foo"
+
+  @test named_meta_entries: ||
+    f = foo 99
+    assert_eq f.keys().to_list(), ["x"]
+
+    assert_eq f.hello, "Hello"
+    assert_eq f.say_hello("you"), "Hello, you!"

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -39,38 +39,38 @@ locals.foo_meta =
 
 
 export tests =
-  test_add: ||
+  @test add: ||
     assert_eq (foo(10) + foo(20)), foo 30
 
-  test_subtract: ||
+  @test subtract: ||
     assert_eq (foo(99) - foo(100)), foo -1
 
-  test_multiply: ||
+  @test multiply: ||
     assert_eq (foo(6) * foo(7)), foo 42
 
-  test_divide: ||
+  @test divide: ||
     assert_eq (foo(42) / foo(2)), foo 21
 
-  test_modulo: ||
+  @test modulo: ||
     assert_eq (foo(42) % foo(10)), foo 2
 
-  test_less: ||
+  @test less: ||
     assert foo(5) < foo(6)
     assert not (foo(5) < foo(5))
 
-  test_less_or_equal: ||
+  @test less_or_equal: ||
     assert foo(5) <= foo(6)
     assert foo(5) <= foo(5)
 
-  test_greater: ||
+  @test greater: ||
     assert foo(40) > foo(30)
     assert not (foo(40) > foo(40))
 
-  test_greater_or_equal: ||
+  @test greater_or_equal: ||
     assert foo(40) >= foo(30)
     assert foo(40) >= foo(40)
 
-  test_equal: ||
+  @test equal: ||
     bar = |x, y|
       x: x
       y: y
@@ -82,20 +82,20 @@ export tests =
     assert not (bar(21, -1) == bar(22, -1))
     assert_eq bar(100, -1), bar(100, -2)
 
-  test_not_equal: ||
+  @test not_equal: ||
     assert foo(7) != foo(8)
     assert not (foo(7) != foo(7))
     # TODO Add an assert_ne test
 
-  test_negate: ||
+  @test negate: ||
     assert_eq -foo(1), foo(-1)
 
-  test_index: ||
+  @test index: ||
     assert_eq foo(10)[5], 15
     assert_eq foo(100)[-1], 99
 
-  test_display: ||
+  @test display: ||
     assert_eq ("{}".format (foo -1)), "Foo (-1)"
 
-  test_type: ||
+  @test type: ||
     assert_eq (koto.type (foo 0)), "Foo"

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -38,7 +38,7 @@ locals.foo_meta =
   @type: "Foo"
 
 
-export tests =
+export @tests =
   @test add: ||
     assert_eq (foo(10) + foo(20)), foo 30
 

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -1,12 +1,12 @@
 import test.assert_eq
 
 export tests =
-  test_creating: ||
+  @test creating: ||
     assert_eq (num4 0), (num4 0, 0, 0, 0)
     assert_eq (num2 1), (num2 1, 1)
     assert_eq (num4 (num2 1)), (num4 1, 1, 0, 0)
 
-  test_mutation_num2: ||
+  @test mutation_num2: ||
     x = num2 10, 11
     x *= 2
     assert_eq x, (num2 20, 22)
@@ -15,7 +15,7 @@ export tests =
     x += num2 10
     assert_eq x, (num2 10, 12)
 
-  test_mutation_num4: ||
+  @test mutation_num4: ||
     x = num4 5, 6, 7, 8
     x *= 2
     assert_eq x, (num4 10, 12, 14, 16)
@@ -24,28 +24,28 @@ export tests =
     x += num4 10
     assert_eq x, (num4 10, 12, 14, 11)
 
-  test_sum: ||
+  @test sum: ||
     assert_eq (num2 1, 2).sum(), 3
     assert_eq (num4 1, 2, 3, 4).sum(), 10
 
-  test_element_access_num2: ||
+  @test element_access_num2: ||
     x = num2 10, 20
     assert_eq x[0], 10
     assert_eq x[1], 20
 
-  test_element_access_num4: ||
+  @test element_access_num4: ||
     x = num4 2, 3, 4, 5
     assert_eq x[0], 2
     assert_eq x[3], 5
 
-  test_element_unpacking_num2: ||
+  @test element_unpacking_num2: ||
     x = num2 1, 2
     a, b, c = x
     assert_eq a, 1
     assert_eq b, 2
     assert_eq c, ()
 
-  test_element_unpacking_num4: ||
+  @test element_unpacking_num4: ||
     x = num4 5, 6, 7, 8
     a, b, c, d, e = x
     assert_eq a, 5

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export tests =
+export @tests =
   @test creating: ||
     assert_eq (num4 0), (num4 0, 0, 0, 0)
     assert_eq (num2 1), (num2 1, 1)

--- a/koto/tests/number_ops.koto
+++ b/koto/tests/number_ops.koto
@@ -5,152 +5,152 @@ from test import assert, assert_eq, assert_near
 epsilon = 1.0e-15
 
 export tests =
-  test_abs: ||
+  @test abs: ||
     assert_eq -1.abs(), 1
     assert_eq 3.abs(), 3
     assert_eq -1.5.abs(), 1.5
     assert_eq 9.1.abs(), 9.1
 
-  test_acos: ||
+  @test acos: ||
     assert_eq 0.acos(), pi / 2
     assert_eq 1.acos(), 0
 
-  test_and: ||
+  @test and_: ||
     assert_eq (0b10101.and 0b00111), 0b00101
     assert_eq (-1.and 1), 1
 
-  test_asin: ||
+  @test asin: ||
     assert_eq 0.asin(), 0
     assert_eq 1.asin(), pi / 2
 
-  test_atan: ||
+  @test atan: ||
     assert_eq 0.atan(), 0
     assert_eq 1.atan(), pi / 4
 
-  test_ceil: ||
+  @test ceil: ||
     assert_eq 0.ceil(), 0
     assert_eq 0.5.ceil(), 1
     assert_eq 1.ceil(), 1
 
-  test_clamp: ||
+  @test clamp: ||
     assert_eq (0.clamp 1, 2), 1
     assert_eq (1.5.clamp 1, 2), 1.5
     assert_eq (3.clamp 1, 2), 2
 
-  test_cos: ||
+  @test cos: ||
     assert_eq 0.cos(), 1
     assert_near (pi / 2).cos(), 0, epsilon
 
-  test_cosh: ||
+  @test cosh: ||
     assert_eq 0.cosh(), 1
     assert_near 1.cosh(), ((1 + e.pow(2)) / (2 * e)), epsilon
 
-  test_degrees: ||
+  @test degrees: ||
     assert_eq 0.degrees(), 0
     assert_eq pi.degrees(), 180
     assert_eq tau.degrees(), 360
 
-  test_exp: ||
+  @test exp: ||
     assert_eq 0.exp(), 1
     assert_eq 1.exp(), e
 
-  test_exp2: ||
+  @test exp2: ||
     assert_eq 0.exp2(), 1
     assert_eq 2.exp2(), 4
 
-  test_flip_bits: ||
+  @test flip_bits: ||
     assert_eq -1.flip_bits(), 0
     assert_eq 0.flip_bits(), -1
     assert_eq 8.flip_bits(), -9
 
-  test_floor: ||
+  @test floor: ||
     assert_eq 1.5.floor(), 1
     assert_eq -1.2.floor(), -2
     assert_eq type(1.1.floor()), "Int"
 
-  test_is_nan: ||
+  @test is_nan: ||
     assert not 0.is_nan()
     assert (0 / 0).is_nan()
 
-  test_ln: ||
+  @test ln: ||
     assert_eq 0.ln(), negative_infinity
     assert_eq 1.ln(), 0
     assert_eq e.ln(), 1
 
-  test_log2: ||
+  @test log2: ||
     assert_eq 0.log2(), negative_infinity
     assert_eq 256.log2(), 8
 
-  test_log10: ||
+  @test log10: ||
     assert_eq 0.log10(), negative_infinity
     assert_eq 100.log10(), 2
 
-  test_max: ||
+  @test max: ||
     assert_eq (1.5.max 2), 2
 
-  test_min: ||
+  @test min: ||
     assert_eq (1.min 2), 1
 
-  test_or: ||
+  @test or_: ||
     assert_eq (0b10101.or 0b01010), 0b11111
     assert_eq (-1.or 1), -1
 
-  test_pow: ||
+  @test pow: ||
     assert_eq (2.pow 8), 256
     assert_eq (4.pow 1.5), 8
 
-  test_radians: ||
+  @test radians: ||
     assert_eq 0.radians(), 0
     assert_eq 180.radians(), pi
     assert_eq 360.radians(), tau
 
-  test_recip: ||
+  @test recip: ||
     assert_eq -2.recip(), -0.5
     assert_eq 0.recip(), infinity
     assert_eq 2.recip(), 0.5
     assert_eq 4.recip(), 0.25
 
-  test_shift_left: ||
+  @test shift_left: ||
     assert_eq 0b10101.shift_left(1), 0b101010
     assert_eq 2.shift_left(3), 16
 
-  test_shift_right: ||
+  @test shift_right: ||
     assert_eq 0b10101.shift_right(1), 0b1010
     assert_eq 256.shift_right(3), 32
 
-  test_sin: ||
+  @test sin: ||
     assert_near 0.sin(), 0, epsilon
     assert_eq (pi / 2).sin(), 1
 
-  test_sinh: ||
+  @test sinh: ||
     assert_near 0.sinh(), 0, epsilon
     assert_near 1.sinh(), ((e.pow(2) - 1) / (2 * e)), epsilon
 
-  test_sqrt: ||
+  @test sqrt: ||
     assert_eq 64.sqrt(), 8
     assert -1.sqrt().is_nan()
 
-  test_tan: ||
+  @test tan: ||
     assert_near (pi / 4).tan(), 1, epsilon
     assert_eq 0.tan(), 0
     assert_near 1.tan(), (1.sin() / 1.cos()), epsilon
 
-  test_tanh: ||
+  @test tanh: ||
     assert_eq 0.tanh(), 0
     assert_eq 1.tanh(), (1.sinh() / 1.cosh())
 
-  test_to_float: ||
+  @test to_float: ||
     x = 1
     assert_eq type(x), "Int"
     assert_eq type(x.to_float()), "Float"
     assert_eq x.to_float(), x
 
-  test_to_int: ||
+  @test to_int: ||
     x = 1.0
     assert_eq type(x), "Float"
     assert_eq type(x.to_int()), "Int"
     assert_eq x.to_int(), x
 
-  test_xor: ||
+  @test xor: ||
     assert_eq (0b10101.xor 0b01011), 0b11110
     assert_eq (-1.xor 1), -2

--- a/koto/tests/number_ops.koto
+++ b/koto/tests/number_ops.koto
@@ -4,7 +4,7 @@ from test import assert, assert_eq, assert_near
 
 epsilon = 1.0e-15
 
-export tests =
+export @tests =
   @test abs: ||
     assert_eq -1.abs(), 1
     assert_eq 3.abs(), 3

--- a/koto/tests/numbers.koto
+++ b/koto/tests/numbers.koto
@@ -1,7 +1,7 @@
 import test.assert_eq
 
 export tests =
-  test_arithmetic: ||
+  @test arithmetic: ||
     assert_eq 1 + 1, 2
     assert_eq 2 - 2, 0
     assert_eq 1+2*3+4, 11 # whitespace around operators is conventional but optional
@@ -11,7 +11,7 @@ export tests =
     assert_eq (3 - 2) / (4 - 2), 0.5
     assert_eq 2 + 5 % 3, 4
 
-  test_long_expression: ||
+  @test long_expression: ||
     # Long expressions can be broken before and after operators
     a = 1 +
         2 * 3
@@ -20,7 +20,7 @@ export tests =
         + 9 / 3
     assert_eq a, 20
 
-  test_assignment_operators: ||
+  @test assignment_operators: ||
     x = 0
     x += 2
     assert_eq x, 2
@@ -33,19 +33,19 @@ export tests =
     x %= 2
     assert_eq x, 1
 
-  test_binary_notation: ||
+  @test binary_notation: ||
     assert_eq 0b0, 0
     assert_eq 0b10, 2
     assert_eq -0b1000, -8
     assert_eq 0b101010, 42
 
-  test_octal_notation: ||
+  @test octal_notation: ||
     assert_eq 0o0, 0
     assert_eq 0o10, 8
     assert_eq -0o1000, -512
     assert_eq 0o707606, 233350
 
-  test_hex_notation: ||
+  @test hex_notation: ||
     assert_eq 0x0, 0
     assert_eq 0xf, 15
     assert_eq -0x1000, -4096

--- a/koto/tests/numbers.koto
+++ b/koto/tests/numbers.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export tests =
+export @tests =
   @test arithmetic: ||
     assert_eq 1 + 1, 2
     assert_eq 2 - 2, 0

--- a/koto/tests/os.koto
+++ b/koto/tests/os.koto
@@ -1,8 +1,8 @@
 import test.assert
 
 export tests =
-  test_cpu_count: ||
+  @test cpu_count: ||
     assert os.cpu_count() > 0
 
-  test_physical_cpu_count: ||
+  @test physical_cpu_count: ||
     assert os.physical_cpu_count() > 0

--- a/koto/tests/os.koto
+++ b/koto/tests/os.koto
@@ -1,6 +1,6 @@
 import test.assert
 
-export tests =
+export @tests =
   @test cpu_count: ||
     assert os.cpu_count() > 0
 

--- a/koto/tests/ranges.koto
+++ b/koto/tests/ranges.koto
@@ -1,7 +1,7 @@
 from test import assert, assert_eq
 
 export tests =
-  test_assignment: ||
+  @test assignment: ||
     # Assigning a range to a value
     r = 0..2
     # Ranges can be compared
@@ -11,61 +11,61 @@ export tests =
     r = 0..=2
     assert_eq [r], [0, 1, 2]
 
-  test_indexing: ||
+  @test indexing: ||
     # Indexing lists with ranges produces sub-lists
     n = [0..10]
     assert_eq n[2..5], [2, 3, 4]
     assert_eq n[2..=4], [2, 3, 4]
 
-  test_evaluated_boundaries: ||
+  @test evaluated_boundaries: ||
     z = |n| n
     x = [(z 10)..=(z 20)]
     y = x[1 + 1..x.size() / 2]
     assert_eq y[0], 12
 
-  test_from_and_to_ranges: ||
+  @test from_and_to_ranges: ||
     n = [0..=10]
     assert_eq n[..=2], [0, 1, 2]
     assert_eq n[8..], [8, 9, 10]
 
-  test_empty_range: ||
+  @test empty_range: ||
     n = [0..10]
     assert_eq n[10..10], []
 
-  test_descending_range: ||
+  @test descending_range: ||
     r = 2..0
     assert_eq [r], [2, 1]
     assert_eq [2..=0], [2, 1, 0]
 
-  test_range_contains: ||
+  @test range_contains: ||
     assert (0..10).contains(5)
     assert not (0..10).contains(15)
 
     assert not (0..10).contains(10)
     assert (0..=10).contains(10)
 
-  test_range_expanded: ||
+  @test range_expanded: ||
     x = 10..20
     assert_eq x.expanded(5), 5..25
     assert_eq x.expanded(-1), 11..19
 
-  test_range_expanded_descending: ||
+  @test range_expanded_descending: ||
     x = 10..0
     assert_eq x.expanded(5), 15..-5
     assert_eq x.expanded(-5), 5..5
 
-  test_range_size: ||
+  @test range_size: ||
     assert_eq (0..10).size(), 10
     assert_eq (0..=10).size(), 11
 
-  test_range_start_end: ||
+  @test range_start_end: ||
     x = 10..20
     assert_eq x.start(), 10
     assert_eq x.end(), 20
 
     assert_eq (10..=20).end(), 21
 
-  test_range_union: ||
+  @test range_union: ||
     x = 10..20
 
     assert_eq x.union(5), 5..20
@@ -77,7 +77,7 @@ export tests =
     assert_eq x.union(5..=25), 5..=25
     assert_eq x.union(25..=5), 5..=25
 
-  test_range_union_descending: ||
+  @test range_union_descending: ||
     x = 10..0
 
     assert_eq x.union(-5), 10..=-5

--- a/koto/tests/ranges.koto
+++ b/koto/tests/ranges.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export tests =
+export @tests =
   @test assignment: ||
     # Assigning a range to a value
     r = 0..2

--- a/koto/tests/string_formatting.koto
+++ b/koto/tests/string_formatting.koto
@@ -1,6 +1,6 @@
 import number.pi, test.assert_eq
 
-export tests =
+export @tests =
   @test format: ||
     # A string is expected as first argument for string.format
     assert_eq (string.format "Hello, World!"), "Hello, World!"

--- a/koto/tests/string_formatting.koto
+++ b/koto/tests/string_formatting.koto
@@ -1,11 +1,11 @@
 import number.pi, test.assert_eq
 
 export tests =
-  test_format: ||
+  @test format: ||
     # A string is expected as first argument for string.format
     assert_eq (string.format "Hello, World!"), "Hello, World!"
 
-  test_placeholders: ||
+  @test placeholders: ||
     hello = "Hello"
     world = "World"
 
@@ -21,12 +21,12 @@ export tests =
     # Identifier placeholders are looked up in a map argument.
     assert_eq ("{first}_{second}".format {first: "O", second: "o"}), "O_o"
 
-  test_dynamic_format_string: ||
+  @test dynamic_format_string: ||
     # The format string can be prepared at runtime.
     x = "{}" + ", {}"
     assert_eq (x.format "Yes", "No"), "Yes, No"
 
-  test_precision_modifier: ||
+  @test precision_modifier: ||
     # The precision modifier defines the number of decimal places to show for numbers.
     assert_eq ("{:.2}".format 1), "1.00"
     assert_eq ("{:.2}".format pi), "3.14"
@@ -36,7 +36,7 @@ export tests =
     # The precision modifier acts as a maximum width for non-number values.
     assert_eq ("{:.4}".format "äbçdef"), "äbçd"
 
-  test_minimum_width_modifier: ||
+  @test minimum_width_modifier: ||
     # The minimum width modifier ensures that a value occupies at least that
     # many characters in the output.
     assert_eq ("{:6}".format "abc"), "abc   "
@@ -52,7 +52,7 @@ export tests =
     assert_eq ("{:4}".format 100), " 100"
     assert_eq ("{:4}".format -10), " -10"
 
-  test_alignment: ||
+  @test alignment: ||
     # The minimum width modifier can be prefixed with an alignment modifier,
     # < - left-aligned
     # ^ - centered
@@ -67,7 +67,7 @@ export tests =
     assert_eq ("{:-^6}".format "ab"), "--ab--"
     assert_eq ("{:ü>6}".format "ab"), "üüüüab"
 
-  test_all_the_bells_and_whistles: ||
+  @test all_the_bells_and_whistles: ||
     assert_eq
       ("{1:_^10.2} -- {x:®>8.4}".format {x: "zyxwvut"}, (1 / 3)),
       "___0.33___ -- ®®®®zyxw"

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -1,7 +1,7 @@
 import koto.type
 from test import assert, assert_eq, assert_ne
 
-export tests =
+export @tests =
   @test comparisons: ||
     assert_eq "Hello", "Hello"
     assert_ne "Hello", "Héllö"

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -2,23 +2,23 @@ import koto.type
 from test import assert, assert_eq, assert_ne
 
 export tests =
-  test_comparisons: ||
+  @test comparisons: ||
     assert_eq "Hello", "Hello"
     assert_ne "Hello", "Héllö"
     assert_eq ("Hello" + ", " + "World!"), "Hello, World!"
     assert "Hello" < "Hiyaa" and "World" <= "World!"
     assert "Hiyaa" > "Hello" and "World!" >= "World"
 
-  test_single_quotes: ||
+  @test single_quotes: ||
     # Strings can use either double or single quotes.
     assert_eq "Hello", 'Hello'
 
-  test_addition: ||
+  @test addition: ||
     x = "^"
     x += "_" + "^"
     assert_eq x, "^_^"
 
-  test_indexing: ||
+  @test indexing: ||
     assert_eq "Héllö"[4], "ö"
     x = "Tschüss"
     assert_eq x[0..3], "Tsc"
@@ -28,7 +28,7 @@ export tests =
     assert_eq x[5..], "ss"
     assert_eq "👋🥳😆"[1], "🥳"
 
-  test_chars: ||
+  @test chars: ||
     hello = "Héllö"
     assert_eq
       hello.chars().to_tuple(),
@@ -41,25 +41,25 @@ export tests =
     assert_eq hello_chars, hello.to_list()
     assert_eq hello_chars.size(), 5
 
-  test_contains: ||
+  @test contains: ||
     assert "O_o".contains("_")
     assert not "O_o".contains("@")
 
-  test_ends_with: ||
+  @test ends_with: ||
     assert "a,b,c".ends_with("")
     assert "a,b,c".ends_with(",c")
     assert not "a,b,c".ends_with(",b")
 
-  test_escape: ||
+  @test escape: ||
     x = "
 "
     assert_eq x.escape(), "\\n"
 
-  test_is_empty: ||
+  @test is_empty: ||
     assert "".is_empty()
     assert not "abc".is_empty()
 
-  test_lines: ||
+  @test lines: ||
     x = "aaa
 bbb
 ccc"
@@ -76,13 +76,13 @@ zzz
     x3 = "foo\nbar\nbaz"
     assert_eq x3.lines().to_tuple(), ("foo", "bar", "baz")
 
-  test_escaped_newlines: ||
+  @test escaped_newlines: ||
     x = "foo \
          bar \
          baz"
     assert_eq x, "foo bar baz"
 
-  test_size: ||
+  @test size: ||
     # size returns the number of unicode graphemes in the string,
     # rather than the number of bytes
     assert_eq "".size(), 0
@@ -90,28 +90,28 @@ zzz
     assert_eq "abcdef".size(), 6
     assert_eq "äbcdéf".size(), 6
 
-  test_slice: ||
+  @test slice: ||
     assert_eq ("abcdef".slice 2, 5), "cde"
     x = "abcdef".slice 2 # end index is optional
     assert_eq x, "cdef"
     assert_eq (x.slice 1, 3), "de"
     assert_eq (x.slice 10, 13), ()
 
-  test_split: ||
+  @test split: ||
     assert_eq "a,b,c".split(",").to_tuple(), ("a", "b", "c")
     assert_eq "O_O".split("O").to_tuple(), ("", "_", "")
     assert_eq "a - b - c".split(" - ").to_tuple(), ("a", "b", "c")
 
-  test_starts_with: ||
+  @test starts_with: ||
     assert "a,b,c".starts_with("")
     assert "a,b,c".starts_with("a,")
     assert not "a,b,c".starts_with(",b")
 
-  test_to_lowercase: ||
+  @test to_lowercase: ||
     assert_eq (string.to_lowercase "ABC 123"), "abc 123"
     assert_eq (string.to_lowercase "HÉLLÖ"), "héllö"
 
-  test_to_number: ||
+  @test to_number: ||
     x = string.to_number "42"
     assert_eq x, 42
     assert_eq type(x), "Int"
@@ -120,11 +120,11 @@ zzz
     assert_eq x, -1.5
     assert_eq type(x), "Float"
 
-  test_to_uppercase: ||
+  @test to_uppercase: ||
     assert_eq (string.to_uppercase "xyz 890"), "XYZ 890"
     assert_eq (string.to_uppercase "Görlitzer Straße"), "GÖRLITZER STRASSE"
 
-  test_trim: ||
+  @test trim: ||
     assert_eq (string.trim "   x    "), "x"
     assert_eq "foo    ".trim(), "foo"
     assert_eq "     bar".trim(), "bar"

--- a/koto/tests/test_module/baz.koto
+++ b/koto/tests/test_module/baz.koto
@@ -1,10 +1,10 @@
-# This file is imported by main.koto
+# This file is imported by ./main.koto
 
-# std modules should be available to import
 import number.pi, test.assert_eq
 assert_eq pi, pi
 
 export qux = ()
-# main functions should be run when loading a module
+
 export main = ||
+  # Redefine qux to check that main is called
   export qux = "O_o"

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -1,4 +1,5 @@
 # A simple test module, used by ../import.koto
+
 export foo = 42
 export bar = -1
 export baz = import baz

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -3,49 +3,49 @@ from test import assert, assert_eq, assert_ne, assert_near, run_tests
 # A script can export a map named 'tests' to have the tests automatically run when
 # the script is loaded.
 export tests =
-  # 'pre_test' will be run before each test
-  pre_test: |self|
+  # '@pre_test' will be run before each test
+  @pre_test: |self|
     self.test_data = 1, 2, 3
 
-  # 'post_test' will be run after each test
-  post_test: |self|
+  # '@post_test' will be run after each test
+  @post_test: |self|
     self.test_data = ()
 
-  # Functions with a name starting with 'test_' will be automatically run as tests
-  test_size: |self|
+  # Functions with that are tagged with @test will be automatically run as tests
+  @test size: |self|
     # assert_eq checks that its two arguments are equal
     assert_eq self.test_data.size(), 3
     # assert_ne checks that its two arguments are not equal
     assert_ne self.test_data.size(), 1
 
   # Test functions don't have to be instance functions
-  test_extra: ||
+  @test extra: ||
     # assert checks that its argument is true
     assert 1 > 0
     # assert_near checks that its arguments are equal, within a specied margin
     allowed_error = 0.1
     assert_near 1.3, 1.301, allowed_error
 
-  test_run_tests: ||
+  @test run_tests: ||
     tests_were_run = {}
     my_tests =
-      pre_test: |self| tests_were_run.pre_test = true
-      post_test: |self| tests_were_run.post_test = true
-      test_foo: || tests_were_run.test_foo = true
-      test_bar: || tests_were_run.test_bar = true
-      # Functions without a test_ prefix shouldn't be run
+      @pre_test: |self| tests_were_run.pre_test = true
+      @post_test: |self| tests_were_run.post_test = true
+      @test foo: || tests_were_run.foo = true
+      @test bar: || tests_were_run.bar = true
+      # Functions that aren't tagged with @test shouldn't be run
       not_run: || test_were_run.not_run = true
       # Tests should be run in order
-      test_failure: || assert false
+      @test failure: || assert false
 
     try
       run_tests my_tests
     catch _
-      tests_were_run.test_failure = true
+      tests_were_run.failure = true
 
     assert tests_were_run.pre_test
     assert tests_were_run.post_test
-    assert tests_were_run.test_foo
-    assert tests_were_run.test_bar
-    assert tests_were_run.test_failure
+    assert tests_were_run.foo
+    assert tests_were_run.bar
+    assert tests_were_run.failure
     assert not tests_were_run.contains_key "not_run"

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -2,7 +2,7 @@ from test import assert, assert_eq, assert_ne, assert_near, run_tests
 
 # A script can export a map named 'tests' to have the tests automatically run when
 # the script is loaded.
-export tests =
+export @tests =
   # '@pre_test' will be run before each test
   @pre_test: |self|
     self.test_data = 1, 2, 3

--- a/koto/tests/threads.koto
+++ b/koto/tests/threads.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export tests =
+export @tests =
   @test spawn_4_threads_and_join: ||
     data = list.with_size 8, 0
 

--- a/koto/tests/threads.koto
+++ b/koto/tests/threads.koto
@@ -1,7 +1,7 @@
 import test.assert_eq
 
 export tests =
-  test_spawn_4_threads_and_join: ||
+  @test spawn_4_threads_and_join: ||
     data = list.with_size 8, 0
 
     worker_count = 4

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -7,19 +7,19 @@ make_foo = |x|
   @==: |self, other| self.x == other.x
 
 export tests =
-  test_for_loop: ||
+  @test for_loop: ||
     a = 1, 2, 3
     z = []
     for x in a
       z.push x
     assert_eq z, [1, 2, 3]
 
-  test_contains: ||
+  @test contains: ||
     x = 1, 2, 3
     assert (x.contains 2)
     assert not (x.contains 99)
 
-  test_contains_with_overloaded_equality_op: ||
+  @test contains_with_overloaded_equality_op: ||
     bar = |x|
       x: x
       @==: |self, other| self.x != other.x # This inverts the usual behaviour of ==
@@ -27,7 +27,7 @@ export tests =
     x = (bar 1), (bar 1)
     assert not x.contains (bar 1)
 
-  test_deep_copy: ||
+  @test deep_copy: ||
     a = [1, 2, 3]
     # x contains 3 shared copies of a
     x = (a, a, a)
@@ -41,17 +41,17 @@ export tests =
     x2[1][0] = 42
     assert_eq x2[0][0], 1
 
-  test_first: ||
+  @test first: ||
     assert_eq (1, 2, 3).first(), 1
     assert_eq [].to_tuple().first(), ()
 
-  test_get: ||
+  @test get: ||
     x = 1, 2, 3
     assert_eq (x.get 0), 1
     assert_eq (x.get 2), 3
     assert_eq (x.get 4), ()
 
-  test_indexing: ||
+  @test indexing: ||
     x = 1, 2, 3
     assert_eq x[0], 1
     assert_eq x[2], 3
@@ -60,23 +60,23 @@ export tests =
     assert_eq x[1..], (2, 3)
     assert_eq x[..=1], (1, 2)
 
-  test_iter: ||
+  @test iter: ||
     assert_eq
       (1, 2, 3)
         .each |n| "{}".format n
         .to_tuple(),
       ("1", "2", "3")
 
-  test_last: ||
+  @test last: ||
     assert_eq (1, 2, 3).last(), 3
     assert_eq [].to_tuple().last(), ()
 
-  test_size: ||
+  @test size: ||
     assert_eq (1, 2).size(), 2
     assert_eq (1, 2, 3).size(), 3
     assert_eq ((1, 2), (3, 4)).size(), 2
 
-  test_sort_copy: ||
+  @test sort_copy: ||
     assert_eq (3, 1, 2).sort_copy(), (1, 2, 3)
     assert_eq ("tuple", "sort", "copy").sort_copy(), ("copy", "sort", "tuple")
 
@@ -88,6 +88,6 @@ export tests =
     assert_eq r, a
 
 
-  test_to_list: ||
+  @test to_list: ||
     assert_eq (1, 2).to_list(), [1, 2]
     assert_eq ((1, 2), (3, 4)).to_list(), [(1, 2), (3, 4)]

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export tests =
+export @tests =
   @test for_loop: ||
     a = 1, 2, 3
     z = []

--- a/koto/tests/types.koto
+++ b/koto/tests/types.koto
@@ -1,7 +1,7 @@
 import koto.type, test.assert_eq
 
 export tests =
-  test_type_returns_type_name: ||
+  @test type_returns_type_name: ||
     assert_eq (type true), "Bool"
     assert_eq (type |x| x * x), "Function"
     assert_eq (type [1, 2, 3]), "List"

--- a/koto/tests/types.koto
+++ b/koto/tests/types.koto
@@ -1,6 +1,6 @@
 import koto.type, test.assert_eq
 
-export tests =
+export @tests =
   @test type_returns_type_name: ||
     assert_eq (type true), "Bool"
     assert_eq (type |x| x * x), "Function"

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -2,7 +2,8 @@ use {
     crate::{DebugInfo, FunctionFlags, Op, TypeId},
     koto_parser::{
         AssignOp, AssignTarget, Ast, AstFor, AstIf, AstIndex, AstNode, AstOp, AstTry,
-        ConstantIndex, Function, LookupNode, MapKey, MatchArm, Node, Scope, Span, SwitchArm,
+        ConstantIndex, Function, LookupNode, MapKey, MatchArm, MetaKeyId, Node, Scope, Span,
+        SwitchArm,
     },
     smallvec::SmallVec,
     std::{convert::TryFrom, error, fmt},
@@ -746,6 +747,11 @@ impl Compiler {
 
                 result
             }
+            Node::Meta(_, _) => {
+                // Meta nodes are currently only compiled in the context of an export assignment,
+                // see compile_assign().
+                unreachable!();
+            }
         };
 
         self.span_stack.pop();
@@ -1064,7 +1070,7 @@ impl Compiler {
                         }
                     }
                     Scope::Export => {
-                        self.compile_set_export(*id_index, value_register.register);
+                        self.compile_value_export(*id_index, value_register.register);
                     }
                 }
             }
@@ -1076,6 +1082,9 @@ impl Compiler {
                     Some(value_register.register),
                     ast,
                 )?;
+            }
+            Node::Meta(meta_id, name) => {
+                self.compile_meta_export(*meta_id, *name, value_register.register);
             }
             Node::Wildcard => {}
             unexpected => {
@@ -1204,12 +1213,33 @@ impl Compiler {
         Ok(result)
     }
 
-    fn compile_set_export(&mut self, id: ConstantIndex, register: u8) {
+    fn compile_value_export(&mut self, id: ConstantIndex, register: u8) {
         if id <= u8::MAX as u32 {
-            self.push_op(Op::SetExport, &[id as u8, register]);
+            self.push_op(Op::ValueExport, &[id as u8, register]);
         } else {
-            self.push_op(Op::SetExportLong, &id.to_le_bytes());
+            self.push_op(Op::ValueExportLong, &id.to_le_bytes());
             self.push_bytes(&[register]);
+        }
+    }
+
+    fn compile_meta_export(
+        &mut self,
+        meta_id: MetaKeyId,
+        name: Option<ConstantIndex>,
+        value_register: u8,
+    ) {
+        if let Some(name) = name {
+            if name <= u8::MAX as u32 {
+                self.push_op(
+                    Op::MetaExportNamed,
+                    &[meta_id as u8, value_register, name as u8],
+                );
+            } else {
+                self.push_op(Op::MetaExportNamedLong, &[meta_id as u8, value_register]);
+                self.push_bytes(&name.to_le_bytes());
+            }
+        } else {
+            self.push_op(Op::MetaExport, &[meta_id as u8, value_register]);
         }
     }
 
@@ -1253,7 +1283,7 @@ impl Compiler {
                 self.commit_local_register(import_register)?;
 
                 if self.settings.repl_mode && self.frame_stack.len() == 1 {
-                    self.compile_set_export(*import_id, import_register);
+                    self.compile_value_export(*import_id, import_register);
                 }
             }
         } else {
@@ -1279,7 +1309,7 @@ impl Compiler {
                 imported.push(import_register);
 
                 if self.settings.repl_mode && self.frame_stack.len() == 1 {
-                    self.compile_set_export(*import_id, import_register);
+                    self.compile_value_export(*import_id, import_register);
                 }
             }
 
@@ -3022,7 +3052,7 @@ impl Compiler {
                     Some(register) => register,
                     None => return compiler_error!(self, "Missing arg register"),
                 };
-                self.compile_set_export(*arg, arg_register);
+                self.compile_value_export(*arg, arg_register);
             }
         }
 

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Chunk, Op},
-    koto_parser::{ConstantIndex, MetaId},
+    koto_parser::{ConstantIndex, MetaKeyId},
     std::{convert::TryInto, fmt, sync::Arc},
 };
 
@@ -93,9 +93,9 @@ pub enum Instruction {
         register: u8,
         constant: ConstantIndex,
     },
-    SetExport {
-        export: ConstantIndex,
-        source: u8,
+    ValueExport {
+        name: ConstantIndex,
+        value: u8,
     },
     Import {
         register: u8,
@@ -337,12 +337,21 @@ pub enum Instruction {
     MetaInsert {
         register: u8,
         value: u8,
-        id: MetaId,
+        id: MetaKeyId,
     },
     MetaInsertNamed {
         register: u8,
         value: u8,
-        id: MetaId,
+        id: MetaKeyId,
+        name: ConstantIndex,
+    },
+    MetaExport {
+        value: u8,
+        id: MetaKeyId,
+    },
+    MetaExportNamed {
+        value: u8,
+        id: MetaKeyId,
         name: ConstantIndex,
     },
     Access {
@@ -382,7 +391,7 @@ impl fmt::Display for Instruction {
             LoadInt { .. } => write!(f, "LoadInt"),
             LoadString { .. } => write!(f, "LoadString"),
             LoadNonLocal { .. } => write!(f, "LoadNonLocal"),
-            SetExport { .. } => write!(f, "SetExport"),
+            ValueExport { .. } => write!(f, "ValueExport"),
             Import { .. } => write!(f, "Import"),
             MakeTuple { .. } => write!(f, "MakeTuple"),
             MakeTempTuple { .. } => write!(f, "MakeTempTuple"),
@@ -436,6 +445,8 @@ impl fmt::Display for Instruction {
             MapInsert { .. } => write!(f, "MapInsert"),
             MetaInsert { .. } => write!(f, "MetaInsert"),
             MetaInsertNamed { .. } => write!(f, "MetaInsertNamed"),
+            MetaExport { .. } => write!(f, "MetaExport"),
+            MetaExportNamed { .. } => write!(f, "MetaExportNamed"),
             Access { .. } => write!(f, "Access"),
             TryStart { .. } => write!(f, "TryStart"),
             TryEnd => write!(f, "TryEnd"),
@@ -475,8 +486,8 @@ impl fmt::Debug for Instruction {
                 "LoadNonLocal\tresult: {}\tconstant: {}",
                 register, constant
             ),
-            SetExport { export, source } => {
-                write!(f, "SetExport\texport: {}\tsource: {}", export, source)
+            ValueExport { name, value } => {
+                write!(f, "ValueExport\tname: {}\tvalue: {}", name, value)
             }
             Import { register, constant } => {
                 write!(f, "Import\t\tresult: {}\tconstant: {}", register, constant)
@@ -803,6 +814,12 @@ impl fmt::Debug for Instruction {
                 "MetaInsertNamed\tmap: {}\t\tvalue: {}\tid: {:?}\tname: {}",
                 register, value, id, name
             ),
+            MetaExport { value, id } => write!(f, "MetaExport\tvalue: {}\tid: {:?}", value, id),
+            MetaExportNamed { value, id, name } => write!(
+                f,
+                "MetaExportNamed\tvalue: {}\tid: {:?}\tname: {}",
+                value, id, name
+            ),
             Access { register, map, key } => write!(
                 f,
                 "Access\t\tresult: {}\tmap: {}\t\tkey: {}",
@@ -965,13 +982,13 @@ impl Iterator for InstructionReader {
                 register: get_byte!(),
                 constant: get_u32!() as ConstantIndex,
             }),
-            Op::SetExport => Some(SetExport {
-                export: get_byte!() as ConstantIndex,
-                source: get_byte!(),
+            Op::ValueExport => Some(ValueExport {
+                name: get_byte!() as ConstantIndex,
+                value: get_byte!(),
             }),
-            Op::SetExportLong => Some(SetExport {
-                export: get_u32!() as ConstantIndex,
-                source: get_byte!(),
+            Op::ValueExportLong => Some(ValueExport {
+                name: get_u32!() as ConstantIndex,
+                value: get_byte!(),
             }),
             Op::Import => Some(Import {
                 register: get_byte!(),
@@ -1292,6 +1309,50 @@ impl Iterator for InstructionReader {
                         id,
                         name,
                     })
+                } else {
+                    Some(Error {
+                        message: format!(
+                            "Unexpected meta id {} found at instruction {}",
+                            meta_id, op_ip
+                        ),
+                    })
+                }
+            }
+            Op::MetaExport => {
+                let meta_id = get_byte!();
+                let value = get_byte!();
+                if let Ok(id) = meta_id.try_into() {
+                    Some(MetaExport { id, value })
+                } else {
+                    Some(Error {
+                        message: format!(
+                            "Unexpected meta id {} found at instruction {}",
+                            meta_id, op_ip
+                        ),
+                    })
+                }
+            }
+            Op::MetaExportNamed => {
+                let meta_id = get_byte!();
+                let value = get_byte!();
+                let name = get_byte!() as ConstantIndex;
+                if let Ok(id) = meta_id.try_into() {
+                    Some(MetaExportNamed { id, value, name })
+                } else {
+                    Some(Error {
+                        message: format!(
+                            "Unexpected meta id {} found at instruction {}",
+                            meta_id, op_ip
+                        ),
+                    })
+                }
+            }
+            Op::MetaExportNamedLong => {
+                let meta_id = get_byte!();
+                let value = get_byte!();
+                let name = get_u32!() as ConstantIndex;
+                if let Ok(id) = meta_id.try_into() {
+                    Some(MetaExportNamed { id, value, name })
                 } else {
                     Some(Error {
                         message: format!(

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -19,8 +19,6 @@ pub enum Op {
     LoadStringLong,      // register, constant[4]
     LoadNonLocal,        // register, constant
     LoadNonLocalLong,    // register, constant[4]
-    SetExport,           // export, source
-    SetExportLong,       // export[4], source
     Import,              // register, constant
     ImportLong,          // register, constant[4]
     MakeTuple,           // register, start register, count
@@ -74,9 +72,14 @@ pub enum Op {
     Index,               // result, list register, index register
     MapInsert,           // map register, value register, key constant
     MapInsertLong,       // map register, value register, key constant[4]
-    MetaInsert,          // map register, value register, key constant
-    MetaInsertNamed,     // map register, value register, key constant, name constant
-    MetaInsertNamedLong, // map register, value register, key constant, name constant[4]
+    MetaInsert,          // map register, value register, key id
+    MetaInsertNamed,     // map register, value register, key id, name constant
+    MetaInsertNamedLong, // map register, value register, key id, name constant[4]
+    MetaExport,          // key id, value register
+    MetaExportNamed,     // key id, value register, name constant
+    MetaExportNamedLong, // key id, value register, name constant[4]
+    ValueExport,         // name, value
+    ValueExportLong,     // name[4], value
     Access,              // register, value register, key
     AccessLong,          // register, value register, key[4]
     IsList,              // register, value
@@ -87,9 +90,6 @@ pub enum Op {
     Debug,               // register, constant[4]
     CheckType,           // register, type (see TypeId)
     CheckSize,           // register, size
-    Unused83,
-    Unused84,
-    Unused85,
     Unused86,
     Unused87,
     Unused88,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -4,89 +4,89 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Op {
-    Copy,             // target, source
-    SetEmpty,         // register
-    SetFalse,         // register
-    SetTrue,          // register
-    Set0,             // register
-    Set1,             // register
-    SetNumberU8,      // register, number
-    LoadFloat,        // register, constant
-    LoadFloatLong,    // register, constant[4]
-    LoadInt,          // register, constant
-    LoadIntLong,      // register, constant[4]
-    LoadString,       // register, constant
-    LoadStringLong,   // register, constant[4]
-    LoadNonLocal,     // register, constant
-    LoadNonLocalLong, // register, constant[4]
-    SetExport,        // export, source
-    SetExportLong,    // export[4], source
-    Import,           // register, constant
-    ImportLong,       // register, constant[4]
-    MakeTuple,        // register, start register, count
-    MakeTempTuple,    // register, start register, count
-    MakeList,         // register, size hint
-    MakeListLong,     // register, size hint[4]
-    MakeMap,          // register, size hint
-    MakeMapLong,      // register, size hint[4]
-    MakeNum2,         // register, element count, first element
-    MakeNum4,         // register, element count, first element
-    MakeIterator,     // register, range
-    Function,         // register, arg count, capture count, flags, size[2]
-    Capture,          // function, target, source
-    Range,            // register, start, end
-    RangeInclusive,   // register, start, end
-    RangeTo,          // register, end
-    RangeToInclusive, // register, end
-    RangeFrom,        // register, start
-    RangeFull,        // register
-    Negate,           // register, source
-    Add,              // result, lhs, rhs
-    Subtract,         // result, lhs, rhs
-    Multiply,         // result, lhs, rhs
-    Divide,           // result, lhs, rhs
-    Modulo,           // result, lhs, rhs
-    Less,             // result, lhs, rhs
-    LessOrEqual,      // result, lhs, rhs
-    Greater,          // result, lhs, rhs
-    GreaterOrEqual,   // result, lhs, rhs
-    Equal,            // result, lhs, rhs
-    NotEqual,         // result, lhs, rhs
-    Jump,             // offset[2]
-    JumpTrue,         // condition, offset[2]
-    JumpFalse,        // condition, offset[2]
-    JumpBack,         // offset[2]
-    JumpBackFalse,    // offset[2]
-    Call,             // result, function, arg register, arg count
-    CallChild,        // result, function, arg register, arg count, parent
-    Return,           // register
-    Yield,            // register
-    Throw,            // register
-    IterNext,         // output, iterator, jump offset[2]
-    IterNextTemp,     // output, iterator, jump offset[2]
-    IterNextQuiet,    // iterator, jump offset[2]
-    ValueIndex,       // result, value register, signed index
-    SliceFrom,        // result, value register, signed index
-    SliceTo,          // result, value register, signed index
-    ListPushValue,    // list, value
-    ListPushValues,   // list, start register, count
-    ListUpdate,       // list, index, value
-    Index,            // result, list register, index register
-    MapInsert,        // map register, value register, key constant
-    MapInsertLong,    // map register, value register, key constant[4]
-    MetaInsert,       // map register, value register, key constant
-    Access,           // register, value register, key
-    AccessLong,       // register, value register, key[4]
-    IsList,           // register, value
-    IsTuple,          // register, value
-    Size,             // register, value
-    TryStart,         // catch arg register, catch body offset[2]
-    TryEnd,           //
-    Debug,            // register, constant[4]
-    CheckType,        // register, type (see TypeId)
-    CheckSize,        // register, size
-    Unused81,
-    Unused82,
+    Copy,                // target, source
+    SetEmpty,            // register
+    SetFalse,            // register
+    SetTrue,             // register
+    Set0,                // register
+    Set1,                // register
+    SetNumberU8,         // register, number
+    LoadFloat,           // register, constant
+    LoadFloatLong,       // register, constant[4]
+    LoadInt,             // register, constant
+    LoadIntLong,         // register, constant[4]
+    LoadString,          // register, constant
+    LoadStringLong,      // register, constant[4]
+    LoadNonLocal,        // register, constant
+    LoadNonLocalLong,    // register, constant[4]
+    SetExport,           // export, source
+    SetExportLong,       // export[4], source
+    Import,              // register, constant
+    ImportLong,          // register, constant[4]
+    MakeTuple,           // register, start register, count
+    MakeTempTuple,       // register, start register, count
+    MakeList,            // register, size hint
+    MakeListLong,        // register, size hint[4]
+    MakeMap,             // register, size hint
+    MakeMapLong,         // register, size hint[4]
+    MakeNum2,            // register, element count, first element
+    MakeNum4,            // register, element count, first element
+    MakeIterator,        // register, range
+    Function,            // register, arg count, capture count, flags, size[2]
+    Capture,             // function, target, source
+    Range,               // register, start, end
+    RangeInclusive,      // register, start, end
+    RangeTo,             // register, end
+    RangeToInclusive,    // register, end
+    RangeFrom,           // register, start
+    RangeFull,           // register
+    Negate,              // register, source
+    Add,                 // result, lhs, rhs
+    Subtract,            // result, lhs, rhs
+    Multiply,            // result, lhs, rhs
+    Divide,              // result, lhs, rhs
+    Modulo,              // result, lhs, rhs
+    Less,                // result, lhs, rhs
+    LessOrEqual,         // result, lhs, rhs
+    Greater,             // result, lhs, rhs
+    GreaterOrEqual,      // result, lhs, rhs
+    Equal,               // result, lhs, rhs
+    NotEqual,            // result, lhs, rhs
+    Jump,                // offset[2]
+    JumpTrue,            // condition, offset[2]
+    JumpFalse,           // condition, offset[2]
+    JumpBack,            // offset[2]
+    JumpBackFalse,       // offset[2]
+    Call,                // result, function, arg register, arg count
+    CallChild,           // result, function, arg register, arg count, parent
+    Return,              // register
+    Yield,               // register
+    Throw,               // register
+    IterNext,            // output, iterator, jump offset[2]
+    IterNextTemp,        // output, iterator, jump offset[2]
+    IterNextQuiet,       // iterator, jump offset[2]
+    ValueIndex,          // result, value register, signed index
+    SliceFrom,           // result, value register, signed index
+    SliceTo,             // result, value register, signed index
+    ListPushValue,       // list, value
+    ListPushValues,      // list, start register, count
+    ListUpdate,          // list, index, value
+    Index,               // result, list register, index register
+    MapInsert,           // map register, value register, key constant
+    MapInsertLong,       // map register, value register, key constant[4]
+    MetaInsert,          // map register, value register, key constant
+    MetaInsertNamed,     // map register, value register, key constant, name constant
+    MetaInsertNamedLong, // map register, value register, key constant, name constant[4]
+    Access,              // register, value register, key
+    AccessLong,          // register, value register, key[4]
+    IsList,              // register, value
+    IsTuple,             // register, value
+    Size,                // register, value
+    TryStart,            // catch arg register, catch body offset[2]
+    TryEnd,              //
+    Debug,               // register, constant[4]
+    CheckType,           // register, type (see TypeId)
+    CheckSize,           // register, size
     Unused83,
     Unused84,
     Unused85,

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -193,15 +193,12 @@ impl Koto {
         match self
             .runtime
             .prelude()
-            .contents_mut()
-            .data
+            .data_mut()
             .get_with_string_mut("koto")
             .unwrap()
         {
             Map(map) => {
-                map.contents_mut()
-                    .data
-                    .add_value("args", Tuple(koto_args.into()));
+                map.data_mut().add_value("args", Tuple(koto_args.into()));
             }
             _ => unreachable!(),
         }
@@ -234,13 +231,12 @@ impl Koto {
         match self
             .runtime
             .prelude()
-            .contents_mut()
-            .data
+            .data_mut()
             .get_with_string_mut("koto")
             .unwrap()
         {
             Map(map) => {
-                let map = &mut map.contents_mut().data;
+                let map = &mut map.data_mut();
                 map.add_value("script_dir", script_dir);
                 map.add_value("script_path", script_path);
             }

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -78,6 +78,7 @@ pub enum SyntaxError {
     ExpectedMatchExpression,
     ExpectedMatchPattern,
     ExpectedMetaKey,
+    ExpectedMetaId,
     ExpectedNegatableExpression,
     ExpectedSwitchArmExpression,
     ExpectedSwitchArmExpressionAfterThen,
@@ -261,6 +262,7 @@ impl fmt::Display for SyntaxError {
             ExpectedMatchExpression => f.write_str("Expected expression after match"),
             ExpectedMatchPattern => f.write_str("Expected pattern for match arm"),
             ExpectedMetaKey => f.write_str("Expected meta key after @"),
+            ExpectedMetaId => f.write_str("Expected id after @meta"),
             ExpectedNegatableExpression => f.write_str("Expected negatable expression"),
             ExpectedSwitchArmExpression => f.write_str("Expected expression in switch arm"),
             ExpectedSwitchArmExpressionAfterThen => {

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -82,6 +82,7 @@ pub enum SyntaxError {
     ExpectedSwitchArmExpression,
     ExpectedSwitchArmExpressionAfterThen,
     ExpectedThenExpression,
+    ExpectedTestName,
     ExpectedUntilCondition,
     ExpectedWhileCondition,
     IfBlockNotAllowedInThisContext,
@@ -265,6 +266,7 @@ impl fmt::Display for SyntaxError {
             ExpectedSwitchArmExpressionAfterThen => {
                 f.write_str("Expected expression after then in switch arm")
             }
+            ExpectedTestName => f.write_str("Expected a test name"),
             ExpectedThenExpression => f.write_str("Expected 'then' expression."),
             ExpectedUntilCondition => f.write_str("Expected condition in until loop"),
             ExpectedWhileCondition => f.write_str("Expected condition in while loop"),

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -9,6 +9,7 @@ pub type ConstantIndex = u32;
 pub enum Node {
     Empty,
     Id(ConstantIndex),
+    Meta(MetaKeyId, Option<ConstantIndex>),
     Lookup((LookupNode, Option<AstIndex>)), // lookup node, next node
     BoolTrue,
     BoolFalse,
@@ -110,6 +111,7 @@ impl fmt::Display for Node {
         match self {
             Empty => write!(f, "Empty"),
             Id(_) => write!(f, "Id"),
+            Meta(_, _) => write!(f, "Meta"),
             Lookup(_) => write!(f, "Lookup"),
             BoolTrue => write!(f, "BoolTrue"),
             BoolFalse => write!(f, "BoolFalse"),
@@ -257,7 +259,7 @@ pub struct SwitchArm {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)]
-pub enum MetaId {
+pub enum MetaKeyId {
     Add,
     Subtract,
     Multiply,
@@ -275,15 +277,16 @@ pub enum MetaId {
     Negate,
     Type,
 
+    Tests,
     Test, // Comes with an associated name
     PreTest,
     PostTest,
 
-    // Must be last, see TryFrom<u8> for MetaId
+    // Must be last, see TryFrom<u8> for MetaKeyId
     Invalid,
 }
 
-impl TryFrom<u8> for MetaId {
+impl TryFrom<u8> for MetaKeyId {
     type Error = u8;
 
     fn try_from(byte: u8) -> Result<Self, Self::Error> {
@@ -300,7 +303,7 @@ impl TryFrom<u8> for MetaId {
 pub enum MapKey {
     Id(ConstantIndex),
     Str(ConstantIndex, QuotationMark),
-    Meta(MetaId, Option<ConstantIndex>),
+    Meta(MetaKeyId, Option<ConstantIndex>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -275,6 +275,10 @@ pub enum MetaId {
     Negate,
     Type,
 
+    Test, // Comes with an associated name
+    PreTest,
+    PostTest,
+
     // Must be last, see TryFrom<u8> for MetaId
     Invalid,
 }
@@ -296,7 +300,7 @@ impl TryFrom<u8> for MetaId {
 pub enum MapKey {
     Id(ConstantIndex),
     Str(ConstantIndex, QuotationMark),
-    Meta(MetaId),
+    Meta(MetaId, Option<ConstantIndex>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -282,6 +282,8 @@ pub enum MetaKeyId {
     PreTest,
     PostTest,
 
+    Named,
+
     // Must be last, see TryFrom<u8> for MetaKeyId
     Invalid,
 }

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -802,6 +802,14 @@ impl<'source> Parser<'source> {
                     }
                     _ => return syntax_error!(ExpectedTestName, self),
                 },
+                "meta" => match self.consume_next_token_on_same_line() {
+                    Some(Token::Id) => {
+                        let id = self.constants.add_string(self.lexer.slice()) as ConstantIndex;
+                        meta_name = Some(id);
+                        MetaKeyId::Named
+                    }
+                    _ => return syntax_error!(ExpectedMetaId, self),
+                },
                 "type" => MetaKeyId::Type,
                 _ => return syntax_error!(UnexpectedMetaKey, self),
             },

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -378,6 +378,7 @@ x"#;
 x =
   @+: 0
   @-: 1
+  @meta foo: 0
 "#;
             check_ast(
                 source,
@@ -385,9 +386,11 @@ x =
                     Id(0), // x
                     Number0,
                     Number1,
+                    Number0,
                     Map(vec![
                         (MapKey::Meta(MetaKeyId::Add, None), Some(1)),
                         (MapKey::Meta(MetaKeyId::Subtract, None), Some(2)),
+                        (MapKey::Meta(MetaKeyId::Named, Some(1)), Some(3)),
                     ]),
                     Assign {
                         target: AssignTarget {
@@ -395,14 +398,14 @@ x =
                             scope: Scope::Local,
                         },
                         op: AssignOp::Equal,
-                        expression: 3,
-                    },
+                        expression: 4,
+                    }, // 5
                     MainBlock {
-                        body: vec![4],
+                        body: vec![5],
                         local_count: 1,
                     },
                 ],
-                Some(&[Constant::Str("x")]),
+                Some(&[Constant::Str("x"), Constant::Str("foo")]),
             )
         }
 

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -271,7 +271,7 @@ x = [
                         (MapKey::Str(0, QuotationMark::Double), Some(1)),
                         (MapKey::Id(2), None),
                         (MapKey::Id(3), Some(2)),
-                        (MapKey::Meta(MetaId::Add), Some(3)),
+                        (MapKey::Meta(MetaId::Add, None), Some(3)),
                     ]),
                     MainBlock {
                         body: vec![0, 4],
@@ -345,7 +345,7 @@ x"#;
                         (MapKey::Id(1), Some(1)),
                         (MapKey::Id(3), None),
                         (MapKey::Str(4, QuotationMark::Double), Some(3)),
-                        (MapKey::Meta(MetaId::Subtract), Some(4)),
+                        (MapKey::Meta(MetaId::Subtract, None), Some(4)),
                     ]), // 5
                     Assign {
                         target: AssignTarget {
@@ -378,6 +378,9 @@ x"#;
 x =
   @+: 0
   @-: 1
+  @pre_test: 0
+  @post_test: 1
+  @test foo: 0
 "#;
             check_ast(
                 source,
@@ -385,24 +388,30 @@ x =
                     Id(0), // x
                     Number0,
                     Number1,
+                    Number0,
+                    Number1,
+                    Number0,
                     Map(vec![
-                        (MapKey::Meta(MetaId::Add), Some(1)),
-                        (MapKey::Meta(MetaId::Subtract), Some(2)),
-                    ]),
+                        (MapKey::Meta(MetaId::Add, None), Some(1)),
+                        (MapKey::Meta(MetaId::Subtract, None), Some(2)),
+                        (MapKey::Meta(MetaId::PreTest, None), Some(3)),
+                        (MapKey::Meta(MetaId::PostTest, None), Some(4)),
+                        (MapKey::Meta(MetaId::Test, Some(1)), Some(5)),
+                    ]), // 5
                     Assign {
                         target: AssignTarget {
                             target_index: 0,
                             scope: Scope::Local,
                         },
                         op: AssignOp::Equal,
-                        expression: 3,
+                        expression: 6,
                     },
                     MainBlock {
-                        body: vec![4],
+                        body: vec![7],
                         local_count: 1,
                     },
                 ],
-                Some(&[Constant::Str("x")]),
+                Some(&[Constant::Str("x"), Constant::Str("foo")]),
             )
         }
 

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -271,7 +271,7 @@ x = [
                         (MapKey::Str(0, QuotationMark::Double), Some(1)),
                         (MapKey::Id(2), None),
                         (MapKey::Id(3), Some(2)),
-                        (MapKey::Meta(MetaId::Add, None), Some(3)),
+                        (MapKey::Meta(MetaKeyId::Add, None), Some(3)),
                     ]),
                     MainBlock {
                         body: vec![0, 4],
@@ -345,7 +345,7 @@ x"#;
                         (MapKey::Id(1), Some(1)),
                         (MapKey::Id(3), None),
                         (MapKey::Str(4, QuotationMark::Double), Some(3)),
-                        (MapKey::Meta(MetaId::Subtract, None), Some(4)),
+                        (MapKey::Meta(MetaKeyId::Subtract, None), Some(4)),
                     ]), // 5
                     Assign {
                         target: AssignTarget {
@@ -378,9 +378,6 @@ x"#;
 x =
   @+: 0
   @-: 1
-  @pre_test: 0
-  @post_test: 1
-  @test foo: 0
 "#;
             check_ast(
                 source,
@@ -388,30 +385,61 @@ x =
                     Id(0), // x
                     Number0,
                     Number1,
-                    Number0,
-                    Number1,
-                    Number0,
                     Map(vec![
-                        (MapKey::Meta(MetaId::Add, None), Some(1)),
-                        (MapKey::Meta(MetaId::Subtract, None), Some(2)),
-                        (MapKey::Meta(MetaId::PreTest, None), Some(3)),
-                        (MapKey::Meta(MetaId::PostTest, None), Some(4)),
-                        (MapKey::Meta(MetaId::Test, Some(1)), Some(5)),
-                    ]), // 5
+                        (MapKey::Meta(MetaKeyId::Add, None), Some(1)),
+                        (MapKey::Meta(MetaKeyId::Subtract, None), Some(2)),
+                    ]),
                     Assign {
                         target: AssignTarget {
                             target_index: 0,
                             scope: Scope::Local,
                         },
                         op: AssignOp::Equal,
-                        expression: 6,
+                        expression: 3,
                     },
                     MainBlock {
-                        body: vec![7],
+                        body: vec![4],
                         local_count: 1,
                     },
                 ],
-                Some(&[Constant::Str("x"), Constant::Str("foo")]),
+                Some(&[Constant::Str("x")]),
+            )
+        }
+
+        #[test]
+        fn map_block_tests() {
+            let source = r#"
+export @tests =
+  @pre_test: 0
+  @post_test: 1
+  @test foo: 0
+"#;
+            check_ast(
+                source,
+                &[
+                    Meta(MetaKeyId::Tests, None),
+                    Number0,
+                    Number1,
+                    Number0,
+                    Map(vec![
+                        (MapKey::Meta(MetaKeyId::PreTest, None), Some(1)),
+                        (MapKey::Meta(MetaKeyId::PostTest, None), Some(2)),
+                        (MapKey::Meta(MetaKeyId::Test, Some(0)), Some(3)),
+                    ]),
+                    Assign {
+                        target: AssignTarget {
+                            target_index: 0,
+                            scope: Scope::Export,
+                        },
+                        op: AssignOp::Equal,
+                        expression: 4,
+                    }, // 5
+                    MainBlock {
+                        body: vec![5],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("foo")]),
             )
         }
 

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -153,7 +153,7 @@ pub fn make_module() -> ValueMap {
                     Ok(file) => {
                         let file_map = make_file_map();
 
-                        file_map.contents_mut().data.insert(
+                        file_map.data_mut().insert(
                             Value::ExternalDataId.into(),
                             Value::make_external_value(File {
                                 file,

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -3,7 +3,7 @@ use crate::{
     value_iterator::{
         make_iterator, ValueIterator, ValueIteratorOutput as Output, ValueIteratorResult,
     },
-    BinaryOp, RuntimeResult, Value, ValueHashMap, ValueList, ValueMap, ValueVec, Vm,
+    BinaryOp, DataMap, RuntimeResult, Value, ValueList, ValueMap, ValueVec, Vm,
 };
 
 pub fn make_module() -> ValueMap {
@@ -475,7 +475,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("to_map", |vm, args| match vm.get_args(args) {
         [iterable] if iterable.is_iterable() => {
             let mut iterator = make_iterator(iterable).unwrap();
-            let mut result = ValueHashMap::new();
+            let mut result = DataMap::new();
 
             loop {
                 match iterator.next() {

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         runtime_error, value_iterator::ValueIteratorOutput as Output, value_sort::compare_values,
-        RuntimeResult, Value, ValueHashMap, ValueIterator, ValueKey, ValueMap, Vm,
+        DataMap, RuntimeResult, Value, ValueIterator, ValueKey, ValueMap, Vm,
     },
     std::{cmp::Ordering, ops::Deref},
 };
@@ -13,16 +13,16 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("clear", |vm, args| match vm.get_args(args) {
         [Map(m)] => {
-            m.contents_mut().data.clear();
+            m.data_mut().clear();
             Ok(Empty)
         }
         _ => runtime_error!("map.clear: Expected map as argument"),
     });
 
     result.add_fn("contains_key", |vm, args| match vm.get_args(args) {
-        [Map(m), key] if key.is_immutable() => Ok(Bool(
-            m.contents().data.contains_key(&ValueKey::from(key.clone())),
-        )),
+        [Map(m), key] if key.is_immutable() => {
+            Ok(Bool(m.data().contains_key(&ValueKey::from(key.clone()))))
+        }
         [other_a, other_b, ..] => runtime_error!(
             "map.contains_key: Expected map and key as arguments, found '{}' and '{}'",
             other_a.type_as_string(),
@@ -32,7 +32,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("copy", |vm, args| match vm.get_args(args) {
-        [Map(m)] => Ok(Map(ValueMap::with_data(m.contents().data.clone()))),
+        [Map(m)] => Ok(Map(ValueMap::with_data(m.data().clone()))),
         _ => runtime_error!("map.copy: Expected map as argument"),
     });
 
@@ -42,7 +42,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("get", |vm, args| match vm.get_args(args) {
-        [Map(m), key] => match m.contents().data.get(&ValueKey::from(key.clone())) {
+        [Map(m), key] => match m.data().get(&ValueKey::from(key.clone())) {
             Some(value) => Ok(value.clone()),
             None => Ok(Empty),
         },
@@ -59,7 +59,7 @@ pub fn make_module() -> ValueMap {
             if *n < 0.0 {
                 return runtime_error!("map.get_index: Negative indices aren't allowed");
             }
-            match m.contents().data.get_index(n.into()) {
+            match m.data().get_index(n.into()) {
                 Some((key, value)) => Ok(Tuple(vec![key.deref().clone(), value.clone()].into())),
                 None => Ok(Empty),
             }
@@ -69,17 +69,13 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("insert", |vm, args| match vm.get_args(args) {
         [Map(m), key] if key.is_immutable() => {
-            match m.contents_mut().data.insert(key.clone().into(), Empty) {
+            match m.data_mut().insert(key.clone().into(), Empty) {
                 Some(old_value) => Ok(old_value),
                 None => Ok(Empty),
             }
         }
         [Map(m), key, value] if key.is_immutable() => {
-            match m
-                .contents_mut()
-                .data
-                .insert(key.clone().into(), value.clone())
-            {
+            match m.data_mut().insert(key.clone().into(), value.clone()) {
                 Some(old_value) => Ok(old_value),
                 None => Ok(Empty),
             }
@@ -93,7 +89,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("is_empty", |vm, args| match vm.get_args(args) {
-        [Map(m)] => Ok(Bool(m.contents().data.is_empty())),
+        [Map(m)] => Ok(Bool(m.data().is_empty())),
         [other, ..] => runtime_error!(
             "map.is_empty: Expected map as argument, found '{}'",
             other.type_as_string(),
@@ -129,11 +125,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("remove", |vm, args| match vm.get_args(args) {
         [Map(m), key] if key.is_immutable() => {
-            match m
-                .contents_mut()
-                .data
-                .shift_remove(&ValueKey::from(key.clone()))
-            {
+            match m.data_mut().shift_remove(&ValueKey::from(key.clone())) {
                 Some(old_value) => Ok(old_value),
                 None => Ok(Empty),
             }
@@ -157,7 +149,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("sort", |vm, args| match vm.get_args(args) {
         [Map(m)] => {
-            m.contents_mut().data.sort_keys();
+            m.data_mut().sort_keys();
             Ok(Empty)
         }
         [Map(l), f] if f.is_callable() => {
@@ -166,53 +158,48 @@ pub fn make_module() -> ValueMap {
             let vm = vm.child_vm();
             let mut error = None;
 
-            let get_sort_key = |vm: &mut Vm,
-                                cache: &mut ValueHashMap,
-                                key: &Value,
-                                value: &Value|
-             -> RuntimeResult {
-                let value = vm.run_function(f.clone(), &[key.clone(), value.clone()])?;
-                cache.insert(key.clone().into(), value.clone());
-                Ok(value)
-            };
+            let get_sort_key =
+                |vm: &mut Vm, cache: &mut DataMap, key: &Value, value: &Value| -> RuntimeResult {
+                    let value = vm.run_function(f.clone(), &[key.clone(), value.clone()])?;
+                    cache.insert(key.clone().into(), value.clone());
+                    Ok(value)
+                };
 
-            let mut cache = ValueHashMap::with_capacity(m.len());
-            m.contents_mut()
-                .data
-                .sort_by(|key_a, value_a, key_b, value_b| {
-                    if error.is_some() {
-                        return Ordering::Equal;
-                    }
+            let mut cache = DataMap::with_capacity(m.len());
+            m.data_mut().sort_by(|key_a, value_a, key_b, value_b| {
+                if error.is_some() {
+                    return Ordering::Equal;
+                }
 
-                    let value_a = match cache.get(key_a) {
-                        Some(value) => value.clone(),
-                        None => match get_sort_key(vm, &mut cache, key_a, value_a) {
-                            Ok(val) => val,
-                            Err(e) => {
-                                error.get_or_insert(Err(e.with_prefix("map.sort")));
-                                Empty
-                            }
-                        },
-                    };
-                    let value_b = match cache.get(key_b) {
-                        Some(value) => value.clone(),
-                        None => match get_sort_key(vm, &mut cache, key_b, value_b) {
-                            Ok(val) => val,
-                            Err(e) => {
-                                error.get_or_insert(Err(e.with_prefix("map.sort")));
-                                Empty
-                            }
-                        },
-                    };
-
-                    match compare_values(vm, &value_a, &value_b) {
-                        Ok(ordering) => ordering,
+                let value_a = match cache.get(key_a) {
+                    Some(value) => value.clone(),
+                    None => match get_sort_key(vm, &mut cache, key_a, value_a) {
+                        Ok(val) => val,
                         Err(e) => {
-                            error.get_or_insert(Err(e));
-                            Ordering::Equal
+                            error.get_or_insert(Err(e.with_prefix("map.sort")));
+                            Empty
                         }
+                    },
+                };
+                let value_b = match cache.get(key_b) {
+                    Some(value) => value.clone(),
+                    None => match get_sort_key(vm, &mut cache, key_b, value_b) {
+                        Ok(val) => val,
+                        Err(e) => {
+                            error.get_or_insert(Err(e.with_prefix("map.sort")));
+                            Empty
+                        }
+                    },
+                };
+
+                match compare_values(vm, &value_a, &value_b) {
+                    Ok(ordering) => ordering,
+                    Err(e) => {
+                        error.get_or_insert(Err(e));
+                        Ordering::Equal
                     }
-                });
+                }
+            });
 
             if let Some(error) = error {
                 error
@@ -268,13 +255,13 @@ fn do_map_update(
     f: Value,
     vm: &mut Vm,
 ) -> RuntimeResult {
-    if !map.contents().data.contains_key(&key) {
-        map.contents_mut().data.insert(key.clone(), default);
+    if !map.data().contains_key(&key) {
+        map.data_mut().insert(key.clone(), default);
     }
-    let value = map.contents().data.get(&key).cloned().unwrap();
+    let value = map.data().get(&key).cloned().unwrap();
     match vm.run_function(f, &[value]) {
         Ok(new_value) => {
-            map.contents_mut().data.insert(key, new_value.clone());
+            map.data_mut().insert(key, new_value.clone());
             Ok(new_value)
         }
         Err(error) => Err(error.with_prefix("map.update")),

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -319,7 +319,7 @@ pub fn format_string(
                 None => return runtime_error!("Missing argument for index {}", n),
             },
             FormatToken::Identifier(id, format_spec) => match format_args.first() {
-                Some(Value::Map(map)) => match map.contents().data.get_with_string(id) {
+                Some(Value::Map(map)) => match map.data().get_with_string(id) {
                     Some(value) => result.push_str(&value_to_string(vm, value, format_spec)?),
                     None => return runtime_error!("Key '{}' not found in map", id),
                 },
@@ -420,7 +420,7 @@ fn value_to_string(
 mod tests {
     use {
         super::*,
-        crate::{ValueHashMap, ValueMap},
+        crate::{DataMap, ValueMap},
     };
 
     fn spec_with_precision(precision: u32) -> FormatSpec {
@@ -586,7 +586,7 @@ mod tests {
 
         #[test]
         fn identifier_placeholders() {
-            let mut map_data = ValueHashMap::new();
+            let mut map_data = DataMap::new();
             map_data.insert("x".into(), Value::Number(42.into()));
             map_data.insert("y".into(), Value::Number(i64::from(-1).into()));
             let map = Value::Map(ValueMap::with_data(map_data));

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -102,16 +102,11 @@ impl<'a> FormatLexer<'a> {
                 self.position += 1;
                 let mut n = n.to_digit(10).unwrap();
 
-                while let Some(c) = chars.peek().cloned() {
-                    match c {
-                        n2 @ '0'..='9' => {
-                            chars.next();
-                            self.position += 1;
-                            n *= 10;
-                            n += n2.to_digit(10).unwrap();
-                        }
-                        _ => break,
-                    }
+                while let Some(n_next @ '0'..='9') = chars.peek().cloned() {
+                    chars.next();
+                    self.position += 1;
+                    n *= 10;
+                    n += n_next.to_digit(10).unwrap();
                 }
 
                 if n <= u32::MAX as u32 {
@@ -121,7 +116,7 @@ impl<'a> FormatLexer<'a> {
                 }
             }
             Some(other) => Err(format!("Expected digit, found '{}'", other)),
-            None => Err(format!("Expected digit")),
+            None => Err("Expected digit".into()),
         }
     }
 }
@@ -243,7 +238,7 @@ impl<'a> Iterator for FormatLexer<'a> {
                             Some(other) => {
                                 Some(Error(format!("Unexpected character - '{}'", other)))
                             }
-                            None => Some(Error(format!("Unexpected end, missing '}}'"))),
+                            None => Some(Error("Unexpected end, missing '}}'".into())),
                         }
                     }
                     Some(_) => {

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -79,11 +79,7 @@ pub fn visit_external_value<T>(
 where
     T: ExternalValue,
 {
-    match map
-        .contents()
-        .data
-        .get(&ValueKey::from(Value::ExternalDataId))
-    {
+    match map.data().get(&ValueKey::from(Value::ExternalDataId)) {
         Some(Value::ExternalValue(maybe_external)) => {
             let mut value = maybe_external.as_ref().write();
             match value.downcast_mut::<T>() {
@@ -102,11 +98,7 @@ pub fn is_external_instance<T>(map: &ValueMap) -> bool
 where
     T: ExternalValue,
 {
-    match map
-        .contents()
-        .data
-        .get(&ValueKey::from(Value::ExternalDataId))
-    {
+    match map.data().get(&ValueKey::from(Value::ExternalDataId)) {
         Some(Value::ExternalValue(maybe_external)) => maybe_external.as_ref().read().is::<T>(),
         _ => false,
     }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -32,7 +32,7 @@ pub use {
     value_iterator::{IntRange, ValueIterator, ValueIteratorOutput},
     value_key::{ValueKey, ValueRef},
     value_list::{ValueList, ValueVec},
-    value_map::{ValueHashMap, ValueMap},
+    value_map::{DataMap, ValueMap},
     value_number::ValueNumber,
     value_string::ValueString,
     value_tuple::ValueTuple,

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod external;
 mod frame;
 mod logger;
+mod meta_map;
 pub mod num2;
 pub mod num4;
 pub mod value;
@@ -24,13 +25,14 @@ pub use {
     koto_bytecode::{CompilerError, Loader, LoaderError},
     koto_parser::ParserError,
     logger::{DefaultLogger, KotoLogger},
+    meta_map::{BinaryOp, MetaKey, MetaMap, UnaryOp},
     num2::Num2,
     num4::Num4,
     value::{RuntimeFunction, Value},
     value_iterator::{IntRange, ValueIterator, ValueIteratorOutput},
     value_key::{ValueKey, ValueRef},
     value_list::{ValueList, ValueVec},
-    value_map::{BinaryOp, MetaKey, UnaryOp, ValueHashMap, ValueMap},
+    value_map::{ValueHashMap, ValueMap},
     value_number::ValueNumber,
     value_string::ValueString,
     value_tuple::ValueTuple,

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -1,0 +1,118 @@
+use {
+    crate::Value,
+    indexmap::IndexMap,
+    koto_parser::MetaId,
+    rustc_hash::FxHasher,
+    std::{
+        fmt,
+        hash::{BuildHasherDefault, Hash},
+    },
+};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BinaryOp {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Modulo,
+    Less,
+    LessOrEqual,
+    Greater,
+    GreaterOrEqual,
+    Equal,
+    NotEqual,
+    Index,
+}
+
+impl fmt::Display for BinaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use BinaryOp::*;
+
+        write!(
+            f,
+            "{}",
+            match self {
+                Add => "+",
+                Subtract => "-",
+                Multiply => "*",
+                Divide => "/",
+                Modulo => "%",
+                Less => "<",
+                LessOrEqual => "<=",
+                Greater => ">",
+                GreaterOrEqual => ">=",
+                Equal => "==",
+                NotEqual => "!=",
+                Index => "[]",
+            }
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum UnaryOp {
+    Negate,
+    Display,
+}
+
+impl fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use UnaryOp::*;
+
+        write!(
+            f,
+            "{}",
+            match self {
+                Negate => "negate",
+                Display => "display",
+            }
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum MetaKey {
+    BinaryOp(BinaryOp),
+    UnaryOp(UnaryOp),
+    Type,
+}
+
+impl From<BinaryOp> for MetaKey {
+    fn from(op: BinaryOp) -> Self {
+        Self::BinaryOp(op)
+    }
+}
+
+impl From<UnaryOp> for MetaKey {
+    fn from(op: UnaryOp) -> Self {
+        Self::UnaryOp(op)
+    }
+}
+
+impl From<MetaId> for MetaKey {
+    fn from(id: MetaId) -> Self {
+        use {BinaryOp::*, UnaryOp::*};
+
+        match id {
+            MetaId::Add => MetaKey::BinaryOp(Add),
+            MetaId::Subtract => MetaKey::BinaryOp(Subtract),
+            MetaId::Multiply => MetaKey::BinaryOp(Multiply),
+            MetaId::Divide => MetaKey::BinaryOp(Divide),
+            MetaId::Modulo => MetaKey::BinaryOp(Modulo),
+            MetaId::Less => MetaKey::BinaryOp(Less),
+            MetaId::LessOrEqual => MetaKey::BinaryOp(LessOrEqual),
+            MetaId::Greater => MetaKey::BinaryOp(Greater),
+            MetaId::GreaterOrEqual => MetaKey::BinaryOp(GreaterOrEqual),
+            MetaId::Equal => MetaKey::BinaryOp(Equal),
+            MetaId::NotEqual => MetaKey::BinaryOp(NotEqual),
+            MetaId::Index => MetaKey::BinaryOp(Index),
+            MetaId::Negate => MetaKey::UnaryOp(Negate),
+            MetaId::Display => MetaKey::UnaryOp(Display),
+            MetaId::Type => MetaKey::Type,
+            _ => unreachable!("Invalid MetaId"),
+        }
+    }
+}
+
+pub type MetaMap = IndexMap<MetaKey, Value, BuildHasherDefault<FxHasher>>;

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -1,3 +1,5 @@
+use crate::ValueString;
+
 use {
     crate::Value,
     indexmap::IndexMap,
@@ -75,6 +77,9 @@ impl fmt::Display for UnaryOp {
 pub enum MetaKey {
     BinaryOp(BinaryOp),
     UnaryOp(UnaryOp),
+    Test(ValueString),
+    PreTest,
+    PostTest,
     Type,
 }
 
@@ -90,29 +95,35 @@ impl From<UnaryOp> for MetaKey {
     }
 }
 
-impl From<MetaId> for MetaKey {
-    fn from(id: MetaId) -> Self {
-        use {BinaryOp::*, UnaryOp::*};
+pub fn meta_id_to_key(id: MetaId, name: Option<&str>) -> Result<MetaKey, String> {
+    use {BinaryOp::*, UnaryOp::*};
 
-        match id {
-            MetaId::Add => MetaKey::BinaryOp(Add),
-            MetaId::Subtract => MetaKey::BinaryOp(Subtract),
-            MetaId::Multiply => MetaKey::BinaryOp(Multiply),
-            MetaId::Divide => MetaKey::BinaryOp(Divide),
-            MetaId::Modulo => MetaKey::BinaryOp(Modulo),
-            MetaId::Less => MetaKey::BinaryOp(Less),
-            MetaId::LessOrEqual => MetaKey::BinaryOp(LessOrEqual),
-            MetaId::Greater => MetaKey::BinaryOp(Greater),
-            MetaId::GreaterOrEqual => MetaKey::BinaryOp(GreaterOrEqual),
-            MetaId::Equal => MetaKey::BinaryOp(Equal),
-            MetaId::NotEqual => MetaKey::BinaryOp(NotEqual),
-            MetaId::Index => MetaKey::BinaryOp(Index),
-            MetaId::Negate => MetaKey::UnaryOp(Negate),
-            MetaId::Display => MetaKey::UnaryOp(Display),
-            MetaId::Type => MetaKey::Type,
-            _ => unreachable!("Invalid MetaId"),
-        }
-    }
+    let result = match id {
+        MetaId::Add => MetaKey::BinaryOp(Add),
+        MetaId::Subtract => MetaKey::BinaryOp(Subtract),
+        MetaId::Multiply => MetaKey::BinaryOp(Multiply),
+        MetaId::Divide => MetaKey::BinaryOp(Divide),
+        MetaId::Modulo => MetaKey::BinaryOp(Modulo),
+        MetaId::Less => MetaKey::BinaryOp(Less),
+        MetaId::LessOrEqual => MetaKey::BinaryOp(LessOrEqual),
+        MetaId::Greater => MetaKey::BinaryOp(Greater),
+        MetaId::GreaterOrEqual => MetaKey::BinaryOp(GreaterOrEqual),
+        MetaId::Equal => MetaKey::BinaryOp(Equal),
+        MetaId::NotEqual => MetaKey::BinaryOp(NotEqual),
+        MetaId::Index => MetaKey::BinaryOp(Index),
+        MetaId::Negate => MetaKey::UnaryOp(Negate),
+        MetaId::Display => MetaKey::UnaryOp(Display),
+        MetaId::Test => MetaKey::Test(
+            name.ok_or_else(|| "Missing name for test".to_string())?
+                .into(),
+        ),
+        MetaId::PreTest => MetaKey::PreTest,
+        MetaId::PostTest => MetaKey::PostTest,
+        MetaId::Type => MetaKey::Type,
+        MetaId::Invalid => return Err("Invalid MetaId".to_string()),
+    };
+
+    Ok(result)
 }
 
 pub type MetaMap = IndexMap<MetaKey, Value, BuildHasherDefault<FxHasher>>;

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -3,7 +3,7 @@ use crate::ValueString;
 use {
     crate::Value,
     indexmap::IndexMap,
-    koto_parser::MetaId,
+    koto_parser::MetaKeyId,
     rustc_hash::FxHasher,
     std::{
         fmt,
@@ -78,6 +78,7 @@ pub enum MetaKey {
     BinaryOp(BinaryOp),
     UnaryOp(UnaryOp),
     Test(ValueString),
+    Tests,
     PreTest,
     PostTest,
     Type,
@@ -95,32 +96,33 @@ impl From<UnaryOp> for MetaKey {
     }
 }
 
-pub fn meta_id_to_key(id: MetaId, name: Option<&str>) -> Result<MetaKey, String> {
+pub fn meta_id_to_key(id: MetaKeyId, name: Option<&str>) -> Result<MetaKey, String> {
     use {BinaryOp::*, UnaryOp::*};
 
     let result = match id {
-        MetaId::Add => MetaKey::BinaryOp(Add),
-        MetaId::Subtract => MetaKey::BinaryOp(Subtract),
-        MetaId::Multiply => MetaKey::BinaryOp(Multiply),
-        MetaId::Divide => MetaKey::BinaryOp(Divide),
-        MetaId::Modulo => MetaKey::BinaryOp(Modulo),
-        MetaId::Less => MetaKey::BinaryOp(Less),
-        MetaId::LessOrEqual => MetaKey::BinaryOp(LessOrEqual),
-        MetaId::Greater => MetaKey::BinaryOp(Greater),
-        MetaId::GreaterOrEqual => MetaKey::BinaryOp(GreaterOrEqual),
-        MetaId::Equal => MetaKey::BinaryOp(Equal),
-        MetaId::NotEqual => MetaKey::BinaryOp(NotEqual),
-        MetaId::Index => MetaKey::BinaryOp(Index),
-        MetaId::Negate => MetaKey::UnaryOp(Negate),
-        MetaId::Display => MetaKey::UnaryOp(Display),
-        MetaId::Test => MetaKey::Test(
+        MetaKeyId::Add => MetaKey::BinaryOp(Add),
+        MetaKeyId::Subtract => MetaKey::BinaryOp(Subtract),
+        MetaKeyId::Multiply => MetaKey::BinaryOp(Multiply),
+        MetaKeyId::Divide => MetaKey::BinaryOp(Divide),
+        MetaKeyId::Modulo => MetaKey::BinaryOp(Modulo),
+        MetaKeyId::Less => MetaKey::BinaryOp(Less),
+        MetaKeyId::LessOrEqual => MetaKey::BinaryOp(LessOrEqual),
+        MetaKeyId::Greater => MetaKey::BinaryOp(Greater),
+        MetaKeyId::GreaterOrEqual => MetaKey::BinaryOp(GreaterOrEqual),
+        MetaKeyId::Equal => MetaKey::BinaryOp(Equal),
+        MetaKeyId::NotEqual => MetaKey::BinaryOp(NotEqual),
+        MetaKeyId::Index => MetaKey::BinaryOp(Index),
+        MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
+        MetaKeyId::Display => MetaKey::UnaryOp(Display),
+        MetaKeyId::Tests => MetaKey::Tests,
+        MetaKeyId::Test => MetaKey::Test(
             name.ok_or_else(|| "Missing name for test".to_string())?
                 .into(),
         ),
-        MetaId::PreTest => MetaKey::PreTest,
-        MetaId::PostTest => MetaKey::PostTest,
-        MetaId::Type => MetaKey::Type,
-        MetaId::Invalid => return Err("Invalid MetaId".to_string()),
+        MetaKeyId::PreTest => MetaKey::PreTest,
+        MetaKeyId::PostTest => MetaKey::PostTest,
+        MetaKeyId::Type => MetaKey::Type,
+        MetaKeyId::Invalid => return Err("Invalid MetaKeyId".to_string()),
     };
 
     Ok(result)

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -77,6 +77,7 @@ impl fmt::Display for UnaryOp {
 pub enum MetaKey {
     BinaryOp(BinaryOp),
     UnaryOp(UnaryOp),
+    Named(ValueString),
     Test(ValueString),
     Tests,
     PreTest,
@@ -114,6 +115,10 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<&str>) -> Result<MetaKey, Stri
         MetaKeyId::Index => MetaKey::BinaryOp(Index),
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),
+        MetaKeyId::Named => MetaKey::Named(
+            name.ok_or_else(|| "Missing name for named meta entry".to_string())?
+                .into(),
+        ),
         MetaKeyId::Tests => MetaKey::Tests,
         MetaKeyId::Test => MetaKey::Test(
             name.ok_or_else(|| "Missing name for test".to_string())?

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -1,9 +1,7 @@
 use {
     crate::{
-        num2, num4,
-        value_map::{ValueMap, ValueMapContents},
-        ExternalFunction, ExternalValue, IntRange, MetaKey, ValueIterator, ValueList, ValueNumber,
-        ValueRef, ValueString, ValueTuple, ValueVec,
+        num2, num4, value_map::ValueMap, ExternalFunction, ExternalValue, IntRange, MetaKey,
+        ValueIterator, ValueList, ValueNumber, ValueRef, ValueString, ValueTuple, ValueVec,
     },
     koto_bytecode::Chunk,
     parking_lot::RwLock,
@@ -110,13 +108,12 @@ impl Value {
             }
             Map(m) => {
                 let data = m
-                    .contents()
-                    .data
+                    .data()
                     .iter()
                     .map(|(k, v)| (k.clone(), v.deep_copy()))
                     .collect();
-                let meta = m.contents().meta.clone();
-                Map(ValueMap::with_contents(ValueMapContents { data, meta }))
+                let meta = m.meta().clone();
+                Map(ValueMap::with_contents(data, meta))
             }
             _ => self.clone(),
         }
@@ -180,7 +177,7 @@ impl Value {
             List(_) => "List".to_string(),
             Range { .. } => "Range".to_string(),
             IndexRange { .. } => "IndexRange".to_string(),
-            Map(m) => match m.contents().meta.get(&MetaKey::Type) {
+            Map(m) => match m.meta().get(&MetaKey::Type) {
                 Some(Str(s)) => s.as_str().to_string(),
                 Some(_) => "Error: expected string for overloaded type".to_string(),
                 None => "Map".to_string(),

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -110,16 +110,12 @@ impl Iterator for ValueIteratorInternals {
                 result
             }
             Iterable::Map(map) => {
-                let result = map
-                    .contents()
-                    .data
-                    .get_index(self.index)
-                    .map(|(key, value)| {
-                        Ok(ValueIteratorOutput::ValuePair(
-                            key.value().clone(),
-                            value.clone(),
-                        ))
-                    });
+                let result = map.data().get_index(self.index).map(|(key, value)| {
+                    Ok(ValueIteratorOutput::ValuePair(
+                        key.value().clone(),
+                        value.clone(),
+                    ))
+                });
                 self.index += 1;
                 result
             }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -16,24 +16,24 @@ use {
     },
 };
 
-type ValueHashMapType = IndexMap<ValueKey, Value, BuildHasherDefault<FxHasher>>;
+type DataMapType = IndexMap<ValueKey, Value, BuildHasherDefault<FxHasher>>;
 
 /// The underlying ValueKey -> Value 'data' hash map used in Koto
 ///
 /// See also: [ValueMap]
 #[repr(C)]
 #[derive(Clone, Debug, Default)]
-pub struct ValueHashMap(ValueHashMapType);
+pub struct DataMap(DataMapType);
 
-impl ValueHashMap {
+impl DataMap {
     #[inline]
     pub fn new() -> Self {
-        Self(ValueHashMapType::default())
+        Self(DataMapType::default())
     }
 
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        Self(ValueHashMapType::with_capacity_and_hasher(
+        Self(DataMapType::with_capacity_and_hasher(
             capacity,
             Default::default(),
         ))
@@ -81,7 +81,7 @@ impl ValueHashMap {
     }
 
     #[inline]
-    pub fn extend(&mut self, other: &ValueHashMap) {
+    pub fn extend(&mut self, other: &DataMap) {
         self.0.extend(other.0.clone().into_iter());
     }
 
@@ -96,105 +96,91 @@ impl ValueHashMap {
     }
 }
 
-impl Deref for ValueHashMap {
-    type Target = ValueHashMapType;
+impl Deref for DataMap {
+    type Target = DataMapType;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for ValueHashMap {
+impl DerefMut for DataMap {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl FromIterator<(ValueKey, Value)> for ValueHashMap {
+impl FromIterator<(ValueKey, Value)> for DataMap {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = (ValueKey, Value)>>(iter: T) -> ValueHashMap {
-        Self(ValueHashMapType::from_iter(iter))
-    }
-}
-
-/// The contents of a ValueMap, combining a data map with a meta map
-#[derive(Clone, Debug, Default)]
-pub struct ValueMapContents {
-    pub data: ValueHashMap,
-    pub meta: MetaMap,
-}
-
-impl ValueMapContents {
-    #[inline]
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            data: ValueHashMap::with_capacity(capacity),
-            meta: MetaMap::default(),
-        }
-    }
-
-    #[inline]
-    pub fn with_data(data: ValueHashMap) -> Self {
-        Self {
-            data,
-            meta: MetaMap::default(),
-        }
-    }
-
-    pub fn extend(&mut self, other: &ValueMapContents) {
-        self.data.extend(&other.data);
-        self.meta.extend(other.meta.clone().into_iter());
+    fn from_iter<T: IntoIterator<Item = (ValueKey, Value)>>(iter: T) -> DataMap {
+        Self(DataMapType::from_iter(iter))
     }
 }
 
 /// The Map value type used in Koto
 #[derive(Clone, Debug, Default)]
-pub struct ValueMap(Arc<RwLock<ValueMapContents>>);
+pub struct ValueMap {
+    data: Arc<RwLock<DataMap>>,
+    meta: Arc<RwLock<MetaMap>>,
+}
 
 impl ValueMap {
     #[inline]
     pub fn new() -> Self {
-        Self::with_contents(ValueMapContents::default())
+        Self::default()
     }
 
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        Self::with_contents(ValueMapContents::with_capacity(capacity))
+        Self::with_contents(DataMap::with_capacity(capacity), MetaMap::default())
     }
 
     #[inline]
-    pub fn with_data(data: ValueHashMap) -> Self {
-        Self::with_contents(ValueMapContents::with_data(data))
+    pub fn with_data(data: DataMap) -> Self {
+        Self::with_contents(data, MetaMap::default())
     }
 
     #[inline]
-    pub fn with_contents(contents: ValueMapContents) -> Self {
-        Self(Arc::new(RwLock::new(contents)))
+    pub fn with_contents(data: DataMap, meta: MetaMap) -> Self {
+        Self {
+            data: Arc::new(RwLock::new(data)),
+            meta: Arc::new(RwLock::new(meta)),
+        }
     }
 
     #[inline]
-    pub fn contents(&self) -> RwLockReadGuard<ValueMapContents> {
-        self.0.read()
+    pub fn data(&self) -> RwLockReadGuard<DataMap> {
+        self.data.read()
     }
 
     #[inline]
-    pub fn contents_mut(&self) -> RwLockWriteGuard<ValueMapContents> {
-        self.0.write()
+    pub fn data_mut(&self) -> RwLockWriteGuard<DataMap> {
+        self.data.write()
+    }
+
+    #[inline]
+    pub fn meta(&self) -> RwLockReadGuard<MetaMap> {
+        self.meta.read()
+    }
+
+    #[inline]
+    pub fn meta_mut(&self) -> RwLockWriteGuard<MetaMap> {
+        self.meta.write()
     }
 
     #[inline]
     pub fn insert(&mut self, key: ValueKey, value: Value) {
-        self.contents_mut().data.insert(key, value);
+        self.data_mut().insert(key, value);
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.contents().data.len()
+        self.data().len()
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.contents().data.is_empty()
+        self.data().is_empty()
     }
 
     #[inline]
@@ -236,7 +222,7 @@ impl fmt::Display for ValueMap {
         write!(f, "{{")?;
         let mut first = true;
         if f.alternate() {
-            for (key, value) in self.contents().data.iter() {
+            for (key, value) in self.data().iter() {
                 if !first {
                     write!(f, ", ")?;
                 }
@@ -244,7 +230,7 @@ impl fmt::Display for ValueMap {
                 first = false;
             }
         } else {
-            for key in self.contents().data.keys() {
+            for key in self.data().keys() {
                 if !first {
                     write!(f, ", ")?;
                 }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -229,14 +229,6 @@ impl ValueMap {
     pub fn add_value(&mut self, id: &str, value: Value) {
         self.insert(id.into(), value);
     }
-
-    // An iterator that clones the map's keys and values
-    //
-    // Useful for avoiding holding on to the underlying RwLock while iterating
-    #[inline]
-    pub fn cloned_iter(&self) -> ValueMapIter {
-        ValueMapIter::new(&self.0)
-    }
 }
 
 impl fmt::Display for ValueMap {
@@ -261,32 +253,5 @@ impl fmt::Display for ValueMap {
             }
         }
         write!(f, "}}")
-    }
-}
-
-pub struct ValueMapIter<'map> {
-    map: &'map RwLock<ValueMapContents>,
-    index: usize,
-}
-
-impl<'map> ValueMapIter<'map> {
-    #[inline]
-    fn new(map: &'map RwLock<ValueMapContents>) -> Self {
-        Self { map, index: 0 }
-    }
-}
-
-impl<'map> Iterator for ValueMapIter<'map> {
-    type Item = (ValueKey, Value);
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.map.read().data.get_index(self.index) {
-            Some((key, value)) => {
-                self.index += 1;
-                Some((key.clone(), value.clone()))
-            }
-            None => None,
-        }
     }
 }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -2,15 +2,14 @@ use {
     crate::{
         external::{Args, ExternalFunction},
         value_key::ValueKeyRef,
-        RuntimeResult, Value, ValueKey, ValueList, Vm,
+        MetaMap, RuntimeResult, Value, ValueKey, ValueList, Vm,
     },
     indexmap::IndexMap,
-    koto_parser::MetaId,
     parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard},
     rustc_hash::FxHasher,
     std::{
         fmt,
-        hash::{BuildHasherDefault, Hash},
+        hash::BuildHasherDefault,
         iter::{FromIterator, IntoIterator},
         ops::{Deref, DerefMut},
         sync::Arc,
@@ -117,114 +116,6 @@ impl FromIterator<(ValueKey, Value)> for ValueHashMap {
         Self(ValueHashMapType::from_iter(iter))
     }
 }
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum BinaryOp {
-    Add,
-    Subtract,
-    Multiply,
-    Divide,
-    Modulo,
-    Less,
-    LessOrEqual,
-    Greater,
-    GreaterOrEqual,
-    Equal,
-    NotEqual,
-    Index,
-}
-
-impl fmt::Display for BinaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use BinaryOp::*;
-
-        write!(
-            f,
-            "{}",
-            match self {
-                Add => "+",
-                Subtract => "-",
-                Multiply => "*",
-                Divide => "/",
-                Modulo => "%",
-                Less => "<",
-                LessOrEqual => "<=",
-                Greater => ">",
-                GreaterOrEqual => ">=",
-                Equal => "==",
-                NotEqual => "!=",
-                Index => "[]",
-            }
-        )
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum UnaryOp {
-    Negate,
-    Display,
-}
-
-impl fmt::Display for UnaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use UnaryOp::*;
-
-        write!(
-            f,
-            "{}",
-            match self {
-                Negate => "negate",
-                Display => "display",
-            }
-        )
-    }
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum MetaKey {
-    BinaryOp(BinaryOp),
-    UnaryOp(UnaryOp),
-    Type,
-}
-
-impl From<BinaryOp> for MetaKey {
-    fn from(op: BinaryOp) -> Self {
-        Self::BinaryOp(op)
-    }
-}
-
-impl From<UnaryOp> for MetaKey {
-    fn from(op: UnaryOp) -> Self {
-        Self::UnaryOp(op)
-    }
-}
-
-impl From<MetaId> for MetaKey {
-    fn from(id: MetaId) -> Self {
-        use {BinaryOp::*, UnaryOp::*};
-
-        match id {
-            MetaId::Add => MetaKey::BinaryOp(Add),
-            MetaId::Subtract => MetaKey::BinaryOp(Subtract),
-            MetaId::Multiply => MetaKey::BinaryOp(Multiply),
-            MetaId::Divide => MetaKey::BinaryOp(Divide),
-            MetaId::Modulo => MetaKey::BinaryOp(Modulo),
-            MetaId::Less => MetaKey::BinaryOp(Less),
-            MetaId::LessOrEqual => MetaKey::BinaryOp(LessOrEqual),
-            MetaId::Greater => MetaKey::BinaryOp(Greater),
-            MetaId::GreaterOrEqual => MetaKey::BinaryOp(GreaterOrEqual),
-            MetaId::Equal => MetaKey::BinaryOp(Equal),
-            MetaId::NotEqual => MetaKey::BinaryOp(NotEqual),
-            MetaId::Index => MetaKey::BinaryOp(Index),
-            MetaId::Negate => MetaKey::UnaryOp(Negate),
-            MetaId::Display => MetaKey::UnaryOp(Display),
-            MetaId::Type => MetaKey::Type,
-            _ => unreachable!("Invalid MetaId"),
-        }
-    }
-}
-
-type MetaMap = IndexMap<MetaKey, Value, BuildHasherDefault<FxHasher>>;
 
 /// The contents of a ValueMap, combining a data map with a meta map
 #[derive(Clone, Debug, Default)]

--- a/src/runtime/src/value_string.rs
+++ b/src/runtime/src/value_string.rs
@@ -51,6 +51,7 @@ impl PartialEq for ValueString {
         self.as_str() == other.as_str()
     }
 }
+impl Eq for ValueString {}
 
 impl Hash for ValueString {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -2444,7 +2444,16 @@ impl Vm {
                 Some(value) => {
                     self.set_register(result_register, value.clone());
                 }
-                None => core_op!(map, true),
+                // TODO get with &str
+                None => match map
+                    .meta()
+                    .get(&MetaKey::Named(self.value_string_from_constant(key)))
+                {
+                    Some(value) => {
+                        self.set_register(result_register, value.clone());
+                    }
+                    None => core_op!(map, true),
+                },
             },
             List(_) => core_op!(list, true),
             Num2(_) => core_op!(num2, false),

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2256,4 +2256,34 @@ foos[0] == foos[1]
             test_script(script, Bool(true));
         }
     }
+
+    mod named_meta_entries {
+        use super::*;
+
+        #[test]
+        fn basic_access() {
+            let script = "
+locals = {}
+foo = |x| {x} + locals.foo_meta
+locals.foo_meta =
+  @meta get_x: |self| self.x
+a = foo 10
+a.x + a.get_x()
+";
+            test_script(script, Number(20.0.into()));
+        }
+
+        #[test]
+        fn lookup_order() {
+            let script = "
+locals = {}
+foo = |x| {x, y: 100} + locals.foo_meta
+locals.foo_meta =
+  @meta y: 0
+a = foo 10
+a.x + a.y # The meta map's y entry is hidden by the data entry
+";
+            test_script(script, Number(110.0.into()));
+        }
+    }
 }

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2,7 +2,7 @@ mod vm {
     use {
         koto_bytecode::Chunk,
         koto_runtime::{
-            num2, num4, runtime_error, BinaryOp, IntRange, Loader, Value, Value::*, ValueHashMap,
+            num2, num4, runtime_error, BinaryOp, DataMap, IntRange, Loader, Value, Value::*,
             ValueList, ValueMap, Vm,
         },
         std::sync::Arc,
@@ -1387,7 +1387,7 @@ sum
 
         #[test]
         fn from_literals() {
-            let mut result_data = ValueHashMap::new();
+            let mut result_data = DataMap::new();
             result_data.add_value("foo", Number(42.0.into()));
             result_data.add_value("bar", Str("baz".into()));
 

--- a/src/serialize/src/lib.rs
+++ b/src/serialize/src/lib.rs
@@ -38,7 +38,7 @@ impl<'a> Serialize for SerializableValue<'a> {
             }
             Value::Map(m) => {
                 let mut seq = s.serialize_map(Some(m.len()))?;
-                for (key, value) in m.contents().data.iter() {
+                for (key, value) in m.data().iter() {
                     seq.serialize_entry(&key.to_string(), &SerializableValue(value))?;
                 }
                 seq.end()


### PR DESCRIPTION
This PR extends `MetaMap` so that it can include named entries, which allows for user-defined meta entries, and is also a pattern that can be used for defining tests.

This will also serve as a foundation for a more straight-forward approach to defining external value types: `ExternalValue` can be extended to include its own `MetaMap` to expose custom behaviour.

See #65 for background discussion.