### PR TITLE
Tweak a few things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ The Koto project adheres to
     - `num2.min` / `num4.min`
     - `num2.normalize` / `num4.normalize`
     - `num2.product` / `num4.product`
+  - Following a parenthesized num2/num4 expression with a lookup is now
+    supported.
+    - e.g.
+      ```koto
+      num2(1, 2).sum()
+      #         ^-- Previously this would result in an 'unexpected token' error.
+      ```
 - Indexing a string with a range starting from 'one past the end' is now
   supported.
 - Throw and debug expressions can now be used more freely, in particular as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,10 @@ The Koto project adheres to
       ```
   - Added core operations:
     - `num2.iter` / `num4.iter`
+    - `num2.length` / `num4.length`
     - `num2.max` / `num4.max`
     - `num2.min` / `num4.min`
+    - `num2.normalize` / `num4.normalize`
     - `num2.product` / `num4.product`
 - Indexing a string with a range starting from 'one past the end' is now
   supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ The Koto project adheres to
       x then debug x # debug would previously require an indented block
     ```
 
+### Changed
+
+- Compilation errors from the top-level Koto struct are now returned as a
+  variant of `KotoError`.
+
 ## [0.8.1] 2021.08.18
 
 ### Fixed

--- a/docs/reference/core_lib/num2.md
+++ b/docs/reference/core_lib/num2.md
@@ -29,8 +29,10 @@ x
 # Reference
 
 - [iter](#iter)
+- [length](#length)
 - [max](#max)
 - [min](#min)
+- [normalize](#normalize)
 - [product](#product)
 - [sum](#sum)
 
@@ -51,6 +53,20 @@ x = (num2 3, 4).iter()
 x.skip(1)
 x.next()
 # 4
+```
+
+## length
+
+`|Num2| -> Float`
+
+Returns the length of the vector represented by the Num2's elements.
+
+### Example
+
+```koto
+x = num2(3, 4)
+x.length()
+# 5
 ```
 
 ## max
@@ -79,6 +95,21 @@ Returns the value of the smallest element in the Num2.
 x = num2(10, 20)
 x.min()
 # 10
+```
+
+## normalize
+
+`|Num2| -> Num2`
+
+Returns a Num2 with the same direction as the input,
+with its length normalized to 1.
+
+### Example
+
+```koto
+x = num2(3, 4)
+x.normalize()
+# num2(0.6, 0.8)
 ```
 
 ## product

--- a/docs/reference/core_lib/num4.md
+++ b/docs/reference/core_lib/num4.md
@@ -2,7 +2,7 @@
 
 A Num4 in Koto is a packed group of 32bit floating-point numbers,
 which can be useful when working with operations that require 3D coordinates,
-RGBA colour values.
+or RGBA colour values.
 
 Element-wise arithmetic operations between Num4s are available,
 while operations with Numbers apply the number to each element.
@@ -29,6 +29,11 @@ x
 # Reference
 
 - [iter](#iter)
+- [length](#length)
+- [max](#max)
+- [min](#min)
+- [normalize](#normalize)
+- [product](#product)
 - [sum](#sum)
 
 ## iter
@@ -48,6 +53,20 @@ x = (num4 3, 4, 5, 6).iter()
 x.skip(2)
 x.next()
 # 5
+```
+
+## length
+
+`|Num4| -> Float`
+
+Returns the length of the vector represented by the Num4's elements.
+
+### Example
+
+```koto
+x = num4(2, -2, 2, -2)
+x.length()
+# 4
 ```
 
 ## max
@@ -76,6 +95,21 @@ Returns the value of the smallest element in the Num4.
 x = num4(10, 20, -50, -10)
 x.min()
 # -50
+```
+
+## normalize
+
+`|Num4| -> Num4`
+
+Returns a Num4 with the same direction as the input,
+with its length normalized to 1.
+
+### Example
+
+```koto
+x = num4(2, -2, 2, -2)
+x.normalize()
+# num4(0.5, -0.5, 0.5, 0.5)
 ```
 
 ## product

--- a/koto/tests/line_breaks.koto
+++ b/koto/tests/line_breaks.koto
@@ -30,6 +30,18 @@ x = (1, 2, 3)
   .fold 0, |a, b| a + b
 assert_eq x, 6
 
+x =
+  [1, 2, 3]
+    .each |n| n
+    # This comment shouldn't interrupt the chain
+    .fold 0, |a, b| a + b
+assert_eq x, 6
+
+x =
+  "hello"
+    .count()
+assert_eq x, 5
+
 assert_equal = |
   long_arg, # This is an argument that needs an explanation
   long_arg_2,

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -3,9 +3,7 @@ from test import assert, assert_eq
 locals = {}
 
 foo = |x|
-  result =
-    x: x
-  result + locals.foo_meta
+  {x} + locals.foo_meta
 
 # Declaring the overloaded operators once and then copying them into the foo instance
 # is more efficient than declaring them each time foo is called.

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -24,6 +24,11 @@ export @tests =
     x += num4 10
     assert_eq x, (num4 10, 12, 14, 11)
 
+  @test length: ||
+    assert_eq (num2 3, 4).length(), 5
+    assert_eq (num2 -3, -4).length(), 5
+    assert_eq (num4 2, -2, 2, -2).length(), 4
+
   @test max: ||
     assert_eq (num2 1, -1).max(), 1
     assert_eq (num4 3, 4, 5, -123).max(), 5
@@ -31,6 +36,11 @@ export @tests =
   @test min: ||
     assert_eq (num2 1, -1).min(), -1
     assert_eq (num4 3, 4, 5, -123).min(), -123
+
+  @test normalize: ||
+    assert_eq (num2 0, 1).normalize(), num2 0, 1
+    assert_eq (num2 3, 4).normalize(), num2 0.6, 0.8
+    assert_eq (num4 2, -2, 2, -2).normalize(), num4 0.5, -0.5, 0.5, -0.5
 
   @test product: ||
     assert_eq (num2 3, 4).product(), 12

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -265,6 +265,7 @@ impl<'source> Parser<'source> {
             .peek_next_token(&ExpressionContext::permissive())
             .is_some()
         {
+            self.consume_next_token(&mut ExpressionContext::permissive());
             return syntax_error!(UnexpectedToken, self);
         }
 

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1365,7 +1365,15 @@ impl<'source> Parser<'source> {
                         return syntax_error!(TooManyNum2Terms, self);
                     }
 
-                    Some(self.push_node_with_start_span(Num2(args), start_span)?)
+                    let num2_node = self.push_node_with_start_span(Num2(args), start_span)?;
+
+                    let result = if self.next_token_is_lookup_start(context) {
+                        self.parse_lookup(num2_node, context)?
+                    } else {
+                        num2_node
+                    };
+
+                    Some(result)
                 }
                 Token::Num4 => {
                     self.consume_next_token(context);
@@ -1383,7 +1391,15 @@ impl<'source> Parser<'source> {
                         return syntax_error!(TooManyNum4Terms, self);
                     }
 
-                    Some(self.push_node_with_start_span(Num4(args), start_span)?)
+                    let num4_node = self.push_node_with_start_span(Num4(args), start_span)?;
+
+                    let result = if self.next_token_is_lookup_start(context) {
+                        self.parse_lookup(num4_node, context)?
+                    } else {
+                        num4_node
+                    };
+
+                    Some(result)
                 }
                 Token::If => self.parse_if_expression(context)?,
                 Token::Match => self.parse_match_expression(context)?,

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -899,10 +899,11 @@ impl<'source> Parser<'source> {
 
             let id_index = self.push_node(Node::Id(constant_index))?;
 
+            let mut context = context.start_new_expression();
             let result = match self.peek_token() {
                 Some(Token::Whitespace) if context.allow_space_separated_call => {
                     let start_span = self.lexer.span();
-                    let args = self.parse_call_args(context)?;
+                    let args = self.parse_call_args(&mut context)?;
 
                     if args.is_empty() {
                         id_index
@@ -916,12 +917,12 @@ impl<'source> Parser<'source> {
                         )?
                     }
                 }
-                Some(_) if self.next_token_is_lookup_start(context) => {
-                    self.parse_lookup(id_index, context)?
+                Some(_) if self.next_token_is_lookup_start(&context) => {
+                    self.parse_lookup(id_index, &mut context)?
                 }
                 Some(_) if context.allow_space_separated_call && context.allow_linebreaks => {
                     let start_span = self.lexer.span();
-                    let args = self.parse_call_args(context)?;
+                    let args = self.parse_call_args(&mut context)?;
 
                     if args.is_empty() {
                         id_index
@@ -1191,13 +1192,7 @@ impl<'source> Parser<'source> {
         };
 
         let range_node = self.push_node(range_node)?;
-
-        let result = if self.next_token_is_lookup_start(context) {
-            self.parse_lookup(range_node, context)?
-        } else {
-            range_node
-        };
-
+        let result = self.check_for_lookup_after_node(range_node, context)?;
         Ok(Some(result))
     }
 
@@ -1337,11 +1332,7 @@ impl<'source> Parser<'source> {
                         QuotationMark::Single
                     };
                     let string_node = self.push_node(Str(constant_index, quote))?;
-                    if self.next_token_is_lookup_start(context) {
-                        Some(self.parse_lookup(string_node, context)?)
-                    } else {
-                        Some(string_node)
-                    }
+                    Some(self.check_for_lookup_after_node(string_node, context)?)
                 }
                 Token::Id => self.parse_id_expression(context)?,
                 Token::Wildcard => {
@@ -1366,15 +1357,8 @@ impl<'source> Parser<'source> {
                         return syntax_error!(TooManyNum2Terms, self);
                     }
 
-                    let num2_node = self.push_node_with_start_span(Num2(args), start_span)?;
-
-                    let result = if self.next_token_is_lookup_start(context) {
-                        self.parse_lookup(num2_node, context)?
-                    } else {
-                        num2_node
-                    };
-
-                    Some(result)
+                    let node = self.push_node_with_start_span(Num2(args), start_span)?;
+                    Some(self.check_for_lookup_after_node(node, context)?)
                 }
                 Token::Num4 => {
                     self.consume_next_token(context);
@@ -1392,15 +1376,8 @@ impl<'source> Parser<'source> {
                         return syntax_error!(TooManyNum4Terms, self);
                     }
 
-                    let num4_node = self.push_node_with_start_span(Num4(args), start_span)?;
-
-                    let result = if self.next_token_is_lookup_start(context) {
-                        self.parse_lookup(num4_node, context)?
-                    } else {
-                        num4_node
-                    };
-
-                    Some(result)
+                    let node = self.push_node_with_start_span(Num4(args), start_span)?;
+                    Some(self.check_for_lookup_after_node(node, context)?)
                 }
                 Token::If => self.parse_if_expression(context)?,
                 Token::Match => self.parse_match_expression(context)?,
@@ -1479,6 +1456,22 @@ impl<'source> Parser<'source> {
         }
     }
 
+    // Checks to see if a lookup starts after the parsed node,
+    // and either returns the node if there's no lookup,
+    // or uses the node as the start of the lookup.
+    fn check_for_lookup_after_node(
+        &mut self,
+        node: AstIndex,
+        context: &ExpressionContext,
+    ) -> Result<AstIndex, ParserError> {
+        let mut lookup_context = context.start_new_expression();
+        if self.next_token_is_lookup_start(&lookup_context) {
+            self.parse_lookup(node, &mut lookup_context)
+        } else {
+            Ok(node)
+        }
+    }
+
     fn parse_number(
         &mut self,
         negate: bool,
@@ -1523,11 +1516,9 @@ impl<'source> Parser<'source> {
             }
         };
 
-        Ok(if self.next_token_is_lookup_start(context) {
-            Some(self.parse_lookup(number_node, context)?)
-        } else {
-            Some(number_node)
-        })
+        Ok(Some(
+            self.check_for_lookup_after_node(number_node, context)?,
+        ))
     }
 
     fn parse_list(
@@ -1577,13 +1568,7 @@ impl<'source> Parser<'source> {
         self.consume_next_token(&mut list_context);
 
         let list_node = self.push_node_with_start_span(Node::List(entries), start_span)?;
-
-        let result = if self.next_token_is_lookup_start(&mut list_context) {
-            self.parse_lookup(list_node, &mut list_context)?
-        } else {
-            list_node
-        };
-
+        let result = self.check_for_lookup_after_node(list_node, &list_context)?;
         Ok(Some(result))
     }
 
@@ -1724,13 +1709,7 @@ impl<'source> Parser<'source> {
         self.consume_next_token(&mut map_end_context);
 
         let map_node = self.push_node_with_start_span(Node::Map(entries), start_span)?;
-
-        let result = if self.next_token_is_lookup_start(context) {
-            self.parse_lookup(map_node, context)?
-        } else {
-            map_node
-        };
-
+        let result = self.check_for_lookup_after_node(map_node, context)?;
         Ok(Some(result))
     }
 
@@ -2220,7 +2199,7 @@ impl<'source> Parser<'source> {
                             }
                         } else {
                             let id_node = self.push_node(Node::Id(id))?;
-                            if self.next_token_is_lookup_start(&mut pattern_context) {
+                            if self.next_token_is_lookup_start(&pattern_context) {
                                 self.frame_mut()?.add_id_access(id);
                                 self.parse_lookup(id_node, &mut pattern_context)?
                             } else {
@@ -2520,7 +2499,7 @@ impl<'source> Parser<'source> {
             }
         }
 
-        let result = match expressions.as_slice() {
+        let expressions_node = match expressions.as_slice() {
             [] => self.push_node(Node::Empty)?,
             [single_expression] if !encountered_comma => *single_expression,
             _ => self.push_node(Node::Tuple(expressions))?,
@@ -2528,11 +2507,7 @@ impl<'source> Parser<'source> {
 
         if let Some(ParenClose) = self.peek_token() {
             self.consume_token();
-            let result = if self.next_token_is_lookup_start(context) {
-                self.parse_lookup(result, context)?
-            } else {
-                result
-            };
+            let result = self.check_for_lookup_after_node(expressions_node, context)?;
             Ok(Some(result))
         } else {
             syntax_error!(ExpectedCloseParen, self)
@@ -2659,7 +2634,7 @@ impl<'source> Parser<'source> {
         })
     }
 
-    fn next_token_is_lookup_start(&mut self, context: &mut ExpressionContext) -> bool {
+    fn next_token_is_lookup_start(&mut self, context: &ExpressionContext) -> bool {
         use Token::*;
 
         if matches!(

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3103,6 +3103,7 @@ x.bar()."baz" = 1
                 Some(&[Constant::Str("f"), Constant::Str("x")]),
             )
         }
+
         #[test]
         fn call_on_call_result() {
             let source = "(f x)(y)";
@@ -3208,6 +3209,46 @@ x.bar()."baz" = 1
                     },
                 ],
                 Some(&[Constant::Str("x"), Constant::Str("values")]),
+            )
+        }
+
+        #[test]
+        fn lookup_on_num2_with_parens() {
+            let source = "num2(1).sum()";
+            check_ast(
+                source,
+                &[
+                    Number1,
+                    Num2(vec![0]),
+                    Lookup((LookupNode::Call(vec![]), None)),
+                    Lookup((LookupNode::Id(0), Some(2))),
+                    Lookup((LookupNode::Root(1), Some(3))),
+                    MainBlock {
+                        body: vec![4],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("sum")]),
+            )
+        }
+
+        #[test]
+        fn lookup_on_num4_with_parens() {
+            let source = "num4(1).sum()";
+            check_ast(
+                source,
+                &[
+                    Number1,
+                    Num4(vec![0]),
+                    Lookup((LookupNode::Call(vec![]), None)),
+                    Lookup((LookupNode::Id(0), Some(2))),
+                    Lookup((LookupNode::Root(1), Some(3))),
+                    MainBlock {
+                        body: vec![4],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("sum")]),
             )
         }
 

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -1,4 +1,4 @@
-use crate::{runtime_error, Value, ValueIterator, ValueMap};
+use crate::{runtime_error, RuntimeResult, Value, ValueIterator, ValueMap};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -7,28 +7,42 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("iter", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Iterator(ValueIterator::with_num2(*n))),
-        _ => runtime_error!("num2.iter: Expected a Num2 as argument"),
+        _ => num2_error("iter"),
+    });
+
+    result.add_fn("length", |vm, args| match vm.get_args(args) {
+        [Num2(n)] => Ok(Number(n.length().into())),
+        _ => num2_error("length"),
     });
 
     result.add_fn("max", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Number((n.0.max(n.1)).into())),
-        _ => runtime_error!("num2.max: Expected a Num2 as argument"),
+        _ => num2_error("max"),
     });
 
     result.add_fn("min", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Number((n.0.min(n.1)).into())),
-        _ => runtime_error!("num2.min: Expected a Num2 as argument"),
+        _ => num2_error("min"),
+    });
+
+    result.add_fn("normalize", |vm, args| match vm.get_args(args) {
+        [Num2(n)] => Ok(Num2(n.normalize())),
+        _ => num2_error("normalize"),
     });
 
     result.add_fn("product", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Number((n.0 * n.1).into())),
-        _ => runtime_error!("num2.product: Expected a Num2 as argument"),
+        _ => num2_error("product"),
     });
 
     result.add_fn("sum", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Number((n.0 + n.1).into())),
-        _ => runtime_error!("num2.sum: Expected a Num2 as argument"),
+        _ => num2_error("sum"),
     });
 
     result
+}
+
+fn num2_error(name: &str) -> RuntimeResult {
+    runtime_error!("num2.{}: Expected a Num2 as argument", name)
 }

--- a/src/runtime/src/core/num4.rs
+++ b/src/runtime/src/core/num4.rs
@@ -1,4 +1,4 @@
-use crate::{runtime_error, Value, ValueIterator, ValueMap};
+use crate::{runtime_error, RuntimeResult, Value, ValueIterator, ValueMap};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -7,36 +7,46 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("iter", |vm, args| match vm.get_args(args) {
         [Num4(n)] => Ok(Iterator(ValueIterator::with_num4(*n))),
-        _ => runtime_error!("num4.iter: Expected a Num4 as argument"),
+        _ => num4_error("iter"),
+    });
+
+    result.add_fn("length", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.length().into())),
+        _ => num4_error("length"),
     });
 
     result.add_fn("max", |vm, args| match vm.get_args(args) {
         [Num4(n)] => Ok(Number((n.0.max(n.1).max(n.2).max(n.3)).into())),
-        _ => runtime_error!("num4.max: Expected a Num4 as argument"),
+        _ => num4_error("max"),
     });
 
     result.add_fn("min", |vm, args| match vm.get_args(args) {
         [Num4(n)] => Ok(Number((n.0.min(n.1).min(n.2).min(n.3)).into())),
-        _ => runtime_error!("num4.min: Expected a Num4 as argument"),
+        _ => num4_error("min"),
+    });
+
+    result.add_fn("normalize", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Num4(n.normalize())),
+        _ => num4_error("normalize"),
     });
 
     result.add_fn("product", |vm, args| match vm.get_args(args) {
         [Num4(n)] => Ok(Number(
             (n.0 as f64 * n.1 as f64 * n.2 as f64 * n.3 as f64).into(),
         )),
-        _ => runtime_error!("num4.product: Expected a Num4 as argument"),
+        _ => num4_error("product"),
     });
 
     result.add_fn("sum", |vm, args| match vm.get_args(args) {
         [Num4(n)] => Ok(Number(
             (n.0 as f64 + n.1 as f64 + n.2 as f64 + n.3 as f64).into(),
         )),
-        [unexpected] => runtime_error!(
-            "num4.sum: Expected Num4, found '{}'",
-            unexpected.type_as_string()
-        ),
-        _ => runtime_error!("num4.sum: Expected a Num4 as argument"),
+        _ => num4_error("sum"),
     });
 
     result
+}
+
+fn num4_error(name: &str) -> RuntimeResult {
+    runtime_error!("num4.{}: Expected a Num4 as argument", name)
 }

--- a/src/runtime/src/num2.rs
+++ b/src/runtime/src/num2.rs
@@ -14,6 +14,14 @@ impl Num2 {
     pub fn abs(&self) -> Self {
         Num2(self.0.abs(), self.1.abs())
     }
+
+    pub fn length(&self) -> f64 {
+        (self.0 * self.0 + self.1 * self.1).sqrt()
+    }
+
+    pub fn normalize(&self) -> Self {
+        *self / self.length()
+    }
 }
 
 impl PartialEq for Num2 {

--- a/src/runtime/src/num4.rs
+++ b/src/runtime/src/num4.rs
@@ -14,6 +14,18 @@ impl Num4 {
     pub fn abs(&self) -> Self {
         Self(self.0.abs(), self.1.abs(), self.2.abs(), self.3.abs())
     }
+
+    pub fn length(&self) -> f64 {
+        let x = self.0 as f64;
+        let y = self.1 as f64;
+        let z = self.2 as f64;
+        let w = self.3 as f64;
+        (x * x + y * y + z * z + w * w).sqrt()
+    }
+
+    pub fn normalize(&self) -> Self {
+        *self / self.length()
+    }
 }
 
 impl PartialEq for Num4 {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1680,7 +1680,7 @@ gen().to_tuple()
         }
     }
 
-    mod num2_test {
+    mod num2 {
         use super::*;
 
         #[test]
@@ -1769,13 +1769,13 @@ x";
         #[test]
         fn iterator_ops() {
             let script = "
-x = num2 1, -1
-x.keep(|n| n < 0).count()";
+num2(1, -1).keep(|n| n < 0).count()
+";
             test_script(script, Number(1.0.into()));
         }
     }
 
-    mod num4_test {
+    mod num4 {
         use super::*;
 
         #[test]
@@ -1885,8 +1885,8 @@ x.sum()";
         #[test]
         fn iterator_ops() {
             let script = "
-x = num4 1, -1, 2, -2
-x.keep(|n| n > 0).count()";
+num4(1, -1, 2, -2).keep(|n| n > 0).count()
+";
             test_script(script, Number(2.0.into()));
         }
     }


### PR DESCRIPTION
This PR contains a collection of tweaks that deal with issues I've come across
in the last couple of days.

- Add num2/num4 length/normalize
- Allow lookups after parenthesized num2/num4 expressions
- Improve the readability of 'unexpected token' errors
- Allow indented lookups on indented assignments
- Return top-level compilation errors as a KotoError variant
