### PR TITLE
Advent of code day 19 tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The Koto project adheres to
 
 ## Unreleased
 
+### Added
+
+- Indexing a string with a range starting from 'one past the end' is now
+  supported.
+
 ## [0.8.1] 2021.08.18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The Koto project adheres to
 
 - Indexing a string with a range starting from 'one past the end' is now
   supported.
+- Throw and debug expressions can now be used more freely, in particular as
+  expressions in match and switch arms.
+  - e.g.
+    ```koto
+    match foo()
+      0 then true
+      1 then false
+      x then debug x # debug would previously require an indented block
+    ```
 
 ## [0.8.1] 2021.08.18
 

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -480,10 +480,6 @@ impl<'source> Parser<'source> {
                 Some(result)
             } else if let Some(result) = self.parse_export(&mut ExpressionContext::line_start())? {
                 Some(result)
-            } else if let Some(result) = self.parse_throw_expression()? {
-                Some(result)
-            } else if let Some(result) = self.parse_debug_expression()? {
-                Some(result)
             } else {
                 self.parse_expressions(&mut ExpressionContext::line_start(), false)?
             };
@@ -1452,9 +1448,10 @@ impl<'source> Parser<'source> {
                     };
                     Some(result)
                 }
+                Token::Throw => self.parse_throw_expression()?,
+                Token::Debug => self.parse_debug_expression()?,
                 Token::From | Token::Import => self.parse_import_expression(context)?,
                 Token::Try => self.parse_try_expression(context)?,
-                // Token::NewLineIndented => self.parse_map_block(current_indent, None)?,
                 Token::Error => return syntax_error!(LexerError, self),
                 _ => None,
             };
@@ -2007,7 +2004,6 @@ impl<'source> Parser<'source> {
         }
 
         // Check for errors now that the match expression is complete
-
         for (arm_index, arm) in arms.iter().enumerate() {
             let last_arm = arm_index == arms.len() - 1;
 
@@ -2024,6 +2020,7 @@ impl<'source> Parser<'source> {
             start_span,
         )?))
     }
+
     fn parse_match_expression(
         &mut self,
         context: &mut ExpressionContext,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -4163,6 +4163,45 @@ match x
         }
 
         #[test]
+        fn match_arm_is_throw_expression() {
+            let source = "
+match x
+  0 then 1
+  else throw 'nope'
+";
+            check_ast(
+                source,
+                &[
+                    Id(0),
+                    Number0,
+                    Number1,
+                    Str(1, QuotationMark::Single),
+                    Throw(3),
+                    Match {
+                        expression: 0,
+                        arms: vec![
+                            MatchArm {
+                                patterns: vec![1],
+                                condition: None,
+                                expression: 2,
+                            },
+                            MatchArm {
+                                patterns: vec![],
+                                condition: None,
+                                expression: 4,
+                            },
+                        ],
+                    }, // 5
+                    MainBlock {
+                        body: vec![5],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x"), Constant::Str("nope")]),
+            )
+        }
+
+        #[test]
         fn switch_expression() {
             let source = "
 switch
@@ -4210,6 +4249,42 @@ switch
                     },
                 ],
                 Some(&[Constant::Str("a"), Constant::Str("b")]),
+            )
+        }
+
+        #[test]
+        fn switch_arm_is_debug_expression() {
+            let source = "
+switch
+  true then 1
+  else debug x
+";
+            check_ast(
+                source,
+                &[
+                    BoolTrue,
+                    Number1,
+                    Id(0),
+                    Debug {
+                        expression_string: 0,
+                        expression: 2,
+                    },
+                    Switch(vec![
+                        SwitchArm {
+                            condition: Some(0),
+                            expression: 1,
+                        },
+                        SwitchArm {
+                            condition: None,
+                            expression: 3,
+                        },
+                    ]),
+                    MainBlock {
+                        body: vec![4],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x")]),
             )
         }
     }

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -42,7 +42,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("get", |vm, args| match vm.get_args(args) {
-        [Map(m), key] => match m.data().get(&ValueKey::from(key.clone())) {
+        [Map(m), key] if key.is_immutable() => match m.data().get(&ValueKey::from(key.clone())) {
             Some(value) => Ok(value.clone()),
             None => Ok(Empty),
         },

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1878,6 +1878,14 @@ x[3]";
         }
 
         #[test]
+        fn index_from_one_past_the_end() {
+            test_script("'x'[0..1]", string("x"));
+            test_script("'x'[1..]", string(""));
+            test_script("'x'[1..1]", string(""));
+            test_script("'héllö'[5..]", string(""));
+        }
+
+        #[test]
         fn index_whole_string() {
             test_script("'héllö'[..]", string("héllö"));
         }


### PR DESCRIPTION
This PR includes some changes that I made while working on [Day 19 of Advent of Code 2020](https://github.com/irh/advent-of-code-koto-2020/blob/main/19.koto).

- Prevent the use of mutable values as key when using map.get
- Allow indexing a string with a range starting from one-past-the-end
- Allow throw and debug expressions to be used more freely
