### PR TITLE
Optimize calling functions with unpacked tuple args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ The Koto project adheres to
 - Internals
   - The AST struct returned by the parser now includes its associated constant
     pool as a member.
+  - Koto functions are now called from the outside with a `CallArgs` argument,
+    which provides more information to the runtime about how the function
+    should be called.
+    - `CallArgs::AsTuple` will pass the arguments into the function as a tuple,
+      using a non-allocating temporary tuple when possible (i.e. when the
+      function immediately unpacks the tuple's values).
 
 ### Fixed
 

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -31,7 +31,9 @@ pub use {koto_bytecode as bytecode, koto_parser as parser, koto_runtime as runti
 use {
     dunce::canonicalize,
     koto_bytecode::{Chunk, LoaderError},
-    koto_runtime::{KotoFile, Loader, MetaKey, RuntimeError, Value, ValueMap, Vm, VmSettings},
+    koto_runtime::{
+        CallArgs, KotoFile, Loader, MetaKey, RuntimeError, Value, ValueMap, Vm, VmSettings,
+    },
     std::{error::Error, fmt, path::PathBuf, sync::Arc},
 };
 
@@ -200,7 +202,9 @@ impl Koto {
             }
 
             if let Some(main) = self.runtime.get_exported_function("main") {
-                self.runtime.run_function(main, &[]).map_err(|e| e.into())
+                self.runtime
+                    .run_function(main, CallArgs::None)
+                    .map_err(|e| e.into())
             } else {
                 Ok(result)
             }
@@ -277,14 +281,14 @@ impl Koto {
         }
     }
 
-    pub fn call_function_by_name(&mut self, function_name: &str, args: &[Value]) -> KotoResult {
+    pub fn run_function_by_name(&mut self, function_name: &str, args: CallArgs) -> KotoResult {
         match self.runtime.get_exported_function(function_name) {
-            Some(f) => self.call_function(f, args),
+            Some(f) => self.run_function(f, args),
             None => Err(KotoError::FunctionNotFound(function_name.into())),
         }
     }
 
-    pub fn call_function(&mut self, function: Value, args: &[Value]) -> KotoResult {
+    pub fn run_function(&mut self, function: Value, args: CallArgs) -> KotoResult {
         self.runtime
             .run_function(function, args)
             .map_err(|e| e.into())

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -1,8 +1,8 @@
 use {
     super::iterator::adaptors,
     crate::{
-        runtime_error, value_sort::compare_values, DataMap, RuntimeResult, Value, ValueIterator,
-        ValueKey, ValueMap, Vm,
+        runtime_error, value_sort::compare_values, CallArgs, DataMap, RuntimeResult, Value,
+        ValueIterator, ValueKey, ValueMap, Vm,
     },
     std::{cmp::Ordering, ops::Deref},
 };
@@ -165,7 +165,10 @@ pub fn make_module() -> ValueMap {
 
             let get_sort_key =
                 |vm: &mut Vm, cache: &mut DataMap, key: &Value, value: &Value| -> RuntimeResult {
-                    let value = vm.run_function(f.clone(), &[key.clone(), value.clone()])?;
+                    let value = vm.run_function(
+                        f.clone(),
+                        CallArgs::Separate(&[key.clone(), value.clone()]),
+                    )?;
                     cache.insert(key.clone().into(), value.clone());
                     Ok(value)
                 };
@@ -255,7 +258,7 @@ fn do_map_update(
         map.data_mut().insert(key.clone(), default);
     }
     let value = map.data().get(&key).cloned().unwrap();
-    match vm.run_function(f, &[value]) {
+    match vm.run_function(f, CallArgs::Single(value)) {
         Ok(new_value) => {
             map.data_mut().insert(key, new_value.clone());
             Ok(new_value)

--- a/src/runtime/src/core/string/iterators.rs
+++ b/src/runtime/src/core/string/iterators.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         make_runtime_error,
         value_iterator::{ExternalIterator, ValueIterator, ValueIteratorOutput as Output},
-        Value, ValueString, Vm,
+        CallArgs, Value, ValueString, Vm,
     },
     unicode_segmentation::UnicodeSegmentation,
 };
@@ -212,7 +212,10 @@ impl Iterator for SplitWith {
                     .input
                     .with_bounds(grapheme_start..grapheme_end)
                     .unwrap();
-                match self.vm.run_function(self.predicate.clone(), &[Str(x)]) {
+                match self
+                    .vm
+                    .run_function(self.predicate.clone(), CallArgs::Single(Str(x)))
+                {
                     Ok(Bool(split_match)) => {
                         if split_match {
                             end = Some(grapheme_start);

--- a/src/runtime/src/core/thread.rs
+++ b/src/runtime/src/core/thread.rs
@@ -1,5 +1,7 @@
 use {
-    crate::{runtime_error, ExternalData, MetaMap, RuntimeError, RwLock, Value, ValueMap},
+    crate::{
+        runtime_error, CallArgs, ExternalData, MetaMap, RuntimeError, RwLock, Value, ValueMap,
+    },
     lazy_static::lazy_static,
     std::{fmt, sync::Arc, thread, thread::JoinHandle, time::Duration},
 };
@@ -15,7 +17,7 @@ pub fn make_module() -> ValueMap {
             let f = f.clone();
             let join_handle = thread::spawn({
                 let mut thread_vm = vm.spawn_shared_concurrent_vm();
-                move || match thread_vm.run_function(f, &[]) {
+                move || match thread_vm.run_function(f, CallArgs::None) {
                     Ok(result) => Ok(result),
                     Err(e) => Err(e.with_prefix("thread.create")),
                 }

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -40,5 +40,5 @@ pub use {
     value_number::ValueNumber,
     value_string::ValueString,
     value_tuple::ValueTuple,
-    vm::{Vm, VmSettings},
+    vm::{CallArgs, Vm, VmSettings},
 };

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -310,6 +310,12 @@ pub struct FunctionInfo {
     pub instance_function: bool,
     /// If the function is variadic, then extra args will be captured in a tuple.
     pub variadic: bool,
+    /// If the function has a single arg, and that arg is an unpacked tuple
+    ///
+    /// This is used to optimize external calls where the caller has a series of args that might be
+    /// unpacked by the function, and it would be wasteful to create a Tuple when it's going to be
+    /// immediately unpacked and discarded.
+    pub arg_is_unpacked_tuple: bool,
     /// The optional list of captures that should be copied into scope when the function is called.
     //
     // Q. Why use a ValueList?


### PR DESCRIPTION
This PR optimizes calls to functions that unpack their tuple argument, making
common iterator operations more efficient.

Iterator chains like `foo.enumerate().each |(i, x)| ...` receive `ValuePair`s
from `.enumerate()`, and then collect the pair into a Tuple before calling
functors. This PR introduces the `CallArgs::AsTuple` concept, which allows the
runtime to collect the pair into a temporary tuple when the function is going to
unpack the tuple, avoiding unnecessary allocations.

This shows performance gains of a few % in relevant benchmark scripts.

Fixes #106.
