### PR TITLE
Fix packaging of koto_cli

### DIFF
--- a/src/cli/src/docs/reference
+++ b/src/cli/src/docs/reference
@@ -1,0 +1,1 @@
+../../../../docs/reference

--- a/src/cli/src/help.rs
+++ b/src/cli/src/help.rs
@@ -16,20 +16,20 @@ impl Help {
         };
 
         let help_modules = [
-            include_str!("../../../docs/reference/core_lib/io.md"),
-            include_str!("../../../docs/reference/core_lib/iterator.md"),
-            include_str!("../../../docs/reference/core_lib/koto.md"),
-            include_str!("../../../docs/reference/core_lib/list.md"),
-            include_str!("../../../docs/reference/core_lib/map.md"),
-            include_str!("../../../docs/reference/core_lib/number.md"),
-            include_str!("../../../docs/reference/core_lib/num2.md"),
-            include_str!("../../../docs/reference/core_lib/num4.md"),
-            include_str!("../../../docs/reference/core_lib/os.md"),
-            include_str!("../../../docs/reference/core_lib/range.md"),
-            include_str!("../../../docs/reference/core_lib/string.md"),
-            include_str!("../../../docs/reference/core_lib/test.md"),
-            include_str!("../../../docs/reference/core_lib/thread.md"),
-            include_str!("../../../docs/reference/core_lib/tuple.md"),
+            include_str!("docs/reference/core_lib/io.md"),
+            include_str!("docs/reference/core_lib/iterator.md"),
+            include_str!("docs/reference/core_lib/koto.md"),
+            include_str!("docs/reference/core_lib/list.md"),
+            include_str!("docs/reference/core_lib/map.md"),
+            include_str!("docs/reference/core_lib/number.md"),
+            include_str!("docs/reference/core_lib/num2.md"),
+            include_str!("docs/reference/core_lib/num4.md"),
+            include_str!("docs/reference/core_lib/os.md"),
+            include_str!("docs/reference/core_lib/range.md"),
+            include_str!("docs/reference/core_lib/string.md"),
+            include_str!("docs/reference/core_lib/test.md"),
+            include_str!("docs/reference/core_lib/thread.md"),
+            include_str!("docs/reference/core_lib/tuple.md"),
         ];
 
         for module in help_modules.iter() {


### PR DESCRIPTION
`cargo package` doesn't pick up the reference docs needed by the help system, so this PR symlinks them into the CLI's `src` folder where they're included automatically.
