### PR TITLE
Import commonly used core lib functions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The Koto project adheres to
   - New additions:
     - `iterator.find`
     - `number.round`
+  - The following items are now imported by default into the top level of the
+    prelude:
+    - `io.print`, `koto.type`, `test.assert`, `test.assert_eq`,
+      `test.assert_ne`, `test.assert_near`
   - List operations that modify the list but previously returned Empty,
     now return the modified list.
     - e.g.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ a try, your early feedback will be invaluable.
 ### A Quick Tour
 
 ```coffee
-import io.print, test.assert_eq
-
 # Numbers
 x = 1 + 2.5 + 100.sqrt()
 assert_eq x, 13.5

--- a/examples/poetry/scripts/readme.koto
+++ b/examples/poetry/scripts/readme.koto
@@ -1,5 +1,3 @@
-import io.print
-
 @main = ||
   input_file = io.extend_path koto.script_dir, "..", "..", "..", "README.md"
   generator = poetry

--- a/examples/poetry/scripts/reference.koto
+++ b/examples/poetry/scripts/reference.koto
@@ -1,5 +1,3 @@
-import io.print
-
 @main = ||
   input_file = io.extend_path koto.script_dir, "..", "..", "..",
     "docs", "reference", "core_lib", "string.md"

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 @main = ||
   n = match koto.args.get 0
     () then 10

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -6,9 +6,6 @@ Based on the Ruby implementation:
 https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fannkuchredux-yarv-1.html
 -#
 
-import io.print
-from test import assert, assert_eq
-
 fannkuch = |n|
   assert n >= 4
   p = (0..=n).to_list()

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 fib = |n|
   switch
     n <= 0 then 0

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -8,7 +8,7 @@ https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-lua-4.
 
 # TODO Using num4 for pos/vel reduces precision compared to the original
 
-import io.print, number.pi, test.assert_near
+import number.pi
 
 solar_mass = 4 * pi * pi
 days_per_year = 365.24

--- a/koto/benches/num4.koto
+++ b/koto/benches/num4.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 @main = ||
   n = match koto.args.get 0
     () then 10

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -6,8 +6,6 @@ Adapted from the Lua implementation by Mike Pall
 https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/spectralnorm-lua-1.html
 -#
 
-import test.assert_near
-
 A = |i, j|
   ij = i + j - 1
   1.0 / (ij * (ij - 1) * 0.5 + i)

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -41,8 +41,6 @@ number_to_english = |n|
 
 @tests =
   @test number_to_english: ||
-    import test.assert_eq
-
     assert_eq (number_to_english 0), "zero"
     assert_eq (number_to_english -42), "minus forty-two"
     assert_eq (number_to_english 217), "two hundred and seventeen"

--- a/koto/tests/assignment.koto
+++ b/koto/tests/assignment.koto
@@ -1,5 +1,3 @@
-from test import assert_eq, assert_ne
-
 @tests =
   @test basic_assignment: ||
     a = 1

--- a/koto/tests/comments.koto
+++ b/koto/tests/comments.koto
@@ -1,5 +1,3 @@
-import test.assert
-
 # This is a comment
 assert true # This is a trailing comment
 a = 1 # Another trailing comment

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 @tests =
   @test inline_if: ||
     x = if true then 10 else 20

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 make_enum = |entries...|
   entries
     .enumerate()

--- a/koto/tests/error_handling.koto
+++ b/koto/tests/error_handling.koto
@@ -1,5 +1,4 @@
 import error_handling_module
-from test import assert, assert_eq
 
 @tests =
   @test try_expression: ||

--- a/koto/tests/function_closures.koto
+++ b/koto/tests/function_closures.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 @tests =
   @test value_capture_on_function_creation: ||
     multipliers = (1..=4)

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 @tests =
   @test square: ||
     square = |x| x * x

--- a/koto/tests/functions_in_lookups.koto
+++ b/koto/tests/functions_in_lookups.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 test_map = ||
   child_map:
     foo: 42

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 #-
 An import expression will attempt to import a module matching the requested name from the
 following locations, in order:

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq, assert_ne
-
 test_path = io.extend_path koto.script_dir, "data", "test.txt"
 
 test_contents = "\

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 make_foo = |x|
   x: x
   @<: |self, other| self.x < other.x

--- a/koto/tests/line_breaks.koto
+++ b/koto/tests/line_breaks.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 a = num4
   0, 1, 2, 3
 b = num4

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_ne, assert_eq
-
 make_foo = |x|
   x: x
   @<: |self, other| self.x < other.x

--- a/koto/tests/lists.koto
+++ b/koto/tests/lists.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq, assert_ne
-
 @tests =
   @test list_indexing: ||
     z = [10, 10 + 10, 30]

--- a/koto/tests/logic.koto
+++ b/koto/tests/logic.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 @tests =
   @test and_not_or: ||
     assert true and true

--- a/koto/tests/loops.koto
+++ b/koto/tests/loops.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 @tests =
   @test for_block: ||
     count = 0

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 make_foo = |x|
   x: x
   @<: |self, other| self.x < other.x

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq, assert_ne
-
 @tests =
   @test access_by_key: ||
     m = key: "value", another_key: "another_value"

--- a/koto/tests/maps_and_lists.koto
+++ b/koto/tests/maps_and_lists.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 @tests =
   @test lists_in_maps: ||
     x =

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 locals = {}
 
 foo = |x|

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 @tests =
   @test creating: ||
     assert_eq (num4 0), (num4 0, 0, 0, 0)

--- a/koto/tests/number_ops.koto
+++ b/koto/tests/number_ops.koto
@@ -1,6 +1,4 @@
-import koto.type
 from number import e, infinity, negative_infinity, pi, tau,
-from test import assert, assert_eq, assert_near
 
 epsilon = 1.0e-15
 

--- a/koto/tests/numbers.koto
+++ b/koto/tests/numbers.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 @tests =
   @test arithmetic: ||
     assert_eq 1 + 1, 2

--- a/koto/tests/primes.koto
+++ b/koto/tests/primes.koto
@@ -1,5 +1,3 @@
-import test.assert_eq
-
 get_primes = |n|
   if n <= 1
     return

--- a/koto/tests/ranges.koto
+++ b/koto/tests/ranges.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq
-
 @tests =
   @test assignment: ||
     # Assigning a range to a value

--- a/koto/tests/string_formatting.koto
+++ b/koto/tests/string_formatting.koto
@@ -1,4 +1,4 @@
-import number.pi, test.assert_eq
+import number.pi
 
 @tests =
   @test format: ||

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -1,6 +1,3 @@
-import koto.type
-from test import assert, assert_eq, assert_ne
-
 @tests =
   @test comparisons: ||
     assert_eq "Hello", "Hello"

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_eq, assert_ne, assert_near, run_tests
-
 # A script can export a map named 'tests' to have the tests automatically run when
 # the script is loaded.
 @tests =
@@ -39,7 +37,7 @@ from test import assert, assert_eq, assert_ne, assert_near, run_tests
       @test failure: || assert false
 
     try
-      run_tests my_tests
+      test.run_tests my_tests
     catch _
       tests_were_run.failure = true
 

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -1,5 +1,3 @@
-from test import assert, assert_ne, assert_eq
-
 make_foo = |x|
   x: x
   @<: |self, other| self.x < other.x

--- a/koto/tests/types.koto
+++ b/koto/tests/types.koto
@@ -1,5 +1,3 @@
-import koto.type, test.assert_eq
-
 @tests =
   @test type_returns_type_name: ||
     assert_eq (type true), "Bool"

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -54,6 +54,46 @@ pub enum ControlFlow {
 // Instructions will place their results in registers, there's no Ok type
 pub type InstructionResult = Result<(), RuntimeError>;
 
+fn setup_core_lib_and_prelude() -> (CoreLib, ValueMap) {
+    let core_lib = CoreLib::default();
+
+    let mut prelude = ValueMap::default();
+    prelude.add_map("io", core_lib.io.clone());
+    prelude.add_map("iterator", core_lib.iterator.clone());
+    prelude.add_map("koto", core_lib.koto.clone());
+    prelude.add_map("list", core_lib.list.clone());
+    prelude.add_map("map", core_lib.map.clone());
+    prelude.add_map("os", core_lib.os.clone());
+    prelude.add_map("number", core_lib.number.clone());
+    prelude.add_map("range", core_lib.range.clone());
+    prelude.add_map("string", core_lib.string.clone());
+    prelude.add_map("test", core_lib.test.clone());
+    prelude.add_map("tuple", core_lib.tuple.clone());
+
+    macro_rules! default_import {
+        ($name:expr, $module:ident) => {{
+            prelude.add_value(
+                $name,
+                core_lib
+                    .$module
+                    .data()
+                    .get_with_string($name)
+                    .unwrap()
+                    .clone(),
+            );
+        }};
+    }
+
+    default_import!("assert", test);
+    default_import!("assert_eq", test);
+    default_import!("assert_ne", test);
+    default_import!("assert_near", test);
+    default_import!("print", io);
+    default_import!("type", koto);
+
+    (core_lib, prelude)
+}
+
 /// Context shared by all VMs across modules
 struct SharedContext {
     pub prelude: ValueMap,
@@ -72,20 +112,7 @@ impl Default for SharedContext {
 
 impl SharedContext {
     fn with_settings(settings: VmSettings) -> Self {
-        let core_lib = CoreLib::default();
-
-        let mut prelude = ValueMap::default();
-        prelude.add_map("io", core_lib.io.clone());
-        prelude.add_map("iterator", core_lib.iterator.clone());
-        prelude.add_map("koto", core_lib.koto.clone());
-        prelude.add_map("list", core_lib.list.clone());
-        prelude.add_map("map", core_lib.map.clone());
-        prelude.add_map("os", core_lib.os.clone());
-        prelude.add_map("number", core_lib.number.clone());
-        prelude.add_map("range", core_lib.range.clone());
-        prelude.add_map("string", core_lib.string.clone());
-        prelude.add_map("test", core_lib.test.clone());
-        prelude.add_map("tuple", core_lib.tuple.clone());
+        let (core_lib, prelude) = setup_core_lib_and_prelude();
 
         Self {
             prelude,


### PR DESCRIPTION
Functions like `io.print` and `test.assert_eq` are imported into nearly every
script, so I think it's time to bring them into the top level of the prelude by
default.
