### PR TITLE
Fix using a quoted key for the first entry in a map block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
+The format of this changelog is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+The Koto project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
+
+### Fixed
+
+- Fixed a regression introduced in `v0.7.0` that prevented Maps from using a
+  quoted string for the first entry's key while using block syntax.
 
 ## [0.8.0] 2021.08.17
 

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -1,33 +1,31 @@
-digits = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+digits = "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
   "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
-  "eighteen", "nineteen"]
+  "eighteen", "nineteen"
 
-tens = ["", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty",
-  "ninety"]
+tens = "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty",
+  "ninety"
 
 number_to_english = |n|
   n = n.floor()
-  if n < 0
-    "minus {}".format number_to_english n.abs()
-  else if n < 20
-    digits[n]
-  else if n < 100
-    x = (n / 10).floor()
-    y = n % 10
-    if y == 0
-      tens[x]
-    else
-      "{}-{}".format tens[x], digits[y]
-  else if n < 1000
-    x = (n / 100).floor()
-    x_string = number_to_english x
-    y = n % 100
-    if y == 0
-      "{} hundred".format x_string
-    else
-      "{} hundred and {}".format x_string, number_to_english y
-  else
-    "???"
+  switch
+    n < 0 then "minus {}".format number_to_english n.abs()
+    n < 20 then digits[n]
+    n < 100 then
+      x = (n / 10).floor()
+      y = n % 10
+      if y == 0
+        tens[x]
+      else
+        "{}-{}".format tens[x], digits[y]
+    n < 1000
+      x = (n / 100).floor()
+      x_string = number_to_english x
+      y = n % 100
+      if y == 0
+        "{} hundred".format x_string
+      else
+        "{} hundred and {}".format x_string, number_to_english y
+    else "???"
 
 export main = ||
   n = match koto.args.get 0
@@ -49,3 +47,4 @@ export @tests =
     assert_eq (number_to_english -42), "minus forty-two"
     assert_eq (number_to_english 217), "two hundred and seventeen"
     assert_eq (number_to_english 999), "nine hundred and ninety-nine"
+    assert_eq (number_to_english 123456), "???"

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -26,10 +26,16 @@ export @tests =
 
   @test map_quoted_keys: ||
     # Quoted strings can be used for keys that would otherwise be disallowed
-    x = {"for": -1, "while": 99, "20": "twenty"}
+    x = {"for": -1, 'while': 99, "20": "twenty"}
     assert_eq x."for", -1
     assert_eq x."while", 99
     assert_eq x."20", "twenty"
+
+    y =
+      "*": 123
+      '.': "xyz"
+    assert_eq y.'*', 123
+    assert_eq y.".", "xyz"
 
   @test unicode_keys: ||
     x = {}

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1604,6 +1604,7 @@ impl<'source> Parser<'source> {
 
             match (peeked_0, peeked_1) {
                 (Token::Id, Some(Token::Colon)) => {}
+                (Token::StringDoubleQuoted | Token::StringSingleQuoted, Some(Token::Colon)) => {}
                 (Token::At, Some(_)) => {}
                 _ => return Ok(None),
             }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -358,12 +358,12 @@ x"#;
                     Id(0),  // x
                     Int(2), // 42
                     Number0,
-                    Map(vec![(MapKey::Id(1), Some(2))]), // baz, nested map
+                    Map(vec![(MapKey::Id(1), Some(2))]), // foo, 0
                     Int(4),
                     Map(vec![
-                        (MapKey::Id(1), Some(1)),
-                        (MapKey::Str(3, QuotationMark::Double), Some(3)),
-                        (MapKey::Meta(MetaKeyId::Subtract, None), Some(4)),
+                        (MapKey::Id(1), Some(1)),                           // foo: 42
+                        (MapKey::Str(3, QuotationMark::Double), Some(3)),   // "baz": nested map
+                        (MapKey::Meta(MetaKeyId::Subtract, None), Some(4)), // @-: -1
                     ]), // 5
                     Assign {
                         target: AssignTarget {
@@ -386,6 +386,35 @@ x"#;
                     Constant::Str("baz"),
                     Constant::I64(-1),
                 ]),
+            )
+        }
+
+        #[test]
+        fn map_block_first_entry_with_string_key() {
+            let source = r#"
+x =
+  "foo": 42
+"#;
+            check_ast(
+                source,
+                &[
+                    Id(0),                                                       // x
+                    Int(2),                                                      // 42
+                    Map(vec![(MapKey::Str(1, QuotationMark::Double), Some(1))]), // "foo", 42
+                    Assign {
+                        target: AssignTarget {
+                            target_index: 0,
+                            scope: Scope::Local,
+                        },
+                        op: AssignOp::Equal,
+                        expression: 2,
+                    },
+                    MainBlock {
+                        body: vec![3],
+                        local_count: 1,
+                    },
+                ],
+                Some(&[Constant::Str("x"), Constant::Str("foo"), Constant::I64(42)]),
             )
         }
 

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -2480,7 +2480,6 @@ impl Vm {
                 let op = self.get_core_op(
                     key_string,
                     &self.context_shared.core_lib.$module,
-                    stringify!($module),
                     $iterator_fallback,
                 )?;
                 self.set_register(result_register, op);
@@ -2530,13 +2529,7 @@ impl Vm {
         Ok(())
     }
 
-    fn get_core_op(
-        &self,
-        key: &str,
-        module: &ValueMap,
-        module_name: &str,
-        iterator_fallback: bool,
-    ) -> RuntimeResult {
+    fn get_core_op(&self, key: &str, module: &ValueMap, iterator_fallback: bool) -> RuntimeResult {
         use Value::*;
 
         let maybe_op = match module.data().get_with_string(key).cloned() {
@@ -2585,7 +2578,7 @@ impl Vm {
                 }
                 other => other,
             },
-            None => return runtime_error!("'{}' not found in module '{}'", key, module_name),
+            None => return runtime_error!("'{}' not found", key),
         };
 
         Ok(result)


### PR DESCRIPTION
Fixes a regression introduced in `v0.7.0` that prevented the use of a quoted key
for the first entry in a map block.
