### PR TITLE
Advent of Code Day 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ The Koto project adheres to
       @main = ||
         ...
       ```
+- Map equality comparisons now don't rely on maps having keys in the same order.
+  - e.g.
+    ```koto
+    x = foo: 42, bar: 99
+    y = bar: 99, foo: 42
+    # Before
+    assert_eq x != y, true
+    # After
+    assert_eq x == y, true
+    ```
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The Koto project adheres to
 ### Added
 
 - Core Library
+  - New additions:
+    - `iterator.find`
+    - `number.round`
   - List operations that modify the list but previously returned Empty,
     now return the modified list.
     - e.g.
@@ -25,7 +28,6 @@ The Koto project adheres to
       x.push 4
       # [1, 2, 3, 4]
       ```
-  - `number.round` has been added.
   - `iterator.consume` now accepts an optional function that will be called
     for each iterator output value.
     - e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ The Koto project adheres to
 ### Added
 
 - Core Library
+  - List operations that modify the list but previously returned Empty,
+    now return the modified list.
+    - e.g.
+      ```koto
+      x = [1, 2, 3]
+
+      # Before
+      x.push 4
+      # ()
+
+      # After
+      x.push 4
+      # [1, 2, 3, 4]
+      ```
   - `number.round` has been added.
   - `iterator.consume` now accepts an optional function that will be called
     for each iterator output value.

--- a/docs/reference/core_lib/iterator.md
+++ b/docs/reference/core_lib/iterator.md
@@ -55,6 +55,7 @@ for x in (2, 3, 4).each |n| n * 2
 - [cycle](#cycle)
 - [each](#each)
 - [enumerate](#enumerate)
+- [find](#find)
 - [fold](#fold)
 - [intersperse](#intersperse)
 - [iter](#iter)
@@ -271,6 +272,32 @@ Returns an iterator that provides each value along with an associated index.
 # [(0, "a"), (1, "b"), (2, "c")]
 ```
 
+## find
+
+`|Iterable, |Value| -> Bool| -> Value`
+
+Returns the first value in the iterable that passes the test function.
+
+The function is called for each value in the iterator, and returns either `true`
+if the value is a match, or `false` if it's not.
+
+The first matching value will cause iteration to stop.
+
+If no match is found then `()` is returned.
+
+### Example
+
+```koto
+(10..20).find |x| x > 14 and x < 16
+# 15
+
+(10..20).find |x| x > 100
+# ()
+```
+
+### See Also
+
+- [`iterator.find`](#find)
 ## fold
 
 `|Iterable, Value, |Value, Value| -> Value| -> Value`
@@ -507,6 +534,10 @@ If no match is found then `()` is returned.
 (10..20).position |x| x == 99
 # ()
 ```
+
+### See Also
+
+- [`iterator.find`](#find)
 
 ## product
 

--- a/docs/reference/core_lib/list.md
+++ b/docs/reference/core_lib/list.md
@@ -137,15 +137,16 @@ x # a deep copy has been made, so x is unaffected by the assignment to y
 
 ## fill
 
-`|List, Value| -> ()`
+`|List, Value| -> List`
 
-Fills the list with copies of the provided value.
+Fills the list with copies of the provided value, and returns the list.
 
 ### Example
 
 ```koto
 x = [1, 2, 3]
 x.fill 99
+# [99, 99, 99]
 x
 # [99, 99, 99]
 ```
@@ -200,9 +201,9 @@ value is returned. If no default value is provided then `()` is returned.
 
 ## insert
 
-`|List, Number, Value| -> ()`
+`|List, Number, Value| -> List`
 
-Inserts the value into the Nth position in the list.
+Inserts the value into the Nth position in the list, and returns the list.
 
 An error is thrown if the position is negative or greater than the size of the
 list.
@@ -210,7 +211,10 @@ list.
 ### Example
 
 ```koto
-[99, -1, 42].insert 2, "hello"
+x = [99, -1, 42]
+x.insert 2, "hello"
+# [99, -1, "hello", 42]
+x
 # [99, -1, "hello", 42]
 ```
 
@@ -283,14 +287,17 @@ x
 
 ## push
 
-`|List, Value| -> ()`
+`|List, Value| -> Value`
 
-Adds the value to the end of the list.
+Adds the value to the end of the list, and returns the list.
 
 ### Example
 
 ```koto
-[99, -1].push "hello"
+x = [99, -1]
+x.push "hello"
+# [99, -1, "hello"]
+x
 # [99, -1, "hello"]
 ```
 
@@ -340,9 +347,10 @@ x
 
 ## retain
 
-`|List, Value| -> ()`
+`|List, Value| -> List`
 
-Retains matching values in the list, discarding values that don't match.
+Retains matching values in the list (discarding values that don't match), and
+returns the list.
 
 If the test value is a function, then the function will be called with each of
 the list's values, and if the function returns `true` then the value will be
@@ -357,26 +365,29 @@ using the `==` equality operator, and then retained if they match.
 ```koto
 x = [1..10]
 x.retain |n| n < 5
+# [1, 2, 3, 4]
 x
 # [1, 2, 3, 4]
 
 x = [1, 3, 8, 3, 9, -1]
 x.retain 3
+# [3, 3]
 x
 # [3, 3]
 ```
 
 ## reverse
 
-`|List| -> ()`
+`|List| -> List`
 
-Reverses the order of the list's contents.
+Reverses the order of the list's contents, and returns the list.
 
 ### Example
 
 ```koto
 x = ["hello", -1, 99, "world"]
 x.reverse()
+# ["world", 99, -1, "hello"]
 x
 # ["world", 99, -1, "hello"]
 ```
@@ -400,14 +411,15 @@ x.size()
 
 ## sort
 
-`|List| -> ()`
+`|List| -> List`
 
-Sorts the list in place.
+Sorts the list in place, and returns the list.
 
-`|List, |Value| -> Value| -> ()`
+`|List, |Value| -> Value| -> List`
 
 Sorts the list in place, based on the output of calling a 'key' function for
-each value. The function result is cached, so it's only called once per value.
+each value, and returns the list. The function result is cached, so it's only
+called once per value.
 
 ### Example
 
@@ -481,20 +493,22 @@ Returns a copy of the list data as a tuple.
 
 ## transform
 
-`|List, |Value| -> Value| -> ()`
+`|List, |Value| -> Value| -> List`
 
-Transforms the list data by calling a function with each value and then
-replacing the value with the function result.
+Transforms the list data by replacing each value with the result of calling the
+provided function, and then returns the list.
 
 ### Example
 
 ```koto
 x = ["aaa", "bb", "c"]
 x.transform string.size
+# [3, 2, 1]
 x
 # [3, 2, 1]
 
 x.transform |n| "{}".format n
+# ["3", "2", "1"]
 x
 # ["3", "2", "1"]
 ```

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -117,6 +117,10 @@ make_foo = |x|
       (10..=12).enumerate().to_tuple(),
       ((0, 10), (1, 11), (2, 12))
 
+  @test find: ||
+    assert_eq (1..10).find(|n| n > 4 and n < 6), 5
+    assert_eq "heyNow".find(|c| c.to_uppercase() == c), "N"
+
   @test fold: ||
     assert_eq (1..=5).fold(0, |sum, x| sum + x), 15
 

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -150,8 +150,9 @@ make_foo = |x|
     z = [a[3], a[1], a[0], a[2]] # 3, 2, 1, 2
     z.sort |n| -n.x # reverse sorting
 
+    a_last = a.size() - 1
     for n in 0..z.size()
-      assert_eq z[n].x, a[a.size() - 1 - n].x
+      assert_eq z[n].x, a[a_last - n].x
 
   @test sort_copy: ||
     assert_eq [42, 10, 9].sort_copy(), [9, 10, 42]

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1089,14 +1089,17 @@ impl<'source> Parser<'source> {
                         self.peek_token(),
                         Some(Token::Id | Token::SingleQuote | Token::DoubleQuote)
                     ) {
+                        // This check prevents detached dot accesses, e.g. `x. foo`
                         return syntax_error!(ExpectedMapKey, self);
                     } else if let Some(id_index) =
                         self.parse_id(&mut ExpressionContext::restricted())?
                     {
-                        lookup.push((LookupNode::Id(id_index), self.current_span()));
+                        node_start_span = self.current_span();
+                        lookup.push((LookupNode::Id(id_index), node_start_span));
                     } else if let Some((lookup_string, span)) =
                         self.parse_string(&mut ExpressionContext::restricted())?
                     {
+                        node_start_span = span;
                         lookup.push((LookupNode::Str(lookup_string), span));
                     } else {
                         return syntax_error!(ExpectedMapKey, self);

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -67,7 +67,7 @@ pub fn make_module() -> ValueMap {
             for v in l.data_mut().iter_mut() {
                 *v = value.clone();
             }
-            Ok(Empty)
+            Ok(List(l.clone()))
         }
         unexpected => unexpected_type_error_with_slice(
             "list.fill",
@@ -112,7 +112,7 @@ pub fn make_module() -> ValueMap {
             }
 
             l.data_mut().insert(index, value.clone());
-            Ok(Empty)
+            Ok(List(l.clone()))
         }
         unexpected => unexpected_type_error_with_slice(
             "list.insert",
@@ -151,7 +151,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("push", |vm, args| match vm.get_args(args) {
         [List(l), value] => {
             l.data_mut().push(value.clone());
-            Ok(Empty)
+            Ok(List(l.clone()))
         }
         unexpected => unexpected_type_error_with_slice(
             "list.push",
@@ -194,7 +194,7 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("retain", |vm, args| {
-        match vm.get_args(args) {
+        let result = match vm.get_args(args) {
             [List(l), f] if f.is_callable() => {
                 let l = l.clone();
                 let f = f.clone();
@@ -220,6 +220,7 @@ pub fn make_module() -> ValueMap {
                     }
                 }
                 l.data_mut().resize(write_index, Empty);
+                l
             }
             [List(l), value] => {
                 let l = l.clone();
@@ -250,6 +251,7 @@ pub fn make_module() -> ValueMap {
                 if let Some(error) = error {
                     return error;
                 }
+                l
             }
             unexpected => {
                 return unexpected_type_error_with_slice(
@@ -258,15 +260,15 @@ pub fn make_module() -> ValueMap {
                     unexpected,
                 )
             }
-        }
+        };
 
-        Ok(Empty)
+        Ok(List(result))
     });
 
     result.add_fn("reverse", |vm, args| match vm.get_args(args) {
         [List(l)] => {
             l.data_mut().reverse();
-            Ok(Empty)
+            Ok(List(l.clone()))
         }
         unexpected => {
             unexpected_type_error_with_slice("list.reverse", "a List as argument", unexpected)
@@ -285,7 +287,7 @@ pub fn make_module() -> ValueMap {
             let l = l.clone();
             let mut data = l.data_mut();
             sort_values(vm, &mut data)?;
-            Ok(Empty)
+            Ok(List(l.clone()))
         }
         [List(l), f] if f.is_callable() => {
             let l = l.clone();
@@ -330,7 +332,7 @@ pub fn make_module() -> ValueMap {
                 .map(|(_key, value)| value.clone())
                 .collect::<_>();
 
-            Ok(Empty)
+            Ok(List(l))
         }
         unexpected => {
             unexpected_type_error_with_slice("list.sort", "a List as argument", unexpected)
@@ -351,7 +353,6 @@ pub fn make_module() -> ValueMap {
     result.add_fn("swap", |vm, args| match vm.get_args(args) {
         [List(a), List(b)] => {
             std::mem::swap(a.data_mut().deref_mut(), b.data_mut().deref_mut());
-
             Ok(Empty)
         }
         unexpected => {
@@ -378,7 +379,7 @@ pub fn make_module() -> ValueMap {
                 }
             }
 
-            Ok(Empty)
+            Ok(List(l))
         }
         unexpected => unexpected_type_error_with_slice(
             "list.transform",

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1795,19 +1795,20 @@ impl Vm {
             return Ok(false);
         }
 
-        for ((key_a, value_a), (key_b, value_b)) in map_a.data().iter().zip(map_b.data().iter()) {
-            if key_a != key_b {
-                return Ok(false);
-            }
-            match self.run_binary_op(BinaryOp::Equal, value_a.clone(), value_b.clone())? {
-                Value::Bool(true) => {}
-                Value::Bool(false) => return Ok(false),
-                other => {
-                    return runtime_error!(
-                        "Expected Bool from equality comparison, found '{}'",
-                        other.type_as_string()
-                    );
+        for (key_a, value_a) in map_a.data().iter() {
+            if let Some(value_b) = map_b.data().get(key_a) {
+                match self.run_binary_op(BinaryOp::Equal, value_a.clone(), value_b.clone())? {
+                    Value::Bool(true) => {}
+                    Value::Bool(false) => return Ok(false),
+                    other => {
+                        return runtime_error!(
+                            "Expected Bool from equality comparison, found '{}'",
+                            other.type_as_string()
+                        );
+                    }
                 }
+            } else {
+                return Ok(false);
             }
         }
 

--- a/src/runtime/tests/runtime_failures.rs
+++ b/src/runtime/tests/runtime_failures.rs
@@ -96,6 +96,14 @@ f [1, 2, 3]
 "#;
                 check_script_fails(script);
             }
+
+            #[test]
+            fn capturing_a_reserved_value_in_a_temporary_function() {
+                let script = "
+x = (1..10).find |n| n == x
+";
+                check_script_fails(script);
+            }
         }
     }
 }

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1505,8 +1505,17 @@ m = {foo: -1, bar: 42} + {foo: 99}
         #[test]
         fn equality() {
             let script = "
-m = {foo: 42, bar: || 99}
-m2 = m
+m = foo: 42, bar: 'abc'
+m2 = m.copy()
+m == m2";
+            test_script(script, true.into());
+        }
+
+        #[test]
+        fn equality_different_key_order() {
+            let script = "
+m = foo: 42, bar: 'abc'
+m2 = bar: 'abc', foo: 42
 m == m2";
             test_script(script, true.into());
         }
@@ -1514,9 +1523,8 @@ m == m2";
         #[test]
         fn inequality() {
             let script = "
-m = {foo: 42, bar: || 99}
-m2 = m.copy()
-m2.foo = 99
+m = foo: 42, bar: 'xyz'
+m2 = foo: 42, bar: 'abc'
 m != m2";
             test_script(script, true.into());
         }


### PR DESCRIPTION
Various improvements that came up while working on Advent of Code Day 6.

- Improve span placement when parsing lookup chains
- Change list modification ops that return Empty so that they return the list
- Allow keys to be in different orders in map equality comparisons
- Add iterator.find
- Don't panic when accessing a reserved id in a temporary function
