### PR TITLE
Allow indented calls on lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The Koto project adheres to
 - Added an optional library for working with YAML data.
 - Indexing a string with a range starting from 'one past the end' is now
   supported.
+  - e.g. `"x"[1..]` is allowed, and produces an empty string.
 - Throw and debug expressions can now be used more freely, in particular as
   expressions in match and switch arms.
   - e.g.
@@ -49,6 +50,14 @@ The Koto project adheres to
       0 then true
       1 then false
       x then debug x # debug would previously require an indented block here.
+    ```
+- Indented function calls are now allowed on lookups.
+  - e.g. The following expression was previously disallowed:
+    ```koto
+    test.assert_eq
+      1 + 1,
+    # ^~~~ An 'unexpected token' error would previously be generated here
+      2
     ```
 
 ### Changed

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1111,6 +1111,16 @@ impl<'source> Parser<'source> {
                         ..node_context
                     };
                 }
+                _ if node_context.allow_space_separated_call && node_context.allow_linebreaks => {
+                    node_context.allow_space_separated_call = false;
+
+                    let args = self.parse_call_args(context)?;
+                    if args.is_empty() {
+                        break;
+                    } else {
+                        lookup.push((LookupNode::Call(args), node_start_span));
+                    }
+                }
                 _ => break,
             }
         }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3032,6 +3032,29 @@ x.bar()."baz" = 1
         }
 
         #[test]
+        fn lookup_indentation_separated_call() {
+            let source = "
+x.foo
+  42
+";
+            check_ast(
+                source,
+                &[
+                    Id(0),
+                    Int(2),
+                    Lookup((LookupNode::Call(vec![1]), None)),
+                    Lookup((LookupNode::Id(1), Some(2))),
+                    Lookup((LookupNode::Root(0), Some(3))),
+                    MainBlock {
+                        body: vec![4],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x"), Constant::Str("foo"), Constant::I64(42)]),
+            )
+        }
+
+        #[test]
         fn map_lookup_in_list() {
             let source = "[m.foo, m.bar]";
             check_ast(

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -185,15 +185,6 @@ f = ||
             use super::*;
 
             #[test]
-            fn detached_index() {
-                let source = "
-x.foo
-  [0]
-";
-                check_parsing_fails(source);
-            }
-
-            #[test]
             fn detached_dot_access() {
                 let source = "
 x. foo

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -191,6 +191,14 @@ x. foo
 ";
                 check_parsing_fails(source);
             }
+
+            #[test]
+            fn detached_dot_access_2() {
+                let source = "
+x .foo
+";
+                check_parsing_fails(source);
+            }
         }
 
         mod maps {


### PR DESCRIPTION
This PR adds missing support for allowing indented function calls on lookups.
