### PR TITLE
Bytecode improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run poetry example
         run: cargo run --example poetry -- -s examples/poetry/scripts/readme.koto
 
-  fmt_and_clippy:
+  code_checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -50,6 +50,11 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features
+
+      - name: Docs
+        run: cargo doc --workspace --exclude koto_cli
+        env:
+          RUSTDOCFLAGS: -Dwarnings
 
   wasm:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The Koto project adheres to
       >> and_this 99
       >> then_that
     ```
+- Maps can now override the behaviour of the `not` operator using the `@not`
+  meta key.
 
 ### Changed
 
@@ -48,8 +50,8 @@ The Koto project adheres to
 
 ### Fixed
 
-- Inline control flow expressions no longer incorrectly produce temporary results when the
-  bodies are implicit tuples.
+- Inline control flow expressions no longer incorrectly produce temporary
+  results when the bodies are implicit tuples.
   - e.g.
     ```koto
     x = if foo then 1, 2, 3 else 4, 5, 6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ The Koto project adheres to
             # ^~~ Previously this indentation would have been disallowed.
           + 321
       ```
+- Internals
+  - The AST struct returned by the parser now includes its associated constant
+    pool as a member.
 
 ### Fixed
 

--- a/docs/reference/core_lib/map.md
+++ b/docs/reference/core_lib/map.md
@@ -142,6 +142,9 @@ Additionally, the following meta functions can customize object behaviour:
 - `@negate`
   - Overloads the unary negation operator:
     - `@negate: |self| make_x -self.data`
+- `@not`
+  - Overloads the unary `not` operator:
+    - `@not: |self| self.data == 0`
 - `@index`
   - Overloads `[]` indexing:
     - `@index: |self, index| self.data + index`

--- a/examples/poetry/src/main.rs
+++ b/examples/poetry/src/main.rs
@@ -121,7 +121,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             .expect("Failed to initialize file watcher");
         hotwatch
             .watch(&args.script, move |event: Event| {
-                // dbg!(&event);
                 match event {
                     Event::Create(script_path) | Event::Write(script_path) => {
                         if let Err(e) = compile_and_run(&mut koto, &script_path) {

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ clippy:
   cargo watch -x "clippy --all-targets --all-features"
 
 doc:
-  cargo watch -x "doc --workspace --exclude koto_cli --open"
+  cargo watch -x "doc --workspace --exclude koto_cli"
 
 fmt:
   cargo fmt --all -- --check

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -26,6 +26,9 @@ locals.foo_meta =
   # Negation
   @negate: |self| foo -self.x
 
+  # Not
+  @not: |self| if self.x == 0 then true else false
+
   # Indexing
   @[]: |self, index| self.x + index
 
@@ -90,6 +93,10 @@ export @tests =
 
   @test negate: ||
     assert_eq -foo(1), foo(-1)
+
+  @test test_not: ||
+    assert_eq not foo(1), false
+    assert_eq not foo(0), true
 
   @test index: ||
     assert_eq foo(10)[5], 15

--- a/src/bytecode/src/chunk.rs
+++ b/src/bytecode/src/chunk.rs
@@ -13,6 +13,10 @@ pub struct DebugInfo {
 }
 
 impl DebugInfo {
+    /// Adds a span to the source map for a given ip
+    ///
+    /// Instructions with matching spans share the same entry, so if the span matches the
+    /// previously pushed span then this is a no-op.
     pub fn push(&mut self, ip: usize, span: Span) {
         if let Some(entry) = self.source_map.last() {
             if entry.1 == span {
@@ -67,6 +71,7 @@ impl Default for Chunk {
 }
 
 impl Chunk {
+    /// Initializes a Chunk
     pub fn new(
         bytes: Vec<u8>,
         constants: ConstantPool,

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -2729,7 +2729,7 @@ impl Compiler {
         function_register: u8,
         args: &[AstIndex],
         piped_arg: Option<u8>,
-        parent: Option<u8>,
+        instance: Option<u8>,
         ast: &Ast,
     ) -> CompileNodeResult {
         use Op::*;
@@ -2737,8 +2737,8 @@ impl Compiler {
         let result = self.get_result_register(result_register)?;
         let stack_count = self.frame().register_stack.len();
 
-        // The frame base is an empty register that may be used for a parent value if needed
-        // (it's decided at runtime if the parent value will be used or not).
+        // The frame base is an empty register that may be used for an instance value if needed
+        // (it's decided at runtime if the instance value will be used or not).
         let frame_base = self.push_register()?;
 
         let mut arg_count = args.len();
@@ -2763,16 +2763,16 @@ impl Compiler {
             frame_base
         };
 
-        match parent {
-            Some(parent_register) => {
+        match instance {
+            Some(instance_register) => {
                 self.push_op(
-                    CallChild,
+                    CallInstance,
                     &[
                         call_result_register,
                         function_register,
                         frame_base,
                         arg_count as u8,
-                        parent_register,
+                        instance_register,
                     ],
                 );
             }

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -864,14 +864,14 @@ impl Compiler {
                 Node::Id(constant_index) => {
                     let local_register = self.assign_local_register(*constant_index)?;
                     self.push_op(
-                        Op::ValueIndex,
+                        Op::TempIndex,
                         &[local_register, container_register, arg_index as u8],
                     );
                 }
                 Node::List(nested_args) => {
                     let list_register = self.push_register()?;
                     self.push_op(
-                        Op::ValueIndex,
+                        Op::TempIndex,
                         &[list_register, container_register, arg_index as u8],
                     );
                     self.push_op(Op::CheckType, &[list_register, TypeId::List as u8]);
@@ -882,7 +882,7 @@ impl Compiler {
                 Node::Tuple(nested_args) => {
                     let tuple_register = self.push_register()?;
                     self.push_op(
-                        Op::ValueIndex,
+                        Op::TempIndex,
                         &[tuple_register, container_register, arg_index as u8],
                     );
                     self.push_op(Op::CheckType, &[tuple_register, TypeId::Tuple as u8]);
@@ -1105,14 +1105,14 @@ impl Compiler {
                 Node::Id(id_index) => {
                     match (target_register, self.scope_for_assign_target(target)) {
                         (Some(target_register), Scope::Local) => {
-                            self.push_op(ValueIndex, &[*target_register, rhs.register, i as u8]);
+                            self.push_op(TempIndex, &[*target_register, rhs.register, i as u8]);
                             // The register was reserved before the RHS was compiled, and now it
                             // needs to be committed.
                             self.commit_local_register(*target_register)?;
                         }
                         (None, Scope::Export) => {
                             let index_register = self.push_register()?;
-                            self.push_op(ValueIndex, &[index_register, rhs.register, i as u8]);
+                            self.push_op(TempIndex, &[index_register, rhs.register, i as u8]);
                             self.compile_value_export(*id_index, index_register)?;
                             self.pop_register()?; // index_register
                         }
@@ -1127,7 +1127,7 @@ impl Compiler {
                 Node::Lookup(lookup) => {
                     let register = self.push_register()?;
 
-                    self.push_op(ValueIndex, &[register, rhs.register, i as u8]);
+                    self.push_op(TempIndex, &[register, rhs.register, i as u8]);
                     self.compile_lookup(ResultRegister::None, lookup, None, Some(register), ast)?;
 
                     self.pop_register()?;
@@ -3194,7 +3194,7 @@ impl Compiler {
                     if match_is_container {
                         let element = self.push_register()?;
                         self.push_op(
-                            ValueIndex,
+                            TempIndex,
                             &[element, params.match_register, pattern_index as u8],
                         );
                         self.push_op(Equal, &[comparison, pattern, element]);
@@ -3230,7 +3230,7 @@ impl Compiler {
                     let id_register = self.assign_local_register(*id)?;
                     if match_is_container {
                         self.push_op(
-                            ValueIndex,
+                            TempIndex,
                             &[id_register, params.match_register, pattern_index as u8],
                         );
                     } else {
@@ -3335,7 +3335,7 @@ impl Compiler {
             // Place the nested container into a register
             let value_register = self.push_register()?;
             self.push_op(
-                ValueIndex,
+                TempIndex,
                 &[value_register, params.match_register, pattern_index as u8],
             );
             value_register
@@ -3502,7 +3502,7 @@ impl Compiler {
                     if let Some(arg) = maybe_arg {
                         let arg_register = self.assign_local_register(*arg)?;
                         self.push_op_without_span(
-                            ValueIndex,
+                            TempIndex,
                             &[arg_register, temp_register, i as u8],
                         );
                     }

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -12,7 +12,9 @@ use {
 /// The error type used to report errors during compilation
 #[derive(Clone, Debug)]
 pub struct CompilerError {
+    /// The error's message
     pub message: String,
+    /// The span in the source where the error occurred
     pub span: Span,
 }
 
@@ -355,6 +357,9 @@ pub struct Compiler {
 }
 
 impl Compiler {
+    /// Compiles an [Ast]
+    ///
+    /// Returns compiled bytecode along with corresponding debug information
     pub fn compile(
         ast: &Ast,
         settings: CompilerSettings,

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -1855,8 +1855,8 @@ impl Compiler {
                     Op::MakeNum2,
                     &[
                         result.register,
-                        elements.len() as u8,
                         first_element_register,
+                        elements.len() as u8,
                     ],
                 );
 
@@ -1907,8 +1907,8 @@ impl Compiler {
                     Op::MakeNum4,
                     &[
                         result.register,
-                        elements.len() as u8,
                         first_element_register,
+                        elements.len() as u8,
                     ],
                 );
 

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -391,6 +391,7 @@ pub enum Instruction {
     },
     StringStart {
         register: u8,
+        size_hint: usize,
     },
     StringPush {
         register: u8,
@@ -870,8 +871,8 @@ impl fmt::Debug for Instruction {
             CheckSize { register, size } => {
                 write!(f, "CheckSize\tregister: {}\tsize: {}", register, size)
             }
-            StringStart { register } => {
-                write!(f, "StringStart\tregister: {}", register)
+            StringStart { register, size_hint } => {
+                write!(f, "StringStart\tregister: {}\t size hint: {}", register, size_hint)
             }
             StringPush { register, value } => {
                 write!(f, "StringPush\tregister: {}\tvalue: {}", register, value)
@@ -1403,6 +1404,11 @@ impl Iterator for InstructionReader {
             }),
             Op::StringStart => Some(StringStart {
                 register: get_u8!(),
+                size_hint: get_u8!() as usize,
+            }),
+            Op::StringStart32 => Some(StringStart {
+                register: get_u8!(),
+                size_hint: get_u32!() as usize,
             }),
             Op::StringPush => Some(StringPush {
                 register: get_u8!(),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -6,6 +6,7 @@ use {
 
 #[derive(Debug)]
 #[repr(u8)]
+#[allow(missing_docs)]
 pub enum TypeId {
     List,
     Tuple,
@@ -23,17 +24,25 @@ impl TypeId {
     }
 }
 
+/// Flags used to define the properties of a Function
 pub struct FunctionFlags {
+    /// True if the function is an instance function
     pub instance_function: bool,
+    /// True if the function has a variadic argument
     pub variadic: bool,
+    /// True if the function is a generator
     pub generator: bool,
 }
 
 impl FunctionFlags {
-    pub const INSTANCE: u8 = 0b0000001;
-    pub const VARIADIC: u8 = 0b0000010;
-    pub const GENERATOR: u8 = 0b0000100;
+    /// Corresponding to [FunctionFlags::instance_function]
+    pub const INSTANCE: u8 = 1 << 0;
+    /// Corresponding to [FunctionFlags::variadic]
+    pub const VARIADIC: u8 = 1 << 1;
+    /// Corresponding to [FunctionFlags::generator]
+    pub const GENERATOR: u8 = 1 << 2;
 
+    /// Initializes a flags struct from a byte
     pub fn from_byte(byte: u8) -> Self {
         Self {
             instance_function: byte & Self::INSTANCE == Self::INSTANCE,
@@ -42,6 +51,7 @@ impl FunctionFlags {
         }
     }
 
+    /// Returns a byte containing the packed flags
     pub fn as_byte(&self) -> u8 {
         let mut result = 0;
         if self.instance_function {
@@ -58,6 +68,9 @@ impl FunctionFlags {
 }
 
 /// Decoded instructions produced by an [InstructionReader] for execution in the runtime
+///
+/// For descriptions of each instruction's purpose, see corresponding [Op] entries.
+#[allow(missing_docs)]
 pub enum Instruction {
     Error {
         message: String,
@@ -887,11 +900,14 @@ impl fmt::Debug for Instruction {
 /// An iterator that converts bytecode into a series of [Instruction]s
 #[derive(Clone, Default)]
 pub struct InstructionReader {
+    /// The chunk that the reader is reading from
     pub chunk: Arc<Chunk>,
+    /// The reader's instruction pointer
     pub ip: usize,
 }
 
 impl InstructionReader {
+    /// Initializes a reader with the given chunk
     pub fn new(chunk: Arc<Chunk>) -> Self {
         Self { chunk, ip: 0 }
     }

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -374,6 +374,11 @@ pub enum Instruction {
     Access {
         register: u8,
         value: u8,
+        key: ConstantIndex,
+    },
+    AccessString {
+        register: u8,
+        value: u8,
         key: u8,
     },
     TryStart {
@@ -481,6 +486,7 @@ impl fmt::Display for Instruction {
             MetaExport { .. } => write!(f, "MetaExport"),
             MetaExportNamed { .. } => write!(f, "MetaExportNamed"),
             Access { .. } => write!(f, "Access"),
+            AccessString { .. } => write!(f, "AccessString"),
             TryStart { .. } => write!(f, "TryStart"),
             TryEnd => write!(f, "TryEnd"),
             Debug { .. } => write!(f, "Debug"),
@@ -859,6 +865,15 @@ impl fmt::Debug for Instruction {
             } => write!(
                 f,
                 "Access\t\tresult: {}\tvalue: {}\tkey: {}",
+                register, value, key
+            ),
+            AccessString {
+                register,
+                value,
+                key,
+            } => write!(
+                f,
+                "AccessString\tresult: {}\tvalue: {}\tkey: {}",
                 register, value, key
             ),
             TryStart {
@@ -1395,6 +1410,23 @@ impl Iterator for InstructionReader {
                 }
             }
             Op::Access => Some(Access {
+                register: get_u8!(),
+                value: get_u8!(),
+                key: ConstantIndex(get_u8!(), 0, 0),
+            }),
+            Op::Access16 => Some(Access {
+                register: get_u8!(),
+                value: get_u8!(),
+                // TODO get_u16_constant!()
+                key: ConstantIndex(get_u8!(), get_u8!(), 0),
+            }),
+            Op::Access24 => Some(Access {
+                register: get_u8!(),
+                value: get_u8!(),
+                // TODO get_u24_constant!()
+                key: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
+            }),
+            Op::AccessString => Some(AccessString {
                 register: get_u8!(),
                 value: get_u8!(),
                 key: get_u8!(),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -275,12 +275,12 @@ pub enum Instruction {
         frame_base: u8,
         arg_count: u8,
     },
-    CallChild {
+    CallInstance {
         result: u8,
         function: u8,
         frame_base: u8,
         arg_count: u8,
-        parent: u8,
+        instance: u8,
     },
     Return {
         register: u8,
@@ -454,7 +454,7 @@ impl fmt::Display for Instruction {
             JumpIf { .. } => write!(f, "JumpIf"),
             JumpBack { .. } => write!(f, "JumpBack"),
             Call { .. } => write!(f, "Call"),
-            CallChild { .. } => write!(f, "CallChild"),
+            CallInstance { .. } => write!(f, "CallInstance"),
             Return { .. } => write!(f, "Return"),
             Yield { .. } => write!(f, "Yield"),
             Throw { .. } => write!(f, "Throw"),
@@ -624,8 +624,8 @@ impl fmt::Debug for Instruction {
                 size,
             } => write!(
                 f,
-                "Function\tresult: {}\targs: {}\t\tcaptures: {}\tsize: {}\n\
-                     \t\t\tinstance: {}\tvariadic: {}\tgenerator: {}",
+                "Function\tresult: {}\targs: {}\t\tcaptures: {}\tsize: {}
+                 \t\t\tinstance: {}\tvariadic: {}\tgenerator: {}",
                 register, arg_count, capture_count, size, instance_function, variadic, generator,
             ),
             Capture {
@@ -716,16 +716,17 @@ impl fmt::Debug for Instruction {
                 "Call\t\tresult: {}\tfunction: {}\tframe base: {}\targs: {}",
                 result, function, frame_base, arg_count
             ),
-            CallChild {
+            CallInstance {
                 result,
                 function,
-                parent,
                 frame_base,
                 arg_count,
+                instance,
             } => write!(
                 f,
-                "CallChild\tresult: {}\tfunction: {}\tframe_base: {}\n\t\t\targs: {}\t\tparent: {}",
-                result, function, frame_base, arg_count, parent
+                "CallInstance\tresult: {}\tfunction: {}\tframe_base: {}
+                 \t\t\targs: {}\t\tinstance: {}",
+                result, function, frame_base, arg_count, instance
             ),
             Return { register } => write!(f, "Return\t\tresult: {}", register),
             Yield { register } => write!(f, "Yield\t\tresult: {}", register),
@@ -1232,12 +1233,12 @@ impl Iterator for InstructionReader {
                 frame_base: get_u8!(),
                 arg_count: get_u8!(),
             }),
-            Op::CallChild => Some(CallChild {
+            Op::CallInstance => Some(CallInstance {
                 result: get_u8!(),
                 function: get_u8!(),
                 frame_base: get_u8!(),
                 arg_count: get_u8!(),
-                parent: get_u8!(),
+                instance: get_u8!(),
             }),
             Op::Return => Some(Return {
                 register: get_u8!(),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -124,13 +124,13 @@ pub enum Instruction {
     },
     MakeNum2 {
         register: u8,
-        count: u8,
         element_register: u8,
+        count: u8,
     },
     MakeNum4 {
         register: u8,
-        count: u8,
         element_register: u8,
+        count: u8,
     },
     SequenceStart {
         register: u8,
@@ -1073,13 +1073,13 @@ impl Iterator for InstructionReader {
             }),
             Op::MakeNum2 => Some(MakeNum2 {
                 register: get_u8!(),
-                count: get_u8!(),
                 element_register: get_u8!(),
+                count: get_u8!(),
             }),
             Op::MakeNum4 => Some(MakeNum4 {
                 register: get_u8!(),
-                count: get_u8!(),
                 element_register: get_u8!(),
+                count: get_u8!(),
             }),
             Op::SequenceStart => Some(SequenceStart {
                 register: get_u8!(),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -269,11 +269,6 @@ pub enum Instruction {
     JumpBack {
         offset: usize,
     },
-    JumpBackIf {
-        register: u8,
-        offset: usize,
-        jump_condition: bool,
-    },
     Call {
         result: u8,
         function: u8,
@@ -458,7 +453,6 @@ impl fmt::Display for Instruction {
             Jump { .. } => write!(f, "Jump"),
             JumpIf { .. } => write!(f, "JumpIf"),
             JumpBack { .. } => write!(f, "JumpBack"),
-            JumpBackIf { .. } => write!(f, "JumpBackIf"),
             Call { .. } => write!(f, "Call"),
             CallChild { .. } => write!(f, "CallChild"),
             Return { .. } => write!(f, "Return"),
@@ -712,15 +706,6 @@ impl fmt::Debug for Instruction {
                 register, offset, jump_condition
             ),
             JumpBack { offset } => write!(f, "JumpBack\toffset: {}", offset),
-            JumpBackIf {
-                register,
-                offset,
-                jump_condition,
-            } => write!(
-                f,
-                "JumpBackIf\tresult: {}\toffset: {}\tcondition: {}",
-                register, offset, jump_condition
-            ),
             Call {
                 result,
                 function,
@@ -1240,11 +1225,6 @@ impl Iterator for InstructionReader {
             }),
             Op::JumpBack => Some(JumpBack {
                 offset: get_u16!() as usize,
-            }),
-            Op::JumpBackFalse => Some(JumpBackIf {
-                register: get_u8!(),
-                offset: get_u16!() as usize,
-                jump_condition: false,
             }),
             Op::Call => Some(Call {
                 result: get_u8!(),

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -938,6 +938,14 @@ impl Iterator for InstructionReader {
 
         macro_rules! get_u8 {
             () => {{
+                #[cfg(not(debug_assertions))]
+                {
+                    let byte = unsafe { self.chunk.bytes.get_unchecked(self.ip) };
+                    self.ip += 1;
+                    *byte
+                }
+
+                #[cfg(debug_assertions)]
                 match self.chunk.bytes.get(self.ip) {
                     Some(byte) => {
                         self.ip += 1;
@@ -954,15 +962,25 @@ impl Iterator for InstructionReader {
 
         macro_rules! get_u16 {
             () => {{
-                match self.chunk.bytes.get(self.ip..self.ip + 2) {
-                    Some(u16_bytes) => {
-                        self.ip += 2;
-                        u16::from_le_bytes(u16_bytes.try_into().unwrap())
-                    }
-                    None => {
-                        return Some(Error {
-                            message: format!("Expected 2 bytes at position {}", self.ip),
-                        });
+                #[cfg(not(debug_assertions))]
+                {
+                    let bytes = unsafe { self.chunk.bytes.get_unchecked(self.ip..self.ip + 2) };
+                    self.ip += 2;
+                    u16::from_le_bytes(bytes.try_into().unwrap())
+                }
+
+                #[cfg(debug_assertions)]
+                {
+                    match self.chunk.bytes.get(self.ip..self.ip + 2) {
+                        Some(u16_bytes) => {
+                            self.ip += 2;
+                            u16::from_le_bytes(u16_bytes.try_into().unwrap())
+                        }
+                        None => {
+                            return Some(Error {
+                                message: format!("Expected 2 bytes at position {}", self.ip),
+                            });
+                        }
                     }
                 }
             }};
@@ -970,15 +988,25 @@ impl Iterator for InstructionReader {
 
         macro_rules! get_u32 {
             () => {{
-                match self.chunk.bytes.get(self.ip..self.ip + 4) {
-                    Some(u32_bytes) => {
-                        self.ip += 4;
-                        u32::from_le_bytes(u32_bytes.try_into().unwrap())
-                    }
-                    None => {
-                        return Some(Error {
-                            message: format!("Expected 4 bytes at position {}", self.ip),
-                        });
+                #[cfg(not(debug_assertions))]
+                {
+                    let bytes = unsafe { self.chunk.bytes.get_unchecked(self.ip..self.ip + 4) };
+                    self.ip += 4;
+                    u32::from_le_bytes(bytes.try_into().unwrap())
+                }
+
+                #[cfg(debug_assertions)]
+                {
+                    match self.chunk.bytes.get(self.ip..self.ip + 4) {
+                        Some(u32_bytes) => {
+                            self.ip += 4;
+                            u32::from_le_bytes(u32_bytes.try_into().unwrap())
+                        }
+                        None => {
+                            return Some(Error {
+                                message: format!("Expected 4 bytes at position {}", self.ip),
+                            });
+                        }
                     }
                 }
             }};
@@ -986,16 +1014,27 @@ impl Iterator for InstructionReader {
 
         macro_rules! get_u16_constant {
             () => {{
-                match self.chunk.bytes.get(self.ip..self.ip + 2) {
-                    Some(bytes) => {
-                        self.ip += 2;
-                        let bytes: [u8; 2] = bytes.try_into().unwrap();
-                        ConstantIndex::from(bytes)
-                    }
-                    None => {
-                        return Some(Error {
-                            message: format!("Expected 2 bytes at position {}", self.ip),
-                        });
+                #[cfg(not(debug_assertions))]
+                {
+                    let bytes = unsafe { self.chunk.bytes.get_unchecked(self.ip..self.ip + 2) };
+                    self.ip += 2;
+                    let bytes: [u8; 2] = bytes.try_into().unwrap();
+                    ConstantIndex::from(bytes)
+                }
+
+                #[cfg(debug_assertions)]
+                {
+                    match self.chunk.bytes.get(self.ip..self.ip + 2) {
+                        Some(bytes) => {
+                            self.ip += 2;
+                            let bytes: [u8; 2] = bytes.try_into().unwrap();
+                            ConstantIndex::from(bytes)
+                        }
+                        None => {
+                            return Some(Error {
+                                message: format!("Expected 2 bytes at position {}", self.ip),
+                            });
+                        }
                     }
                 }
             }};
@@ -1003,16 +1042,27 @@ impl Iterator for InstructionReader {
 
         macro_rules! get_u24_constant {
             () => {{
-                match self.chunk.bytes.get(self.ip..self.ip + 3) {
-                    Some(bytes) => {
-                        self.ip += 3;
-                        let bytes: [u8; 3] = bytes.try_into().unwrap();
-                        ConstantIndex::from(bytes)
-                    }
-                    None => {
-                        return Some(Error {
-                            message: format!("Expected 3 bytes at position {}", self.ip),
-                        });
+                #[cfg(not(debug_assertions))]
+                {
+                    let bytes = unsafe { self.chunk.bytes.get_unchecked(self.ip..self.ip + 3) };
+                    self.ip += 3;
+                    let bytes: [u8; 3] = bytes.try_into().unwrap();
+                    ConstantIndex::from(bytes)
+                }
+
+                #[cfg(debug_assertions)]
+                {
+                    match self.chunk.bytes.get(self.ip..self.ip + 3) {
+                        Some(bytes) => {
+                            self.ip += 3;
+                            let bytes: [u8; 3] = bytes.try_into().unwrap();
+                            ConstantIndex::from(bytes)
+                        }
+                        None => {
+                            return Some(Error {
+                                message: format!("Expected 3 bytes at position {}", self.ip),
+                            });
+                        }
                     }
                 }
             }};

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -984,6 +984,40 @@ impl Iterator for InstructionReader {
             }};
         }
 
+        macro_rules! get_u16_constant {
+            () => {{
+                match self.chunk.bytes.get(self.ip..self.ip + 2) {
+                    Some(bytes) => {
+                        self.ip += 2;
+                        let bytes: [u8; 2] = bytes.try_into().unwrap();
+                        ConstantIndex::from(bytes)
+                    }
+                    None => {
+                        return Some(Error {
+                            message: format!("Expected 2 bytes at position {}", self.ip),
+                        });
+                    }
+                }
+            }};
+        }
+
+        macro_rules! get_u24_constant {
+            () => {{
+                match self.chunk.bytes.get(self.ip..self.ip + 3) {
+                    Some(bytes) => {
+                        self.ip += 3;
+                        let bytes: [u8; 3] = bytes.try_into().unwrap();
+                        ConstantIndex::from(bytes)
+                    }
+                    None => {
+                        return Some(Error {
+                            message: format!("Expected 3 bytes at position {}", self.ip),
+                        });
+                    }
+                }
+            }};
+        }
+
         let op = match self.chunk.bytes.get(self.ip) {
             Some(byte) => Op::from(*byte),
             None => return None,
@@ -1022,51 +1056,51 @@ impl Iterator for InstructionReader {
             }),
             Op::LoadFloat => Some(LoadFloat {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), 0, 0),
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadFloat16 => Some(LoadFloat {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+                constant: get_u16_constant!(),
             }),
             Op::LoadFloat24 => Some(LoadFloat {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
+                constant: get_u24_constant!(),
             }),
             Op::LoadInt => Some(LoadInt {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), 0, 0),
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadInt16 => Some(LoadInt {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+                constant: get_u16_constant!(),
             }),
             Op::LoadInt24 => Some(LoadInt {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
+                constant: get_u24_constant!(),
             }),
             Op::LoadString => Some(LoadString {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), 0, 0),
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadString16 => Some(LoadString {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+                constant: get_u16_constant!(),
             }),
             Op::LoadString24 => Some(LoadString {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
+                constant: get_u24_constant!(),
             }),
             Op::LoadNonLocal => Some(LoadNonLocal {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), 0, 0),
+                constant: ConstantIndex::from(get_u8!()),
             }),
             Op::LoadNonLocal16 => Some(LoadNonLocal {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), 0),
+                constant: get_u16_constant!(),
             }),
             Op::LoadNonLocal24 => Some(LoadNonLocal {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
+                constant: get_u24_constant!(),
             }),
             Op::ValueExport => Some(ValueExport {
                 name: get_u8!(),
@@ -1412,19 +1446,17 @@ impl Iterator for InstructionReader {
             Op::Access => Some(Access {
                 register: get_u8!(),
                 value: get_u8!(),
-                key: ConstantIndex(get_u8!(), 0, 0),
+                key: ConstantIndex::from(get_u8!()),
             }),
             Op::Access16 => Some(Access {
                 register: get_u8!(),
                 value: get_u8!(),
-                // TODO get_u16_constant!()
-                key: ConstantIndex(get_u8!(), get_u8!(), 0),
+                key: get_u16_constant!(),
             }),
             Op::Access24 => Some(Access {
                 register: get_u8!(),
                 value: get_u8!(),
-                // TODO get_u24_constant!()
-                key: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
+                key: get_u24_constant!(),
             }),
             Op::AccessString => Some(AccessString {
                 register: get_u8!(),
@@ -1438,7 +1470,7 @@ impl Iterator for InstructionReader {
             Op::TryEnd => Some(TryEnd),
             Op::Debug => Some(Debug {
                 register: get_u8!(),
-                constant: ConstantIndex(get_u8!(), get_u8!(), get_u8!()),
+                constant: get_u24_constant!(),
             }),
             Op::CheckType => {
                 let register = get_u8!();

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -309,7 +309,7 @@ pub enum Instruction {
         iterator: u8,
         jump_offset: usize,
     },
-    ValueIndex {
+    TempIndex {
         register: u8,
         value: u8,
         index: i8,
@@ -463,7 +463,7 @@ impl fmt::Display for Instruction {
             IterNext { .. } => write!(f, "IterNext"),
             IterNextTemp { .. } => write!(f, "IterNextTemp"),
             IterNextQuiet { .. } => write!(f, "IterNextQuiet"),
-            ValueIndex { .. } => write!(f, "ValueIndex"),
+            TempIndex { .. } => write!(f, "TempIndex"),
             SliceFrom { .. } => write!(f, "SliceFrom"),
             SliceTo { .. } => write!(f, "SliceTo"),
             IsTuple { .. } => write!(f, "IsTuple"),
@@ -759,13 +759,13 @@ impl fmt::Debug for Instruction {
                 "IterNextQuiet\titerator: {}\tjump offset: {}",
                 iterator, jump_offset
             ),
-            ValueIndex {
+            TempIndex {
                 register,
                 value,
                 index,
             } => write!(
                 f,
-                "ValueIndex\tresult: {}\tvalue: {}\tindex: {}",
+                "TempIndex\tresult: {}\tvalue: {}\tindex: {}",
                 register, value, index
             ),
             SliceFrom {
@@ -1268,7 +1268,7 @@ impl Iterator for InstructionReader {
                 iterator: get_u8!(),
                 jump_offset: get_u16!() as usize,
             }),
-            Op::ValueIndex => Some(ValueIndex {
+            Op::TempIndex => Some(TempIndex {
                 register: get_u8!(),
                 value: get_u8!(),
                 index: get_u8!() as i8,

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -201,7 +201,11 @@ pub enum Instruction {
     },
     Negate {
         register: u8,
-        source: u8,
+        value: u8,
+    },
+    Not {
+        register: u8,
+        value: u8,
     },
     Add {
         register: u8,
@@ -440,6 +444,7 @@ impl fmt::Display for Instruction {
             Function { .. } => write!(f, "Function"),
             Capture { .. } => write!(f, "Capture"),
             Negate { .. } => write!(f, "Negate"),
+            Not { .. } => write!(f, "Not"),
             Add { .. } => write!(f, "Add"),
             Subtract { .. } => write!(f, "Subtract"),
             Multiply { .. } => write!(f, "Multiply"),
@@ -638,8 +643,11 @@ impl fmt::Debug for Instruction {
                 "Capture\t\tfunction: {}\ttarget: {}\tsource: {}",
                 function, target, source
             ),
-            Negate { register, source } => {
-                write!(f, "Negate\t\tresult: {}\tsource: {}", register, source)
+            Negate { register, value } => {
+                write!(f, "Negate\t\tresult: {}\tsource: {}", register, value)
+            }
+            Not { register, value } => {
+                write!(f, "Not\t\tresult: {}\tsource: {}", register, value)
             }
             Add { register, lhs, rhs } => write!(
                 f,
@@ -871,8 +879,15 @@ impl fmt::Debug for Instruction {
             CheckSize { register, size } => {
                 write!(f, "CheckSize\tregister: {}\tsize: {}", register, size)
             }
-            StringStart { register, size_hint } => {
-                write!(f, "StringStart\tregister: {}\t size hint: {}", register, size_hint)
+            StringStart {
+                register,
+                size_hint,
+            } => {
+                write!(
+                    f,
+                    "StringStart\tregister: {}\tsize hint: {}",
+                    register, size_hint
+                )
             }
             StringPush { register, value } => {
                 write!(f, "StringPush\tregister: {}\tvalue: {}", register, value)
@@ -1155,7 +1170,11 @@ impl Iterator for InstructionReader {
             }),
             Op::Negate => Some(Negate {
                 register: get_u8!(),
-                source: get_u8!(),
+                value: get_u8!(),
+            }),
+            Op::Not => Some(Not {
+                register: get_u8!(),
+                value: get_u8!(),
             }),
             Op::Add => Some(Add {
                 register: get_u8!(),

--- a/src/bytecode/src/lib.rs
+++ b/src/bytecode/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains Koto's compiler and its bytecode operations
 
+#![warn(missing_docs)]
+
 mod chunk;
 mod compiler;
 mod instruction_reader;

--- a/src/bytecode/src/loader.rs
+++ b/src/bytecode/src/loader.rs
@@ -7,12 +7,14 @@ use {
 
 /// Errors that can be returned from [Loader] operations
 #[derive(Clone, Debug)]
+#[allow(missing_docs)]
 pub enum LoaderErrorType {
     Parser(ParserError),
     Compiler(CompilerError),
     Io(String),
 }
 
+/// The error type used by the [Loader]
 #[derive(Clone, Debug)]
 pub struct LoaderError {
     error: LoaderErrorType,
@@ -21,7 +23,7 @@ pub struct LoaderError {
 }
 
 impl LoaderError {
-    pub fn from_parser_error(
+    pub(crate) fn from_parser_error(
         error: ParserError,
         source: &str,
         source_path: Option<PathBuf>,
@@ -33,7 +35,7 @@ impl LoaderError {
         }
     }
 
-    pub fn from_compiler_error(
+    pub(crate) fn from_compiler_error(
         error: CompilerError,
         source: &str,
         source_path: Option<PathBuf>,
@@ -45,7 +47,7 @@ impl LoaderError {
         }
     }
 
-    pub fn io_error(error: String) -> Self {
+    pub(crate) fn io_error(error: String) -> Self {
         Self {
             error: LoaderErrorType::Io(error),
             source: "".into(),
@@ -53,6 +55,7 @@ impl LoaderError {
         }
     }
 
+    /// Returns true if the error was caused by the expectation of indentation during parsing
     pub fn is_indentation_error(&self) -> bool {
         match &self.error {
             LoaderErrorType::Parser(e) => e.is_indentation_error(),
@@ -132,10 +135,12 @@ impl Loader {
         }
     }
 
+    /// Compiles a script in REPL mode
     pub fn compile_repl(&mut self, script: &str) -> Result<Arc<Chunk>, LoaderError> {
         self.compile(script, None, CompilerSettings { repl_mode: true })
     }
 
+    /// Compiles a script
     pub fn compile_script(
         &mut self,
         script: &str,
@@ -144,6 +149,7 @@ impl Loader {
         self.compile(script, script_path.clone(), CompilerSettings::default())
     }
 
+    /// Finds a module from its name, and then compiles it
     pub fn compile_module(
         &mut self,
         name: &str,

--- a/src/bytecode/src/loader.rs
+++ b/src/bytecode/src/loader.rs
@@ -116,7 +116,7 @@ impl Loader {
         compiler_settings: CompilerSettings,
     ) -> Result<Arc<Chunk>, LoaderError> {
         match Parser::parse(script) {
-            Ok((ast, constants)) => {
+            Ok(ast) => {
                 let (bytes, mut debug_info) = match Compiler::compile(&ast, compiler_settings) {
                     Ok((bytes, debug_info)) => (bytes, debug_info),
                     Err(e) => return Err(LoaderError::from_compiler_error(e, script, script_path)),
@@ -126,7 +126,7 @@ impl Loader {
 
                 Ok(Arc::new(Chunk::new(
                     bytes,
-                    constants,
+                    ast.consume_constants(),
                     script_path,
                     debug_info,
                 )))

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -145,12 +145,12 @@ pub enum Op {
     /// `[*target, *iterable]`
     MakeIterator,
 
-    /// Makes a SequenceBuilder with the given size hint
+    /// Makes a SequenceBuilder with a u8 size hint
     ///
     /// `[*target, size hint]`
     SequenceStart,
 
-    /// Makes a SequenceBuilder with the given u32 size hint
+    /// Makes a SequenceBuilder with a u32 size hint
     ///
     /// `[*target, size hint[4]]`
     SequenceStart32,
@@ -175,12 +175,15 @@ pub enum Op {
     /// `[*register]`
     SequenceToTuple,
 
-    /// Makes a StringBuilder
+    /// Makes a StringBuilder with a u8 size hint
     ///
-    /// TODO Add a size hint
-    ///
-    /// [*target]
+    /// `[*target, size hint]`
     StringStart,
+
+    /// Makes a StringBuilder with a u32 size hint
+    ///
+    /// `[*target, size hint[4]]`
+    StringStart32,
 
     /// Pushes a value to the end of a StringBuilder
     ///
@@ -505,11 +508,10 @@ pub enum Op {
     ///
     /// Used when matching function arguments.
     ///
-    /// [*value, size]
+    /// `[*value, size]`
     CheckSize,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused88,
     Unused89,
     Unused90,
     Unused91,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -460,12 +460,27 @@ pub enum Op {
     /// `[*name, *value]`
     ValueExport,
 
-    /// Access a contained value via key
+    /// Accesses a contained value via a constant key
     ///
-    /// Used in '.' access operations.
+    /// `[*target, constant]`
+    Access,
+
+    /// Accesses a contained value via a u16 constant key
+    ///
+    /// `[*target, constant[2]]`
+    Access16,
+
+    /// Accesses a contained value via a u24 constant key
+    ///
+    /// `[*target, constant[3]]`
+    Access24,
+
+    /// Access a contained value via a string key
+    ///
+    /// Used in '.' access operations that use a quoted string, e.g. `foo."bar"`.
     ///
     /// `[*result, *value, *key]`
-    Access,
+    AccessString,
 
     /// Sets the result register to true if the value is a List
     ///
@@ -518,9 +533,6 @@ pub enum Op {
     CheckSize,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused90,
-    Unused91,
-    Unused92,
     Unused93,
     Unused94,
     Unused95,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -132,16 +132,12 @@ pub enum Op {
 
     /// Makes a Num2 in the target register
     ///
-    /// TODO switch byte order to match MakeTempTuple
-    ///
-    /// [*target, value count, *start]
+    /// `[*target, *start, value count]`
     MakeNum2,
 
     /// Makes a Num4 in the target register
     ///
-    /// TODO switch byte order to match MakeTempTuple
-    ///
-    /// [*target, value count, *start]
+    /// `[*target, *start, value count]`
     MakeNum4,
 
     /// Makes an Iterator out of an iterable value

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -334,12 +334,10 @@ pub enum Op {
     /// `[*result, *function, *first arg, arg count]`
     Call,
 
-    /// Calls a child function
+    /// Calls an instance function
     ///
-    /// TODO rename to CallInstance ?
-    ///
-    /// [*result, *function, *first arg, arg count, *parent]
-    CallChild,
+    /// `[*result, *function, *first arg, arg count, *instance]`
+    CallInstance,
 
     /// Returns from the current frame with the given result
     ///

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -1,7 +1,8 @@
 /// The operations used in Koto bytecode
 ///
 /// Each operation is made up of a byte, followed by N additional bytes that define its behaviour.
-/// The combined operation bytes are interpreted as an [Instruction] by the [InstructionReader].
+/// The combined operation bytes are interpreted as an [Instruction](crate::Instruction) by the
+/// [InstructionReader](crate::InstructionReader).
 ///
 /// In the comments for each operation, the additional bytes are specified inside square brackets.
 /// Bytes prefixed with * show that the byte is referring to a register.
@@ -209,7 +210,7 @@ pub enum Op {
     ///
     /// Like a SimpleFunction, but with extended properties and captured values.
     ///
-    /// The flags are a bitfield constructed from [FunctionFlags].
+    /// The flags are a bitfield constructed from [FunctionFlags](crate::FunctionFlags).
     /// The N size bytes following this instruction make up the body of the function.
     ///
     /// `[*target, arg count, capture count, flags, function size[2]]`
@@ -497,7 +498,7 @@ pub enum Op {
     ///
     /// Used when matching function arguments.
     ///
-    /// See [TypeId] for the list of types that are checked against.
+    /// See [TypeId](crate::TypeId) for the list of types that are checked against.
     ///
     /// `[*value, type]`
     CheckType,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -255,8 +255,15 @@ pub enum Op {
 
     /// Negates a value
     ///
+    /// Used for the unary negation operator, i.e. `x = -y`
+    ///
     /// `[*target, *source]`
     Negate,
+
+    /// Flips the value of a boolean
+    ///
+    /// `[*target, *source]`
+    Not,
 
     /// Adds lhs and rhs together
     ///
@@ -511,7 +518,6 @@ pub enum Op {
     CheckSize,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused89,
     Unused90,
     Unused91,
     Unused92,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -329,13 +329,6 @@ pub enum Op {
     /// `[offset[2]]`
     JumpBack,
 
-    /// Causes the instruction pointer to jump back, if a condition is false
-    ///
-    /// TODO Can this be removed?
-    ///
-    /// [*condition, offset[2]]
-    JumpBackFalse,
-
     /// Calls a function
     ///
     /// `[*result, *function, *first arg, arg count]`
@@ -518,6 +511,7 @@ pub enum Op {
     CheckSize,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
+    Unused88,
     Unused89,
     Unused90,
     Unused91,

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -382,15 +382,13 @@ pub enum Op {
     /// `[*iterator, offset[2]]`
     IterNextQuiet,
 
-    /// Accesses a contained value using a u8 index
+    /// Accesses a contained value from a temporary value using a u8 index
     ///
     /// This is used for internal indexing operations.
     /// e.g. when unpacking a temporary value in multi-assignment
     ///
-    /// TODO rename to Index8 or similar
-    ///
-    /// [*result, *value, index]
-    ValueIndex,
+    /// `[*result, *value, index]`
+    TempIndex,
 
     /// Takes a slice from the end of a given List or Tuple, starting from a u8 index
     ///

--- a/src/bytecode/tests/compile_failures.rs
+++ b/src/bytecode/tests/compile_failures.rs
@@ -6,7 +6,7 @@ mod bytecode {
 
     fn check_compilation_fails(source: &str) {
         match Parser::parse(source) {
-            Ok((ast, _constants)) => {
+            Ok(ast) => {
                 if Compiler::compile(&ast, CompilerSettings::default()).is_ok() {
                     panic!("\nUnexpected success while compiling: {}", source,);
                 }

--- a/src/parser/src/ast.rs
+++ b/src/parser/src/ast.rs
@@ -91,8 +91,8 @@ impl Ast {
 
     /// Moves the constants out of the AST
     ///
-    /// This is used when building a [Chunk] after compilation. The constants get transferred to
-    /// the Chunk once the AST has been converted into bytecode.
+    /// This is used when building a `Chunk` after compilation.
+    /// The constants get transferred to the `Chunk` once the AST has been converted into bytecode.
     pub fn consume_constants(self) -> ConstantPool {
         self.constants
     }

--- a/src/parser/src/constant_index.rs
+++ b/src/parser/src/constant_index.rs
@@ -30,6 +30,18 @@ impl From<u8> for ConstantIndex {
     }
 }
 
+impl From<[u8; 2]> for ConstantIndex {
+    fn from(x: [u8; 2]) -> Self {
+        Self(x[0], x[1], 0)
+    }
+}
+
+impl From<[u8; 3]> for ConstantIndex {
+    fn from(x: [u8; 3]) -> Self {
+        Self(x[0], x[1], x[2])
+    }
+}
+
 impl TryFrom<usize> for ConstantIndex {
     type Error = ConstantIndexTryFromOutOfRange;
 

--- a/src/parser/src/constant_pool.rs
+++ b/src/parser/src/constant_pool.rs
@@ -32,9 +32,9 @@ pub enum Constant<'a> {
     Str(&'a str),
 }
 
-/// A constant pool produced by the [Parser] for a Koto script
+/// A constant pool produced by the [Parser](crate::Parser) for a Koto script
 ///
-/// A [ConstantPoolBuilder] is used to prepare the pool.
+/// A `ConstantPoolBuilder` is used to prepare the pool.
 #[derive(Clone, Debug)]
 pub struct ConstantPool {
     // The list of constants in the pool

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -162,7 +162,7 @@ impl fmt::Display for ErrorType {
     }
 }
 
-/// An error that can be produced by the [Parser]
+/// An error that can be produced by the [Parser](crate::Parser)
 #[derive(Clone, Debug)]
 pub struct ParserError {
     /// The error itself

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -3,9 +3,9 @@ use {
     std::{convert::TryFrom, fmt},
 };
 
-/// A parsed node that can be included in the [AST](ast).
+/// A parsed node that can be included in the [AST](crate::Ast).
 ///
-/// Nodes refer to each other via [AstIndex]s, see [AstNode].
+/// Nodes refer to each other via [AstIndex]s, see [AstNode](crate::AstNode).
 #[derive(Clone, Debug, PartialEq)]
 pub enum Node {
     /// An Empty node, used for `()` empty expressions
@@ -157,7 +157,7 @@ pub enum Node {
 
     /// An assignment expression
     ///
-    /// Used for single-assignment, multiple-assignment is represented by [MultiAssign].
+    /// Used for single-assignment, multiple-assignment is represented by [Node::MultiAssign].
     Assign {
         /// The target of the assignment
         target: AssignTarget,
@@ -472,12 +472,12 @@ pub enum Scope {
 /// In other words, some series of operations involving indexing, `.` accesses, and function calls.
 ///
 /// e.g.
-/// foo.bar."baz"[0](42)
-/// |  |   |     |  ^ Call {args: 42, with_parens: true}
-/// |  |   |     ^ Index (0)
-/// |  |   ^ Str (baz)
-/// |  ^ Id (bar)
-/// ^ Root (foo)
+/// `foo.bar."baz"[0](42)`
+///  |  |   |     |  ^ Call {args: 42, with_parens: true}
+///  |  |   |     ^ Index (0)
+///  |  |   ^ Str (baz)
+///  |  ^ Id (bar)
+///  ^ Root (foo)
 #[derive(Clone, Debug, PartialEq)]
 pub enum LookupNode {
     /// The root of the lookup chain
@@ -500,7 +500,6 @@ pub enum LookupNode {
         ///   `99 >> foo.bar 42` is equivalent to `foo.bar(42, 99)`
         /// but:
         ///   `99 >> foo.bar(42)` is equivalent to `foo.bar(42)(99)`.
-        /// ```
         with_parens: bool,
     },
 }
@@ -578,14 +577,14 @@ pub enum MetaKeyId {
 
     /// @tests
     Tests,
-    /// @test [test_name]
+    /// @test test_name
     Test,
     /// @pre_test
     PreTest,
     /// @post_test
     PostTest,
 
-    /// @meta [name]
+    /// @meta name
     Named,
 
     /// Unused

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -177,10 +177,18 @@ pub enum Node {
         expression: AstIndex,
     },
 
+    /// A unary operation
+    UnaryOp {
+        /// The operator to use
+        op: AstUnaryOp,
+        /// The value used in the operation
+        value: AstIndex,
+    },
+
     /// A binary operation
     BinaryOp {
         /// The operator to use
-        op: AstOp,
+        op: AstBinaryOp,
         /// The "left hand side" of the operation
         lhs: AstIndex,
         /// The "right hand side" of the operation
@@ -245,11 +253,6 @@ pub enum Node {
     /// A return expression, with optional return value
     Return(Option<AstIndex>),
 
-    /// A negation expression
-    ///
-    /// Used for both inverting the sign of a numerical value and for the `not` operator.
-    Negate(AstIndex),
-
     /// A try expression
     Try(AstTry),
 
@@ -302,12 +305,12 @@ impl fmt::Display for Node {
             Map(_) => write!(f, "Map"),
             MainBlock { .. } => write!(f, "MainBlock"),
             Block(_) => write!(f, "Block"),
-            Negate(_) => write!(f, "Negate"),
             Function(_) => write!(f, "Function"),
             NamedCall { .. } => write!(f, "NamedCall"),
             Import { .. } => write!(f, "Import"),
             Assign { .. } => write!(f, "Assign"),
             MultiAssign { .. } => write!(f, "MultiAssign"),
+            UnaryOp { .. } => write!(f, "UnaryOp"),
             BinaryOp { .. } => write!(f, "BinaryOp"),
             If(_) => write!(f, "If"),
             Match { .. } => write!(f, "Match"),
@@ -401,10 +404,18 @@ pub struct AstIf {
     pub else_node: Option<AstIndex>,
 }
 
+/// An operation used in UnaryOp expressions
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(missing_docs)]
+pub enum AstUnaryOp {
+    Negate,
+    Not,
+}
+
 /// An operation used in BinaryOp expressions
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(missing_docs)]
-pub enum AstOp {
+pub enum AstBinaryOp {
     Add,
     Subtract,
     Multiply,
@@ -572,6 +583,8 @@ pub enum MetaKeyId {
     Display,
     /// @negate
     Negate,
+    /// @not
+    Not,
     /// @type
     Type,
 

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -218,8 +218,8 @@ pub struct Parser<'source> {
 }
 
 impl<'source> Parser<'source> {
-    /// Takes in a source script, and produces an Ast and associated [ConstantPool]
-    pub fn parse(source: &'source str) -> Result<(Ast, ConstantPool), ParserError> {
+    /// Takes in a source script, and produces an Ast
+    pub fn parse(source: &'source str) -> Result<Ast, ParserError> {
         let capacity_guess = source.len() / 4;
         let mut parser = Parser {
             ast: Ast::with_capacity(capacity_guess),
@@ -230,8 +230,9 @@ impl<'source> Parser<'source> {
 
         let main_block = parser.parse_main_block()?;
         parser.ast.set_entry_point(main_block);
+        parser.ast.set_constants(parser.constants.build());
 
-        Ok((parser.ast, parser.constants.build()))
+        Ok(parser.ast)
     }
 
     fn frame(&self) -> Result<&Frame, ParserError> {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -5,7 +5,7 @@ mod parser {
         println!("{}", source);
 
         match Parser::parse(source) {
-            Ok((ast, constants)) => {
+            Ok(ast) => {
                 for (i, (ast_node, expected_node)) in
                     ast.nodes().iter().zip(expected_ast.iter()).enumerate()
                 {
@@ -19,12 +19,12 @@ mod parser {
 
                 if let Some(expected_constants) = expected_constants {
                     for (constant, expected_constant) in
-                        constants.iter().zip(expected_constants.iter())
+                        ast.constants().iter().zip(expected_constants.iter())
                     {
                         assert_eq!(constant, *expected_constant);
                     }
                     assert_eq!(
-                        constants.size(),
+                        ast.constants().size(),
                         expected_constants.len(),
                         "Constant pool size mismatch"
                     );

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -237,7 +237,7 @@ a
                     Int(constant(0)),
                     Int(constant(1)),
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 0,
                         rhs: 1,
                     },
@@ -266,21 +266,30 @@ a
                 &[
                     Float(constant(0)),
                     Id(constant(1)),
-                    Negate(1),
+                    UnaryOp {
+                        op: AstUnaryOp::Negate,
+                        value: 1,
+                    },
                     Id(constant(2)),
                     Number0,
                     Lookup((LookupNode::Index(4), None)), // 5
                     Lookup((LookupNode::Root(3), Some(5))),
-                    Negate(6),
+                    UnaryOp {
+                        op: AstUnaryOp::Negate,
+                        value: 6,
+                    },
                     Number1,
                     Number1,
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 8,
                         rhs: 9,
                     }, // 10
                     Nested(10),
-                    Negate(11),
+                    UnaryOp {
+                        op: AstUnaryOp::Negate,
+                        value: 11,
+                    },
                     MainBlock {
                         body: vec![0, 2, 7, 12],
                         local_count: 0,
@@ -711,14 +720,14 @@ export @tests =
                     Number0,
                     Number1,
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 0,
                         rhs: 1,
                     },
                     Number1,
                     Number0,
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 3,
                         rhs: 4,
                     }, // 5
@@ -1005,7 +1014,7 @@ num4(
                     Number1,
                     Number1,
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 1,
                         rhs: 2,
                     },
@@ -1290,13 +1299,13 @@ x %= 4";
                     Number1,
                     Number0,
                     BinaryOp {
-                        op: AstOp::Subtract,
+                        op: AstBinaryOp::Subtract,
                         lhs: 0,
                         rhs: 1,
                     },
                     Number1,
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 2,
                         rhs: 3,
                     },
@@ -1319,18 +1328,18 @@ x %= 4";
                     Number0,
                     Number1,
                     BinaryOp {
-                        op: AstOp::Multiply,
+                        op: AstBinaryOp::Multiply,
                         lhs: 1,
                         rhs: 2,
                     },
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 0,
                         rhs: 3,
                     },
                     Number0, // 5
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 4,
                         rhs: 5,
                     },
@@ -1352,7 +1361,7 @@ x %= 4";
                     Number1,
                     Number0,
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 0,
                         rhs: 1,
                     },
@@ -1360,13 +1369,13 @@ x %= 4";
                     Number1,
                     Number0, // 5
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 4,
                         rhs: 5,
                     },
                     Nested(6),
                     BinaryOp {
-                        op: AstOp::Multiply,
+                        op: AstBinaryOp::Multiply,
                         lhs: 3,
                         rhs: 7,
                     },
@@ -1388,13 +1397,13 @@ x %= 4";
                     Int(constant(0)),
                     Int(constant(1)),
                     BinaryOp {
-                        op: AstOp::Divide,
+                        op: AstBinaryOp::Divide,
                         lhs: 0,
                         rhs: 1,
                     },
                     Int(constant(2)),
                     BinaryOp {
-                        op: AstOp::Modulo,
+                        op: AstBinaryOp::Modulo,
                         lhs: 2,
                         rhs: 3,
                     },
@@ -1416,7 +1425,7 @@ x %= 4";
                     string_literal(0, QuotationMark::Single),
                     Id(constant(1)),
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 0,
                         rhs: 1,
                     },
@@ -1443,7 +1452,7 @@ x %= 4";
                         args: vec![2],
                     },
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 1,
                         rhs: 3,
                     },
@@ -1479,12 +1488,12 @@ a = 1 +
                     Int(constant(1)),
                     Int(constant(2)),
                     BinaryOp {
-                        op: AstOp::Multiply,
+                        op: AstBinaryOp::Multiply,
                         lhs: 2,
                         rhs: 3,
                     },
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 1,
                         rhs: 4,
                     }, // 5
@@ -1520,12 +1529,12 @@ a = 1
                     Int(constant(1)),
                     Int(constant(2)),
                     BinaryOp {
-                        op: AstOp::Multiply,
+                        op: AstBinaryOp::Multiply,
                         lhs: 2,
                         rhs: 3,
                     },
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 1,
                         rhs: 4,
                     }, // 5
@@ -1559,25 +1568,25 @@ a = 1
                     Number0,
                     Number1,
                     BinaryOp {
-                        op: AstOp::Less,
+                        op: AstBinaryOp::Less,
                         lhs: 0,
                         rhs: 1,
                     },
                     Number1,
                     Number0,
                     BinaryOp {
-                        op: AstOp::Greater,
+                        op: AstBinaryOp::Greater,
                         lhs: 3,
                         rhs: 4,
                     },
                     BinaryOp {
-                        op: AstOp::And,
+                        op: AstBinaryOp::And,
                         lhs: 2,
                         rhs: 5,
                     },
                     BoolTrue,
                     BinaryOp {
-                        op: AstOp::Or,
+                        op: AstBinaryOp::Or,
                         lhs: 6,
                         rhs: 7,
                     },
@@ -1600,12 +1609,12 @@ a = 1
                     Number1,
                     Number1,
                     BinaryOp {
-                        op: AstOp::LessOrEqual,
+                        op: AstBinaryOp::LessOrEqual,
                         lhs: 1,
                         rhs: 2,
                     },
                     BinaryOp {
-                        op: AstOp::Less,
+                        op: AstBinaryOp::Less,
                         lhs: 0,
                         rhs: 3,
                     },
@@ -1639,7 +1648,7 @@ a = 1
                         else_node: Some(3),
                     }),
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 0,
                         rhs: 4,
                     },
@@ -1825,7 +1834,7 @@ while x > y
                     Id(constant(0)), // x
                     Id(constant(1)), // y
                     BinaryOp {
-                        op: AstOp::Greater,
+                        op: AstBinaryOp::Greater,
                         lhs: 0,
                         rhs: 1,
                     },
@@ -1858,7 +1867,7 @@ until x < y
                     Id(constant(0)), // x
                     Id(constant(1)), // y
                     BinaryOp {
-                        op: AstOp::Less,
+                        op: AstBinaryOp::Less,
                         lhs: 0,
                         rhs: 1,
                     },
@@ -2008,7 +2017,7 @@ a()";
                     Id(constant(0)),
                     Id(constant(1)),
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 2,
                         rhs: 3,
                     },
@@ -2050,7 +2059,7 @@ a()";
                     Lookup((LookupNode::Id(constant(2)), Some(4))), // 5
                     Lookup((LookupNode::Root(3), Some(5))),
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 2,
                         rhs: 6,
                     },
@@ -2220,7 +2229,10 @@ f 42";
                 &[
                     Id(constant(1)),
                     Id(constant(1)),
-                    Negate(1),
+                    UnaryOp {
+                        op: AstUnaryOp::Negate,
+                        value: 1,
+                    },
                     NamedCall {
                         id: constant(0), // f
                         args: vec![0, 2],
@@ -2243,7 +2255,7 @@ f 42";
                     Id(constant(1)),
                     Number1,
                     BinaryOp {
-                        op: AstOp::Subtract,
+                        op: AstBinaryOp::Subtract,
                         lhs: 0,
                         rhs: 1,
                     },
@@ -2269,7 +2281,10 @@ f 42";
                     Id(constant(0)),
                     Id(constant(1)),
                     Id(constant(1)),
-                    Negate(2),
+                    UnaryOp {
+                        op: AstUnaryOp::Negate,
+                        value: 2,
+                    },
                     Lookup((
                         LookupNode::Call {
                             args: vec![1, 3],
@@ -2454,13 +2469,13 @@ f x";
                     },
                     Id(constant(2)), // g
                     BinaryOp {
-                        op: AstOp::Pipe,
+                        op: AstBinaryOp::Pipe,
                         lhs: 1,
                         rhs: 2,
                     },
                     Id(constant(3)), // h
                     BinaryOp {
-                        op: AstOp::Pipe,
+                        op: AstBinaryOp::Pipe,
                         lhs: 3,
                         rhs: 4,
                     }, // 5
@@ -2501,13 +2516,13 @@ foo.bar x
                     Lookup((LookupNode::Root(0), Some(3))),
                     Id(constant(3)), // 5 - y
                     BinaryOp {
-                        op: AstOp::Pipe,
+                        op: AstBinaryOp::Pipe,
                         lhs: 4,
                         rhs: 5,
                     },
                     Id(constant(4)), // z
                     BinaryOp {
-                        op: AstOp::Pipe,
+                        op: AstBinaryOp::Pipe,
                         lhs: 6,
                         rhs: 7,
                     },
@@ -2784,7 +2799,7 @@ f = |n|
                     Id(constant(3)), // i
                     Id(constant(1)),
                     BinaryOp {
-                        op: AstOp::Equal,
+                        op: AstBinaryOp::Equal,
                         lhs: 7,
                         rhs: 8,
                     },
@@ -2865,7 +2880,7 @@ f = |n|
                     Id(constant(0)),
                     Number1,
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 1,
                         rhs: 2,
                     },
@@ -2954,7 +2969,7 @@ y z";
                     Id(constant(3)),
                     Number1,
                     BinaryOp {
-                        op: AstOp::Greater,
+                        op: AstBinaryOp::Greater,
                         lhs: 6,
                         rhs: 7,
                     },
@@ -3324,7 +3339,7 @@ y z";
                     Lookup((LookupNode::Root(0), Some(2))),
                     Number1,
                     BinaryOp {
-                        op: AstOp::Subtract,
+                        op: AstBinaryOp::Subtract,
                         lhs: 3,
                         rhs: 4,
                     }, // 5
@@ -3868,13 +3883,13 @@ foo.bar
                     Lookup((LookupNode::Id(constant(2)), None)),
                     Lookup((LookupNode::Root(3), Some(4))), // 5
                     BinaryOp {
-                        op: AstOp::Or,
+                        op: AstBinaryOp::Or,
                         lhs: 2,
                         rhs: 5,
                     },
                     BoolFalse,
                     BinaryOp {
-                        op: AstOp::Or,
+                        op: AstBinaryOp::Or,
                         lhs: 6,
                         rhs: 7,
                     },
@@ -3930,11 +3945,14 @@ assert_eq x, "hello"
                 source,
                 &[
                     BoolTrue,
-                    Negate(0),
+                    UnaryOp {
+                        op: AstUnaryOp::Not,
+                        value: 0,
+                    },
                     Id(constant(0)),
                     Id(constant(0)),
                     BinaryOp {
-                        op: AstOp::Add,
+                        op: AstBinaryOp::Add,
                         lhs: 2,
                         rhs: 3,
                     },
@@ -4573,7 +4591,7 @@ match x
                     Id(constant(1)),
                     Int(constant(2)),
                     BinaryOp {
-                        op: AstOp::Greater,
+                        op: AstBinaryOp::Greater,
                         lhs: 2,
                         rhs: 3,
                     },
@@ -4582,7 +4600,7 @@ match x
                     Id(constant(1)),
                     Int(constant(3)),
                     BinaryOp {
-                        op: AstOp::Less,
+                        op: AstBinaryOp::Less,
                         lhs: 7,
                         rhs: 8,
                     },
@@ -4820,7 +4838,7 @@ switch
                     Number1,
                     Number0,
                     BinaryOp {
-                        op: AstOp::Equal,
+                        op: AstBinaryOp::Equal,
                         lhs: 0,
                         rhs: 1,
                     },
@@ -4828,7 +4846,7 @@ switch
                     Id(constant(0)),
                     Id(constant(1)), // 5
                     BinaryOp {
-                        op: AstOp::Greater,
+                        op: AstBinaryOp::Greater,
                         lhs: 4,
                         rhs: 5,
                     },

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -9,7 +9,7 @@ mod parser {
             panic!(
                 "Unexpected success while parsing:\n{}\n{:#?}",
                 source,
-                ast.0.nodes()
+                ast.nodes()
             );
         }
     }
@@ -20,7 +20,7 @@ mod parser {
             panic!(
                 "Unexpected success while parsing:\n{}\n{:#?}",
                 source,
-                ast.0.nodes()
+                ast.nodes()
             );
         }
     }

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -439,6 +439,7 @@ impl fmt::Display for BinaryOp {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum UnaryOp {
     Negate,
+    Not,
     Display,
 }
 
@@ -451,6 +452,7 @@ impl fmt::Display for UnaryOp {
             "{}",
             match self {
                 Negate => "negate",
+                Not => "not",
                 Display => "display",
             }
         )
@@ -474,6 +476,7 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKe
         MetaKeyId::NotEqual => MetaKey::BinaryOp(NotEqual),
         MetaKeyId::Index => MetaKey::BinaryOp(Index),
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
+        MetaKeyId::Not => MetaKey::UnaryOp(Not),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),
         MetaKeyId::Named => {
             MetaKey::Named(name.ok_or_else(|| "Missing name for named meta entry".to_string())?)

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -49,8 +49,8 @@ pub enum Value {
 
     /// A function that produces an Iterator when called
     ///
-    /// A [Vm] gets spawned for the function to run in, which pauses each time a yield instruction
-    /// is encountered. See Vm::call_generator and Iterable::Generator.
+    /// A [Vm](crate::Vm) gets spawned for the function to run in, which pauses each time a yield
+    /// instruction is encountered. See Vm::call_generator and Iterable::Generator.
     Generator(FunctionInfo),
 
     /// The iterator type used in Koto
@@ -158,7 +158,7 @@ impl Value {
     /// x = [1, 2, 3] # x has size 3
     /// a, b, c = x
     ///
-    /// See [Op::Size] and [Op::CheckSize]
+    /// See [Op::Size](koto_bytecode::Op::Size) and [Op::CheckSize](koto_bytecode::Op::CheckSize).
     pub fn size(&self) -> usize {
         use Value::*;
 

--- a/src/runtime/src/value_key.rs
+++ b/src/runtime/src/value_key.rs
@@ -8,7 +8,7 @@ use {
     },
 };
 
-/// The key type used by [ValueMap]
+/// The key type used by [ValueMap](crate::ValueMap)
 ///
 /// Only immutable values can be used as keys, see [Value::is_immutable]
 #[derive(Clone, Debug)]

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -767,18 +767,18 @@ impl Vm {
                 arg_count,
                 None,
             ),
-            Instruction::CallChild {
+            Instruction::CallInstance {
                 result,
                 function,
                 frame_base,
                 arg_count,
-                parent,
+                instance,
             } => self.call_callable(
                 result,
                 self.clone_register(function),
                 frame_base,
                 arg_count,
-                Some(parent),
+                Some(instance),
             ),
             Instruction::Return { register } => {
                 if let Some(return_value) = self.pop_frame(self.clone_register(register))? {

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -755,11 +755,6 @@ impl Vm {
                 self.jump_ip_back(offset);
                 Ok(())
             }
-            Instruction::JumpBackIf {
-                register,
-                offset,
-                jump_condition,
-            } => self.run_jump_back_if(register, offset, jump_condition),
             Instruction::Call {
                 result,
                 function,
@@ -1827,25 +1822,6 @@ impl Vm {
             Value::Bool(b) => {
                 if *b == jump_condition {
                     self.jump_ip(offset);
-                }
-            }
-            unexpected => {
-                return self.unexpected_type_error("JumpIf: expected Bool", unexpected);
-            }
-        }
-        Ok(())
-    }
-
-    fn run_jump_back_if(
-        &mut self,
-        register: u8,
-        offset: usize,
-        jump_condition: bool,
-    ) -> InstructionResult {
-        match self.get_register(register) {
-            Value::Bool(b) => {
-                if *b == jump_condition {
-                    self.jump_ip_back(offset);
                 }
             }
             unexpected => {

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -589,7 +589,7 @@ impl Vm {
                 runtime_error!("{}", message)
             }
             Instruction::Copy { target, source } => {
-                self.run_copy(target, source);
+                self.set_register(target, self.clone_register(source));
                 Ok(())
             }
             Instruction::SetEmpty { register } => {
@@ -915,18 +915,6 @@ impl Vm {
         }?;
 
         Ok(control_flow)
-    }
-
-    fn run_copy(&mut self, target: u8, source: u8) {
-        let value = match self.clone_register(source) {
-            Value::TemporaryTuple(RegisterSlice { start, count }) => {
-                // A temporary tuple shouldn't make it into a named value,
-                // so here it gets converted into a regular tuple.
-                Value::Tuple(self.register_slice(start, count).into())
-            }
-            other => other,
-        };
-        self.set_register(target, value);
     }
 
     fn run_load_non_local(

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -674,8 +674,11 @@ impl Vm {
             }
             Instruction::SequenceToList { sequence } => self.run_sequence_to_list(sequence),
             Instruction::SequenceToTuple { sequence } => self.run_sequence_to_tuple(sequence),
-            Instruction::StringStart { register } => {
-                self.set_register(register, StringBuilder(String::new()));
+            Instruction::StringStart {
+                register,
+                size_hint,
+            } => {
+                self.set_register(register, StringBuilder(String::with_capacity(size_hint)));
                 Ok(())
             }
             Instruction::StringPush { register, value } => self.run_string_push(register, value),

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -843,11 +843,11 @@ impl Vm {
                 iterator,
                 jump_offset,
             } => self.run_iterator_next(None, iterator, jump_offset, false),
-            Instruction::ValueIndex {
+            Instruction::TempIndex {
                 register,
                 value,
                 index,
-            } => self.run_value_index(register, value, index),
+            } => self.run_temp_index(register, value, index),
             Instruction::SliceFrom {
                 register,
                 value,
@@ -1105,7 +1105,7 @@ impl Vm {
         Ok(())
     }
 
-    fn run_value_index(&mut self, register: u8, value: u8, index: i8) -> InstructionResult {
+    fn run_temp_index(&mut self, register: u8, value: u8, index: i8) -> InstructionResult {
         use Value::*;
 
         let result = match self.get_register(value) {

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -644,14 +644,14 @@ impl Vm {
             }
             Instruction::MakeNum2 {
                 register,
-                count,
                 element_register,
-            } => self.run_make_num2(register, count, element_register),
+                count,
+            } => self.run_make_num2(register, element_register, count),
             Instruction::MakeNum4 {
                 register,
-                count,
                 element_register,
-            } => self.run_make_num4(register, count, element_register),
+                count,
+            } => self.run_make_num4(register, element_register, count),
             Instruction::SequenceStart {
                 register,
                 size_hint,
@@ -1983,8 +1983,8 @@ impl Vm {
     fn run_make_num2(
         &mut self,
         result_register: u8,
-        element_count: u8,
         element_register: u8,
+        element_count: u8,
     ) -> InstructionResult {
         use Value::*;
 
@@ -2033,8 +2033,8 @@ impl Vm {
     fn run_make_num4(
         &mut self,
         result_register: u8,
-        element_count: u8,
         element_register: u8,
+        element_count: u8,
     ) -> InstructionResult {
         use Value::*;
         let result = if element_count == 1 {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1616,7 +1616,6 @@ m.foo 1, 2, 3
             let script = "
 m =
   foo: |self, first, xs...|
-    debug self
     for x in xs
       yield self.offset + first + x
     self.offset + xs.fold x, |a, b| a + b


### PR DESCRIPTION
A collection of improvements to Koto's bytecode

User facing improvements:
- Performance improvements
  - Size hinting when building strings
  - Optimized access operations
  - Only perform runtime validation of bytecode when debug assertions are active
- `not` behaviour is now split out from arithmetic negation

