### PR TITLE
Changes from Advent of Code days 5 and 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The Koto project adheres to
     # num4(1, 2, 3, 0)
     ```
 
+### Fixed
+
+- Error traces have been made more reliable, with the correct positions being
+  displayed more consistently in calling functions.
+
 ## [0.10.0] 2021.12.02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The Koto project adheres to
 
 ## Unreleased
 
+### Added
+
+- Tuples can now be used when creating Num2 or Num4 values
+  - e.g.
+    ```koto
+    x = 1, 2, 3
+    num4 x
+    # num4(1, 2, 3, 0)
+    ```
+
 ## [0.10.0] 2021.12.02
 
 ### Added

--- a/docs/reference/core_lib/map.md
+++ b/docs/reference/core_lib/map.md
@@ -509,10 +509,10 @@ x
 `|Map, Key, |Value| -> Value| -> Value`
 
 Updates the value associated with a given key by calling a function with either
-the existing value, or `()` if it doesn't there isn't a matching entry.
+the existing value, or `()` if there isn't a matching entry.
 
 The result of the function will either replace an existing value, or if no value
-existed then an entry with the given key will be inserted into the map with the
+existed then an entry will be inserted into the map with the given key and the
 function's result.
 
 The function result is then returned from `update`.

--- a/libs/json/src/lib.rs
+++ b/libs/json/src/lib.rs
@@ -23,7 +23,7 @@ pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<Value, Stri
         JsonValue::Array(a) => {
             match a
                 .iter()
-                .map(|entry| json_value_to_koto_value(entry))
+                .map(json_value_to_koto_value)
                 .collect::<Result<ValueVec, String>>()
             {
                 Ok(result) => Value::List(ValueList::with_data(result)),

--- a/libs/toml/src/lib.rs
+++ b/libs/toml/src/lib.rs
@@ -17,7 +17,7 @@ pub fn toml_to_koto_value(value: &Toml) -> Result<Value, String> {
         Toml::Array(a) => {
             match a
                 .iter()
-                .map(|entry| toml_to_koto_value(entry))
+                .map(toml_to_koto_value)
                 .collect::<Result<ValueVec, String>>()
             {
                 Ok(result) => Value::List(ValueList::with_data(result)),

--- a/libs/yaml/src/lib.rs
+++ b/libs/yaml/src/lib.rs
@@ -23,7 +23,7 @@ pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, Stri
         YamlValue::Sequence(sequence) => {
             match sequence
                 .iter()
-                .map(|entry| yaml_value_to_koto_value(entry))
+                .map(yaml_value_to_koto_value)
                 .collect::<Result<ValueVec, String>>()
             {
                 Ok(result) => Value::List(ValueList::with_data(result)),

--- a/src/bytecode/src/chunk.rs
+++ b/src/bytecode/src/chunk.rs
@@ -47,7 +47,7 @@ impl DebugInfo {
 }
 
 /// A compiled chunk of bytecode, along with its associated constants and metadata
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Chunk {
     /// The bytes representing the chunk's bytecode
     pub bytes: Vec<u8>,
@@ -57,17 +57,6 @@ pub struct Chunk {
     pub source_path: Option<PathBuf>,
     /// Debug information associated with the chunk's bytecode
     pub debug_info: DebugInfo,
-}
-
-impl Default for Chunk {
-    fn default() -> Self {
-        Self {
-            bytes: vec![],
-            constants: ConstantPool::default(),
-            source_path: None,
-            debug_info: DebugInfo::default(),
-        }
-    }
 }
 
 impl Chunk {
@@ -143,7 +132,7 @@ impl Chunk {
                     .line
                     .min(source_lines.len() as u32)
                     .max(1) as usize;
-                result += &format!("|{}| {}\n", line.to_string(), source_lines[line - 1]);
+                result += &format!("|{}| {}\n", line, source_lines[line - 1]);
                 span = Some(instruction_span);
             }
 

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -171,7 +171,7 @@ fn run() -> Result<(), ()> {
                     println!("{}\n", &Chunk::bytes_as_string(chunk.clone()));
                 }
                 if args.show_instructions {
-                    println!("Constants\n---------\n{}\n", chunk.constants.to_string());
+                    println!("Constants\n---------\n{}\n", chunk.constants);
 
                     let script_lines = script.lines().collect::<Vec<_>>();
                     println!(

--- a/src/cli/src/repl.rs
+++ b/src/cli/src/repl.rs
@@ -245,7 +245,7 @@ impl Repl {
                         println!("{}\n", &Chunk::bytes_as_string(chunk.clone()));
                     }
                     if self.settings.show_instructions {
-                        println!("Constants\n---------\n{}\n", chunk.constants.to_string());
+                        println!("Constants\n---------\n{}\n", chunk.constants);
 
                         let script_lines = input.lines().collect::<Vec<_>>();
                         println!(
@@ -326,9 +326,8 @@ impl Repl {
             Some(self.get_help(None))
         } else if input.starts_with("help") {
             input
-                .splitn(2, char::is_whitespace)
-                .nth(1)
-                .map(|search_string| format!("\n{}", self.get_help(Some(search_string))))
+                .split_once(char::is_whitespace)
+                .map(|(_, search_string)| format!("\n{}", self.get_help(Some(search_string))))
         } else {
             None
         }

--- a/src/koto/tests/repl_mode_tests.rs
+++ b/src/koto/tests/repl_mode_tests.rs
@@ -32,7 +32,7 @@ fn run_repl_mode_test(inputs_and_expected_outputs: &[(&str, &str)]) {
         if let Err(error) = koto.run() {
             for (input, chunk) in chunks.iter() {
                 println!("\n--------\n{}\n--------\n", input);
-                println!("Constants\n---------\n{}\n", chunk.constants.to_string());
+                println!("Constants\n---------\n{}\n", chunk.constants);
                 println!(
                     "Instructions\n------------\n{}",
                     Chunk::instructions_as_string(chunk.clone(), &[input])

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -385,13 +385,10 @@ pub fn format_error_with_excerpt(
             );
 
             excerpt += &format!(
-                "{}|{}",
+                "{}|{}{}",
                 padding,
-                format!(
-                    "{}{}",
-                    " ".repeat(start_pos.column as usize),
-                    "^".repeat((end_pos.column - start_pos.column) as usize)
-                ),
+                " ".repeat(start_pos.column as usize),
+                "^".repeat((end_pos.column - start_pos.column) as usize)
             );
 
             (excerpt, padding)

--- a/src/runtime/src/core/string/iterators.rs
+++ b/src/runtime/src/core/string/iterators.rs
@@ -224,8 +224,8 @@ impl Iterator for SplitWith {
                     }
                     Ok(unexpected) => {
                         let error = make_runtime_error!(format!(
-                            "string.split: Expected a bool from match function, got '{}'",
-                            unexpected.to_string()
+                            "string.split: Expected a Bool from the match function, found '{}'",
+                            unexpected.type_as_string()
                         ));
                         return Some(Output::Error(error));
                     }

--- a/src/runtime/src/frame.rs
+++ b/src/runtime/src/frame.rs
@@ -7,6 +7,8 @@ pub(crate) struct Frame {
     // The index in the VM value stack of the first argument register,
     // or the first local register if there are no arguments.
     pub register_base: usize,
+    // When returning to this frame, the ip that produced the most recently read instruction
+    pub return_instruction_ip: usize,
     // When returning to this frame, the register for the return value and the ip to resume from.
     pub return_register_and_ip: Option<(u8, usize)>,
     // A stack of catch points for handling errors
@@ -23,6 +25,7 @@ impl Frame {
             chunk,
             register_base,
             return_register_and_ip: None,
+            return_instruction_ip: 0,
             catch_stack: vec![],
             execution_barrier: false,
         }

--- a/src/runtime/src/value_number.rs
+++ b/src/runtime/src/value_number.rs
@@ -77,8 +77,8 @@ impl ValueNumber {
 impl fmt::Debug for ValueNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ValueNumber::F64(n) => write!(f, "Float({})", n.to_string()),
-            ValueNumber::I64(n) => write!(f, "Int({})", n.to_string()),
+            ValueNumber::F64(n) => write!(f, "Float({})", n),
+            ValueNumber::I64(n) => write!(f, "Int({})", n),
         }
     }
 }

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1046,11 +1046,11 @@ impl Vm {
                     end: None,
                 })
             }
+            (Some(Number(_)), Some(unexpected)) | (None, Some(unexpected)) => {
+                return unexpected_type_error("Number for range end", unexpected);
+            }
             (Some(unexpected), _) => {
                 return unexpected_type_error("Number for range start", unexpected);
-            }
-            (_, Some(unexpected)) => {
-                return unexpected_type_error("Number for range end", unexpected);
             }
         };
 

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -2013,6 +2013,16 @@ impl Vm {
                     }
                     result
                 }
+                Tuple(tuple) => {
+                    let mut result = num2::Num2::default();
+                    for (i, value) in tuple.data().iter().take(2).enumerate() {
+                        match value {
+                            Number(n) => result[i] = n.into(),
+                            unexpected => return unexpected_type_error("Number", unexpected),
+                        }
+                    }
+                    result
+                }
                 unexpected => return unexpected_type_error("Number, Num2, or List", unexpected),
             }
         } else {
@@ -2050,6 +2060,16 @@ impl Vm {
                 List(list) => {
                     let mut result = num4::Num4::default();
                     for (i, value) in list.data().iter().take(4).enumerate() {
+                        match value {
+                            Number(n) => result[i] = n.into(),
+                            unexpected => return unexpected_type_error("Number", unexpected),
+                        }
+                    }
+                    result
+                }
+                Tuple(tuple) => {
+                    let mut result = num4::Num4::default();
+                    for (i, value) in tuple.data().iter().take(4).enumerate() {
                         match value {
                             Number(n) => result[i] = n.into(),
                             unexpected => return unexpected_type_error("Number", unexpected),

--- a/src/runtime/tests/runtime_test_utils.rs
+++ b/src/runtime/tests/runtime_test_utils.rs
@@ -41,13 +41,13 @@ pub fn test_script_with_vm(mut vm: Vm, script: &str, expected_output: Value) {
                 }
                 Err(e) => {
                     print_chunk(script, vm.chunk());
-                    panic!("Error while comparing output value: {}", e.to_string());
+                    panic!("Error while comparing output value: {}", e);
                 }
             }
         }
         Err(e) => {
             print_chunk(script, vm.chunk());
-            panic!("Error while running script: {}", e.to_string());
+            panic!("Error while running script: {}", e);
         }
     }
 }
@@ -56,7 +56,7 @@ pub fn print_chunk(script: &str, chunk: Rc<Chunk>) {
     println!("{}\n", script);
     let script_lines = script.lines().collect::<Vec<_>>();
 
-    println!("Constants\n---------\n{}\n", chunk.constants.to_string());
+    println!("Constants\n---------\n{}\n", chunk.constants);
     println!(
         "Instructions\n------------\n{}",
         Chunk::instructions_as_string(chunk, &script_lines)

--- a/src/runtime/tests/stdout.rs
+++ b/src/runtime/tests/stdout.rs
@@ -57,7 +57,7 @@ mod vm {
             println!("{}\n", script);
             let script_lines = script.lines().collect::<Vec<_>>();
 
-            println!("Constants\n---------\n{}\n", chunk.constants.to_string());
+            println!("Constants\n---------\n{}\n", chunk.constants);
             println!(
                 "Instructions\n------------\n{}",
                 Chunk::instructions_as_string(chunk, &script_lines)
@@ -79,7 +79,7 @@ mod vm {
             }
             Err(e) => {
                 print_chunk(script, vm.chunk());
-                panic!("Error while running script: {}", e.to_string());
+                panic!("Error while running script: {}", e);
             }
         }
     }


### PR DESCRIPTION
A collection of various issues I found while working on Avent of Code days
[5](https://github.com/irh/advent-of-code-koto-2021/blob/main/05.koto) and
[6](https://github.com/irh/advent-of-code-koto-2021/blob/main/06.koto).

- Fix typo in map.update docs
- Allow tuples as argument when constructing num2/num4
- Fix misleading error message when passing Empty as range end
- Fix error traces so that correct calling frame positions are displayed
- Listen to clippy
