### PR TITLE
String interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,21 @@ The Koto project adheres to
       #         ^-- Previously this would result in an 'unexpected token' error.
       ```
 - Added an optional library for working with YAML data.
-- Indexing a string with a range starting from 'one past the end' is now
-  supported.
-  - e.g. `"x"[1..]` is allowed, and produces an empty string.
+- String improvements
+  - String interpolation is now supported.
+    - e.g.
+      ```koto
+      x = 42
+
+      "The answer is $x"
+      # The answer is 42
+
+      "$x divided by 3 is ${x / 3}."
+      # 42 divided by 3 is 14.
+      ```
+  - Indexing a string with a range starting from 'one past the end' is now
+    supported.
+    - e.g. `"x"[1..]` is allowed, and produces an empty string.
 - Throw and debug expressions can now be used more freely, in particular as
   expressions in match and switch arms.
   - e.g.
@@ -65,6 +77,8 @@ The Koto project adheres to
 
 - Compilation errors from the top-level Koto struct are now returned as a
   variant of `KotoError`.
+- `$` symbols in string literals now need to be escaped (i.e. `\$`) due to
+  the addition of string interpolation.
 
 ## [0.8.1] 2021.08.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ The Koto project adheres to
 
 ### Added
 
-- The Koto struct now has a `Koto::exports()` getter that allows access to a script's exported values.
+- String improvements
+  - Support for string interpolation has been added.
+    - e.g.
+      ```koto
+      x = 42
+
+      "The answer is $x"
+      # The answer is 42
+
+      "$x divided by 3 is ${x / 3}."
+      # 42 divided by 3 is 14.
+      ```
+  - Indexing a string with a range starting from 'one past the end' is now
+    supported.
+    - e.g. `"x"[1..]` is allowed, and produces an empty string.
 - Num2 / Num4 improvements.
   - Elements can now be assigned via indexing.
     - e.g.
@@ -40,21 +54,6 @@ The Koto project adheres to
       #         ^-- Previously this would result in an 'unexpected token' error.
       ```
 - Added an optional library for working with YAML data.
-- String improvements
-  - String interpolation is now supported.
-    - e.g.
-      ```koto
-      x = 42
-
-      "The answer is $x"
-      # The answer is 42
-
-      "$x divided by 3 is ${x / 3}."
-      # 42 divided by 3 is 14.
-      ```
-  - Indexing a string with a range starting from 'one past the end' is now
-    supported.
-    - e.g. `"x"[1..]` is allowed, and produces an empty string.
 - Throw and debug expressions can now be used more freely, in particular as
   expressions in match and switch arms.
   - e.g.
@@ -72,13 +71,15 @@ The Koto project adheres to
     # ^~~~ An 'unexpected token' error would previously be generated here
       2
     ```
+- The Koto struct now has a `Koto::exports()` getter that allows access to a
+  script's exported values.
 
 ### Changed
 
 - Compilation errors from the top-level Koto struct are now returned as a
   variant of `KotoError`.
-- `$` symbols in string literals now need to be escaped (i.e. `\$`) due to
-  the addition of string interpolation.
+- `$` symbols in string literals now need to be escaped due to the addition of
+  string interpolation.
 
 ## [0.8.1] 2021.08.18
 
@@ -92,8 +93,8 @@ The Koto project adheres to
 ### Added
 
 - CLI improvements
-  - The REPL now contains a help system that provides reference documentation for
-    the core library.
+  - The REPL now contains a help system that provides reference documentation
+    for the core library.
   - An `--eval` option has been added to allow for direct evaluation of an
     expression.
 - New features for Strings.

--- a/docs/reference/core_lib/string.md
+++ b/docs/reference/core_lib/string.md
@@ -2,16 +2,50 @@
 
 Koto's strings are immutable sequences of characters with UTF-8 encoding.
 
+## Syntax
+
 String literals can be created with either double or single quotation marks.
 Both styles are offered as a convenience to reduce the need for escaping,
 e.g. `'a "b" c'` is equivalent to `"a \"b\" c"`,
 and `"a 'b' c"` is equivalent to `'a \'b\' c'`
 
+## Data sharing
+
 Functions that produce sub-strings (e.g. `string.trim`) share the string
 data between the original string and the sub-string.
 
+## Indexing
+
 Strings support indexing operations, with string indices referring to
 grapheme clusters.
+
+e.g.
+
+```koto
+'👋🥳😆'[1]
+# 🥳
+```
+
+## String Interpolation
+
+String interpolation allows for the results of expressions to be embedded
+into placeholders in a string, using `$` as the placeholder symbol.
+
+Default formatting is used when embedding the value in the string.
+For more advanced string formatting, see [`string.format`](#format).
+
+### Example
+
+```koto
+a = "Hello"
+b = "World"
+'$a, $b!'
+# Hello, World!
+
+x = 64
+"The square root of $x is ${x.sqrt()}."
+# The square root of 64 is 8.0.
+```
 
 ## Escape codes
 
@@ -30,17 +64,7 @@ escape code, then it can be escaped with an additional `\`.
 - `\'`: Single quote
 - `\"`: Double quote
 - `\\`: Backslash
-
-## Example
-
-```koto
-a = "Hello"
-b = 'World!'
-x = "{}, {}!".format a, b
-# Hello, World!
-'👋🥳😆'[1]
-# 🥳
-```
+- `\$`: Dollar
 
 # Reference
 

--- a/examples/poetry/scripts/reference.koto
+++ b/examples/poetry/scripts/reference.koto
@@ -16,7 +16,7 @@ export main = ||
       words = [word, word, word]
       match random.pick 0..4
         n if n < 3 then words[n] = words[n].to_uppercase()
-      print "{}, {}. {}!", words[0], words[1], words[2]
+      print "${words[0]}, ${words[1]}. ${words[2]}!"
     print ""
 
   print separator

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -99,7 +99,7 @@ export @tests =
       make_map() +
         foo_2: 57
         get_foo_2: |self| self.foo_2
-        set_foo_2: |self x| self.foo_2 = x
+        set_foo_2: |self, x| self.foo_2 = x
         sum_foo: |self| self.foo + self.foo_2
 
     m2 = make_map_2()
@@ -107,17 +107,6 @@ export @tests =
     assert_eq m2.get_foo_2(), 57 # .get_foo_2 receives m2 as first argument
     m2.set_foo_2 58 # .set_foo_2 receives m2 as first argument, 58 as second argument
     assert_eq m2.sum_foo(), 100
-
-  @test instance_function_outside_of_map: ||
-    m =
-      foo: 42
-      get_foo: |self| self.foo
-    getter = m.get_foo
-    assert_eq (getter m), 42
-
-  @test map_in_list_comprehension: ||
-    a = [{foo, bar} for foo, bar in 1..=3, 4..=6]
-    assert_eq a, [{foo: 1, bar: 4}, {foo: 2, bar: 5}, {foo: 3, bar: 6}]
 
   @test map_blocks_in_if_expression: ||
     make_map = |n|
@@ -146,7 +135,7 @@ export @tests =
           c:
             d:
               foo: -1
-              set_foo: |self x| self.foo = x
+              set_foo: |self, x| self.foo = x
     assert_eq deep.a.b.c.d.foo, -1
     deep.a.b.c.d.set_foo(42)
     assert_eq deep.a.b.c.d.foo, 42

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -41,11 +41,16 @@ export @tests =
     a = 123
     z = {'key$a': 42}
     assert_eq z.key123, 42
+    assert_eq z."key$a", 42
+
+    z.'key$a' = a
+    assert_eq z.'key$a', a
 
   @test unicode_keys: ||
-    x = {}
-    x.ƒöó = 123
+    x = {ƒöó: 123}
+    x.bär = -1
     assert_eq x.ƒöó, 123
+    assert_eq x.bär, -1
 
   @test function_value: ||
     o = {}

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -24,8 +24,8 @@ export @tests =
       assert_ne key, ()
       assert_ne value, ()
 
-  @test map_quoted_keys: ||
-    # Quoted strings can be used for keys that would otherwise be disallowed
+  @test map_string_keys: ||
+    # Strings can be used for keys that would otherwise be disallowed
     x = {"for": -1, 'while': 99, "20": "twenty"}
     assert_eq x."for", -1
     assert_eq x."while", 99
@@ -36,6 +36,11 @@ export @tests =
       '.': "xyz"
     assert_eq y.'*', 123
     assert_eq y.".", "xyz"
+
+    # Keys can also be defined dynamically using string interpolation
+    a = 123
+    z = {'key$a': 42}
+    assert_eq z.key123, 42
 
   @test unicode_keys: ||
     x = {}

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -13,6 +13,15 @@ export @tests =
     # Strings can use either double or single quotes.
     assert_eq "Hello", 'Hello'
 
+  @test interpolation: ||
+    # Identifiers prefixed with $ are formatted into the string
+    hello = "Hello"
+    world = "World"
+    assert_eq "$hello, $world!", "Hello, World!"
+
+    x = 99
+    assert_eq "$x$x-$x$x", "9999-9999"
+
   @test addition: ||
     x = "^"
     x += "_" + "^"

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -14,13 +14,16 @@ export @tests =
     assert_eq "Hello", 'Hello'
 
   @test interpolation: ||
-    # Identifiers prefixed with $ are formatted into the string
+    # Identifiers prefixed with $ are formatted into the string.
     hello = "Hello"
     world = "World"
     assert_eq "$hello, $world!", "Hello, World!"
 
     x = 99
     assert_eq "$x$x-$x$x", "9999-9999"
+
+    # Expressions can be formatted into the string with ${...} syntax.
+    assert_eq "x times 10 is ${x * 10}", "x times 10 is 990"
 
   @test addition: ||
     x = "^"

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -331,8 +331,8 @@ pub enum Instruction {
     },
     MapInsert {
         register: u8,
+        key: u8,
         value: u8,
-        key: ConstantIndex,
     },
     MetaInsert {
         register: u8,
@@ -1275,13 +1275,8 @@ impl Iterator for InstructionReader {
             }),
             Op::MapInsert => Some(MapInsert {
                 register: get_byte!(),
+                key: get_byte!(),
                 value: get_byte!(),
-                key: get_byte!() as ConstantIndex,
-            }),
-            Op::MapInsertLong => Some(MapInsert {
-                register: get_byte!(),
-                value: get_byte!(),
-                key: get_u32!() as ConstantIndex,
             }),
             Op::MetaInsert => {
                 let register = get_byte!();

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -356,8 +356,8 @@ pub enum Instruction {
     },
     Access {
         register: u8,
-        map: u8,
-        key: ConstantIndex,
+        value: u8,
+        key: u8,
     },
     TryStart {
         arg_register: u8,
@@ -837,10 +837,14 @@ impl fmt::Debug for Instruction {
                 "MetaExportNamed\tvalue: {}\tid: {:?}\tname: {}",
                 value, id, name
             ),
-            Access { register, map, key } => write!(
+            Access {
+                register,
+                value,
+                key,
+            } => write!(
                 f,
-                "Access\t\tresult: {}\tmap: {}\t\tkey: {}",
-                register, map, key
+                "Access\t\tresult: {}\tvalue: {}\tkey: {}",
+                register, value, key
             ),
             TryStart {
                 arg_register,
@@ -1385,13 +1389,8 @@ impl Iterator for InstructionReader {
             }
             Op::Access => Some(Access {
                 register: get_byte!(),
-                map: get_byte!(),
-                key: get_byte!() as ConstantIndex,
-            }),
-            Op::AccessLong => Some(Access {
-                register: get_byte!(),
-                map: get_byte!(),
-                key: get_u32!() as ConstantIndex,
+                value: get_byte!(),
+                key: get_byte!(),
             }),
             Op::TryStart => Some(TryStart {
                 arg_register: get_byte!(),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -376,6 +376,16 @@ pub enum Instruction {
         register: u8,
         size: usize,
     },
+    StringStart {
+        register: u8,
+    },
+    StringPush {
+        register: u8,
+        value: u8,
+    },
+    StringFinish {
+        register: u8,
+    },
 }
 
 impl fmt::Display for Instruction {
@@ -453,6 +463,9 @@ impl fmt::Display for Instruction {
             Debug { .. } => write!(f, "Debug"),
             CheckType { .. } => write!(f, "CheckType"),
             CheckSize { .. } => write!(f, "CheckSize"),
+            StringStart { .. } => write!(f, "StringStart"),
+            StringPush { .. } => write!(f, "StringPush"),
+            StringFinish { .. } => write!(f, "StringFinish"),
         }
     }
 }
@@ -846,6 +859,15 @@ impl fmt::Debug for Instruction {
             }
             CheckSize { register, size } => {
                 write!(f, "CheckSize\tregister: {}\tsize: {}", register, size)
+            }
+            StringStart { register } => {
+                write!(f, "StringStart\tregister: {}", register)
+            }
+            StringPush { register, value } => {
+                write!(f, "StringPush\tregister: {}\tvalue: {}", register, value)
+            }
+            StringFinish { register } => {
+                write!(f, "StringFinish\tregister: {}", register)
             }
         }
     }
@@ -1397,6 +1419,16 @@ impl Iterator for InstructionReader {
             Op::CheckSize => Some(CheckSize {
                 register: get_byte!(),
                 size: get_byte!() as usize,
+            }),
+            Op::StringStart => Some(StringStart {
+                register: get_byte!(),
+            }),
+            Op::StringPush => Some(StringPush {
+                register: get_byte!(),
+                value: get_byte!(),
+            }),
+            Op::StringFinish => Some(StringFinish {
+                register: get_byte!(),
             }),
             _ => Some(Error {
                 message: format!("Unexpected opcode {:?} found at instruction {}", op, op_ip),

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -79,8 +79,7 @@ pub enum Op {
     MetaExportNamedLong, // key id, value register, name constant[4]
     ValueExport,         // name, value
     ValueExportLong,     // name[4], value
-    Access,              // register, value register, key
-    AccessLong,          // register, value register, key[4]
+    Access,              // result, value, key
     IsList,              // register, value
     IsTuple,             // register, value
     Size,                // register, value
@@ -92,6 +91,7 @@ pub enum Op {
     StringStart,         // register
     StringPush,          // register, value register
     StringFinish,        // register
+    Unused87,
     Unused88,
     Unused89,
     Unused90,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -70,8 +70,7 @@ pub enum Op {
     ListPushValues,      // list, start register, count
     Index,               // result, indexable, index
     SetIndex,            // indexable, index, value
-    MapInsert,           // map register, value register, key constant
-    MapInsertLong,       // map register, value register, key constant[4]
+    MapInsert,           // map, key, value
     MetaInsert,          // map register, value register, key id
     MetaInsertNamed,     // map register, value register, key id, name constant
     MetaInsertNamedLong, // map register, value register, key id, name constant[4]
@@ -93,6 +92,7 @@ pub enum Op {
     StringStart,         // register
     StringPush,          // register, value register
     StringFinish,        // register
+    Unused88,
     Unused89,
     Unused90,
     Unused91,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -90,9 +90,9 @@ pub enum Op {
     Debug,               // register, constant[4]
     CheckType,           // register, type (see TypeId)
     CheckSize,           // register, size
-    Unused86,
-    Unused87,
-    Unused88,
+    StringStart,         // register
+    StringPush,          // register, value register
+    StringFinish,        // register
     Unused89,
     Unused90,
     Unused91,

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -27,13 +27,13 @@ pub enum Token {
     Dollar,
     Dot,
     Ellipsis,
-    ParenOpen,
-    ParenClose,
     Function,
-    ListStart,
-    ListEnd,
-    MapStart,
-    MapEnd,
+    RoundOpen,
+    RoundClose,
+    SquareOpen,
+    SquareClose,
+    CurlyOpen,
+    CurlyClose,
     Wildcard,
     Range,
     RangeInclusive,
@@ -493,13 +493,13 @@ impl<'a> TokenLexer<'a> {
         check_symbol!(":", Colon);
         check_symbol!(",", Comma);
         check_symbol!(".", Dot);
-        check_symbol!("(", ParenOpen);
-        check_symbol!(")", ParenClose);
+        check_symbol!("(", RoundOpen);
+        check_symbol!(")", RoundClose);
         check_symbol!("|", Function);
-        check_symbol!("[", ListStart);
-        check_symbol!("]", ListEnd);
-        check_symbol!("{", MapStart);
-        check_symbol!("}", MapEnd);
+        check_symbol!("[", SquareOpen);
+        check_symbol!("]", SquareClose);
+        check_symbol!("{", CurlyOpen);
+        check_symbol!("}", CurlyClose);
         check_symbol!("_", Wildcard);
 
         None
@@ -919,8 +919,8 @@ false #
                 (CommentMulti, Some("#-\nmultiline -\nfalse #\n-#"), 5),
                 (True, None, 5),
                 (NewLine, None, 6),
-                (ParenOpen, None, 6),
-                (ParenClose, None, 6),
+                (RoundOpen, None, 6),
+                (RoundClose, None, 6),
             ],
         );
     }
@@ -1041,15 +1041,15 @@ false #
                 (Number, Some("1.0"), 1),
                 (Dot, None, 1),
                 (Id, Some("sin"), 1),
-                (ParenOpen, None, 1),
-                (ParenClose, None, 1),
+                (RoundOpen, None, 1),
+                (RoundClose, None, 1),
                 (NewLine, None, 2),
                 (Subtract, None, 2),
                 (Number, Some("1e-3"), 2),
                 (Dot, None, 2),
                 (Id, Some("abs"), 2),
-                (ParenOpen, None, 2),
-                (ParenClose, None, 2),
+                (RoundOpen, None, 2),
+                (RoundClose, None, 2),
                 (NewLine, None, 3),
                 (Number, Some("1"), 3),
                 (Dot, None, 3),
@@ -1059,8 +1059,8 @@ false #
                 (Number, Some("9"), 4),
                 (Dot, None, 4),
                 (Id, Some("exp"), 4),
-                (ParenOpen, None, 4),
-                (ParenClose, None, 4),
+                (RoundOpen, None, 4),
+                (RoundClose, None, 4),
             ],
         );
     }
@@ -1098,14 +1098,14 @@ x = [i for i in 0..5]";
             input,
             &[
                 (Id, Some("a"), 1),
-                (ListStart, None, 1),
+                (SquareOpen, None, 1),
                 (RangeInclusive, None, 1),
                 (Number, Some("9"), 1),
-                (ListEnd, None, 1),
+                (SquareClose, None, 1),
                 (NewLine, None, 2),
                 (Id, Some("x"), 2),
                 (Assign, None, 2),
-                (ListStart, None, 2),
+                (SquareOpen, None, 2),
                 (Id, Some("i"), 2),
                 (For, None, 2),
                 (Id, Some("i"), 2),
@@ -1113,7 +1113,7 @@ x = [i for i in 0..5]";
                 (Number, Some("0"), 2),
                 (Range, None, 2),
                 (Number, Some("5"), 2),
-                (ListEnd, None, 2),
+                (SquareClose, None, 2),
             ],
         );
     }
@@ -1145,14 +1145,14 @@ f()";
                 (Id, Some("b"), 2, 2),
                 (Dot, None, 2, 2),
                 (Id, Some("size"), 2, 2),
-                (ParenOpen, None, 2, 2),
-                (ParenClose, None, 2, 2),
+                (RoundOpen, None, 2, 2),
+                (RoundClose, None, 2, 2),
                 (NewLineIndented, None, 3, 2),
                 (Id, Some("c"), 3, 2),
                 (NewLine, None, 4, 0),
                 (Id, Some("f"), 4, 0),
-                (ParenOpen, None, 4, 0),
-                (ParenClose, None, 4, 0),
+                (RoundOpen, None, 4, 0),
+                (RoundClose, None, 4, 0),
             ],
         );
     }
@@ -1216,13 +1216,13 @@ else
                 (Id, Some("检验"), 1),
                 (Dot, None, 1),
                 (Id, Some("foo"), 1),
-                (ListStart, None, 1),
+                (SquareOpen, None, 1),
                 (Number, Some("1"), 1),
-                (ListEnd, None, 1),
+                (SquareClose, None, 1),
                 (Dot, None, 1),
                 (Id, Some("bär"), 1),
-                (ParenOpen, None, 1),
-                (ParenClose, None, 1),
+                (RoundOpen, None, 1),
+                (RoundClose, None, 1),
             ],
         );
     }
@@ -1237,8 +1237,8 @@ else
                 (Id, Some("foo"), 1),
                 (Dot, None, 1),
                 (Id, Some("and"), 1),
-                (ParenOpen, None, 1),
-                (ParenClose, None, 1),
+                (RoundOpen, None, 1),
+                (RoundClose, None, 1),
             ],
         );
     }

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -17,7 +17,7 @@ pub enum Node {
     Number1,
     Int(ConstantIndex),
     Float(ConstantIndex),
-    Str(ConstantIndex, QuotationMark),
+    Str(AstString),
     Num2(Vec<AstIndex>),
     Num4(Vec<AstIndex>),
     List(Vec<AstIndex>),
@@ -119,7 +119,7 @@ impl fmt::Display for Node {
             Int(_) => write!(f, "Int"),
             Number0 => write!(f, "Number0"),
             Number1 => write!(f, "Number1"),
-            Str(_, _) => write!(f, "Str"),
+            Str(_) => write!(f, "Str"),
             Num2(_) => write!(f, "Num2"),
             Num4(_) => write!(f, "Num4"),
             List(_) => write!(f, "List"),
@@ -172,6 +172,22 @@ pub struct Function {
     pub is_instance_function: bool,
     pub is_variadic: bool,
     pub is_generator: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AstString {
+    pub quotation_mark: QuotationMark,
+    pub nodes: Vec<StringNode>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum StringNode {
+    // A string literal
+    Literal(ConstantIndex),
+    // An id that should be evaluated and inserted into the string
+    Id(ConstantIndex),
+    // An expression that should be evaluated and inserted into the string
+    Expr(AstIndex),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -301,7 +317,7 @@ impl TryFrom<u8> for MetaKeyId {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MapKey {
     Id(ConstantIndex),
     Str(ConstantIndex, QuotationMark),

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -248,6 +248,7 @@ pub enum Scope {
 pub enum LookupNode {
     Root(AstIndex),
     Id(ConstantIndex),
+    Str(AstString),
     Index(AstIndex),
     Call(Vec<AstIndex>),
 }

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -315,10 +315,10 @@ impl TryFrom<u8> for MetaKeyId {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MapKey {
     Id(ConstantIndex),
-    Str(ConstantIndex, QuotationMark),
+    Str(AstString),
     Meta(MetaKeyId, Option<ConstantIndex>),
 }
 

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -317,7 +317,7 @@ impl TryFrom<u8> for MetaKeyId {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MapKey {
     Id(ConstantIndex),
     Str(ConstantIndex, QuotationMark),

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -184,8 +184,6 @@ pub struct AstString {
 pub enum StringNode {
     // A string literal
     Literal(ConstantIndex),
-    // An id that should be evaluated and inserted into the string
-    Id(ConstantIndex),
     // An expression that should be evaluated and inserted into the string
     Expr(AstIndex),
 }

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1331,12 +1331,16 @@ impl<'source> Parser<'source> {
                     self.consume_next_token(context);
                     let s = self.parse_string(self.lexer.slice())?;
                     let constant_index = self.constants.add_string(&s) as u32;
-                    let quote = if token == Token::StringDoubleQuoted {
+                    let quotation_mark = if token == Token::StringDoubleQuoted {
                         QuotationMark::Double
                     } else {
                         QuotationMark::Single
                     };
-                    let string_node = self.push_node(Str(constant_index, quote))?;
+                    let nodes = vec![StringNode::Literal(constant_index)];
+                    let string_node = self.push_node(Str(AstString {
+                        quotation_mark,
+                        nodes,
+                    }))?;
                     Some(self.check_for_lookup_after_node(string_node, context)?)
                 }
                 Token::Id => self.parse_id_expression(context)?,

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -2678,6 +2678,21 @@ impl<'source> Parser<'source> {
                             let id_node = self.push_node(Node::Id(id))?;
                             nodes.push(StringNode::Expr(id_node));
                         }
+                        Some(CurlyOpen) => {
+                            self.consume_token();
+
+                            if let Some(expression) =
+                                self.parse_expressions(&mut ExpressionContext::inline(), true)?
+                            {
+                                nodes.push(StringNode::Expr(expression));
+                            } else {
+                                return syntax_error!(ExpectedExpression, self);
+                            }
+
+                            if self.consume_token() != Some(CurlyClose) {
+                                return syntax_error!(ExpectedMapEnd, self); // TODO better error
+                            }
+                        }
                         Some(_) => {
                             return syntax_error!(UnexpectedToken, self); // TODO better error
                         }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -34,6 +34,13 @@ mod parser {
         }
     }
 
+    fn string_literal(literal_index: ConstantIndex, quotation_mark: QuotationMark) -> Node {
+        Node::Str(AstString {
+            quotation_mark,
+            nodes: vec![StringNode::Literal(literal_index)],
+        })
+    }
+
     mod values {
         use super::*;
 
@@ -55,8 +62,8 @@ a
                     BoolFalse,
                     Number1,
                     Float(0),
-                    Str(1, QuotationMark::Double),
-                    Str(2, QuotationMark::Single),
+                    string_literal(1, QuotationMark::Double),
+                    string_literal(2, QuotationMark::Single),
                     Id(3),
                     Empty,
                     MainBlock {
@@ -123,8 +130,8 @@ a
             check_ast(
                 source,
                 &[
-                    Str(0, QuotationMark::Double),
-                    Str(1, QuotationMark::Double),
+                    string_literal(0, QuotationMark::Double),
+                    string_literal(1, QuotationMark::Double),
                     MainBlock {
                         body: vec![0, 1],
                         local_count: 0,
@@ -146,8 +153,8 @@ a
             check_ast(
                 source,
                 &[
-                    Str(0, QuotationMark::Double),
-                    Str(1, QuotationMark::Single),
+                    string_literal(0, QuotationMark::Double),
+                    string_literal(1, QuotationMark::Single),
                     MainBlock {
                         body: vec![0, 1],
                         local_count: 0,
@@ -203,7 +210,7 @@ a
                 &[
                     Number0,
                     Id(0),
-                    Str(1, QuotationMark::Double),
+                    string_literal(1, QuotationMark::Double),
                     Id(0),
                     Int(2),
                     List(vec![0, 1, 2, 3, 4]),
@@ -285,7 +292,7 @@ x = [
                 &[
                     Map(vec![]),
                     Int(1),
-                    Str(4, QuotationMark::Double),
+                    string_literal(4, QuotationMark::Double),
                     Int(5),
                     Map(vec![
                         (MapKey::Str(0, QuotationMark::Double), Some(1)),
@@ -322,7 +329,7 @@ x = [
                 source,
                 &[
                     Int(1),
-                    Str(4, QuotationMark::Double),
+                    string_literal(4, QuotationMark::Double),
                     Map(vec![
                         (MapKey::Str(0, QuotationMark::Single), Some(0)),
                         (MapKey::Id(2), None),
@@ -1226,7 +1233,7 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    Str(0, QuotationMark::Single),
+                    string_literal(0, QuotationMark::Single),
                     Id(1),
                     BinaryOp {
                         op: AstOp::Add,
@@ -3176,7 +3183,7 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Str(0, QuotationMark::Single),
+                    string_literal(0, QuotationMark::Single),
                     Id(2),
                     Lookup((LookupNode::Call(vec![1]), None)),
                     Lookup((LookupNode::Id(1), Some(2))),
@@ -3438,7 +3445,7 @@ assert_eq x, "hello"
                     }, // 5
                     Id(2),
                     Id(0),
-                    Str(3, QuotationMark::Double),
+                    string_literal(3, QuotationMark::Double),
                     Call {
                         function: 6,
                         args: vec![7, 8],
@@ -3728,7 +3735,7 @@ finally
             check_ast(
                 source,
                 &[
-                    Str(0, QuotationMark::Single),
+                    string_literal(0, QuotationMark::Single),
                     Throw(0),
                     MainBlock {
                         body: vec![1],
@@ -3750,7 +3757,7 @@ throw
                 source,
                 &[
                     Id(1),
-                    Str(3, QuotationMark::Double),
+                    string_literal(3, QuotationMark::Double),
                     Map(vec![(MapKey::Id(0), Some(0)), (MapKey::Id(2), Some(1))]),
                     Throw(2),
                     MainBlock {
@@ -3837,10 +3844,10 @@ match x
                 source,
                 &[
                     Id(0),
-                    Str(1, QuotationMark::Single),
+                    string_literal(1, QuotationMark::Single),
                     Int(2),
-                    Str(3, QuotationMark::Double),
-                    Str(4, QuotationMark::Double),
+                    string_literal(3, QuotationMark::Double),
+                    string_literal(4, QuotationMark::Double),
                     Break, // 5
                     Match {
                         expression: 0,
@@ -4239,7 +4246,7 @@ match x
                     Id(0),
                     Number0,
                     Number1,
-                    Str(1, QuotationMark::Single),
+                    string_literal(1, QuotationMark::Single),
                     Throw(3),
                     Match {
                         expression: 0,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -216,6 +216,34 @@ a
         }
 
         #[test]
+        fn strings_with_interpolated_expression() {
+            let source = "
+'${123 + 456}!'
+";
+            check_ast(
+                source,
+                &[
+                    Int(0),
+                    Int(1),
+                    BinaryOp {
+                        op: AstOp::Add,
+                        lhs: 0,
+                        rhs: 1,
+                    },
+                    Str(AstString {
+                        quotation_mark: QuotationMark::Single,
+                        nodes: vec![StringNode::Expr(2), StringNode::Literal(2)],
+                    }),
+                    MainBlock {
+                        body: vec![3],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::I64(123), Constant::I64(456), Constant::Str("!")]),
+            )
+        }
+
+        #[test]
         fn negatives() {
             let source = "\
 -12.0

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3084,7 +3084,13 @@ x.bar()."baz" = 1
                 source,
                 &[
                     Id(0),
-                    Lookup((LookupNode::Id(2), None)),
+                    Lookup((
+                        LookupNode::Str(AstString {
+                            quotation_mark: QuotationMark::Double,
+                            nodes: vec![StringNode::Literal(2)],
+                        }),
+                        None,
+                    )),
                     Lookup((LookupNode::Call(vec![]), Some(1))),
                     Lookup((LookupNode::Id(1), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -41,6 +41,16 @@ mod parser {
         })
     }
 
+    fn string_literal_map_key(
+        literal_index: ConstantIndex,
+        quotation_mark: QuotationMark,
+    ) -> MapKey {
+        MapKey::Str(AstString {
+            quotation_mark,
+            nodes: vec![StringNode::Literal(literal_index)],
+        })
+    }
+
     mod values {
         use super::*;
 
@@ -374,7 +384,7 @@ x = [
                     string_literal(4, QuotationMark::Double),
                     Int(5),
                     Map(vec![
-                        (MapKey::Str(0, QuotationMark::Double), Some(1)),
+                        (string_literal_map_key(0, QuotationMark::Double), Some(1)),
                         (MapKey::Id(2), None),
                         (MapKey::Id(3), Some(2)),
                         (MapKey::Meta(MetaKeyId::Add, None), Some(3)),
@@ -410,7 +420,7 @@ x = [
                     Int(1),
                     string_literal(4, QuotationMark::Double),
                     Map(vec![
-                        (MapKey::Str(0, QuotationMark::Single), Some(0)),
+                        (string_literal_map_key(0, QuotationMark::Single), Some(0)),
                         (MapKey::Id(2), None),
                         (MapKey::Id(3), Some(1)),
                     ]),
@@ -447,9 +457,9 @@ x"#;
                     Map(vec![(MapKey::Id(1), Some(2))]), // foo, 0
                     Int(4),
                     Map(vec![
-                        (MapKey::Id(1), Some(1)),                           // foo: 42
-                        (MapKey::Str(3, QuotationMark::Double), Some(3)),   // "baz": nested map
-                        (MapKey::Meta(MetaKeyId::Subtract, None), Some(4)), // @-: -1
+                        (MapKey::Id(1), Some(1)),                                    // foo: 42
+                        (string_literal_map_key(3, QuotationMark::Double), Some(3)), // "baz": nested map
+                        (MapKey::Meta(MetaKeyId::Subtract, None), Some(4)),          // @-: -1
                     ]), // 5
                     Assign {
                         target: AssignTarget {
@@ -484,9 +494,12 @@ x =
             check_ast(
                 source,
                 &[
-                    Id(0),                                                       // x
-                    Int(2),                                                      // 42
-                    Map(vec![(MapKey::Str(1, QuotationMark::Double), Some(1))]), // "foo", 42
+                    Id(0),  // x
+                    Int(2), // 42
+                    Map(vec![(
+                        string_literal_map_key(1, QuotationMark::Double),
+                        Some(1),
+                    )]), // "foo", 42
                     Assign {
                         target: AssignTarget {
                             target_index: 0,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -165,6 +165,57 @@ a
         }
 
         #[test]
+        fn strings_with_interpolated_ids() {
+            let source = r#"
+'Hello, $name!'
+"$foo"
+'$x $y'
+"#;
+            check_ast(
+                source,
+                &[
+                    Id(1),
+                    Str(AstString {
+                        quotation_mark: QuotationMark::Single,
+                        nodes: vec![
+                            StringNode::Literal(0),
+                            StringNode::Expr(0),
+                            StringNode::Literal(2),
+                        ],
+                    }),
+                    Id(3),
+                    Str(AstString {
+                        quotation_mark: QuotationMark::Double,
+                        nodes: vec![StringNode::Expr(2)],
+                    }),
+                    Id(4),
+                    Id(6), // 5
+                    Str(AstString {
+                        quotation_mark: QuotationMark::Single,
+                        nodes: vec![
+                            StringNode::Expr(4),
+                            StringNode::Literal(5),
+                            StringNode::Expr(5),
+                        ],
+                    }),
+                    MainBlock {
+                        body: vec![1, 3, 6],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("Hello, "),
+                    Constant::Str("name"),
+                    Constant::Str("!"),
+                    Constant::Str("foo"),
+                    Constant::Str("x"),
+                    Constant::Str(" "),
+                    Constant::Str("y"),
+                ]),
+            )
+        }
+
+        #[test]
         fn negatives() {
             let source = "\
 -12.0

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -205,6 +205,35 @@ x .foo
             use super::*;
 
             #[test]
+            fn block_without_indentation() {
+                let source = "
+foo: 42
+bar: 99
+";
+                check_parsing_fails(source);
+            }
+
+            #[test]
+            fn block_starting_on_same_line_as_assignment() {
+                let source = "
+x = foo: 42
+    bar: 99
+";
+                check_parsing_fails(source);
+            }
+
+            #[test]
+            fn block_without_indentation_in_function_after_first_line() {
+                let source = "
+f = ||
+  a = 1
+  foo: 42
+  bar: 99
+";
+                check_parsing_fails(source);
+            }
+
+            #[test]
             fn block_key_without_value() {
                 let source = "
 x =

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -294,24 +294,35 @@ match
 
             #[test]
             fn unterminated_string() {
-                let source = "
-'hello
-";
-                check_parsing_fails(source);
+                check_parsing_fails("'hello");
             }
 
             #[test]
             fn incorrect_terminating_quote() {
-                let source = r#"
-'hello"
-"#;
-                check_parsing_fails(source);
+                check_parsing_fails("'hello\"");
             }
 
             #[test]
             fn missing_template_identifier() {
+                check_parsing_fails("'hello, $");
+            }
+
+            #[test]
+            fn unterminated_template_expression() {
+                check_parsing_fails("'hello, ${name'");
+            }
+
+            #[test]
+            fn incomplete_template_expression() {
+                check_parsing_fails("'${1 + }'");
+            }
+
+            #[test]
+            fn multiline_template_expression() {
                 let source = "
-hello, $
+'foo: ${
+42
+}'
 ";
                 check_parsing_fails(source);
             }

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -288,5 +288,33 @@ match
                 check_parsing_fails(source);
             }
         }
+
+        mod strings {
+            use super::*;
+
+            #[test]
+            fn unterminated_string() {
+                let source = "
+'hello
+";
+                check_parsing_fails(source);
+            }
+
+            #[test]
+            fn incorrect_terminating_quote() {
+                let source = r#"
+'hello"
+"#;
+                check_parsing_fails(source);
+            }
+
+            #[test]
+            fn missing_template_identifier() {
+                let source = "
+hello, $
+";
+                check_parsing_fails(source);
+            }
+        }
     }
 }

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -74,6 +74,11 @@ pub enum Value {
     ///
     /// Note: this is intended for internal use only.
     TemporaryTuple(RegisterSlice),
+
+    /// The string builder used during string interpolation
+    ///
+    /// Note: this is intended for internal use only.
+    StringBuilder(String),
 }
 
 impl Value {
@@ -188,6 +193,7 @@ impl Value {
             ExternalData(data) => data.read().value_type(),
             Iterator(_) => "Iterator".to_string(),
             TemporaryTuple { .. } => "TemporaryTuple".to_string(),
+            StringBuilder(_) => "StringBuilder".to_string(),
         }
     }
 }
@@ -234,6 +240,7 @@ impl fmt::Display for Value {
             TemporaryTuple(RegisterSlice { start, count }) => {
                 write!(f, "TemporaryTuple [{}..{}]", start, start + count)
             }
+            StringBuilder(s) => write!(f, "StringBuilder({})", s),
         }
     }
 }

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -865,9 +865,9 @@ impl Vm {
             } => self.run_set_index(register, index, value),
             Instruction::MapInsert {
                 register,
-                value,
                 key,
-            } => self.run_map_insert(register, value, key),
+                value,
+            } => self.run_map_insert(register, key, value),
             Instruction::MetaInsert {
                 register,
                 value,
@@ -2417,15 +2417,15 @@ impl Vm {
     fn run_map_insert(
         &mut self,
         map_register: u8,
-        value: u8,
-        key: ConstantIndex,
+        key_register: u8,
+        value_register: u8,
     ) -> InstructionResult {
-        let key_string = self.value_string_from_constant(key);
-        let value = self.clone_register(value);
+        let key = self.clone_register(key_register);
+        let value = self.clone_register(value_register);
 
         match self.get_register_mut(map_register) {
             Value::Map(map) => {
-                map.data_mut().insert(key_string.into(), value);
+                map.data_mut().insert(key.into(), value);
                 Ok(())
             }
             unexpected => runtime_error!(

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2020,6 +2020,17 @@ f()
 ";
             test_script(script, string("x * 2 == 20"));
         }
+
+        #[test]
+        fn interpolated_string_as_map_key() {
+            let script = "
+x = 99
+m =
+  'key$x': 'foo'
+m.key99
+";
+            test_script(script, string("foo"));
+        }
     }
 
     mod error_recovery {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1965,6 +1965,25 @@ num4(1, -1, 2, -2).keep(|n| n > 0).count()
             test_script("'héllö'[3..][..]", string("lö"));
             test_script("'héllö'[3..][1]", string("ö"));
         }
+
+        #[test]
+        fn interpolated_id() {
+            let script = "
+x = 1
+'$x + $x'
+";
+            test_script(script, string("1 + 1"));
+        }
+
+        #[test]
+        fn interpolated_id_from_capture() {
+            let script = "
+x = 1
+f = || '$x.$x'
+f()
+";
+            test_script(script, string("1.1"));
+        }
     }
 
     mod error_recovery {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1300,7 +1300,7 @@ sum
             result_data.add_value("bar", Str("baz".into()));
 
             test_script(
-                "{foo: 42, bar: \"baz\"}",
+                "{foo: 42, bar: 'baz'}",
                 Map(ValueMap::with_data(result_data)),
             );
         }
@@ -1338,6 +1338,15 @@ foo, baz = 42, -1
 m = {foo, bar: 99, baz}
 m.baz";
             test_script(script, Number(f64::from(-1).into()));
+        }
+
+        #[test]
+        fn string_keys() {
+            let script = r#"
+foo, bar = 42, -1
+m = {foo, bar, 'baz': 99}
+m.baz"#;
+            test_script(script, Number(99.into()));
         }
 
         #[test]
@@ -1553,35 +1562,35 @@ m.foo
         fn function_body_in_iterator_chain() {
             // The result.insert() call in a function block, followed by a continued iterator chain
             // at a lower indentation level caused a parser error.
-            let script = r#"
+            let script = "
 result = {}
 (1..=5)
   .each |x|
     result.insert(x, x * x)
   .consume()
 result.size()
-"#;
+";
             test_script(script, Number(5.0.into()));
         }
 
         #[test]
         fn inline_function_body_in_call_args() {
-            let script = r#"
+            let script = "
 equal = |x, y| x == y
 equal
   (0..10).position(|n| n == 5),
   5
-"#;
+";
             test_script(script, Bool(true));
         }
 
         #[test]
         fn range_in_call_args() {
-            let script = r#"
+            let script = "
 foo = |range, x| range.size() + x
 min, max = 0, 10
 foo min..max, 20
-"#;
+";
             test_script(script, Number(30.0.into()));
         }
     }
@@ -2031,6 +2040,29 @@ m.key99
 ";
             test_script(script, string("foo"));
         }
+
+        #[test]
+        fn interpolated_string_in_lookup() {
+            let script = "
+x = 99
+m =
+  'key$x': 'foo'
+m.'key$x'
+";
+            test_script(script, string("foo"));
+        }
+
+        #[test]
+        fn interpolated_string_in_lookup_assignment() {
+            let script = "
+x = 99
+m =
+  'key$x': 'foo'
+m.'key$x' = 123
+m.'key$x'
+";
+            test_script(script, Number(123.into()));
+        }
     }
 
     mod error_recovery {
@@ -2046,7 +2078,7 @@ try
 catch _
   x + 1
 ";
-            test_script(script, Number(3.0.into()));
+            test_script(script, Number(3.into()));
         }
 
         #[test]
@@ -2074,7 +2106,7 @@ try
 catch error
   error.data
 "#;
-            test_script(script, Number(2.0.into()));
+            test_script(script, Number(2.into()));
         }
 
         #[test]
@@ -2087,7 +2119,7 @@ catch e
 finally
   99
 ";
-            test_script(script, Number(99.0.into()));
+            test_script(script, Number(99.into()));
         }
 
         #[test]
@@ -2105,7 +2137,7 @@ try
 catch _
   x += 1
 ";
-            test_script(script, Number(4.0.into()));
+            test_script(script, Number(4.into()));
         }
     }
 
@@ -2127,7 +2159,7 @@ locals.foo_meta =
 z = ((foo 2) * (foo 10) / (foo 4) + (foo 1) - (foo 2)) % foo 3
 z.x
 ";
-            test_script(script, Number(1.0.into()));
+            test_script(script, Number(1.into()));
         }
 
         #[test]

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1984,6 +1984,42 @@ f()
 ";
             test_script(script, string("1.1"));
         }
+
+        #[test]
+        fn interpolated_expression() {
+            let script = "
+x = 100
+'sqrt(x): ${x.sqrt()}'
+";
+            test_script(script, string("sqrt(x): 10.0"));
+        }
+
+        #[test]
+        fn interpolated_expression_nested() {
+            let script = "
+'foo${': ${42}'}'
+";
+            test_script(script, string("foo: 42"));
+        }
+
+        #[test]
+        fn interpolated_expression_inline_map() {
+            let script = "
+foo = |m| m.size()
+'${foo {bar: 42, baz: 99}}!'
+";
+            test_script(script, string("2!"));
+        }
+
+        #[test]
+        fn interpolated_expression_using_capture() {
+            let script = "
+x = 10
+f = || 'x * 2 == ${x * 2}'
+f()
+";
+            test_script(script, string("x * 2 == 20"));
+        }
     }
 
     mod error_recovery {


### PR DESCRIPTION
This PR adds support for string interpolation.

e.g.

```koto
x = 42

"The answer is $x"
# The answer is 42

"$x divided by 3 is ${x / 3}."
# 42 divided by 3 is 14.
```

h/t @alisomay for the helpful syntax discussion.
