### PR TITLE
Improvements to the constant pool

### DIFF
--- a/src/bytecode/src/chunk.rs
+++ b/src/bytecode/src/chunk.rs
@@ -49,8 +49,6 @@ pub struct Chunk {
     pub bytes: Vec<u8>,
     /// The constant data associated with the chunk's bytecode
     pub constants: ConstantPool,
-    /// The constant string data associated with the chunk's bytecode
-    pub string_constants_arc: Arc<str>,
     /// The path of the program's source file
     pub source_path: Option<PathBuf>,
     /// Debug information associated with the chunk's bytecode
@@ -62,7 +60,6 @@ impl Default for Chunk {
         Self {
             bytes: vec![],
             constants: ConstantPool::default(),
-            string_constants_arc: String::default().into(),
             source_path: None,
             debug_info: DebugInfo::default(),
         }
@@ -78,7 +75,6 @@ impl Chunk {
     ) -> Self {
         Self {
             bytes,
-            string_constants_arc: constants.string_data().into(),
             constants,
             source_path,
             debug_info,

--- a/src/parser/src/constant_pool.rs
+++ b/src/parser/src/constant_pool.rs
@@ -175,7 +175,13 @@ impl Hash for ConstantPool {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+/// A builder of [ConstantPool]s
+///
+/// The parser uses this builder to build up a pool of constants.
+///
+/// [ConstantPoolBuilder::build]() is called when parsing is finished to produce a finalized
+/// ConstantPool.
+#[derive(Default)]
 pub(crate) struct ConstantPoolBuilder {
     // The list of constants
     constants: Vec<ConstantEntry>,
@@ -192,10 +198,6 @@ pub(crate) struct ConstantPoolBuilder {
 }
 
 impl ConstantPoolBuilder {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn add_string(&mut self, s: &str) -> Result<ConstantIndex, ConstantIndexTryFromOutOfRange> {
         match self.string_map.get(s) {
             Some(index) => Ok(*index),
@@ -272,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_adding_strings() {
-        let mut builder = ConstantPoolBuilder::new();
+        let mut builder = ConstantPoolBuilder::default();
 
         let s1 = "test";
         let s2 = "test2";
@@ -295,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_adding_numbers() {
-        let mut builder = ConstantPoolBuilder::new();
+        let mut builder = ConstantPoolBuilder::default();
 
         let n1 = 3;
         let n2 = 9.87654321;
@@ -320,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_adding_numbers_and_strings() {
-        let mut builder = ConstantPoolBuilder::new();
+        let mut builder = ConstantPoolBuilder::default();
 
         let n1 = -1.1;
         let n2 = 99;
@@ -347,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        let mut builder = ConstantPoolBuilder::new();
+        let mut builder = ConstantPoolBuilder::default();
 
         let n1 = -1;
         let n2 = 99.9;

--- a/src/parser/src/constant_pool.rs
+++ b/src/parser/src/constant_pool.rs
@@ -60,7 +60,7 @@ impl Default for ConstantPool {
 
 impl ConstantPool {
     /// Provides the number of constants in the pool
-    pub fn len(&self) -> usize {
+    pub fn size(&self) -> usize {
         self.constants.len()
     }
 
@@ -290,7 +290,7 @@ mod tests {
         assert_eq!(s1, pool.get_str(ConstantIndex::from(0_u8)));
         assert_eq!(s2, pool.get_str(ConstantIndex::from(1_u8)));
 
-        assert_eq!(2, pool.len());
+        assert_eq!(2, pool.size());
     }
 
     #[test]
@@ -315,7 +315,7 @@ mod tests {
             pool.get_f64(ConstantIndex::from(1_u8))
         ));
 
-        assert_eq!(2, pool.len());
+        assert_eq!(2, pool.size());
     }
 
     #[test]
@@ -342,7 +342,7 @@ mod tests {
         assert_eq!(n2, pool.get_i64(ConstantIndex::from(2_u8)));
         assert_eq!(s2, pool.get_str(ConstantIndex::from(3_u8)));
 
-        assert_eq!(4, pool.len());
+        assert_eq!(4, pool.size());
     }
 
     #[test]

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -313,7 +313,7 @@ impl<'source> Parser<'source> {
             self.consume_until_next_token(&mut args_context);
             match self.parse_id_or_wildcard(&mut args_context)? {
                 Some(ConstantIndexOrWildcard::Index(constant_index)) => {
-                    if self.constants.pool().get_str(constant_index) == "self" {
+                    if self.constants.get_str(constant_index) == "self" {
                         return syntax_error!(SelfArgNotInFirstPosition, self);
                     }
 
@@ -381,7 +381,7 @@ impl<'source> Parser<'source> {
             self.consume_until_next_token(&mut args_context);
             match self.parse_id_or_wildcard(context)? {
                 Some(ConstantIndexOrWildcard::Index(constant_index)) => {
-                    if self.constants.pool().get_str(constant_index) == "self" {
+                    if self.constants.get_str(constant_index) == "self" {
                         if !arg_nodes.is_empty() {
                             return syntax_error!(SelfArgNotInFirstPosition, self);
                         }

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -223,7 +223,7 @@ impl<'source> Parser<'source> {
         let capacity_guess = source.len() / 4;
         let mut parser = Parser {
             ast: Ast::with_capacity(capacity_guess),
-            constants: ConstantPoolBuilder::new(),
+            constants: ConstantPoolBuilder::default(),
             lexer: Lexer::new(source),
             frame_stack: Vec::new(),
         };

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -24,9 +24,9 @@ mod parser {
                         assert_eq!(constant, *expected_constant);
                     }
                     assert_eq!(
-                        constants.len(),
+                        constants.size(),
                         expected_constants.len(),
-                        "Constant list length mismatch"
+                        "Constant pool size mismatch"
                     );
                 }
             }

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -3255,9 +3255,12 @@ impl Vm {
     }
 
     fn value_string_from_constant(&self, constant_index: ConstantIndex) -> ValueString {
-        let bounds = self.reader.chunk.constants.get_str_bounds(constant_index);
-        ValueString::new_with_bounds(self.reader.chunk.string_constants_arc.clone(), bounds)
-            .unwrap() // The bounds have been already checked in the constant pool
+        let constants = &self.reader.chunk.constants;
+        let bounds = constants.get_str_bounds(constant_index);
+
+        ValueString::new_with_bounds(constants.string_data().clone(), bounds)
+            // The bounds have been already checked in the constant pool
+            .unwrap()
     }
 
     fn unexpected_type_error<T>(&self, message: &str, value: &Value) -> Result<T, RuntimeError> {


### PR DESCRIPTION
- Avoid lookup indirection when dealing with numeric constants
- Store the constant pool's string data in an Arc<str> instead of a String
