### PR TITLE
Add exports getter to Koto implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The Koto project adheres to
 
 ### Added
 
+- The Koto struct now has a `Koto::exports()` getter that allows access to a script's exported values.
 - Num2 / Num4 improvements.
   - Elements can now be assigned via indexing.
     - e.g.

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -207,6 +207,10 @@ impl Koto {
         self.runtime.prelude()
     }
 
+    pub fn exports(&self) -> ValueMap {
+        self.runtime.context().exports.clone()
+    }
+
     pub fn set_args(&mut self, args: &[String]) {
         use Value::{Map, Str, Tuple};
 


### PR DESCRIPTION
This PR aims to to expose exports from the module by adding a getter named `exports` to the `Koto` struct implementation.