### PR TITLE
Fix bug with continuing expressions after lookups

### DIFF
--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -581,25 +581,17 @@ impl<'source> Parser<'source> {
         min_precedence: u8,
         context: &mut ExpressionContext,
     ) -> Result<Option<AstIndex>, ParserError> {
-        let start_line = self.current_line_number();
-
         let expression_start = match self.parse_term(context)? {
             Some(term) => term,
             None => return Ok(None),
         };
 
-        let continue_expression = start_line == self.current_line_number();
-
-        if continue_expression {
-            if let Some(lhs) = lhs {
-                let mut lhs_with_expression_start = lhs.to_vec();
-                lhs_with_expression_start.push(expression_start);
-                self.parse_expression_continued(&lhs_with_expression_start, min_precedence, context)
-            } else {
-                self.parse_expression_continued(&[expression_start], min_precedence, context)
-            }
+        if let Some(lhs) = lhs {
+            let mut lhs_with_expression_start = lhs.to_vec();
+            lhs_with_expression_start.push(expression_start);
+            self.parse_expression_continued(&lhs_with_expression_start, min_precedence, context)
         } else {
-            Ok(Some(expression_start))
+            self.parse_expression_continued(&[expression_start], min_precedence, context)
         }
     }
 

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -603,10 +603,9 @@ impl<'source> Parser<'source> {
     ) -> Result<Option<AstIndex>, ParserError> {
         use Token::*;
 
-        let last_lhs = match lhs {
-            [last] => *last,
-            [.., last] => *last,
-            _ => return internal_error!(MissingContinuedExpressionLhs, self),
+        let last_lhs = match lhs.last() {
+            Some(last) => *last,
+            None => return internal_error!(MissingContinuedExpressionLhs, self),
         };
 
         if let Some(next) = self.peek_next_token(context) {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3499,6 +3499,46 @@ x.iter()
                 ]),
             )
         }
+
+        #[test]
+        fn lookup_followed_by_continued_expression_on_next_line() {
+            let source = "
+foo.bar
+  or foo.baz or
+    false
+";
+            check_ast(
+                source,
+                &[
+                    Id(constant(0)),
+                    Lookup((LookupNode::Id(constant(1)), None)),
+                    Lookup((LookupNode::Root(0), Some(1))),
+                    Id(constant(0)),
+                    Lookup((LookupNode::Id(constant(2)), None)),
+                    Lookup((LookupNode::Root(3), Some(4))), // 5
+                    BinaryOp {
+                        op: AstOp::Or,
+                        lhs: 2,
+                        rhs: 5,
+                    },
+                    BoolFalse,
+                    BinaryOp {
+                        op: AstOp::Or,
+                        lhs: 6,
+                        rhs: 7,
+                    },
+                    MainBlock {
+                        body: vec![8],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("foo"),
+                    Constant::Str("bar"),
+                    Constant::Str("baz"),
+                ]),
+            )
+        }
     }
 
     mod keywords {


### PR DESCRIPTION
This PR fixes the parsing of continuing expressions directly after a lookup on the next line.

e.g. The following expression was triggering an error:
```coffee
foo.bar
  or foo.baz
# ^~~ Unexpected token error
```
