### PR TITLE
Bytecode improvements

### DIFF
--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -438,14 +438,14 @@ impl Compiler {
             Node::Float(constant) => {
                 let result = self.get_result_register(result_register)?;
                 if let Some(result) = result {
-                    self.load_constant(result.register, *constant, LoadFloat, LoadFloatLong);
+                    self.load_constant(result.register, *constant, LoadFloat, LoadFloat32);
                 }
                 result
             }
             Node::Int(constant) => {
                 let result = self.get_result_register(result_register)?;
                 if let Some(result) = result {
-                    self.load_constant(result.register, *constant, LoadInt, LoadIntLong);
+                    self.load_constant(result.register, *constant, LoadInt, LoadInt32);
                 }
                 result
             }
@@ -1213,7 +1213,7 @@ impl Compiler {
         value_register: u8,
     ) -> Result<(), CompilerError> {
         let id_register = self.push_register()?;
-        self.load_constant(id_register, id, Op::LoadString, Op::LoadStringLong);
+        self.load_constant(id_register, id, Op::LoadString, Op::LoadString32);
         self.push_op(Op::ValueExport, &[id_register, value_register]);
         self.pop_register()?;
         Ok(())
@@ -1227,7 +1227,7 @@ impl Compiler {
     ) -> Result<(), CompilerError> {
         if let Some(name) = name {
             let name_register = self.push_register()?;
-            self.load_constant(name_register, name, Op::LoadString, Op::LoadStringLong);
+            self.load_constant(name_register, name, Op::LoadString, Op::LoadString32);
             self.push_op_without_span(
                 Op::MetaExportNamed,
                 &[meta_id as u8, name_register, value_register],
@@ -1245,7 +1245,7 @@ impl Compiler {
         if id <= u8::MAX as u32 {
             self.push_op(LoadNonLocal, &[result_register, id as u8]);
         } else {
-            self.push_op(LoadNonLocalLong, &[result_register]);
+            self.push_op(LoadNonLocal32, &[result_register]);
             self.push_bytes(&id.to_le_bytes());
         }
     }
@@ -1362,7 +1362,7 @@ impl Compiler {
             if id <= u8::MAX as u32 {
                 self.push_op(Import, &[result_register, id as u8]);
             } else {
-                self.push_op(ImportLong, &[result_register]);
+                self.push_op(Import32, &[result_register]);
                 self.push_bytes(&id.to_le_bytes());
             }
         }
@@ -1694,7 +1694,7 @@ impl Compiler {
                         result.register,
                         *constant_index,
                         Op::LoadString,
-                        Op::LoadStringLong,
+                        Op::LoadString32,
                     );
                 }
             }
@@ -1713,7 +1713,7 @@ impl Compiler {
                                     node_register,
                                     *constant_index,
                                     Op::LoadString,
-                                    Op::LoadStringLong,
+                                    Op::LoadString32,
                                 );
                                 self.push_op_without_span(
                                     Op::StringPush,
@@ -1928,7 +1928,7 @@ impl Compiler {
                 if size_hint <= u8::MAX as usize {
                     self.push_op(MakeList, &[result.register, size_hint as u8]);
                 } else {
-                    self.push_op(MakeListLong, &[result.register]);
+                    self.push_op(MakeList32, &[result.register]);
                     self.push_bytes(&size_hint.to_le_bytes());
                 }
 
@@ -1999,7 +1999,7 @@ impl Compiler {
                 if size_hint <= u8::MAX as usize {
                     self.push_op(MakeMap, &[result.register, size_hint as u8]);
                 } else {
-                    self.push_op(MakeMapLong, &[result.register]);
+                    self.push_op(MakeMap32, &[result.register]);
                     self.push_bytes(&size_hint.to_le_bytes());
                 }
 
@@ -2364,7 +2364,7 @@ impl Compiler {
         match key {
             MapKey::Id(id) => {
                 let key_register = self.push_register()?;
-                self.load_constant(key_register, *id, LoadString, LoadStringLong);
+                self.load_constant(key_register, *id, LoadString, LoadString32);
                 self.push_op_without_span(
                     Op::MapInsert,
                     &[map_register, key_register, value_register],
@@ -2384,7 +2384,7 @@ impl Compiler {
                 let key = *key as u8;
                 if let Some(name) = name {
                     let name_register = self.push_register()?;
-                    self.load_constant(name_register, *name, LoadString, LoadStringLong);
+                    self.load_constant(name_register, *name, LoadString, LoadString32);
                     self.push_op_without_span(
                         Op::MetaInsertNamed,
                         &[map_register, key, name_register, value_register],
@@ -2406,7 +2406,7 @@ impl Compiler {
         key: ConstantIndex,
     ) -> Result<(), CompilerError> {
         let key_register = self.push_register()?;
-        self.load_constant(key_register, key, Op::LoadString, Op::LoadStringLong);
+        self.load_constant(key_register, key, Op::LoadString, Op::LoadString32);
         self.push_op(Op::Access, &[result_register, value_register, key_register]);
         self.pop_register()?;
         Ok(())

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -982,35 +982,51 @@ impl Iterator for InstructionReader {
             }),
             Op::LoadFloat => Some(LoadFloat {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u8!()),
+                constant: ConstantIndex(get_u8!(), 0, 0),
             }),
-            Op::LoadFloat32 => Some(LoadFloat {
+            Op::LoadFloat16 => Some(LoadFloat {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u32!()),
+                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+            }),
+            Op::LoadFloat24 => Some(LoadFloat {
+                register: get_u8!(),
+                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
             }),
             Op::LoadInt => Some(LoadInt {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u8!()),
+                constant: ConstantIndex(get_u8!(), 0, 0),
             }),
-            Op::LoadInt32 => Some(LoadInt {
+            Op::LoadInt16 => Some(LoadInt {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u32!()),
+                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+            }),
+            Op::LoadInt24 => Some(LoadInt {
+                register: get_u8!(),
+                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
             }),
             Op::LoadString => Some(LoadString {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u8!()),
+                constant: ConstantIndex(get_u8!(), 0, 0),
             }),
-            Op::LoadString32 => Some(LoadString {
+            Op::LoadString16 => Some(LoadString {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u32!()),
+                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+            }),
+            Op::LoadString24 => Some(LoadString {
+                register: get_u8!(),
+                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
             }),
             Op::LoadNonLocal => Some(LoadNonLocal {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u8!()),
+                constant: ConstantIndex(get_u8!(), 0, 0),
             }),
-            Op::LoadNonLocal32 => Some(LoadNonLocal {
+            Op::LoadNonLocal16 => Some(LoadNonLocal {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u32!()),
+                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+            }),
+            Op::LoadNonLocal24 => Some(LoadNonLocal {
+                register: get_u8!(),
+                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
             }),
             Op::ValueExport => Some(ValueExport {
                 name: get_u8!(),
@@ -1018,11 +1034,15 @@ impl Iterator for InstructionReader {
             }),
             Op::Import => Some(Import {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u8!()),
+                constant: ConstantIndex(get_u8!(), 0, 0),
             }),
-            Op::Import32 => Some(Import {
+            Op::Import16 => Some(Import {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u32!()),
+                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+            }),
+            Op::Import24 => Some(Import {
+                register: get_u8!(),
+                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
             }),
             Op::MakeTuple => Some(MakeTuple {
                 register: get_u8!(),
@@ -1359,7 +1379,7 @@ impl Iterator for InstructionReader {
             Op::TryEnd => Some(TryEnd),
             Op::Debug => Some(Debug {
                 register: get_u8!(),
-                constant: ConstantIndex::from(get_u32!()),
+                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
             }),
             Op::CheckType => {
                 let register = get_u8!();

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -896,7 +896,7 @@ impl Iterator for InstructionReader {
     fn next(&mut self) -> Option<Self::Item> {
         use Instruction::*;
 
-        macro_rules! get_byte {
+        macro_rules! get_u8 {
             () => {{
                 match self.chunk.bytes.get(self.ip) {
                     Some(byte) => {
@@ -954,146 +954,146 @@ impl Iterator for InstructionReader {
 
         match op {
             Op::Copy => Some(Copy {
-                target: get_byte!(),
-                source: get_byte!(),
+                target: get_u8!(),
+                source: get_u8!(),
             }),
             Op::SetEmpty => Some(SetEmpty {
-                register: get_byte!(),
+                register: get_u8!(),
             }),
             Op::SetFalse => Some(SetBool {
-                register: get_byte!(),
+                register: get_u8!(),
                 value: false,
             }),
             Op::SetTrue => Some(SetBool {
-                register: get_byte!(),
+                register: get_u8!(),
                 value: true,
             }),
             Op::Set0 => Some(SetNumber {
-                register: get_byte!(),
+                register: get_u8!(),
                 value: 0,
             }),
             Op::Set1 => Some(SetNumber {
-                register: get_byte!(),
+                register: get_u8!(),
                 value: 1,
             }),
             Op::SetNumberU8 => Some(SetNumber {
-                register: get_byte!(),
-                value: get_byte!() as i64,
+                register: get_u8!(),
+                value: get_u8!() as i64,
             }),
             Op::LoadFloat => Some(LoadFloat {
-                register: get_byte!(),
-                constant: get_byte!() as ConstantIndex,
+                register: get_u8!(),
+                constant: get_u8!() as ConstantIndex,
             }),
             Op::LoadFloatLong => Some(LoadFloat {
-                register: get_byte!(),
+                register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
             Op::LoadInt => Some(LoadInt {
-                register: get_byte!(),
-                constant: get_byte!() as ConstantIndex,
+                register: get_u8!(),
+                constant: get_u8!() as ConstantIndex,
             }),
             Op::LoadIntLong => Some(LoadInt {
-                register: get_byte!(),
+                register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
             Op::LoadString => Some(LoadString {
-                register: get_byte!(),
-                constant: get_byte!() as ConstantIndex,
+                register: get_u8!(),
+                constant: get_u8!() as ConstantIndex,
             }),
             Op::LoadStringLong => Some(LoadString {
-                register: get_byte!(),
+                register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
             Op::LoadNonLocal => Some(LoadNonLocal {
-                register: get_byte!(),
-                constant: get_byte!() as ConstantIndex,
+                register: get_u8!(),
+                constant: get_u8!() as ConstantIndex,
             }),
             Op::LoadNonLocalLong => Some(LoadNonLocal {
-                register: get_byte!(),
+                register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
             Op::ValueExport => Some(ValueExport {
-                name: get_byte!(),
-                value: get_byte!(),
+                name: get_u8!(),
+                value: get_u8!(),
             }),
             Op::Import => Some(Import {
-                register: get_byte!(),
-                constant: get_byte!() as ConstantIndex,
+                register: get_u8!(),
+                constant: get_u8!() as ConstantIndex,
             }),
             Op::ImportLong => Some(Import {
-                register: get_byte!(),
+                register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
             Op::MakeTuple => Some(MakeTuple {
-                register: get_byte!(),
-                start: get_byte!(),
-                count: get_byte!(),
+                register: get_u8!(),
+                start: get_u8!(),
+                count: get_u8!(),
             }),
             Op::MakeTempTuple => Some(MakeTempTuple {
-                register: get_byte!(),
-                start: get_byte!(),
-                count: get_byte!(),
+                register: get_u8!(),
+                start: get_u8!(),
+                count: get_u8!(),
             }),
             Op::MakeList => Some(MakeList {
-                register: get_byte!(),
-                size_hint: get_byte!() as usize,
+                register: get_u8!(),
+                size_hint: get_u8!() as usize,
             }),
             Op::MakeListLong => Some(MakeList {
-                register: get_byte!(),
+                register: get_u8!(),
                 size_hint: get_u32!() as usize,
             }),
             Op::MakeMap => Some(MakeMap {
-                register: get_byte!(),
-                size_hint: get_byte!() as usize,
+                register: get_u8!(),
+                size_hint: get_u8!() as usize,
             }),
             Op::MakeMapLong => Some(MakeMap {
-                register: get_byte!(),
+                register: get_u8!(),
                 size_hint: get_u32!() as usize,
             }),
             Op::MakeNum2 => Some(MakeNum2 {
-                register: get_byte!(),
-                count: get_byte!(),
-                element_register: get_byte!(),
+                register: get_u8!(),
+                count: get_u8!(),
+                element_register: get_u8!(),
             }),
             Op::MakeNum4 => Some(MakeNum4 {
-                register: get_byte!(),
-                count: get_byte!(),
-                element_register: get_byte!(),
+                register: get_u8!(),
+                count: get_u8!(),
+                element_register: get_u8!(),
             }),
             Op::Range => Some(Range {
-                register: get_byte!(),
-                start: get_byte!(),
-                end: get_byte!(),
+                register: get_u8!(),
+                start: get_u8!(),
+                end: get_u8!(),
             }),
             Op::RangeInclusive => Some(RangeInclusive {
-                register: get_byte!(),
-                start: get_byte!(),
-                end: get_byte!(),
+                register: get_u8!(),
+                start: get_u8!(),
+                end: get_u8!(),
             }),
             Op::RangeTo => Some(RangeTo {
-                register: get_byte!(),
-                end: get_byte!(),
+                register: get_u8!(),
+                end: get_u8!(),
             }),
             Op::RangeToInclusive => Some(RangeToInclusive {
-                register: get_byte!(),
-                end: get_byte!(),
+                register: get_u8!(),
+                end: get_u8!(),
             }),
             Op::RangeFrom => Some(RangeFrom {
-                register: get_byte!(),
-                start: get_byte!(),
+                register: get_u8!(),
+                start: get_u8!(),
             }),
             Op::RangeFull => Some(RangeFull {
-                register: get_byte!(),
+                register: get_u8!(),
             }),
             Op::MakeIterator => Some(MakeIterator {
-                register: get_byte!(),
-                iterable: get_byte!(),
+                register: get_u8!(),
+                iterable: get_u8!(),
             }),
             Op::Function => {
-                let register = get_byte!();
-                let arg_count = get_byte!();
-                let capture_count = get_byte!();
-                let flags = FunctionFlags::from_byte(get_byte!());
+                let register = get_u8!();
+                let arg_count = get_u8!();
+                let capture_count = get_u8!();
+                let flags = FunctionFlags::from_byte(get_u8!());
                 let size = get_u16!() as usize;
 
                 Some(Function {
@@ -1107,79 +1107,79 @@ impl Iterator for InstructionReader {
                 })
             }
             Op::Capture => Some(Capture {
-                function: get_byte!(),
-                target: get_byte!(),
-                source: get_byte!(),
+                function: get_u8!(),
+                target: get_u8!(),
+                source: get_u8!(),
             }),
             Op::Negate => Some(Negate {
-                register: get_byte!(),
-                source: get_byte!(),
+                register: get_u8!(),
+                source: get_u8!(),
             }),
             Op::Add => Some(Add {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Subtract => Some(Subtract {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Multiply => Some(Multiply {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Divide => Some(Divide {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Modulo => Some(Modulo {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Less => Some(Less {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::LessOrEqual => Some(LessOrEqual {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Greater => Some(Greater {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::GreaterOrEqual => Some(GreaterOrEqual {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Equal => Some(Equal {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::NotEqual => Some(NotEqual {
-                register: get_byte!(),
-                lhs: get_byte!(),
-                rhs: get_byte!(),
+                register: get_u8!(),
+                lhs: get_u8!(),
+                rhs: get_u8!(),
             }),
             Op::Jump => Some(Jump {
                 offset: get_u16!() as usize,
             }),
             Op::JumpTrue => Some(JumpIf {
-                register: get_byte!(),
+                register: get_u8!(),
                 offset: get_u16!() as usize,
                 jump_condition: true,
             }),
             Op::JumpFalse => Some(JumpIf {
-                register: get_byte!(),
+                register: get_u8!(),
                 offset: get_u16!() as usize,
                 jump_condition: false,
             }),
@@ -1187,101 +1187,101 @@ impl Iterator for InstructionReader {
                 offset: get_u16!() as usize,
             }),
             Op::JumpBackFalse => Some(JumpBackIf {
-                register: get_byte!(),
+                register: get_u8!(),
                 offset: get_u16!() as usize,
                 jump_condition: false,
             }),
             Op::Call => Some(Call {
-                result: get_byte!(),
-                function: get_byte!(),
-                frame_base: get_byte!(),
-                arg_count: get_byte!(),
+                result: get_u8!(),
+                function: get_u8!(),
+                frame_base: get_u8!(),
+                arg_count: get_u8!(),
             }),
             Op::CallChild => Some(CallChild {
-                result: get_byte!(),
-                function: get_byte!(),
-                frame_base: get_byte!(),
-                arg_count: get_byte!(),
-                parent: get_byte!(),
+                result: get_u8!(),
+                function: get_u8!(),
+                frame_base: get_u8!(),
+                arg_count: get_u8!(),
+                parent: get_u8!(),
             }),
             Op::Return => Some(Return {
-                register: get_byte!(),
+                register: get_u8!(),
             }),
             Op::Yield => Some(Yield {
-                register: get_byte!(),
+                register: get_u8!(),
             }),
             Op::Throw => Some(Throw {
-                register: get_byte!(),
+                register: get_u8!(),
             }),
             Op::Size => Some(Size {
-                register: get_byte!(),
-                value: get_byte!(),
+                register: get_u8!(),
+                value: get_u8!(),
             }),
             Op::IterNext => Some(IterNext {
-                register: get_byte!(),
-                iterator: get_byte!(),
+                register: get_u8!(),
+                iterator: get_u8!(),
                 jump_offset: get_u16!() as usize,
             }),
             Op::IterNextTemp => Some(IterNextTemp {
-                register: get_byte!(),
-                iterator: get_byte!(),
+                register: get_u8!(),
+                iterator: get_u8!(),
                 jump_offset: get_u16!() as usize,
             }),
             Op::IterNextQuiet => Some(IterNextQuiet {
-                iterator: get_byte!(),
+                iterator: get_u8!(),
                 jump_offset: get_u16!() as usize,
             }),
             Op::ValueIndex => Some(ValueIndex {
-                register: get_byte!(),
-                value: get_byte!(),
-                index: get_byte!() as i8,
+                register: get_u8!(),
+                value: get_u8!(),
+                index: get_u8!() as i8,
             }),
             Op::SliceFrom => Some(SliceFrom {
-                register: get_byte!(),
-                value: get_byte!(),
-                index: get_byte!() as i8,
+                register: get_u8!(),
+                value: get_u8!(),
+                index: get_u8!() as i8,
             }),
             Op::SliceTo => Some(SliceTo {
-                register: get_byte!(),
-                value: get_byte!(),
-                index: get_byte!() as i8,
+                register: get_u8!(),
+                value: get_u8!(),
+                index: get_u8!() as i8,
             }),
             Op::IsTuple => Some(IsTuple {
-                register: get_byte!(),
-                value: get_byte!(),
+                register: get_u8!(),
+                value: get_u8!(),
             }),
             Op::IsList => Some(IsList {
-                register: get_byte!(),
-                value: get_byte!(),
+                register: get_u8!(),
+                value: get_u8!(),
             }),
             Op::ListPushValue => Some(ListPushValue {
-                list: get_byte!(),
-                value: get_byte!(),
+                list: get_u8!(),
+                value: get_u8!(),
             }),
             Op::ListPushValues => Some(ListPushValues {
-                list: get_byte!(),
-                values_start: get_byte!(),
-                count: get_byte!(),
+                list: get_u8!(),
+                values_start: get_u8!(),
+                count: get_u8!(),
             }),
             Op::Index => Some(Index {
-                register: get_byte!(),
-                value: get_byte!(),
-                index: get_byte!(),
+                register: get_u8!(),
+                value: get_u8!(),
+                index: get_u8!(),
             }),
             Op::SetIndex => Some(SetIndex {
-                register: get_byte!(),
-                index: get_byte!(),
-                value: get_byte!(),
+                register: get_u8!(),
+                index: get_u8!(),
+                value: get_u8!(),
             }),
             Op::MapInsert => Some(MapInsert {
-                register: get_byte!(),
-                key: get_byte!(),
-                value: get_byte!(),
+                register: get_u8!(),
+                key: get_u8!(),
+                value: get_u8!(),
             }),
             Op::MetaInsert => {
-                let register = get_byte!();
-                let meta_id = get_byte!();
-                let value = get_byte!();
+                let register = get_u8!();
+                let meta_id = get_u8!();
+                let value = get_u8!();
                 if let Ok(id) = meta_id.try_into() {
                     Some(MetaInsert {
                         register,
@@ -1298,10 +1298,10 @@ impl Iterator for InstructionReader {
                 }
             }
             Op::MetaInsertNamed => {
-                let register = get_byte!();
-                let meta_id = get_byte!();
-                let name = get_byte!();
-                let value = get_byte!();
+                let register = get_u8!();
+                let meta_id = get_u8!();
+                let name = get_u8!();
+                let value = get_u8!();
                 if let Ok(id) = meta_id.try_into() {
                     Some(MetaInsertNamed {
                         register,
@@ -1319,8 +1319,8 @@ impl Iterator for InstructionReader {
                 }
             }
             Op::MetaExport => {
-                let meta_id = get_byte!();
-                let value = get_byte!();
+                let meta_id = get_u8!();
+                let value = get_u8!();
                 if let Ok(id) = meta_id.try_into() {
                     Some(MetaExport { id, value })
                 } else {
@@ -1333,9 +1333,9 @@ impl Iterator for InstructionReader {
                 }
             }
             Op::MetaExportNamed => {
-                let meta_id = get_byte!();
-                let name = get_byte!();
-                let value = get_byte!();
+                let meta_id = get_u8!();
+                let name = get_u8!();
+                let value = get_u8!();
                 if let Ok(id) = meta_id.try_into() {
                     Some(MetaExportNamed { id, value, name })
                 } else {
@@ -1348,22 +1348,22 @@ impl Iterator for InstructionReader {
                 }
             }
             Op::Access => Some(Access {
-                register: get_byte!(),
-                value: get_byte!(),
-                key: get_byte!(),
+                register: get_u8!(),
+                value: get_u8!(),
+                key: get_u8!(),
             }),
             Op::TryStart => Some(TryStart {
-                arg_register: get_byte!(),
+                arg_register: get_u8!(),
                 catch_offset: get_u16!() as usize,
             }),
             Op::TryEnd => Some(TryEnd),
             Op::Debug => Some(Debug {
-                register: get_byte!(),
+                register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
             Op::CheckType => {
-                let register = get_byte!();
-                match TypeId::from_byte(get_byte!()) {
+                let register = get_u8!();
+                match TypeId::from_byte(get_u8!()) {
                     Ok(type_id) => Some(CheckType { register, type_id }),
                     Err(byte) => Some(Error {
                         message: format!("Unexpected value for CheckType id: {}", byte),
@@ -1371,18 +1371,18 @@ impl Iterator for InstructionReader {
                 }
             }
             Op::CheckSize => Some(CheckSize {
-                register: get_byte!(),
-                size: get_byte!() as usize,
+                register: get_u8!(),
+                size: get_u8!() as usize,
             }),
             Op::StringStart => Some(StringStart {
-                register: get_byte!(),
+                register: get_u8!(),
             }),
             Op::StringPush => Some(StringPush {
-                register: get_byte!(),
-                value: get_byte!(),
+                register: get_u8!(),
+                value: get_u8!(),
             }),
             Op::StringFinish => Some(StringFinish {
-                register: get_byte!(),
+                register: get_u8!(),
             }),
             _ => Some(Error {
                 message: format!("Unexpected opcode {:?} found at instruction {}", op, op_ip),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -984,7 +984,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 constant: get_u8!() as ConstantIndex,
             }),
-            Op::LoadFloatLong => Some(LoadFloat {
+            Op::LoadFloat32 => Some(LoadFloat {
                 register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
@@ -992,7 +992,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 constant: get_u8!() as ConstantIndex,
             }),
-            Op::LoadIntLong => Some(LoadInt {
+            Op::LoadInt32 => Some(LoadInt {
                 register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
@@ -1000,7 +1000,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 constant: get_u8!() as ConstantIndex,
             }),
-            Op::LoadStringLong => Some(LoadString {
+            Op::LoadString32 => Some(LoadString {
                 register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
@@ -1008,7 +1008,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 constant: get_u8!() as ConstantIndex,
             }),
-            Op::LoadNonLocalLong => Some(LoadNonLocal {
+            Op::LoadNonLocal32 => Some(LoadNonLocal {
                 register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
@@ -1020,7 +1020,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 constant: get_u8!() as ConstantIndex,
             }),
-            Op::ImportLong => Some(Import {
+            Op::Import32 => Some(Import {
                 register: get_u8!(),
                 constant: get_u32!() as ConstantIndex,
             }),
@@ -1038,7 +1038,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 size_hint: get_u8!() as usize,
             }),
-            Op::MakeListLong => Some(MakeList {
+            Op::MakeList32 => Some(MakeList {
                 register: get_u8!(),
                 size_hint: get_u32!() as usize,
             }),
@@ -1046,7 +1046,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 size_hint: get_u8!() as usize,
             }),
-            Op::MakeMapLong => Some(MakeMap {
+            Op::MakeMap32 => Some(MakeMap {
                 register: get_u8!(),
                 size_hint: get_u32!() as usize,
             }),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -982,35 +982,35 @@ impl Iterator for InstructionReader {
             }),
             Op::LoadFloat => Some(LoadFloat {
                 register: get_u8!(),
-                constant: get_u8!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadFloat32 => Some(LoadFloat {
                 register: get_u8!(),
-                constant: get_u32!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u32!()),
             }),
             Op::LoadInt => Some(LoadInt {
                 register: get_u8!(),
-                constant: get_u8!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadInt32 => Some(LoadInt {
                 register: get_u8!(),
-                constant: get_u32!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u32!()),
             }),
             Op::LoadString => Some(LoadString {
                 register: get_u8!(),
-                constant: get_u8!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadString32 => Some(LoadString {
                 register: get_u8!(),
-                constant: get_u32!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u32!()),
             }),
             Op::LoadNonLocal => Some(LoadNonLocal {
                 register: get_u8!(),
-                constant: get_u8!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadNonLocal32 => Some(LoadNonLocal {
                 register: get_u8!(),
-                constant: get_u32!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u32!()),
             }),
             Op::ValueExport => Some(ValueExport {
                 name: get_u8!(),
@@ -1018,11 +1018,11 @@ impl Iterator for InstructionReader {
             }),
             Op::Import => Some(Import {
                 register: get_u8!(),
-                constant: get_u8!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::Import32 => Some(Import {
                 register: get_u8!(),
-                constant: get_u32!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u32!()),
             }),
             Op::MakeTuple => Some(MakeTuple {
                 register: get_u8!(),
@@ -1359,7 +1359,7 @@ impl Iterator for InstructionReader {
             Op::TryEnd => Some(TryEnd),
             Op::Debug => Some(Debug {
                 register: get_u8!(),
-                constant: get_u32!() as ConstantIndex,
+                constant: ConstantIndex::from(get_u32!()),
             }),
             Op::CheckType => {
                 let register = get_u8!();

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -4,90 +4,90 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Op {
-    Copy,                // target, source
-    SetEmpty,            // register
-    SetFalse,            // register
-    SetTrue,             // register
-    Set0,                // register
-    Set1,                // register
-    SetNumberU8,         // register, number
-    LoadFloat,           // register, constant
-    LoadFloatLong,       // register, constant[4]
-    LoadInt,             // register, constant
-    LoadIntLong,         // register, constant[4]
-    LoadString,          // register, constant
-    LoadStringLong,      // register, constant[4]
-    LoadNonLocal,        // register, constant
-    LoadNonLocalLong,    // register, constant[4]
-    Import,              // register, constant
-    ImportLong,          // register, constant[4]
-    MakeTuple,           // register, start register, count
-    MakeTempTuple,       // register, start register, count
-    MakeList,            // register, size hint
-    MakeListLong,        // register, size hint[4]
-    MakeMap,             // register, size hint
-    MakeMapLong,         // register, size hint[4]
-    MakeNum2,            // register, element count, first element
-    MakeNum4,            // register, element count, first element
-    MakeIterator,        // register, range
-    Function,            // register, arg count, capture count, flags, size[2]
-    Capture,             // function, target, source
-    Range,               // register, start, end
-    RangeInclusive,      // register, start, end
-    RangeTo,             // register, end
-    RangeToInclusive,    // register, end
-    RangeFrom,           // register, start
-    RangeFull,           // register
-    Negate,              // register, source
-    Add,                 // result, lhs, rhs
-    Subtract,            // result, lhs, rhs
-    Multiply,            // result, lhs, rhs
-    Divide,              // result, lhs, rhs
-    Modulo,              // result, lhs, rhs
-    Less,                // result, lhs, rhs
-    LessOrEqual,         // result, lhs, rhs
-    Greater,             // result, lhs, rhs
-    GreaterOrEqual,      // result, lhs, rhs
-    Equal,               // result, lhs, rhs
-    NotEqual,            // result, lhs, rhs
-    Jump,                // offset[2]
-    JumpTrue,            // condition, offset[2]
-    JumpFalse,           // condition, offset[2]
-    JumpBack,            // offset[2]
-    JumpBackFalse,       // offset[2]
-    Call,                // result, function, arg register, arg count
-    CallChild,           // result, function, arg register, arg count, parent
-    Return,              // register
-    Yield,               // register
-    Throw,               // register
-    IterNext,            // output, iterator, jump offset[2]
-    IterNextTemp,        // output, iterator, jump offset[2]
-    IterNextQuiet,       // iterator, jump offset[2]
-    ValueIndex,          // result, value register, signed index
-    SliceFrom,           // result, value register, signed index
-    SliceTo,             // result, value register, signed index
-    ListPushValue,       // list, value
-    ListPushValues,      // list, start register, count
-    Index,               // result, indexable, index
-    SetIndex,            // indexable, index, value
-    MapInsert,           // map, key, value
-    MetaInsert,          // map register, key id, value register
-    MetaInsertNamed,     // map register, key id, name register, value register
-    MetaExport,          // key id, value register
-    MetaExportNamed,     // key id, name register, value register
-    ValueExport,         // name, value
-    Access,              // result, value, key
-    IsList,              // register, value
-    IsTuple,             // register, value
-    Size,                // register, value
-    TryStart,            // catch arg register, catch body offset[2]
-    TryEnd,              //
-    Debug,               // register, constant[4]
-    CheckType,           // register, type (see TypeId)
-    CheckSize,           // register, size
-    StringStart,         // register
-    StringPush,          // register, value register
-    StringFinish,        // register
+    Copy,             // target, source
+    SetEmpty,         // register
+    SetFalse,         // register
+    SetTrue,          // register
+    Set0,             // register
+    Set1,             // register
+    SetNumberU8,      // register, number
+    LoadFloat,        // register, constant
+    LoadFloat32,      // register, constant[4]
+    LoadInt,          // register, constant
+    LoadInt32,        // register, constant[4]
+    LoadString,       // register, constant
+    LoadString32,     // register, constant[4]
+    LoadNonLocal,     // register, constant
+    LoadNonLocal32,   // register, constant[4]
+    Import,           // register, constant
+    Import32,         // register, constant[4]
+    MakeTuple,        // register, start register, count
+    MakeTempTuple,    // register, start register, count
+    MakeList,         // register, size hint
+    MakeList32,       // register, size hint[4]
+    MakeMap,          // register, size hint
+    MakeMap32,        // register, size hint[4]
+    MakeNum2,         // register, element count, first element
+    MakeNum4,         // register, element count, first element
+    MakeIterator,     // register, range
+    Function,         // register, arg count, capture count, flags, size[2]
+    Capture,          // function, target, source
+    Range,            // register, start, end
+    RangeInclusive,   // register, start, end
+    RangeTo,          // register, end
+    RangeToInclusive, // register, end
+    RangeFrom,        // register, start
+    RangeFull,        // register
+    Negate,           // register, source
+    Add,              // result, lhs, rhs
+    Subtract,         // result, lhs, rhs
+    Multiply,         // result, lhs, rhs
+    Divide,           // result, lhs, rhs
+    Modulo,           // result, lhs, rhs
+    Less,             // result, lhs, rhs
+    LessOrEqual,      // result, lhs, rhs
+    Greater,          // result, lhs, rhs
+    GreaterOrEqual,   // result, lhs, rhs
+    Equal,            // result, lhs, rhs
+    NotEqual,         // result, lhs, rhs
+    Jump,             // offset[2]
+    JumpTrue,         // condition, offset[2]
+    JumpFalse,        // condition, offset[2]
+    JumpBack,         // offset[2]
+    JumpBackFalse,    // offset[2]
+    Call,             // result, function, arg register, arg count
+    CallChild,        // result, function, arg register, arg count, parent
+    Return,           // register
+    Yield,            // register
+    Throw,            // register
+    IterNext,         // output, iterator, jump offset[2]
+    IterNextTemp,     // output, iterator, jump offset[2]
+    IterNextQuiet,    // iterator, jump offset[2]
+    ValueIndex,       // result, value register, signed index
+    SliceFrom,        // result, value register, signed index
+    SliceTo,          // result, value register, signed index
+    ListPushValue,    // list, value
+    ListPushValues,   // list, start register, count
+    Index,            // result, indexable, index
+    SetIndex,         // indexable, index, value
+    MapInsert,        // map, key, value
+    MetaInsert,       // map register, key id, value register
+    MetaInsertNamed,  // map register, key id, name register, value register
+    MetaExport,       // key id, value register
+    MetaExportNamed,  // key id, name register, value register
+    ValueExport,      // name, value
+    Access,           // result, value, key
+    IsList,           // register, value
+    IsTuple,          // register, value
+    Size,             // register, value
+    TryStart,         // catch arg register, catch body offset[2]
+    TryEnd,           //
+    Debug,            // register, constant[4]
+    CheckType,        // register, type (see TypeId)
+    CheckSize,        // register, size
+    StringStart,      // register
+    StringPush,       // register, value register
+    StringFinish,     // register
     Unused84,
     Unused85,
     Unused86,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -12,15 +12,20 @@ pub enum Op {
     Set1,             // register
     SetNumberU8,      // register, number
     LoadFloat,        // register, constant
-    LoadFloat32,      // register, constant[4]
+    LoadFloat16,      // register, constant[2]
+    LoadFloat24,      // register, constant[3]
     LoadInt,          // register, constant
-    LoadInt32,        // register, constant[4]
+    LoadInt16,        // register, constant[2]
+    LoadInt24,        // register, constant[3]
     LoadString,       // register, constant
-    LoadString32,     // register, constant[4]
+    LoadString16,     // register, constant[2]
+    LoadString24,     // register, constant[3]
     LoadNonLocal,     // register, constant
-    LoadNonLocal32,   // register, constant[4]
+    LoadNonLocal16,   // register, constant[2]
+    LoadNonLocal24,   // register, constant[3]
     Import,           // register, constant
-    Import32,         // register, constant[4]
+    Import16,         // register, constant[2]
+    Import24,         // register, constant[3]
     MakeTuple,        // register, start register, count
     MakeTempTuple,    // register, start register, count
     MakeList,         // register, size hint
@@ -82,17 +87,12 @@ pub enum Op {
     Size,             // register, value
     TryStart,         // catch arg register, catch body offset[2]
     TryEnd,           //
-    Debug,            // register, constant[4]
+    Debug,            // register, constant[3]
     CheckType,        // register, type (see TypeId)
     CheckSize,        // register, size
     StringStart,      // register
     StringPush,       // register, value register
     StringFinish,     // register
-    Unused84,
-    Unused85,
-    Unused86,
-    Unused87,
-    Unused88,
     Unused89,
     Unused90,
     Unused91,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -71,14 +71,11 @@ pub enum Op {
     Index,               // result, indexable, index
     SetIndex,            // indexable, index, value
     MapInsert,           // map, key, value
-    MetaInsert,          // map register, value register, key id
-    MetaInsertNamed,     // map register, value register, key id, name constant
-    MetaInsertNamedLong, // map register, value register, key id, name constant[4]
+    MetaInsert,          // map register, key id, value register
+    MetaInsertNamed,     // map register, key id, name register, value register
     MetaExport,          // key id, value register
-    MetaExportNamed,     // key id, value register, name constant
-    MetaExportNamedLong, // key id, value register, name constant[4]
+    MetaExportNamed,     // key id, name register, value register
     ValueExport,         // name, value
-    ValueExportLong,     // name[4], value
     Access,              // result, value, key
     IsList,              // register, value
     IsTuple,             // register, value
@@ -91,6 +88,9 @@ pub enum Op {
     StringStart,         // register
     StringPush,          // register, value register
     StringFinish,        // register
+    Unused84,
+    Unused85,
+    Unused86,
     Unused87,
     Unused88,
     Unused89,

--- a/src/parser/src/constant_index.rs
+++ b/src/parser/src/constant_index.rs
@@ -1,0 +1,97 @@
+use std::{convert::TryFrom, fmt};
+
+const CONSTANT_INDEX_MAX: usize = 2_usize.pow(24) - 1;
+
+/// A 24 bit index for constants
+///
+/// Values are stored as little-endian 24 bit values.
+///
+/// Q: Why not just use a u32?
+/// A: Minimizing the memory footprint for a complex script with lots of constants seems like a
+///    healthy idea. Having a dedicated u24 type also forces the validity of a value to be checked
+///    when its first created, after creation an in-range index is guaranteed.
+/// Q: What if we need more than 2^24 constants in a script?
+/// A: Let's wait and see, ConstantIndex can be transitioned to a u32
+///    (along with corresponding constant loading ops) if it really turns out to be necessary.
+#[derive(Clone, Copy, Debug, Hash, PartialEq)]
+pub struct ConstantIndex(pub u8, pub u8, pub u8);
+
+impl ConstantIndex {
+    pub fn bytes(&self) -> [u8; 3] {
+        [self.0, self.1, self.2]
+    }
+}
+
+impl From<u8> for ConstantIndex {
+    fn from(x: u8) -> Self {
+        Self(x, 0, 0)
+    }
+}
+
+impl From<u32> for ConstantIndex {
+    fn from(x: u32) -> Self {
+        let bytes = x.to_le_bytes();
+        assert_eq!(bytes[3], 0); // TODO - remove From<u32> once 32bit constant ops are removed
+        Self(bytes[0], bytes[1], bytes[2])
+    }
+}
+
+impl TryFrom<usize> for ConstantIndex {
+    type Error = ConstantIndexTryFromOutOfRange;
+
+    fn try_from(x: usize) -> Result<Self, Self::Error> {
+        if x <= CONSTANT_INDEX_MAX {
+            let bytes = x.to_le_bytes();
+            Ok(Self(bytes[0], bytes[1], bytes[2]))
+        } else {
+            Err(ConstantIndexTryFromOutOfRange())
+        }
+    }
+}
+
+impl From<ConstantIndex> for usize {
+    fn from(x: ConstantIndex) -> Self {
+        (x.0 as usize) | (x.1 as usize) << 8 | (x.2 as usize) << 16
+    }
+}
+
+impl From<&ConstantIndex> for usize {
+    fn from(x: &ConstantIndex) -> Self {
+        usize::from(*x)
+    }
+}
+
+impl Eq for ConstantIndex {}
+
+impl PartialEq<ConstantIndex> for usize {
+    fn eq(&self, other: &ConstantIndex) -> bool {
+        self == &usize::from(other)
+    }
+}
+
+impl fmt::Display for ConstantIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", usize::from(self))
+    }
+}
+
+/// The error returned from TryFrom implementations for ConstantIndex
+#[derive(Debug)]
+pub struct ConstantIndexTryFromOutOfRange();
+
+impl fmt::Display for ConstantIndexTryFromOutOfRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_behaviour() {
+        let x = ConstantIndex::from(2_u8);
+        assert_eq!(2usize, usize::from(x));
+    }
+}

--- a/src/parser/src/constant_index.rs
+++ b/src/parser/src/constant_index.rs
@@ -90,8 +90,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_basic_behaviour() {
-        let x = ConstantIndex::from(2_u8);
-        assert_eq!(2usize, usize::from(x));
+    fn test_bytes_from_usize() {
+        let x = usize::from_le_bytes([12, 34, 56, 0, 0, 0, 0, 0]);
+        let constant = ConstantIndex::try_from(x).unwrap();
+        assert_eq!(constant.bytes(), [12, 34, 56]);
     }
 }

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -7,6 +7,7 @@ use {
 pub enum InternalError {
     ArgumentsParseFailure,
     AstCapacityOverflow,
+    ConstantPoolCapacityOverflow,
     ExpectedIdInImportItem,
     ForParseFailure,
     FunctionParseFailure,
@@ -181,6 +182,9 @@ impl fmt::Display for InternalError {
             ArgumentsParseFailure => f.write_str("Failed to parse arguments"),
             AstCapacityOverflow => {
                 f.write_str("There are more nodes in the program than the AST can support")
+            }
+            ConstantPoolCapacityOverflow => {
+                f.write_str("There are more constants in the program than the runtime can support")
             }
             ExpectedIdInImportItem => f.write_str("Expected ID in import item"),
             ForParseFailure => f.write_str("Failed to parse for loop"),

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -85,6 +85,7 @@ pub enum SyntaxError {
     ExpectedNegatableExpression,
     ExpectedSwitchArmExpression,
     ExpectedSwitchArmExpressionAfterThen,
+    ExpectedStringPlaceholderEnd,
     ExpectedThenExpression,
     ExpectedTestName,
     ExpectedUntilCondition,
@@ -107,10 +108,12 @@ pub enum SyntaxError {
     UnexpectedMetaKey,
     UnexpectedSwitchElse,
     UnexpectedToken,
+    UnexpectedTokenAfterDollarInString,
     UnexpectedTokenAfterExportId,
     UnexpectedTokenInImportExpression,
     UnicodeEscapeCodeOutOfRange,
     UnterminatedNumericEscapeCode,
+    UnterminatedString,
 }
 
 #[derive(Clone, Debug)]
@@ -277,6 +280,9 @@ impl fmt::Display for SyntaxError {
             ExpectedMetaKey => f.write_str("Expected meta key after @"),
             ExpectedMetaId => f.write_str("Expected id after @meta"),
             ExpectedNegatableExpression => f.write_str("Expected negatable expression"),
+            ExpectedStringPlaceholderEnd => {
+                f.write_str("Expected '}' at end of string placeholder")
+            }
             ExpectedSwitchArmExpression => f.write_str("Expected expression in switch arm"),
             ExpectedSwitchArmExpressionAfterThen => {
                 f.write_str("Expected expression after then in switch arm")
@@ -315,6 +321,9 @@ impl fmt::Display for SyntaxError {
             UnexpectedMetaKey => f.write_str("Unexpected meta key"),
             UnexpectedSwitchElse => f.write_str("Unexpected else in switch arm"),
             UnexpectedToken => f.write_str("Unexpected token"),
+            UnexpectedTokenAfterDollarInString => {
+                f.write_str("Unexpected token after $ in string, expected $ID or ${expression}")
+            }
             UnexpectedTokenAfterExportId => f.write_str("Unexpected token after export ID"),
             UnexpectedTokenInImportExpression => {
                 f.write_str("Unexpected token in import expression")
@@ -323,6 +332,7 @@ impl fmt::Display for SyntaxError {
                 f.write_str("Unicode value out of range, the maximum is \\u{10ffff}")
             }
             UnterminatedNumericEscapeCode => f.write_str("Unterminated numeric escape code"),
+            UnterminatedString => f.write_str("Unterminated string"),
         }
     }
 }

--- a/src/parser/src/lib.rs
+++ b/src/parser/src/lib.rs
@@ -1,6 +1,7 @@
 //! Contains the parser and AST format used by the Koto language
 
 mod ast;
+mod constant_index;
 mod constant_pool;
 mod error;
 mod node;
@@ -8,6 +9,7 @@ mod parser;
 
 pub use {
     ast::*,
+    constant_index::{ConstantIndex, ConstantIndexTryFromOutOfRange},
     constant_pool::{Constant, ConstantPool},
     error::{format_error_with_excerpt, ParserError},
     koto_lexer::{Position, Span},

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -1,9 +1,7 @@
 use {
-    crate::ast::AstIndex,
+    crate::{ast::AstIndex, ConstantIndex},
     std::{convert::TryFrom, fmt},
 };
-
-pub type ConstantIndex = u32;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Node {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -34,20 +34,21 @@ mod parser {
         }
     }
 
-    fn string_literal(literal_index: ConstantIndex, quotation_mark: QuotationMark) -> Node {
+    fn constant(index: u8) -> ConstantIndex {
+        ConstantIndex::from(index)
+    }
+
+    fn string_literal(literal_index: u8, quotation_mark: QuotationMark) -> Node {
         Node::Str(AstString {
             quotation_mark,
-            nodes: vec![StringNode::Literal(literal_index)],
+            nodes: vec![StringNode::Literal(constant(literal_index))],
         })
     }
 
-    fn string_literal_map_key(
-        literal_index: ConstantIndex,
-        quotation_mark: QuotationMark,
-    ) -> MapKey {
+    fn string_literal_map_key(literal_index: u8, quotation_mark: QuotationMark) -> MapKey {
         MapKey::Str(AstString {
             quotation_mark,
-            nodes: vec![StringNode::Literal(literal_index)],
+            nodes: vec![StringNode::Literal(constant(literal_index))],
         })
     }
 
@@ -71,10 +72,10 @@ a
                     BoolTrue,
                     BoolFalse,
                     Number1,
-                    Float(0),
+                    Float(constant(0)),
                     string_literal(1, QuotationMark::Double),
                     string_literal(2, QuotationMark::Single),
-                    Id(3),
+                    Id(constant(3)),
                     Empty,
                     MainBlock {
                         body: vec![0, 1, 2, 3, 4, 5, 6, 7],
@@ -107,12 +108,12 @@ a
                 &[
                     Number1,
                     Number1,
-                    Int(0),
-                    Int(1),
+                    Int(constant(0)),
+                    Int(constant(1)),
                     Number1,
-                    Int(2),
+                    Int(constant(2)),
                     Number1,
-                    Int(3),
+                    Int(constant(3)),
                     MainBlock {
                         body: vec![0, 1, 2, 3, 4, 5, 6, 7],
                         local_count: 0,
@@ -184,27 +185,27 @@ a
             check_ast(
                 source,
                 &[
-                    Id(1),
+                    Id(constant(1)),
                     Str(AstString {
                         quotation_mark: QuotationMark::Single,
                         nodes: vec![
-                            StringNode::Literal(0),
+                            StringNode::Literal(constant(0)),
                             StringNode::Expr(0),
-                            StringNode::Literal(2),
+                            StringNode::Literal(constant(2)),
                         ],
                     }),
-                    Id(3),
+                    Id(constant(3)),
                     Str(AstString {
                         quotation_mark: QuotationMark::Double,
                         nodes: vec![StringNode::Expr(2)],
                     }),
-                    Id(4),
-                    Id(6), // 5
+                    Id(constant(4)),
+                    Id(constant(6)), // 5
                     Str(AstString {
                         quotation_mark: QuotationMark::Single,
                         nodes: vec![
                             StringNode::Expr(4),
-                            StringNode::Literal(5),
+                            StringNode::Literal(constant(5)),
                             StringNode::Expr(5),
                         ],
                     }),
@@ -233,8 +234,8 @@ a
             check_ast(
                 source,
                 &[
-                    Int(0),
-                    Int(1),
+                    Int(constant(0)),
+                    Int(constant(1)),
                     BinaryOp {
                         op: AstOp::Add,
                         lhs: 0,
@@ -242,7 +243,7 @@ a
                     },
                     Str(AstString {
                         quotation_mark: QuotationMark::Single,
-                        nodes: vec![StringNode::Expr(2), StringNode::Literal(2)],
+                        nodes: vec![StringNode::Expr(2), StringNode::Literal(constant(2))],
                     }),
                     MainBlock {
                         body: vec![3],
@@ -263,10 +264,10 @@ a
             check_ast(
                 source,
                 &[
-                    Float(0),
-                    Id(1),
+                    Float(constant(0)),
+                    Id(constant(1)),
                     Negate(1),
-                    Id(2),
+                    Id(constant(2)),
                     Number0,
                     Lookup((LookupNode::Index(4), None)), // 5
                     Lookup((LookupNode::Root(3), Some(5))),
@@ -298,10 +299,10 @@ a
                 source,
                 &[
                     Number0,
-                    Id(0),
+                    Id(constant(0)),
                     string_literal(1, QuotationMark::Double),
-                    Id(0),
-                    Int(2),
+                    Id(constant(0)),
+                    Int(constant(2)),
                     List(vec![0, 1, 2, 3, 4]),
                     List(vec![]),
                     MainBlock {
@@ -323,9 +324,9 @@ a
                 &[
                     Number0,
                     Number1,
-                    Int(0),
+                    Int(constant(0)),
                     List(vec![1, 2]),
-                    Int(1),
+                    Int(constant(1)),
                     List(vec![0, 3, 4]), // 5
                     MainBlock {
                         body: vec![5],
@@ -347,7 +348,7 @@ x = [
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number0,
                     Number1,
                     Number0,
@@ -380,13 +381,13 @@ x = [
                 source,
                 &[
                     Map(vec![]),
-                    Int(1),
+                    Int(constant(1)),
                     string_literal(4, QuotationMark::Double),
-                    Int(5),
+                    Int(constant(5)),
                     Map(vec![
                         (string_literal_map_key(0, QuotationMark::Double), Some(1)),
-                        (MapKey::Id(2), None),
-                        (MapKey::Id(3), Some(2)),
+                        (MapKey::Id(constant(2)), None),
+                        (MapKey::Id(constant(3)), Some(2)),
                         (MapKey::Meta(MetaKeyId::Add, None), Some(3)),
                     ]),
                     MainBlock {
@@ -417,12 +418,12 @@ x = [
             check_ast(
                 source,
                 &[
-                    Int(1),
+                    Int(constant(1)),
                     string_literal(4, QuotationMark::Double),
                     Map(vec![
                         (string_literal_map_key(0, QuotationMark::Single), Some(0)),
-                        (MapKey::Id(2), None),
-                        (MapKey::Id(3), Some(1)),
+                        (MapKey::Id(constant(2)), None),
+                        (MapKey::Id(constant(3)), Some(1)),
                     ]),
                     MainBlock {
                         body: vec![2],
@@ -451,13 +452,13 @@ x"#;
             check_ast(
                 source,
                 &[
-                    Id(0),  // x
-                    Int(2), // 42
+                    Id(constant(0)),  // x
+                    Int(constant(2)), // 42
                     Number0,
-                    Map(vec![(MapKey::Id(1), Some(2))]), // foo, 0
-                    Int(4),
+                    Map(vec![(MapKey::Id(constant(1)), Some(2))]), // foo, 0
+                    Int(constant(4)),
                     Map(vec![
-                        (MapKey::Id(1), Some(1)),                                    // foo: 42
+                        (MapKey::Id(constant(1)), Some(1)), // foo: 42
                         (string_literal_map_key(3, QuotationMark::Double), Some(3)), // "baz": nested map
                         (MapKey::Meta(MetaKeyId::Subtract, None), Some(4)),          // @-: -1
                     ]), // 5
@@ -469,7 +470,7 @@ x"#;
                         op: AssignOp::Equal,
                         expression: 5,
                     },
-                    Id(0),
+                    Id(constant(0)),
                     MainBlock {
                         body: vec![6, 7],
                         local_count: 1,
@@ -494,8 +495,8 @@ x =
             check_ast(
                 source,
                 &[
-                    Id(0),  // x
-                    Int(2), // 42
+                    Id(constant(0)),  // x
+                    Int(constant(2)), // 42
                     Map(vec![(
                         string_literal_map_key(1, QuotationMark::Double),
                         Some(1),
@@ -528,14 +529,14 @@ x =
             check_ast(
                 source,
                 &[
-                    Id(0), // x
+                    Id(constant(0)), // x
                     Number0,
                     Number1,
                     Number0,
                     Map(vec![
                         (MapKey::Meta(MetaKeyId::Add, None), Some(1)),
                         (MapKey::Meta(MetaKeyId::Subtract, None), Some(2)),
-                        (MapKey::Meta(MetaKeyId::Named, Some(1)), Some(3)),
+                        (MapKey::Meta(MetaKeyId::Named, Some(constant(1))), Some(3)),
                     ]),
                     Assign {
                         target: AssignTarget {
@@ -572,7 +573,7 @@ export @tests =
                     Map(vec![
                         (MapKey::Meta(MetaKeyId::PreTest, None), Some(1)),
                         (MapKey::Meta(MetaKeyId::PostTest, None), Some(2)),
-                        (MapKey::Meta(MetaKeyId::Test, Some(0)), Some(3)),
+                        (MapKey::Meta(MetaKeyId::Test, Some(constant(0))), Some(3)),
                     ]),
                     Assign {
                         target: AssignTarget {
@@ -666,7 +667,7 @@ min..max
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number0,
                     Assign {
                         target: AssignTarget {
@@ -676,8 +677,8 @@ min..max
                         op: AssignOp::Equal,
                         expression: 1,
                     },
-                    Id(1),
-                    Int(2),
+                    Id(constant(1)),
+                    Int(constant(2)),
                     Assign {
                         target: AssignTarget {
                             target_index: 3,
@@ -686,8 +687,8 @@ min..max
                         op: AssignOp::Equal,
                         expression: 4,
                     }, // 5
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Range {
                         start: 6,
                         end: 7,
@@ -712,11 +713,11 @@ min..max
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Lookup((LookupNode::Id(1), None)),
+                    Id(constant(0)),
+                    Lookup((LookupNode::Id(constant(1)), None)),
                     Lookup((LookupNode::Root(0), Some(1))),
-                    Id(0),
-                    Lookup((LookupNode::Id(2), None)),
+                    Id(constant(0)),
+                    Lookup((LookupNode::Id(constant(2)), None)),
                     Lookup((LookupNode::Root(3), Some(4))), // 5
                     Range {
                         start: 2,
@@ -753,13 +754,13 @@ min..max
                     },
                     List(vec![2]),
                     Number0,
-                    Int(0), // 5
+                    Int(constant(0)), // 5
                     Range {
                         start: 4,
                         end: 5,
                         inclusive: false,
                     },
-                    Int(0),
+                    Int(constant(0)),
                     Number0,
                     Range {
                         start: 7,
@@ -789,7 +790,7 @@ num2
                     Number0,
                     Num2(vec![0]),
                     Number1,
-                    Id(0),
+                    Id(constant(0)),
                     Num2(vec![2, 3]),
                     MainBlock {
                         body: vec![1, 4],
@@ -815,12 +816,12 @@ num4(
                     Number0,
                     Num4(vec![0]),
                     Number1,
-                    Id(0),
+                    Id(constant(0)),
                     Num4(vec![2, 3]),
-                    Id(0), // 5
+                    Id(constant(0)), // 5
                     Number0,
                     Number1,
-                    Id(0),
+                    Id(constant(0)),
                     Num4(vec![5, 6, 7, 8]),
                     MainBlock {
                         body: vec![1, 4, 9],
@@ -896,7 +897,7 @@ num4(
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
                     Assign {
                         target: AssignTarget {
@@ -921,7 +922,7 @@ num4(
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
                     Number1,
                     BinaryOp {
@@ -952,7 +953,7 @@ num4(
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
                     Number0,
                     Tuple(vec![1, 2]),
@@ -979,12 +980,12 @@ num4(
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number0,
                     Number1,
                     Tuple(vec![1, 2]),
-                    Int(1),
-                    Int(2), // 5
+                    Int(constant(1)),
+                    Int(constant(2)), // 5
                     Tuple(vec![4, 5]),
                     Tuple(vec![3, 6]),
                     Assign {
@@ -1010,8 +1011,8 @@ num4(
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Number0,
                     Lookup((LookupNode::Index(2), None)),
                     Lookup((LookupNode::Root(1), Some(3))),
@@ -1050,8 +1051,8 @@ x";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Number1,
                     Number0,
                     TempTuple(vec![2, 3]),
@@ -1068,7 +1069,7 @@ x";
                         ],
                         expression: 4,
                     }, // 5
-                    Id(0),
+                    Id(constant(0)),
                     MainBlock {
                         body: vec![5, 6],
                         local_count: 2,
@@ -1084,10 +1085,10 @@ x";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Wildcard,
-                    Id(1),
-                    Id(2),
+                    Id(constant(1)),
+                    Id(constant(2)),
                     Lookup((LookupNode::Call(vec![]), None)),
                     Lookup((LookupNode::Root(3), Some(4))), // 5
                     MultiAssign {
@@ -1127,7 +1128,7 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number0,
                     Assign {
                         target: AssignTarget {
@@ -1137,7 +1138,7 @@ x %= 4";
                         op: AssignOp::Add,
                         expression: 1,
                     },
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
                     Assign {
                         target: AssignTarget {
@@ -1147,8 +1148,8 @@ x %= 4";
                         op: AssignOp::Subtract,
                         expression: 4,
                     }, // 5
-                    Id(0),
-                    Int(1),
+                    Id(constant(0)),
+                    Int(constant(1)),
                     Assign {
                         target: AssignTarget {
                             target_index: 6,
@@ -1157,8 +1158,8 @@ x %= 4";
                         op: AssignOp::Multiply,
                         expression: 7,
                     },
-                    Id(0),
-                    Int(2), // 10
+                    Id(constant(0)),
+                    Int(constant(2)), // 10
                     Assign {
                         target: AssignTarget {
                             target_index: 9,
@@ -1167,8 +1168,8 @@ x %= 4";
                         op: AssignOp::Divide,
                         expression: 10,
                     },
-                    Id(0),
-                    Int(3),
+                    Id(constant(0)),
+                    Int(constant(3)),
                     Assign {
                         target: AssignTarget {
                             target_index: 12,
@@ -1297,14 +1298,14 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    Int(0),
-                    Int(1),
+                    Int(constant(0)),
+                    Int(constant(1)),
                     BinaryOp {
                         op: AstOp::Divide,
                         lhs: 0,
                         rhs: 1,
                     },
-                    Int(2),
+                    Int(constant(2)),
                     BinaryOp {
                         op: AstOp::Modulo,
                         lhs: 2,
@@ -1326,7 +1327,7 @@ x %= 4";
                 source,
                 &[
                     string_literal(0, QuotationMark::Single),
-                    Id(1),
+                    Id(constant(1)),
                     BinaryOp {
                         op: AstOp::Add,
                         lhs: 0,
@@ -1347,10 +1348,10 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
-                    Id(1),
-                    Id(2),
+                    Id(constant(1)),
+                    Id(constant(2)),
                     Call {
                         function: 2,
                         args: vec![3],
@@ -1387,10 +1388,10 @@ a = 1 +
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
-                    Int(1),
-                    Int(2),
+                    Int(constant(1)),
+                    Int(constant(2)),
                     BinaryOp {
                         op: AstOp::Multiply,
                         lhs: 2,
@@ -1428,10 +1429,10 @@ a = 1
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
-                    Int(1),
-                    Int(2),
+                    Int(constant(1)),
+                    Int(constant(2)),
                     BinaryOp {
                         op: AstOp::Multiply,
                         lhs: 2,
@@ -1580,7 +1581,7 @@ a";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     BoolFalse,
                     Number0,
                     BoolTrue,
@@ -1602,7 +1603,7 @@ a";
                         op: AssignOp::Equal,
                         expression: 8,
                     },
-                    Id(0),
+                    Id(constant(0)),
                     MainBlock {
                         body: vec![9, 10],
                         local_count: 1,
@@ -1618,8 +1619,8 @@ a";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     BoolTrue,
                     Number0,
                     Number1,
@@ -1675,12 +1676,12 @@ a";
                         else_if_blocks: vec![],
                         else_node: None,
                     }),
-                    Id(0),
+                    Id(constant(0)),
                     Block(vec![2, 3]),
                     Function(koto_parser::Function {
                         args: vec![],
                         local_count: 0,
-                        accessed_non_locals: vec![0],
+                        accessed_non_locals: vec![constant(0)],
                         body: 4,
                         is_instance_function: false,
                         is_variadic: false,
@@ -1707,16 +1708,16 @@ for x in y
             check_ast(
                 source,
                 &[
-                    Id(1),
-                    Id(2),
-                    Id(0),
+                    Id(constant(1)),
+                    Id(constant(2)),
+                    Id(constant(0)),
                     Call {
                         function: 1,
                         args: vec![2],
                     },
                     For(AstFor {
-                        args: vec![Some(0)], // constant 0
-                        range: 0,            // ast 0
+                        args: vec![Some(constant(0))], // constant 0
+                        range: 0,                      // ast 0
                         body: 3,
                     }),
                     MainBlock {
@@ -1736,15 +1737,15 @@ while x > y
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     BinaryOp {
                         op: AstOp::Greater,
                         lhs: 0,
                         rhs: 1,
                     },
-                    Id(2),
-                    Id(0),
+                    Id(constant(2)),
+                    Id(constant(0)),
                     Call {
                         function: 3,
                         args: vec![4],
@@ -1770,15 +1771,15 @@ until x < y
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     BinaryOp {
                         op: AstOp::Less,
                         lhs: 0,
                         rhs: 1,
                     },
-                    Id(2),
-                    Id(1),
+                    Id(constant(2)),
+                    Id(constant(1)),
                     Call {
                         function: 3,
                         args: vec![4],
@@ -1808,11 +1809,11 @@ for x in y
                 source,
                 &[
                     List(vec![]),
-                    Id(1),
-                    Id(0),
+                    Id(constant(1)),
+                    Id(constant(0)),
                     For(AstFor {
-                        args: vec![Some(0)], // constant 0
-                        range: 1,            // ast 1
+                        args: vec![Some(constant(0))],
+                        range: 1,
                         body: 2,
                     }),
                     MainBlock {
@@ -1833,15 +1834,15 @@ for a in x.zip y
             check_ast(
                 source,
                 &[
-                    Id(1),
-                    Id(3),
+                    Id(constant(1)),
+                    Id(constant(3)),
                     Lookup((LookupNode::Call(vec![1]), None)),
-                    Lookup((LookupNode::Id(2), Some(2))),
+                    Lookup((LookupNode::Id(constant(2)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
-                    Id(0),
+                    Id(constant(0)), // 5
                     For(AstFor {
-                        args: vec![Some(0)], // constant 0
-                        range: 4,            // ast 1
+                        args: vec![Some(constant(0))],
+                        range: 4,
                         body: 5,
                     }),
                     MainBlock {
@@ -1870,8 +1871,8 @@ a()";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Int(1),
+                    Id(constant(0)),
+                    Int(constant(1)),
                     Function(koto_parser::Function {
                         args: vec![],
                         local_count: 0,
@@ -1889,7 +1890,7 @@ a()";
                         op: AssignOp::Equal,
                         expression: 2,
                     },
-                    Id(0),
+                    Id(constant(0)),
                     Lookup((LookupNode::Call(vec![]), None)), // 5
                     Lookup((LookupNode::Root(4), Some(5))),
                     MainBlock {
@@ -1907,10 +1908,10 @@ a()";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     BinaryOp {
                         op: AstOp::Add,
                         lhs: 2,
@@ -1940,12 +1941,12 @@ a()";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(2), Some(4))), // 5
+                    Lookup((LookupNode::Id(constant(2)), Some(4))), // 5
                     Lookup((LookupNode::Root(3), Some(5))),
                     BinaryOp {
                         op: AstOp::Add,
@@ -1984,10 +1985,10 @@ f 42";
             check_ast(
                 source,
                 &[
-                    Id(0), // f
-                    Id(1), // x
-                    Id(2), // y
-                    Id(1), // x
+                    Id(constant(0)), // f
+                    Id(constant(1)), // x
+                    Id(constant(2)), // y
+                    Id(constant(1)), // x
                     Assign {
                         target: AssignTarget {
                             target_index: 2,
@@ -1996,7 +1997,7 @@ f 42";
                         op: AssignOp::Equal,
                         expression: 3,
                     },
-                    Id(2), // 5
+                    Id(constant(2)), // 5
                     Block(vec![4, 5]),
                     Function(koto_parser::Function {
                         args: vec![1],
@@ -2015,8 +2016,8 @@ f 42";
                         op: AssignOp::Equal,
                         expression: 7,
                     },
-                    Id(0),
-                    Int(3), // 10
+                    Id(constant(0)),
+                    Int(constant(3)), // 10
                     Call {
                         function: 9,
                         args: vec![10],
@@ -2046,11 +2047,11 @@ f 42";
             check_ast(
                 source,
                 &[
-                    Id(0), // f
-                    Id(1), // x
-                    Id(2), // y
-                    Id(3), // z
-                    Id(3), // z
+                    Id(constant(0)), // f
+                    Id(constant(1)), // x
+                    Id(constant(2)), // y
+                    Id(constant(3)), // z
+                    Id(constant(3)), // z
                     Function(koto_parser::Function {
                         args: vec![3],
                         local_count: 1,
@@ -2068,8 +2069,8 @@ f 42";
                         op: AssignOp::Equal,
                         expression: 5,
                     },
-                    Id(2), // y
-                    Id(1), // x
+                    Id(constant(2)), // y
+                    Id(constant(1)), // x
                     Call {
                         function: 7,
                         args: vec![8],
@@ -2092,8 +2093,8 @@ f 42";
                         op: AssignOp::Equal,
                         expression: 11,
                     },
-                    Id(0), // f
-                    Int(4),
+                    Id(constant(0)), // f
+                    Int(constant(4)),
                     Call {
                         function: 13,
                         args: vec![14],
@@ -2119,9 +2120,9 @@ f 42";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Id(constant(1)),
                     Negate(2),
                     Call {
                         function: 0,
@@ -2142,8 +2143,8 @@ f 42";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Number1,
                     BinaryOp {
                         op: AstOp::Subtract,
@@ -2169,9 +2170,9 @@ f 42";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Id(constant(1)),
                     Negate(2),
                     Lookup((LookupNode::Call(vec![1, 3]), None)),
                     Lookup((LookupNode::Root(0), Some(4))),
@@ -2193,9 +2194,9 @@ foo
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Id(2),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Id(constant(2)),
                     Call {
                         function: 0,
                         args: vec![1, 2],
@@ -2218,14 +2219,14 @@ f x";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Call {
                         function: 0,
                         args: vec![1],
                     },
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Call {
                         function: 3,
                         args: vec![4],
@@ -2245,10 +2246,10 @@ f x";
             check_ast(
                 source,
                 &[
-                    Id(0), // f
-                    Id(1), // x
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)), // f
+                    Id(constant(1)), // x
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Call {
                         function: 2,
                         args: vec![3],
@@ -2256,7 +2257,7 @@ f x";
                     Function(koto_parser::Function {
                         args: vec![1],
                         local_count: 1,
-                        accessed_non_locals: vec![0],
+                        accessed_non_locals: vec![constant(0)],
                         body: 4,
                         is_instance_function: false,
                         is_variadic: false,
@@ -2285,11 +2286,11 @@ f x";
             check_ast(
                 source,
                 &[
-                    Id(0), // f
-                    Id(1), // g
-                    Id(2), // x
-                    Id(0),
-                    Id(2),
+                    Id(constant(0)), // f
+                    Id(constant(1)), // g
+                    Id(constant(2)), // x
+                    Id(constant(0)),
+                    Id(constant(2)),
                     Call {
                         function: 3,
                         args: vec![4],
@@ -2297,15 +2298,15 @@ f x";
                     Function(koto_parser::Function {
                         args: vec![2],
                         local_count: 1,
-                        accessed_non_locals: vec![0],
+                        accessed_non_locals: vec![constant(0)],
                         body: 5,
                         is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
-                    Id(2), // x
-                    Id(1), // g
-                    Id(2),
+                    Id(constant(2)), // x
+                    Id(constant(1)), // g
+                    Id(constant(2)),
                     Call {
                         function: 8,
                         args: vec![9],
@@ -2313,7 +2314,7 @@ f x";
                     Function(koto_parser::Function {
                         args: vec![7],
                         local_count: 1,
-                        accessed_non_locals: vec![1],
+                        accessed_non_locals: vec![constant(1)],
                         body: 10,
                         is_instance_function: false,
                         is_variadic: false,
@@ -2348,13 +2349,13 @@ f x";
             check_ast(
                 source,
                 &[
-                    Int(1),
-                    Id(3), // self
-                    Id(4), // x
-                    Id(3),
-                    Lookup((LookupNode::Id(0), None)),
+                    Int(constant(1)),
+                    Id(constant(3)), // self
+                    Id(constant(4)), // x
+                    Id(constant(3)),
+                    Lookup((LookupNode::Id(constant(0)), None)),
                     Lookup((LookupNode::Root(3), Some(4))), // 5
-                    Id(4),
+                    Id(constant(4)),
                     Assign {
                         target: AssignTarget {
                             target_index: 5,
@@ -2372,7 +2373,10 @@ f x";
                         is_variadic: false,
                         is_generator: false,
                     }),
-                    Map(vec![(MapKey::Id(0), Some(0)), (MapKey::Id(2), Some(8))]),
+                    Map(vec![
+                        (MapKey::Id(constant(0)), Some(0)),
+                        (MapKey::Id(constant(2)), Some(8)),
+                    ]),
                     MainBlock {
                         body: vec![9],
                         local_count: 0,
@@ -2398,14 +2402,17 @@ f = ||
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(2),
+                    Id(constant(0)),
+                    Id(constant(2)),
                     Number0,
-                    Map(vec![(MapKey::Id(1), Some(1)), (MapKey::Id(3), Some(2))]),
+                    Map(vec![
+                        (MapKey::Id(constant(1)), Some(1)),
+                        (MapKey::Id(constant(3)), Some(2)),
+                    ]),
                     Function(koto_parser::Function {
                         args: vec![],
                         local_count: 0,
-                        accessed_non_locals: vec![2],
+                        accessed_non_locals: vec![constant(2)],
                         body: 3,
                         is_instance_function: false,
                         is_variadic: false,
@@ -2443,14 +2450,14 @@ f()";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Int(2),
-                    Id(4), // self
-                    Id(5), // x
-                    Id(4),
-                    Lookup((LookupNode::Id(1), None)), // 5
+                    Id(constant(0)),
+                    Int(constant(2)),
+                    Id(constant(4)), // self
+                    Id(constant(5)), // x
+                    Id(constant(4)),
+                    Lookup((LookupNode::Id(constant(1)), None)), // 5
                     Lookup((LookupNode::Root(4), Some(5))),
-                    Id(5),
+                    Id(constant(5)),
                     Assign {
                         target: AssignTarget {
                             target_index: 6,
@@ -2468,7 +2475,10 @@ f()";
                         is_variadic: false,
                         is_generator: false,
                     }),
-                    Map(vec![(MapKey::Id(1), Some(1)), (MapKey::Id(3), Some(9))]), // 10
+                    Map(vec![
+                        (MapKey::Id(constant(1)), Some(1)),
+                        (MapKey::Id(constant(3)), Some(9)),
+                    ]), // 10
                     Function(koto_parser::Function {
                         args: vec![],
                         local_count: 0,
@@ -2486,7 +2496,7 @@ f()";
                         op: AssignOp::Equal,
                         expression: 11,
                     },
-                    Id(0),
+                    Id(constant(0)),
                     Lookup((LookupNode::Call(vec![]), None)),
                     Lookup((LookupNode::Root(13), Some(14))), // 15
                     MainBlock {
@@ -2518,10 +2528,10 @@ f = |n|
             check_ast(
                 source,
                 &[
-                    Id(0), // f
-                    Id(1), // n
-                    Id(2), // f2
-                    Id(1),
+                    Id(constant(0)), // f
+                    Id(constant(1)), // n
+                    Id(constant(2)), // f2
+                    Id(constant(1)),
                     Number0,
                     Number1, // 5
                     Range {
@@ -2529,14 +2539,14 @@ f = |n|
                         end: 5,
                         inclusive: false,
                     },
-                    Id(3), // i
-                    Id(1),
+                    Id(constant(3)), // i
+                    Id(constant(1)),
                     BinaryOp {
                         op: AstOp::Equal,
                         lhs: 7,
                         rhs: 8,
                     },
-                    Id(3), // 10
+                    Id(constant(3)), // 10
                     ReturnExpression(10),
                     If(AstIf {
                         condition: 9,
@@ -2545,7 +2555,7 @@ f = |n|
                         else_node: None,
                     }),
                     For(AstFor {
-                        args: vec![Some(3)],
+                        args: vec![Some(constant(3))],
                         range: 6,
                         body: 12,
                     }),
@@ -2566,7 +2576,7 @@ f = |n|
                         op: AssignOp::Equal,
                         expression: 14,
                     }, // 15
-                    Id(2),
+                    Id(constant(2)),
                     Block(vec![15, 16]),
                     Function(koto_parser::Function {
                         args: vec![1],
@@ -2609,8 +2619,8 @@ f = |n|
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(0),
+                    Id(constant(0)),
+                    Id(constant(0)),
                     Number1,
                     BinaryOp {
                         op: AstOp::Add,
@@ -2625,12 +2635,12 @@ f = |n|
                         op: AssignOp::Equal,
                         expression: 3,
                     },
-                    Id(0), // 5
+                    Id(constant(0)), // 5
                     Block(vec![4, 5]),
                     Function(koto_parser::Function {
                         args: vec![],
                         local_count: 1,
-                        accessed_non_locals: vec![0], // initial read of x via capture
+                        accessed_non_locals: vec![constant(0)], // initial read of x via capture
                         body: 6,
                         is_instance_function: false,
                         is_variadic: false,
@@ -2653,7 +2663,7 @@ f = |n|
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
                     Assign {
                         target: AssignTarget {
@@ -2666,7 +2676,7 @@ f = |n|
                     Function(koto_parser::Function {
                         args: vec![],
                         local_count: 0,
-                        accessed_non_locals: vec![0], // initial read of x via capture
+                        accessed_non_locals: vec![constant(0)], // initial read of x via capture
                         body: 2,
                         is_instance_function: false,
                         is_variadic: false,
@@ -2689,18 +2699,18 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0), // z
-                    Id(1), // y
+                    Id(constant(0)), // z
+                    Id(constant(1)), // y
                     Number0,
-                    Int(2),
+                    Int(constant(2)),
                     Range {
                         start: 2,
                         end: 3,
                         inclusive: false,
                     },
-                    List(vec![4]), // 5
-                    Id(3),         // x
-                    Id(3),
+                    List(vec![4]),   // 5
+                    Id(constant(3)), // x
+                    Id(constant(3)),
                     Number1,
                     BinaryOp {
                         op: AstOp::Greater,
@@ -2728,8 +2738,8 @@ y z";
                         op: AssignOp::Equal,
                         expression: 11,
                     },
-                    Id(1),
-                    Id(0),
+                    Id(constant(1)),
+                    Id(constant(0)),
                     Call {
                         function: 13,
                         args: vec![14],
@@ -2812,8 +2822,8 @@ y z";
             check_ast(
                 source,
                 &[
-                    Int(1),
-                    Map(vec![(MapKey::Id(0), Some(0))]),
+                    Int(constant(1)),
+                    Map(vec![(MapKey::Id(constant(0)), Some(0))]),
                     Yield(1),
                     Function(koto_parser::Function {
                         args: vec![],
@@ -2842,14 +2852,14 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0), // a
+                    Id(constant(0)), // a
                     Wildcard,
-                    Id(1), // c
-                    Id(2), // d
+                    Id(constant(1)), // c
+                    Id(constant(2)), // d
                     Tuple(vec![2, 3]),
                     Tuple(vec![1, 4]), // 5
-                    Id(3),             // e
-                    Id(0),
+                    Id(constant(3)),   // e
+                    Id(constant(0)),
                     Function(koto_parser::Function {
                         args: vec![0, 5, 6],
                         local_count: 4,
@@ -2882,14 +2892,14 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0), // a
+                    Id(constant(0)), // a
                     Wildcard,
-                    Id(1), // c
-                    Id(2), // d
+                    Id(constant(1)), // c
+                    Id(constant(2)), // d
                     List(vec![2, 3]),
                     List(vec![1, 4]), // 5
-                    Id(3),            // e
-                    Id(0),
+                    Id(constant(3)),  // e
+                    Id(constant(0)),
                     Function(koto_parser::Function {
                         args: vec![0, 5, 6],
                         local_count: 4,
@@ -2924,11 +2934,11 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number0,
                     Lookup((LookupNode::Index(1), None)),
                     Lookup((LookupNode::Root(0), Some(2))),
-                    Id(0),
+                    Id(constant(0)),
                     Number1, // 5
                     Lookup((LookupNode::Index(5), None)),
                     Lookup((LookupNode::Root(4), Some(6))),
@@ -2955,7 +2965,7 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     RangeFull,
                     Lookup((LookupNode::Index(1), None)),
                     Lookup((LookupNode::Root(0), Some(2))),
@@ -2974,8 +2984,8 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Int(1),
+                    Id(constant(0)),
+                    Int(constant(1)),
                     RangeTo {
                         end: 1,
                         inclusive: false,
@@ -2997,8 +3007,8 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Int(1),
+                    Id(constant(0)),
+                    Int(constant(1)),
                     RangeFrom { start: 1 },
                     Number0,
                     Lookup((LookupNode::Index(3), None)),
@@ -3019,8 +3029,8 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Lookup((LookupNode::Id(1), None)),
+                    Id(constant(0)),
+                    Lookup((LookupNode::Id(constant(1)), None)),
                     Lookup((LookupNode::Root(0), Some(1))),
                     MainBlock {
                         body: vec![2],
@@ -3037,9 +3047,9 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(1), Some(1))),
+                    Lookup((LookupNode::Id(constant(1)), Some(1))),
                     Lookup((LookupNode::Root(0), Some(2))),
                     MainBlock {
                         body: vec![3],
@@ -3056,9 +3066,9 @@ y z";
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(1), Some(1))),
+                    Lookup((LookupNode::Id(constant(1)), Some(1))),
                     Lookup((LookupNode::Root(0), Some(2))),
                     Number1,
                     BinaryOp {
@@ -3083,16 +3093,16 @@ x.bar()."baz" = 1
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Lookup((
                         LookupNode::Str(AstString {
                             quotation_mark: QuotationMark::Double,
-                            nodes: vec![StringNode::Literal(2)],
+                            nodes: vec![StringNode::Literal(constant(2))],
                         }),
                         None,
                     )),
                     Lookup((LookupNode::Call(vec![]), Some(1))),
-                    Lookup((LookupNode::Id(1), Some(2))),
+                    Lookup((LookupNode::Id(constant(1)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
                     Number1, // 5
                     Assign {
@@ -3122,10 +3132,10 @@ x.bar()."baz" = 1
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Int(2),
+                    Id(constant(0)),
+                    Int(constant(2)),
                     Lookup((LookupNode::Call(vec![1]), None)),
-                    Lookup((LookupNode::Id(1), Some(2))),
+                    Lookup((LookupNode::Id(constant(1)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
                     MainBlock {
                         body: vec![4],
@@ -3145,10 +3155,10 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Int(2),
+                    Id(constant(0)),
+                    Int(constant(2)),
                     Lookup((LookupNode::Call(vec![1]), None)),
-                    Lookup((LookupNode::Id(1), Some(2))),
+                    Lookup((LookupNode::Id(constant(1)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
                     MainBlock {
                         body: vec![4],
@@ -3165,11 +3175,11 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Lookup((LookupNode::Id(1), None)),
+                    Id(constant(0)),
+                    Lookup((LookupNode::Id(constant(1)), None)),
                     Lookup((LookupNode::Root(0), Some(1))),
-                    Id(0),
-                    Lookup((LookupNode::Id(2), None)),
+                    Id(constant(0)),
+                    Lookup((LookupNode::Id(constant(2)), None)),
                     Lookup((LookupNode::Root(3), Some(4))), // 5
                     List(vec![2, 5]),
                     MainBlock {
@@ -3191,13 +3201,13 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Call {
                         function: 0,
                         args: vec![1],
                     },
-                    Lookup((LookupNode::Id(2), None)),
+                    Lookup((LookupNode::Id(constant(2)), None)),
                     Lookup((LookupNode::Root(2), Some(3))),
                     MainBlock {
                         body: vec![4],
@@ -3214,8 +3224,8 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Call {
                         function: 0,
                         args: vec![1],
@@ -3238,13 +3248,13 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Call {
                         function: 0,
                         args: vec![1],
                     },
-                    Id(2),
+                    Id(constant(2)),
                     Lookup((LookupNode::Call(vec![3]), None)),
                     Lookup((LookupNode::Root(2), Some(4))),
                     MainBlock {
@@ -3264,7 +3274,7 @@ x.foo
                 &[
                     Number1,
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(0), Some(1))),
+                    Lookup((LookupNode::Id(constant(0)), Some(1))),
                     Lookup((LookupNode::Root(0), Some(2))),
                     MainBlock {
                         body: vec![3],
@@ -3282,9 +3292,9 @@ x.foo
                 source,
                 &[
                     string_literal(0, QuotationMark::Single),
-                    Id(2),
+                    Id(constant(2)),
                     Lookup((LookupNode::Call(vec![1]), None)),
-                    Lookup((LookupNode::Id(1), Some(2))),
+                    Lookup((LookupNode::Id(constant(1)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
                     MainBlock {
                         body: vec![4],
@@ -3308,9 +3318,9 @@ x.foo
                     Number0,
                     Number1,
                     List(vec![0, 1]),
-                    Id(1),
+                    Id(constant(1)),
                     Lookup((LookupNode::Call(vec![3]), None)),
-                    Lookup((LookupNode::Id(0), Some(4))), // 5
+                    Lookup((LookupNode::Id(constant(0)), Some(4))), // 5
                     Lookup((LookupNode::Root(2), Some(5))),
                     MainBlock {
                         body: vec![6],
@@ -3327,9 +3337,9 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Map(vec![(MapKey::Id(0), None)]),
+                    Map(vec![(MapKey::Id(constant(0)), None)]),
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(1), Some(1))),
+                    Lookup((LookupNode::Id(constant(1)), Some(1))),
                     Lookup((LookupNode::Root(0), Some(2))),
                     MainBlock {
                         body: vec![3],
@@ -3349,7 +3359,7 @@ x.foo
                     Number1,
                     Num2(vec![0]),
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(0), Some(2))),
+                    Lookup((LookupNode::Id(constant(0)), Some(2))),
                     Lookup((LookupNode::Root(1), Some(3))),
                     MainBlock {
                         body: vec![4],
@@ -3369,7 +3379,7 @@ x.foo
                     Number1,
                     Num4(vec![0]),
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(0), Some(2))),
+                    Lookup((LookupNode::Id(constant(0)), Some(2))),
                     Lookup((LookupNode::Root(1), Some(3))),
                     MainBlock {
                         body: vec![4],
@@ -3394,7 +3404,7 @@ x.foo
                         inclusive: false,
                     },
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(0), Some(3))),
+                    Lookup((LookupNode::Id(constant(0)), Some(3))),
                     Lookup((LookupNode::Root(2), Some(4))), // 5
                     MainBlock {
                         body: vec![5],
@@ -3422,7 +3432,7 @@ x.foo
                         inclusive: false,
                     },
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(0), Some(3))),
+                    Lookup((LookupNode::Id(constant(0)), Some(3))),
                     Lookup((LookupNode::Root(2), Some(4))), // 5
                     MainBlock {
                         body: vec![5],
@@ -3439,10 +3449,10 @@ x.foo
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(2),
+                    Id(constant(0)),
+                    Id(constant(2)),
                     Lookup((LookupNode::Call(vec![1]), None)),
-                    Lookup((LookupNode::Id(1), Some(2))),
+                    Lookup((LookupNode::Id(constant(1)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
                     MainBlock {
                         body: vec![4],
@@ -3467,14 +3477,14 @@ x.iter()
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number1,
                     Lookup((LookupNode::Call(vec![]), None)),
-                    Lookup((LookupNode::Id(3), Some(2))),
+                    Lookup((LookupNode::Id(constant(3)), Some(2))),
                     Lookup((LookupNode::Call(vec![1]), Some(3))),
-                    Lookup((LookupNode::Id(2), Some(4))), // 5
+                    Lookup((LookupNode::Id(constant(2)), Some(4))), // 5
                     Lookup((LookupNode::Call(vec![]), Some(5))),
-                    Lookup((LookupNode::Id(1), Some(6))),
+                    Lookup((LookupNode::Id(constant(1)), Some(6))),
                     Lookup((LookupNode::Root(0), Some(7))),
                     MainBlock {
                         body: vec![8],
@@ -3530,19 +3540,19 @@ assert_eq x, "hello"
                 &[
                     BoolTrue,
                     Negate(0),
-                    Id(0),
-                    Id(0),
+                    Id(constant(0)),
+                    Id(constant(0)),
                     BinaryOp {
                         op: AstOp::Add,
                         lhs: 2,
                         rhs: 3,
                     },
                     Debug {
-                        expression_string: 1,
+                        expression_string: constant(1),
                         expression: 4,
                     }, // 5
-                    Id(2),
-                    Id(0),
+                    Id(constant(2)),
+                    Id(constant(0)),
                     string_literal(3, QuotationMark::Double),
                     Call {
                         function: 6,
@@ -3574,7 +3584,7 @@ assert_eq x, "hello"
                 &[
                     Import {
                         from: vec![],
-                        items: vec![vec![0]],
+                        items: vec![vec![constant(0)]],
                     },
                     MainBlock {
                         body: vec![0],
@@ -3593,7 +3603,7 @@ assert_eq x, "hello"
                 &[
                     Import {
                         from: vec![],
-                        items: vec![vec![0, 1]],
+                        items: vec![vec![constant(0), constant(1)]],
                     },
                     MainBlock {
                         body: vec![0],
@@ -3610,10 +3620,10 @@ assert_eq x, "hello"
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Import {
                         from: vec![],
-                        items: vec![vec![1, 2]],
+                        items: vec![vec![constant(1), constant(2)]],
                     },
                     Assign {
                         target: AssignTarget {
@@ -3644,7 +3654,7 @@ assert_eq x, "hello"
                 &[
                     Import {
                         from: vec![],
-                        items: vec![vec![0], vec![1], vec![2]],
+                        items: vec![vec![constant(0)], vec![constant(1)], vec![constant(2)]],
                     },
                     MainBlock {
                         body: vec![0],
@@ -3666,8 +3676,8 @@ assert_eq x, "hello"
                 source,
                 &[
                     Import {
-                        from: vec![0],
-                        items: vec![vec![1], vec![2]],
+                        from: vec![constant(0)],
+                        items: vec![vec![constant(1)], vec![constant(2)]],
                     },
                     MainBlock {
                         body: vec![0],
@@ -3689,8 +3699,8 @@ assert_eq x, "hello"
                 source,
                 &[
                     Import {
-                        from: vec![0, 1],
-                        items: vec![vec![2, 3], vec![4]],
+                        from: vec![constant(0), constant(1)],
+                        items: vec![vec![constant(2), constant(3)], vec![constant(4)]],
                     },
                     MainBlock {
                         body: vec![0],
@@ -3722,17 +3732,17 @@ catch e
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Lookup((LookupNode::Call(vec![]), None)),
                     Lookup((LookupNode::Root(0), Some(1))),
-                    Id(1),
+                    Id(constant(1)),
                     Debug {
-                        expression_string: 1,
+                        expression_string: constant(1),
                         expression: 3,
                     },
                     Try(AstTry {
                         try_block: 2,
-                        catch_arg: Some(1),
+                        catch_arg: Some(constant(1)),
                         catch_block: 4,
                         finally_block: None,
                     }), // 5
@@ -3756,8 +3766,8 @@ catch _
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Try(AstTry {
                         try_block: 0,
                         catch_arg: None,
@@ -3786,18 +3796,18 @@ finally
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Lookup((LookupNode::Call(vec![]), None)),
                     Lookup((LookupNode::Root(0), Some(1))),
-                    Id(1),
+                    Id(constant(1)),
                     Debug {
-                        expression_string: 1,
+                        expression_string: constant(1),
                         expression: 3,
                     },
                     Number0, // 5
                     Try(AstTry {
                         try_block: 2,
-                        catch_arg: Some(1),
+                        catch_arg: Some(constant(1)),
                         catch_block: 4,
                         finally_block: Some(5),
                     }),
@@ -3816,7 +3826,7 @@ finally
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Throw(0),
                     MainBlock {
                         body: vec![1],
@@ -3854,9 +3864,12 @@ throw
             check_ast(
                 source,
                 &[
-                    Id(1),
+                    Id(constant(1)),
                     string_literal(3, QuotationMark::Double),
-                    Map(vec![(MapKey::Id(0), Some(0)), (MapKey::Id(2), Some(1))]),
+                    Map(vec![
+                        (MapKey::Id(constant(0)), Some(0)),
+                        (MapKey::Id(constant(2)), Some(1)),
+                    ]),
                     Throw(2),
                     MainBlock {
                         body: vec![3],
@@ -3886,13 +3899,13 @@ x = match y
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     Number0,
                     Number1,
-                    Int(2),
-                    Id(3), // 5
-                    Int(4),
+                    Int(constant(2)),
+                    Id(constant(3)), // 5
+                    Int(constant(4)),
                     Match {
                         expression: 1,
                         arms: vec![
@@ -3941,9 +3954,9 @@ match x
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     string_literal(1, QuotationMark::Single),
-                    Int(2),
+                    Int(constant(2)),
                     string_literal(3, QuotationMark::Double),
                     string_literal(4, QuotationMark::Double),
                     Break, // 5
@@ -3987,18 +4000,18 @@ match (x, y, z)
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Id(2),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Id(constant(2)),
                     Tuple(vec![0, 1, 2]),
                     Number0,
-                    Id(3), // 5
+                    Id(constant(3)), // 5
                     Wildcard,
                     Tuple(vec![4, 5, 6]),
-                    Id(3),
+                    Id(constant(3)),
                     Wildcard,
                     Number0, // 10
-                    Id(4),
+                    Id(constant(4)),
                     Tuple(vec![10, 11]),
                     Wildcard,
                     Tuple(vec![9, 12, 13]),
@@ -4043,7 +4056,7 @@ match x
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Ellipsis(None),
                     Number0,
                     Tuple(vec![1, 2]),
@@ -4086,15 +4099,15 @@ match y
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Ellipsis(Some(1)),
+                    Id(constant(0)),
+                    Ellipsis(Some(constant(1))),
                     Number0,
                     Number1,
                     Tuple(vec![1, 2, 3]),
                     Number0, // 5
                     Number1,
                     Number0,
-                    Ellipsis(Some(2)),
+                    Ellipsis(Some(constant(2))),
                     Tuple(vec![6, 7, 8]),
                     Number1, // 10
                     Match {
@@ -4138,27 +4151,27 @@ match x
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Id(1),
-                    Int(2),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Id(constant(1)),
+                    Int(constant(2)),
                     BinaryOp {
                         op: AstOp::Greater,
                         lhs: 2,
                         rhs: 3,
                     },
                     Number0, // 5
-                    Id(1),
-                    Id(1),
-                    Int(3),
+                    Id(constant(1)),
+                    Id(constant(1)),
+                    Int(constant(3)),
                     BinaryOp {
                         op: AstOp::Less,
                         lhs: 7,
                         rhs: 8,
                     },
                     Number1, // 10
-                    Id(1),
-                    Int(4),
+                    Id(constant(1)),
+                    Int(constant(4)),
                     Match {
                         expression: 0,
                         arms: vec![
@@ -4206,21 +4219,21 @@ match x, y
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
+                    Id(constant(0)),
+                    Id(constant(1)),
                     TempTuple(vec![0, 1]),
                     Number0,
                     Number1,
                     TempTuple(vec![3, 4]), // 5
-                    Int(2),
-                    Int(3),
+                    Int(constant(2)),
+                    Int(constant(3)),
                     TempTuple(vec![6, 7]),
-                    Id(4),
+                    Id(constant(4)),
                     Number0, // 10
-                    Id(5),
+                    Id(constant(5)),
                     Empty,
                     TempTuple(vec![11, 12]),
-                    Id(5),
+                    Id(constant(5)),
                     Number0, // 15
                     Match {
                         expression: 2,
@@ -4268,10 +4281,10 @@ match x.foo 42
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Int(2),
+                    Id(constant(0)),
+                    Int(constant(2)),
                     Lookup((LookupNode::Call(vec![1]), None)),
-                    Lookup((LookupNode::Id(1), Some(2))),
+                    Lookup((LookupNode::Id(constant(1)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
                     Empty, // 5
                     Number0,
@@ -4309,9 +4322,9 @@ match x
             check_ast(
                 source,
                 &[
-                    Id(0),
-                    Id(1),
-                    Lookup((LookupNode::Id(2), None)),
+                    Id(constant(0)),
+                    Id(constant(1)),
+                    Lookup((LookupNode::Id(constant(2)), None)),
                     Lookup((LookupNode::Root(1), Some(2))),
                     Number0,
                     Match {
@@ -4341,7 +4354,7 @@ match x
             check_ast(
                 source,
                 &[
-                    Id(0),
+                    Id(constant(0)),
                     Number0,
                     Number1,
                     string_literal(1, QuotationMark::Single),
@@ -4389,15 +4402,15 @@ switch
                         rhs: 1,
                     },
                     Number0,
-                    Id(0),
-                    Id(1), // 5
+                    Id(constant(0)),
+                    Id(constant(1)), // 5
                     BinaryOp {
                         op: AstOp::Greater,
                         lhs: 4,
                         rhs: 5,
                     },
                     Number1,
-                    Id(0),
+                    Id(constant(0)),
                     Switch(vec![
                         SwitchArm {
                             condition: Some(2),
@@ -4433,9 +4446,9 @@ switch
                 &[
                     BoolTrue,
                     Number1,
-                    Id(0),
+                    Id(constant(0)),
                     Debug {
-                        expression_string: 0,
+                        expression_string: constant(0),
                         expression: 2,
                     },
                     Switch(vec![

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -457,7 +457,7 @@ impl fmt::Display for UnaryOp {
     }
 }
 
-pub fn meta_id_to_key(id: MetaKeyId, name: Option<&str>) -> Result<MetaKey, String> {
+pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKey, String> {
     use {BinaryOp::*, UnaryOp::*};
 
     let result = match id {
@@ -475,15 +475,11 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<&str>) -> Result<MetaKey, Stri
         MetaKeyId::Index => MetaKey::BinaryOp(Index),
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),
-        MetaKeyId::Named => MetaKey::Named(
-            name.ok_or_else(|| "Missing name for named meta entry".to_string())?
-                .into(),
-        ),
+        MetaKeyId::Named => {
+            MetaKey::Named(name.ok_or_else(|| "Missing name for named meta entry".to_string())?)
+        }
         MetaKeyId::Tests => MetaKey::Tests,
-        MetaKeyId::Test => MetaKey::Test(
-            name.ok_or_else(|| "Missing name for test".to_string())?
-                .into(),
-        ),
+        MetaKeyId::Test => MetaKey::Test(name.ok_or_else(|| "Missing name for test".to_string())?),
         MetaKeyId::PreTest => MetaKey::PreTest,
         MetaKeyId::PostTest => MetaKey::PostTest,
         MetaKeyId::Type => MetaKey::Type,


### PR DESCRIPTION
- Rework ops that always make a ValueString from a constant
- Introduce a 24 bit ConstantIndex type
- Replace 32 bit 'long' constant ops with 8/16/24 bit ops
