### PR TITLE
Meta value assignment improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,33 @@ The Koto project adheres to
     # num4(1, 2, 3, 0)
     ```
 
+### Changed
+
+- Assigning to a module's meta map has been reworked
+  - The `export` keyword is no longer needed to assign to a meta key, as meta
+    keys can never be assigned locally.
+    - e.g.
+      ```koto
+      # Before
+      export @tests =
+        ...
+      # After
+      @tests =
+        ...
+      ```
+  - `main` functions are now defined using the `@main` meta key.
+    - This is so that modules don't have to pollute their public exported API to
+      take advantage of having a main funciton.
+    - e.g.
+      ```koto
+      # Before
+      export main = ||
+        ...
+      # After
+      @main = ||
+        ...
+      ```
+
 ### Fixed
 
 - Error traces have been made more reliable, with the correct positions being

--- a/docs/reference/core_lib/test.md
+++ b/docs/reference/core_lib/test.md
@@ -4,7 +4,7 @@ A collection of utilities for writing tests.
 
 ## Writing tests
 
-To add tests to a Koto script, `export` a Map named `@tests`, and then any
+To add tests to a Koto script, create a Map named `@tests`, and then any
 functions in the Map tagged with `@test` will be run as tests.
 
 If a function named `@pre_test` is in the `@tests` Map, then it will be run
@@ -20,8 +20,8 @@ first argument, then the `@tests` Map itself will be passed in as `self`.
 ### Example
 
 ```koto
-# Tests are exported from a module as a map named `@tests`
-export @tests =
+# A module's tests are defined as a map named `@tests`
+@tests =
   # '@pre_test' will be run before each test
   @pre_test: |self|
     self.test_data = 1, 2, 3

--- a/examples/poetry/scripts/readme.koto
+++ b/examples/poetry/scripts/readme.koto
@@ -1,6 +1,6 @@
 import io.print
 
-export main = ||
+@main = ||
   input_file = io.extend_path koto.script_dir, "..", "..", "..", "README.md"
   generator = poetry
     .new io.read_to_string input_file

--- a/examples/poetry/scripts/reference.koto
+++ b/examples/poetry/scripts/reference.koto
@@ -1,6 +1,6 @@
 import io.print
 
-export main = ||
+@main = ||
   input_file = io.extend_path koto.script_dir, "..", "..", "..",
     "docs", "reference", "core_lib", "string.md"
   input_file = koto.script_dir + "/../../../docs/reference/core_lib/string.md"

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export main = ||
+@main = ||
   n = match koto.args.get 0
     () then 10
     arg then arg.to_number()

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -9,7 +9,7 @@ export main = ||
   for i in 0..n
     a = (10..20).enumerate().to_tuple()
 
-export @tests =
+@tests =
   @test it_works: ||
     x = (1..=3).enumerate().to_tuple()
     assert_eq x, ((0, 1), (1, 2), (2, 3))

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -62,7 +62,7 @@ fannkuch = |n|
         t = p.remove 1
         p.insert (i + 1), t
 
-export main = ||
+@main = ||
   n = match koto.args.get 0
     () then 4
     arg then arg.to_number()

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -73,7 +73,7 @@ export main = ||
     print sum
     print "Pfannkuchen($n) = $flips"
 
-export @tests =
+@tests =
   @test fannkuch_5: ||
     sum, flips = fannkuch 5
     assert_eq sum, 11

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -6,7 +6,7 @@ fib = |n|
     n == 1 then 1
     else (fib n - 1) + (fib n - 2)
 
-export main = ||
+@main = ||
   n = match koto.args.get 0
     () then 8
     arg then arg.to_number()

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -13,7 +13,7 @@ export main = ||
 
   fib n
 
-export @tests =
+@tests =
   @test fib: ||
     assert_eq (fib 4), 3
     assert_eq (fib 5), 5

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -127,7 +127,7 @@ export main = ||
     print "{:.9}", initial_energy
     print "{:.9}", end_energy
 
-export @tests =
+@tests =
   @test nbody_100: ||
     initial_energy, end_energy = run_nbody 100
     assert_near initial_energy, -0.16907514, 1.0e-8

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -114,7 +114,7 @@ run_nbody = |n|
   initial_energy, end_energy
 
 
-export main = ||
+@main = ||
   n = match koto.args.get 0
     () then 100
     arg then arg.to_number()

--- a/koto/benches/num4.koto
+++ b/koto/benches/num4.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export main = ||
+@main = ||
   n = match koto.args.get 0
     () then 10
     arg then arg.to_number()

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -46,8 +46,7 @@ spectral_norm = |n|
     vv = vv + vi * vi
   (vBv / vv).sqrt()
 
-
-export main = ||
+@main = ||
   n = match koto.args.get 0
     () then 4
     arg then arg.to_number()
@@ -56,7 +55,6 @@ export main = ||
 
   if (koto.args.get 1) != "quiet"
     io.print result
-
 
 @tests =
   @test spectral_norm_5: ||

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -58,6 +58,6 @@ export main = ||
     io.print result
 
 
-export @tests =
+@tests =
   @test spectral_norm_5: ||
     assert_near (spectral_norm 5), 1.261218, 1e-6

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -27,7 +27,7 @@ number_to_english = |n|
         "$x_string hundred and ${number_to_english y}"
     else "???"
 
-export main = ||
+@main = ||
   n = match koto.args.get 0
     () then 50
     arg then arg.to_number()

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -39,7 +39,7 @@ export main = ||
   if not (koto.args.get 1) == "quiet"
     io.print result
 
-export @tests =
+@tests =
   @test number_to_english: ||
     import test.assert_eq
 

--- a/koto/tests/assignment.koto
+++ b/koto/tests/assignment.koto
@@ -1,6 +1,6 @@
 from test import assert_eq, assert_ne
 
-export @tests =
+@tests =
   @test basic_assignment: ||
     a = 1
     b = -a

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test inline_if: ||
     x = if true then 10 else 20
     assert_eq x, 10

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -14,7 +14,7 @@ make_bidirectional_enum = |entries...|
       enum.insert index, id
       enum
 
-export @tests =
+@tests =
   @test make_enum: ||
     enum = make_enum "foo", "bar", "baz"
     assert_eq enum.foo, 0

--- a/koto/tests/error_handling.koto
+++ b/koto/tests/error_handling.koto
@@ -1,7 +1,7 @@
 import error_handling_module
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test try_expression: ||
     x = try
       42

--- a/koto/tests/function_closures.koto
+++ b/koto/tests/function_closures.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export @tests =
+@tests =
   @test value_capture_on_function_creation: ||
     multipliers = (1..=4)
       .each |i| return |n| n * i

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test square: ||
     square = |x| x * x
     assert_eq (square 7), 49

--- a/koto/tests/functions_in_lookups.koto
+++ b/koto/tests/functions_in_lookups.koto
@@ -9,7 +9,7 @@ test_map = ||
 # Make a list of two test maps
 maps = [test_map(), test_map()]
 
-export @tests =
+@tests =
   @test call_setter_in_child_map_in_list: ||
     # set the first map's child foo
     assert_eq maps[0].get_child_map().foo, 42

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -18,7 +18,7 @@ If a string is used for the imported name, then the imported module isn't automa
 brought into scope, and it needs to be assigned to a local value.
 -#
 
-export @tests =
+@tests =
   @test import_module: ||
     # The test_module module being imported here is defined in the neighbouring
     # test_module directory, with test_module/main.koto as its entry point.

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -8,7 +8,7 @@ bbb
 ccc
 "
 
-export @tests =
+@tests =
   @test current_dir: ||
     assert_ne io.current_dir(), ""
 

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export @tests =
+@tests =
   @test next: ||
     i = (1..=3).iter()
     assert_eq i.next(), 1
@@ -91,7 +91,7 @@ export @tests =
 
   @test cycle: ||
     result = 1..=3
-      .cycle() 
+      .cycle()
       .take(10)
       .to_list()
     assert_eq result, [1, 2, 3, 1, 2, 3, 1, 2, 3, 1]

--- a/koto/tests/libs/json.koto
+++ b/koto/tests/libs/json.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test serialize_and_deserialize_json: ||
     file_data = try
       path = io.extend_path koto.script_dir, "data", "test.json"

--- a/koto/tests/libs/random.koto
+++ b/koto/tests/libs/random.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq, assert_ne, assert_near
 
-export @tests =
+@tests =
   @pre_test: ||
     # random.seed seeds the default generator
     random.seed 0

--- a/koto/tests/libs/tempfile.koto
+++ b/koto/tests/libs/tempfile.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test temp_file: ||
     temp = tempfile.temp_file()
     temp.write_line "hello"

--- a/koto/tests/libs/toml.koto
+++ b/koto/tests/libs/toml.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export @tests =
+@tests =
   @test serialize_and_deserialize_toml: ||
     path = io.extend_path koto.script_dir, "data", "test.toml"
     file_data = io.read_to_string path

--- a/koto/tests/libs/yaml.koto
+++ b/koto/tests/libs/yaml.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export @tests =
+@tests =
   @test serialize_and_deserialize_yaml: ||
     path = io.extend_path koto.script_dir, "data", "test.yaml"
     file_data = io.read_to_string path

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export @tests =
+@tests =
   @test clear: ||
     x = [1, 2, 3, 4, 5]
     x.clear()

--- a/koto/tests/lists.koto
+++ b/koto/tests/lists.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq, assert_ne
 
-export @tests =
+@tests =
   @test list_indexing: ||
     z = [10, 10 + 10, 30]
     assert_eq z[0], 10

--- a/koto/tests/logic.koto
+++ b/koto/tests/logic.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test and_not_or: ||
     assert true and true
     assert not true and false

--- a/koto/tests/loops.koto
+++ b/koto/tests/loops.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test for_block: ||
     count = 0
     for x in 0..10

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export @tests =
+@tests =
   @test clear: ||
     m = foo: 42, bar: 99
     m.clear()

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq, assert_ne
 
-export @tests =
+@tests =
   @test access_by_key: ||
     m = key: "value", another_key: "another_value"
     assert_eq m.key, "value"

--- a/koto/tests/maps_and_lists.koto
+++ b/koto/tests/maps_and_lists.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export @tests =
+@tests =
   @test lists_in_maps: ||
     x =
       foo: [10, 11, 12]

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -42,7 +42,7 @@ locals.foo_meta =
   @meta hello: "Hello"
   @meta say_hello: |self, name| "${self.hello}, $name!"
 
-export @tests =
+@tests =
   @test add: ||
     assert_eq (foo(10) + foo(20)), foo 30
 

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export @tests =
+@tests =
   @test creating: ||
     assert_eq (num4 0), (num4 0, 0, 0, 0)
     assert_eq (num2 1), (num2 1, 1)

--- a/koto/tests/number_ops.koto
+++ b/koto/tests/number_ops.koto
@@ -4,7 +4,7 @@ from test import assert, assert_eq, assert_near
 
 epsilon = 1.0e-15
 
-export @tests =
+@tests =
   @test abs: ||
     assert_eq -1.abs(), 1
     assert_eq 3.abs(), 3

--- a/koto/tests/numbers.koto
+++ b/koto/tests/numbers.koto
@@ -1,6 +1,6 @@
 import test.assert_eq
 
-export @tests =
+@tests =
   @test arithmetic: ||
     assert_eq 1 + 1, 2
     assert_eq 2 - 2, 0

--- a/koto/tests/ranges.koto
+++ b/koto/tests/ranges.koto
@@ -1,6 +1,6 @@
 from test import assert, assert_eq
 
-export @tests =
+@tests =
   @test assignment: ||
     # Assigning a range to a value
     r = 0..2

--- a/koto/tests/string_formatting.koto
+++ b/koto/tests/string_formatting.koto
@@ -1,6 +1,6 @@
 import number.pi, test.assert_eq
 
-export @tests =
+@tests =
   @test format: ||
     # A string is expected as first argument for string.format
     assert_eq (string.format "Hello, World!"), "Hello, World!"

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -1,7 +1,7 @@
 import koto.type
 from test import assert, assert_eq, assert_ne
 
-export @tests =
+@tests =
   @test comparisons: ||
     assert_eq "Hello", "Hello"
     assert_ne "Hello", "Héllö"

--- a/koto/tests/test_module/baz.koto
+++ b/koto/tests/test_module/baz.koto
@@ -5,6 +5,6 @@ assert_eq pi, pi
 
 export qux = ()
 
-export main = ||
+@main = ||
   # Redefine qux to check that main has been called
   export qux = "O_o"

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -14,6 +14,6 @@ export square = |x| x * x
 
 export tests_were_run = false
 
-export @tests =
+@tests =
   @test run_tests: ||
     export tests_were_run = true

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -2,7 +2,7 @@ from test import assert, assert_eq, assert_ne, assert_near, run_tests
 
 # A script can export a map named 'tests' to have the tests automatically run when
 # the script is loaded.
-export @tests =
+@tests =
   # '@pre_test' will be run before each test
   @pre_test: |self|
     self.test_data = 1, 2, 3

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -6,7 +6,7 @@ make_foo = |x|
   @>: |self, other| self.x > other.x
   @==: |self, other| self.x == other.x
 
-export @tests =
+@tests =
   @test for_loop: ||
     a = 1, 2, 3
     z = []

--- a/koto/tests/types.koto
+++ b/koto/tests/types.koto
@@ -1,6 +1,6 @@
 import koto.type, test.assert_eq
 
-export @tests =
+@tests =
   @test type_returns_type_name: ||
     assert_eq (type true), "Bool"
     assert_eq (type |x| x * x), "Function"

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -961,7 +961,7 @@ impl Compiler {
                     return compiler_error!(self, "Expected Id in AST, found {}", unexpected)
                 }
             },
-            Scope::Export => None,
+            _ => None,
         };
 
         Ok(result)

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -441,14 +441,14 @@ pub enum Op {
 
     /// Adds a key/value entry into the module's exported metamap
     ///
-    /// Used for expressions like `export @tests = ...`
+    /// Used for expressions like `@tests = ...`
     ///
     /// `[*key, *value]`
     MetaExport,
 
     /// Adds a named key/value entry into the module's exported metamap
     ///
-    /// Used for expressions like `export @tests = ...`
+    /// Used for expressions like `@tests = ...`
     ///
     /// `[*key, *name, *value]`
     MetaExportNamed,

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -201,7 +201,14 @@ impl Koto {
                 }
             }
 
-            if let Some(main) = self.runtime.get_exported_function("main") {
+            let maybe_main = self
+                .runtime
+                .context()
+                .exports
+                .meta()
+                .get(&MetaKey::Main)
+                .cloned();
+            if let Some(main) = maybe_main {
                 self.runtime
                     .run_function(main, CallArgs::None)
                     .map_err(|e| e.into())

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -55,6 +55,7 @@ pub enum SyntaxError {
     AsciiEscapeCodeOutOfRange,
     ExpectedArgsEnd,
     ExpectedAssignmentTarget,
+    ExpectedAssignmentAfterMetaKey,
     ExpectedCatchArgument,
     ExpectedCatch,
     ExpectedCloseParen,
@@ -119,6 +120,7 @@ pub enum SyntaxError {
     UnexpectedTokenAfterDollarInString,
     UnexpectedTokenInImportExpression,
     UnicodeEscapeCodeOutOfRange,
+    UnnecessaryExportKeywordForMetaKey,
     UnterminatedNumericEscapeCode,
     UnterminatedString,
 }
@@ -257,6 +259,7 @@ impl fmt::Display for SyntaxError {
             }
             ExpectedArgsEnd => f.write_str("Expected end of arguments ')'"),
             ExpectedAssignmentTarget => f.write_str("Expected target for assignment"),
+            ExpectedAssignmentAfterMetaKey => f.write_str("Expected '=' assignment after meta key"),
             ExpectedCatchArgument => f.write_str("Expected argument for catch expression"),
             ExpectedCatch => f.write_str("Expected catch expression after try"),
             ExpectedCloseParen => f.write_str("Expected closing parenthesis"),
@@ -348,6 +351,9 @@ impl fmt::Display for SyntaxError {
             }
             UnicodeEscapeCodeOutOfRange => {
                 f.write_str("Unicode value out of range, the maximum is \\u{10ffff}")
+            }
+            UnnecessaryExportKeywordForMetaKey => {
+                f.write_str("'export' is unnecessary when assigning to a meta key")
             }
             UnterminatedNumericEscapeCode => f.write_str("Unterminated numeric escape code"),
             UnterminatedString => f.write_str("Unterminated string"),

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -110,13 +110,13 @@ pub enum SyntaxError {
     UnexpectedElseIndentation,
     UnexpectedElseIfIndentation,
     UnexpectedEscapeInString,
+    UnexpectedExportAssignmentOp,
     UnexpectedMatchElse,
     UnexpectedMatchIf,
     UnexpectedMetaKey,
     UnexpectedSwitchElse,
     UnexpectedToken,
     UnexpectedTokenAfterDollarInString,
-    UnexpectedTokenAfterExportId,
     UnexpectedTokenInImportExpression,
     UnicodeEscapeCodeOutOfRange,
     UnterminatedNumericEscapeCode,
@@ -332,6 +332,9 @@ impl fmt::Display for SyntaxError {
             UnexpectedElseIndentation => f.write_str("Unexpected indentation for else block"),
             UnexpectedElseIfIndentation => f.write_str("Unexpected indentation for else if block"),
             UnexpectedEscapeInString => f.write_str("Unexpected escape pattern in string"),
+            UnexpectedExportAssignmentOp => {
+                f.write_str("Unexpected assignment op for export expression (expected '=')")
+            }
             UnexpectedMatchElse => f.write_str("Unexpected else in match arm"),
             UnexpectedMatchIf => f.write_str("Unexpected if condition in match arm"),
             UnexpectedMetaKey => f.write_str("Unexpected meta key"),
@@ -340,7 +343,6 @@ impl fmt::Display for SyntaxError {
             UnexpectedTokenAfterDollarInString => {
                 f.write_str("Unexpected token after $ in string, expected $ID or ${expression}")
             }
-            UnexpectedTokenAfterExportId => f.write_str("Unexpected token after export ID"),
             UnexpectedTokenInImportExpression => {
                 f.write_str("Unexpected token in import expression")
             }

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -597,6 +597,9 @@ pub enum MetaKeyId {
     /// @post_test
     PostTest,
 
+    /// @main
+    Main,
+
     /// @meta name
     Named,
 

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -843,6 +843,7 @@ impl<'source> Parser<'source> {
                     _ => return syntax_error!(ExpectedMetaId, self),
                 },
                 "type" => MetaKeyId::Type,
+                "main" => MetaKeyId::Main,
                 _ => return syntax_error!(UnexpectedMetaKey, self),
             },
             Some(Token::SquareOpen) => match self.consume_token() {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -34,6 +34,16 @@ mod parser {
         }
     }
 
+    fn check_ast_for_equivalent_sources(
+        sources: &[&str],
+        expected_ast: &[Node],
+        expected_constants: Option<&[Constant]>,
+    ) {
+        for source in sources {
+            check_ast(source, expected_ast, expected_constants)
+        }
+    }
+
     fn constant(index: u8) -> ConstantIndex {
         ConstantIndex::from(index)
     }
@@ -1006,9 +1016,18 @@ num4(
 
         #[test]
         fn single_export() {
-            let source = "export a = 1 + 1";
-            check_ast(
-                source,
+            let sources = [
+                "export a = 1 + 1",
+                "
+export a
+  = 1 + 1",
+                "
+export a =
+  1 + 1",
+            ];
+
+            check_ast_for_equivalent_sources(
+                &sources,
                 &[
                     Id(constant(0)),
                     Number1,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -654,9 +654,9 @@ x =
         }
 
         #[test]
-        fn map_block_tests() {
+        fn assigning_map_to_meta_key() {
             let source = r#"
-export @tests =
+@tests =
   @pre_test: 0
   @post_test: 1
   @test foo: 0

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -43,6 +43,11 @@ mod parser {
             check_parsing_fails("import foo bar");
         }
 
+        #[test]
+        fn unnecessary_export_with_meta_key() {
+            check_parsing_fails("export @tests = 42");
+        }
+
         mod indentation {
             use super::*;
 

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -360,6 +360,7 @@ pub enum MetaKey {
     Tests,
     PreTest,
     PostTest,
+    Main,
     Type,
 }
 
@@ -373,6 +374,7 @@ impl MetaKey {
             MetaKey::Tests => MetaKeyRef::Tests,
             MetaKey::PreTest => MetaKeyRef::PreTest,
             MetaKey::PostTest => MetaKeyRef::PostTest,
+            MetaKey::Main => MetaKeyRef::Main,
             MetaKey::Type => MetaKeyRef::Type,
         }
     }
@@ -480,6 +482,7 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKe
         MetaKeyId::Test => MetaKey::Test(name.ok_or_else(|| "Missing name for test".to_string())?),
         MetaKeyId::PreTest => MetaKey::PreTest,
         MetaKeyId::PostTest => MetaKey::PostTest,
+        MetaKeyId::Main => MetaKey::Main,
         MetaKeyId::Type => MetaKey::Type,
         MetaKeyId::Invalid => return Err("Invalid MetaKeyId".to_string()),
     };
@@ -497,6 +500,7 @@ enum MetaKeyRef<'a> {
     Tests,
     PreTest,
     PostTest,
+    Main,
     Type,
 }
 


### PR DESCRIPTION
- The `export` keyword is no longer needed to assign to a meta key, as meta keys can never be assigned locally.
  - e.g.
    ```coffee
    # Before
    export @tests =
      ...
    # After
    @tests =
      ...
    ```
- `main` functions are now defined using the `@main` meta key.
  - This is so that modules don't have to pollute their public exported API to take advantage of having a main funciton.
  - e.g.
    ```coffee
    # Before
    export main = ||
      ...
    # After
    @main = ||
      ...
    ```
