### PR TITLE
Add time utilities to the os module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ The Koto project adheres to
 
 - Error traces have been made more reliable, with the correct positions being
   displayed more consistently in calling functions.
+- `io.print` now correctly prints values that are printed without a format
+  string and that override @display.
 
 ## [0.10.0] 2021.12.02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The Koto project adheres to
   - New additions:
     - `iterator.find`
     - `number.round`
+    - `os.time`
+      - Provides information about the current date and time.
+    - `os.start_timer`
+      - Provides a timer that can be used for measuring the duration between
+        moments in time.
   - The following items are now imported by default into the top level of the
     prelude:
     - `io.print`, `koto.type`, `test.assert`, `test.assert_eq`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "js-sys",
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +323,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -374,11 +389,14 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -534,8 +552,10 @@ dependencies = [
 name = "koto_runtime"
 version = "0.10.0"
 dependencies = [
+ "chrono",
  "downcast-rs",
  "indexmap",
+ "instant",
  "koto_bytecode",
  "koto_lexer",
  "koto_parser",
@@ -764,6 +784,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -1153,6 +1183,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1262,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/docs/reference/core_lib/os.md
+++ b/docs/reference/core_lib/os.md
@@ -5,6 +5,21 @@ A collection of utilities for working with the operating system.
 # Reference
 
 - [name](#name)
+- [start_timer](#start_timer)
+- [time](#time)
+- [DateTime](#datetime)
+- [DateTime.year](#datetimeyear)
+- [DateTime.month](#datetimemonth)
+- [DateTime.day](#datetimeday)
+- [DateTime.hour](#datetimehour)
+- [DateTime.minute](#datetimeminute)
+- [DateTime.nanosecond](#datetimenanosecond)
+- [DateTime.timestamp](#datetimetimestamp)
+- [DateTime.timezone_offset](#datetimetimezone_offset)
+- [DateTime.timestamp_string](#datetimetimestamp_string)
+- [Timer](#timer)
+- [Timer.@-](#timer-)
+- [Timer.elapsed](#timerelapsed)
 
 ## name
 
@@ -12,3 +27,148 @@ A collection of utilities for working with the operating system.
 
 Returns a string containing the name of the current operating system, e.g.
 "linux", "macos", "windows", etc.
+
+## start_timer
+
+`|| -> Timer`
+
+Returns a timer that can be used to measure how much time has passed while a
+script is running.
+
+### Example
+
+```koto
+t = os.start_timer()
+
+# ...after some time...
+print "Time taken: ${t.elapsed()}s"
+
+t2 = os.start_timer()
+print "Seconds between then and now: ${t2 - t}"
+```
+
+## time
+
+`|| -> DateTime`
+
+Returns a DateTime set to the current time, using the local timezone.
+
+`|Number| -> DateTime`
+
+Returns a DateTime set to the provided timestamp in seconds,
+using the local timezone.
+
+`|Number, Number| -> DateTime`
+
+Returns a DateTime set to the provided timestamp in seconds,
+using a time offset in seconds.
+
+### Example
+
+```koto
+now = os.time()
+# 2021-12-11 21:51:14
+
+now.year()
+# 2021
+
+now.hour()
+# 21
+
+now.timestamp()
+# 1639255874.53419
+```
+
+## DateTime
+
+See [`os.time`](#time).
+
+## DateTime.year
+
+`|DateTime| -> Integer`
+
+Returns the year component of the provided DateTime.
+
+## DateTime.month
+
+`|DateTime| -> Integer`
+
+Returns the month component of the provided DateTime.
+
+## DateTime.day
+
+`|DateTime| -> Integer`
+
+Returns the day component of the provided DateTime.
+
+## DateTime.hour
+
+`|DateTime| -> Integer`
+
+Returns the hour component of the provided DateTime.
+
+## DateTime.minute
+
+`|DateTime| -> Integer`
+
+Returns the minute component of the provided DateTime.
+
+## DateTime.nanosecond
+
+`|DateTime| -> Integer`
+
+Returns the nanosecond component of the provided DateTime.
+
+## DateTime.timestamp
+
+`|DateTime| -> Float`
+
+Returns the number of seconds since 00:00:00 UTC on January 1st 1970.
+
+## DateTime.timezone_offset
+
+`|DateTime| -> Integer`
+
+Returns the DateTime's timezone offset in seconds.
+
+## DateTime.timestamp_string
+
+`|DateTime| -> String`
+
+Returns a string representing the DateTime's timezone offset in seconds.
+
+## Timer
+
+See [`os.start_timer`](#start_timer).
+
+## Timer.@-
+
+`|Timer, Timer| -> Float`
+
+Returns the time difference in seconds between two timers.
+
+### Example
+
+```koto
+t1 = os.start_timer()
+t2 = os.start_timer()
+# t2 was started later than t1, so the time difference is positive
+assert (t2 - t1) > 0
+# t1 was started earlier than t2, so the time difference is negative
+assert (t1 - t2) < 0
+```
+
+## Timer.elapsed
+
+`|Timer| -> Float`
+
+Returns the number of seconds that have elapsed since the timer was started.
+
+### Example
+
+```koto
+t = os.start_timer()
+
+# ...after some time...
+print "Time taken: ${t.elapsed()}s"
+```

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -4,7 +4,7 @@ use {
         make_runtime_error, unexpected_type_error_with_slice, ExternalData, ExternalIterator,
         ExternalValue, MetaMap, Value, ValueIterator, ValueIteratorOutput, ValueMap,
     },
-    std::{cell::RefCell, fmt, rc::Rc},
+    std::{cell::RefCell, rc::Rc},
 };
 
 pub fn make_module() -> ValueMap {
@@ -109,14 +109,4 @@ impl KotoPoetry {
     }
 }
 
-impl ExternalData for KotoPoetry {
-    fn value_type(&self) -> String {
-        "Poetry".to_string()
-    }
-}
-
-impl fmt::Display for KotoPoetry {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Poetry")
-    }
-}
+impl ExternalData for KotoPoetry {}

--- a/examples/wasm/public/main.js
+++ b/examples/wasm/public/main.js
@@ -8,8 +8,6 @@ var editorDiv = document.getElementById("editor");
 editorDiv.innerHTML = `\
 # Fizz buzz in Koto
 
-import io.print
-
 fizz_buzz = |n|
   match n % 3, n % 5
     0, 0 then "Fizz Buzz"
@@ -25,6 +23,7 @@ var editor = ace.edit("editor");
 editor.setTheme("ace/theme/solarized_dark");
 editor.session.on("change", compile_and_run);
 editor.setShowPrintMargin(false);
+editor.setBehavioursEnabled(false);
 
 function compile_and_run() {
   const result = koto.compile_and_run(editor.session.getValue());

--- a/koto/tests/os.koto
+++ b/koto/tests/os.koto
@@ -1,0 +1,37 @@
+@tests =
+  @test name:
+    assert not os.name().is_empty()
+
+  @test start_timer:
+    t1 = os.start_timer()
+    elapsed1 = t1.elapsed()
+    assert elapsed1 > 0
+    elapsed2 = t1.elapsed()
+    assert elapsed2 > elapsed1
+
+    t2 = os.start_timer()
+    # t2 was started later than t1, so the time difference is positive
+    assert (t2 - t1) > 0
+    # t1 was started earlier than t2, so the time difference is negative
+    assert (t1 - t2) < 0
+
+  @test time:
+    # Calling os.time() without args returns the current time
+    now1 = os.time()
+    assert now1.timestamp() > 0
+    now2 = os.time()
+    assert now2.timestamp() > now1.timestamp()
+
+    # os.time() takes an optional timestamp in seconds which will return a time
+    # value at that timestamp. An optional time offset in seconds can be
+    # provided to set the timezone, otherwise the local timezone will be used.
+    sometime = os.time 1234567890, 3600
+    assert_eq sometime.year(), 2009
+    assert_eq sometime.month(), 2
+    assert_eq sometime.day(), 14
+    assert_eq sometime.hour(), 0
+    assert_eq sometime.minute(), 31
+    assert_eq sometime.second(), 30
+    assert_eq sometime.nanosecond(), 0
+    assert_eq sometime.timezone_offset(), 3600
+    assert_eq sometime.timezone_string(), "+0100"

--- a/src/cli/src/repl.rs
+++ b/src/cli/src/repl.rs
@@ -254,7 +254,17 @@ impl Repl {
                         );
                     }
                     match self.koto.run() {
-                        Ok(result) => writeln!(stdout, "{}\n", result).unwrap(),
+                        Ok(result) => match self.koto.value_to_string(result.clone()) {
+                            Ok(result_string) => writeln!(stdout, "{}\n", result_string).unwrap(),
+                            Err(e) => {
+                                writeln!(
+                                    stdout,
+                                    "Error while getting display string for value '{}' - {}",
+                                    result, e
+                                )
+                                .unwrap();
+                            }
+                        },
                         Err(error) => {
                             if let Some(help) = self.run_help(&input) {
                                 writeln!(stdout, "{}\n", help).unwrap()

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -32,7 +32,7 @@ use {
     dunce::canonicalize,
     koto_bytecode::{Chunk, LoaderError},
     koto_runtime::{
-        CallArgs, KotoFile, Loader, MetaKey, RuntimeError, Value, ValueMap, Vm, VmSettings,
+        CallArgs, KotoFile, Loader, MetaKey, RuntimeError, UnaryOp, Value, ValueMap, Vm, VmSettings,
     },
     std::{error::Error, fmt, path::PathBuf, rc::Rc},
 };
@@ -218,6 +218,25 @@ impl Koto {
         }
     }
 
+    pub fn run_function_by_name(&mut self, function_name: &str, args: CallArgs) -> KotoResult {
+        match self.runtime.get_exported_function(function_name) {
+            Some(f) => self.run_function(f, args),
+            None => Err(KotoError::FunctionNotFound(function_name.into())),
+        }
+    }
+
+    pub fn run_function(&mut self, function: Value, args: CallArgs) -> KotoResult {
+        self.runtime
+            .run_function(function, args)
+            .map_err(|e| e.into())
+    }
+
+    pub fn value_to_string(&mut self, value: Value) -> KotoResult {
+        self.runtime
+            .run_unary_op(UnaryOp::Display, value)
+            .map_err(|e| e.into())
+    }
+
     pub fn prelude(&self) -> ValueMap {
         self.runtime.prelude()
     }
@@ -286,18 +305,5 @@ impl Koto {
             }
             _ => unreachable!(),
         }
-    }
-
-    pub fn run_function_by_name(&mut self, function_name: &str, args: CallArgs) -> KotoResult {
-        match self.runtime.get_exported_function(function_name) {
-            Some(f) => self.run_function(f, args),
-            None => Err(KotoError::FunctionNotFound(function_name.into())),
-        }
-    }
-
-    pub fn run_function(&mut self, function: Value, args: CallArgs) -> KotoResult {
-        self.runtime
-            .run_function(function, args)
-            .map_err(|e| e.into())
     }
 }

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -117,6 +117,7 @@ assert_near 1, 2, 0.1
     koto_test!(number_ops);
     koto_test!(numbers);
     koto_test!(num2_4);
+    koto_test!(os);
     koto_test!(primes);
     koto_test!(ranges);
     koto_test!(strings);

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -23,3 +23,11 @@ indexmap = "1.4.0"
 rustc-hash = "1.1.0"
 smallvec = "1.2.0"
 unicode-segmentation = "1.7.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+chrono = "0.4.19"
+instant = "0.1.12"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+chrono = {version = "0.4.19", features = ["wasmbind"]}
+instant = {version = "0.1.12", features = ["wasm-bindgen"]}

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -95,7 +95,19 @@ pub fn make_module() -> ValueMap {
     result.add_fn("print", |vm, args| {
         let result = match vm.get_args(args) {
             [Str(s)] => vm.stdout().write_line(s.as_str()),
-            [value] => vm.stdout().write_line(&value.to_string()),
+            [value] => {
+                let value = value.clone();
+                match vm.run_unary_op(crate::UnaryOp::Display, value)? {
+                    Str(s) => vm.stdout().write_line(s.as_str()),
+                    unexpected => {
+                        return unexpected_type_error_with_slice(
+                            "io.print",
+                            "string from @display",
+                            &[unexpected],
+                        )
+                    }
+                }
+            }
             [Str(format), format_args @ ..] => {
                 let format = format.clone();
                 let format_args = format_args.to_vec();

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -290,23 +290,7 @@ impl File {
     }
 }
 
-impl ExternalData for File {
-    fn value_type(&self) -> String {
-        "File".to_string()
-    }
-}
-
-impl fmt::Display for File {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.deref())
-    }
-}
-
-impl fmt::Debug for File {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
-    }
-}
+impl ExternalData for File {}
 
 struct BufferedSystemFile<T>
 where

--- a/src/runtime/src/core/os.rs
+++ b/src/runtime/src/core/os.rs
@@ -1,9 +1,167 @@
-use crate::ValueMap;
+use crate::unexpected_type_error_with_slice;
+
+use {
+    crate::{
+        runtime_error, BinaryOp, ExternalData, ExternalValue, MetaMap, RuntimeResult, UnaryOp,
+        Value, ValueMap,
+    },
+    chrono::prelude::*,
+    instant::Instant,
+    std::{cell::RefCell, rc::Rc},
+};
 
 pub fn make_module() -> ValueMap {
+    use Value::Number;
+
     let mut result = ValueMap::new();
 
-    result.add_fn("name", |_vm, _args| Ok(std::env::consts::OS.into()));
+    result.add_fn("name", |_, _| Ok(std::env::consts::OS.into()));
+
+    result.add_fn("time", |vm, args| match vm.get_args(args) {
+        [] => Ok(DateTime::now()),
+        [Number(seconds)] => DateTime::from_seconds(seconds.into(), None),
+        [Number(seconds), Number(offset)] => {
+            DateTime::from_seconds(seconds.into(), Some(offset.into()))
+        }
+        unexpected => unexpected_type_error_with_slice(
+            "os.time",
+            "no args, or a timestamp in seconds, with optional timezone offset in seconds",
+            unexpected,
+        ),
+    });
+
+    result.add_fn("start_timer", |_, _| Ok(Timer::now()));
 
     result
 }
+
+pub struct DateTime(chrono::DateTime<Local>);
+
+impl DateTime {
+    fn with_chrono_datetime(time: chrono::DateTime<Local>) -> Value {
+        let result = ExternalValue::with_shared_meta_map(Self(time), Self::meta_map());
+        Value::ExternalValue(result)
+    }
+
+    fn now() -> Value {
+        Self::with_chrono_datetime(Local::now())
+    }
+
+    fn from_seconds(seconds: f64, maybe_offset: Option<i64>) -> RuntimeResult {
+        let seconds_i64 = seconds as i64;
+        let sub_nanos = (seconds.fract() * 1.0e9) as u32;
+        let offset = match maybe_offset {
+            Some(offset) => match FixedOffset::east_opt(offset as i32) {
+                Some(offset) => offset,
+                None => return runtime_error!("time offset is out of range: {}", offset),
+            },
+            None => *Local::now().offset(),
+        };
+        match NaiveDateTime::from_timestamp_opt(seconds_i64, sub_nanos) {
+            Some(utc) => Ok(Self::with_chrono_datetime(
+                chrono::DateTime::<Local>::from_utc(utc, offset),
+            )),
+            None => return runtime_error!("timestamp in seconds is out of range: {}", seconds),
+        }
+    }
+
+    fn meta_map() -> Rc<RefCell<MetaMap>> {
+        SYSTEM_TIME_META.with(|meta| meta.clone())
+    }
+}
+
+impl ExternalData for DateTime {}
+
+thread_local!(
+    pub static SYSTEM_TIME_META: Rc<RefCell<MetaMap>> = {
+        let mut meta = MetaMap::with_type_name("DateTime");
+
+        meta.add_unary_op(UnaryOp::Display, |data: &DateTime, _| {
+            Ok(data.0.format("%F %T").to_string().into())
+        });
+
+        meta.add_named_instance_fn("day", |data: &DateTime, _, _| {
+            Ok(data.0.day().into())
+        });
+
+        meta.add_named_instance_fn("hour", |data: &DateTime, _, _| {
+            Ok(data.0.hour().into())
+        });
+
+        meta.add_named_instance_fn("minute", |data: &DateTime, _, _| {
+            Ok(data.0.minute().into())
+        });
+
+        meta.add_named_instance_fn("month", |data: &DateTime, _, _| {
+            Ok(data.0.month().into())
+        });
+
+        meta.add_named_instance_fn("second", |data: &DateTime, _, _| {
+            Ok(data.0.second().into())
+        });
+
+        meta.add_named_instance_fn("nanosecond", |data: &DateTime, _, _| {
+            Ok(data.0.nanosecond().into())
+        });
+
+        meta.add_named_instance_fn("timestamp", |data: &DateTime, _, _| {
+            let seconds = data.0.timestamp() as f64;
+            let sub_nanos = data.0.timestamp_subsec_nanos();
+            Ok((seconds + sub_nanos as f64 / 1.0e9).into())
+        });
+
+        meta.add_named_instance_fn("timezone_offset", |data: &DateTime, _, _| {
+            Ok(data.0.offset().local_minus_utc().into())
+        });
+
+        meta.add_named_instance_fn("timezone_string", |data: &DateTime, _, _| {
+            Ok(data.0.format("%z").to_string().into())
+        });
+
+        meta.add_named_instance_fn("year", |data: &DateTime, _, _| {
+            Ok(data.0.year().into())
+        });
+
+        Rc::new(RefCell::new(meta))
+    }
+);
+
+pub struct Timer(Instant);
+
+impl Timer {
+    fn now() -> Value {
+        let meta = TIMER_META.with(|meta| meta.clone());
+        let result = ExternalValue::with_shared_meta_map(Self(Instant::now()), meta);
+        Value::ExternalValue(result)
+    }
+}
+
+impl ExternalData for Timer {}
+
+thread_local!(
+    pub static TIMER_META: Rc<RefCell<MetaMap>> = {
+        let mut meta = MetaMap::with_type_name("Timer");
+
+        meta.add_unary_op(UnaryOp::Display, |data: &Timer, _| {
+            Ok(format!("Timer({:.3}s)", data.0.elapsed().as_secs_f64()).into())
+        });
+
+        meta.add_binary_op(
+            BinaryOp::Subtract,
+            |a: &Timer, b, _, _| {
+                let result = if a.0 >= b.0 {
+                     a.0.duration_since(b.0).as_secs_f64()
+                } else {
+                    -(b.0.duration_since(a.0).as_secs_f64())
+                };
+                Ok(result.into())
+            },
+        );
+
+        meta.add_named_instance_fn("elapsed", |instant: &Timer, _, _| {
+            Ok(instant.0.elapsed().as_secs_f64().into())
+        });
+
+        Rc::new(RefCell::new(meta))
+    }
+);

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -366,7 +366,7 @@ fn value_to_string(
             }
             other => {
                 return runtime_error!(
-                    "Expected string from value display, found '{}'",
+                    "Expected string from @display, found '{}'",
                     other.type_as_string()
                 )
             }

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -14,9 +14,21 @@ pub use downcast_rs::Downcast;
 use crate::MetaMap;
 
 /// A trait for external data
-pub trait ExternalData: fmt::Debug + fmt::Display + Downcast {
+pub trait ExternalData: Downcast {
     fn value_type(&self) -> String {
         "External Data".to_string()
+    }
+}
+
+impl fmt::Display for dyn ExternalData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.value_type())
+    }
+}
+
+impl fmt::Debug for dyn ExternalData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.value_type())
     }
 }
 

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -246,8 +246,7 @@ impl fmt::Display for Value {
             Generator(_) => write!(f, "Generator"),
             Iterator(_) => write!(f, "Iterator"),
             ExternalFunction(_) => write!(f, "||"),
-            ExternalValue(ref value) => write!(f, "{}", value.data()),
-            ExternalData(ref value) => write!(f, "{}", value.borrow()),
+            ExternalValue(_) | ExternalData(_) => f.write_str(&self.type_as_string()),
             IndexRange(self::IndexRange { .. }) => f.write_str("IndexRange"),
             TemporaryTuple(RegisterSlice { start, count }) => {
                 write!(f, "TemporaryTuple [{}..{}]", start, start + count)

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1857,6 +1857,12 @@ impl Vm {
         value_register: u8,
         op: Value,
     ) -> InstructionResult {
+        // Ensure that the result register is present in the stack, otherwise it might be lost after
+        // the call to the op, which expects a frame base at or after the result register.
+        if self.register_index(result_register) >= self.value_stack.len() {
+            self.set_register(result_register, Value::Empty);
+        }
+
         // Set up the call registers at the end of the stack
         let stack_len = self.value_stack.len();
         let frame_base = (stack_len - self.register_base()) as u8;
@@ -1878,6 +1884,12 @@ impl Vm {
         rhs: Value,
         op: Value,
     ) -> InstructionResult {
+        // Ensure that the result register is present in the stack, otherwise it might be lost after
+        // the call to the op, which expects a frame base at or after the result register.
+        if self.register_index(result_register) >= self.value_stack.len() {
+            self.set_register(result_register, Value::Empty);
+        }
+
         // Set up the call registers at the end of the stack
         let stack_len = self.value_stack.len();
         let frame_base = (stack_len - self.register_base()) as u8;

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -329,4 +329,27 @@ x[23]
             test_script_with_external_value(script, 123.into());
         }
     }
+
+    mod temporaries {
+        use super::*;
+
+        #[test]
+        fn overloaded_unary_op_as_lookup_root() {
+            let script = "
+x = make_external -100
+(-x).to_number()
+    ";
+            test_script_with_external_value(script, 100.into());
+        }
+
+        #[test]
+        fn overloaded_binary_op_as_lookup_root() {
+            let script = "
+x = make_external 100
+y = make_external 100
+(x - y).to_number()
+    ";
+            test_script_with_external_value(script, 0.into());
+        }
+    }
 }

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -6,7 +6,7 @@ mod external_values {
         koto_runtime::{
             runtime_error, BinaryOp, ExternalData, ExternalValue, MetaMap, UnaryOp, Value, Vm,
         },
-        std::{cell::RefCell, fmt, rc::Rc},
+        std::{cell::RefCell, rc::Rc},
     };
 
     #[derive(Debug)]
@@ -15,12 +15,6 @@ mod external_values {
     }
 
     impl ExternalData for TestExternalData {}
-
-    impl fmt::Display for TestExternalData {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "TestExternalData: {}", self.x)
-        }
-    }
 
     thread_local!(
         static EXTERNAL_META: Rc<RefCell<MetaMap>> = {

--- a/src/runtime/tests/stdout.rs
+++ b/src/runtime/tests/stdout.rs
@@ -87,7 +87,6 @@ mod vm {
     #[test]
     fn print_loop() {
         let script = "
-import io.print
 for i in 0..5
   print 'foo {}', i
 ";
@@ -99,6 +98,22 @@ foo 1
 foo 2
 foo 3
 foo 4
+",
+        );
+    }
+
+    #[test]
+    fn print_value_with_overridden_display() {
+        let script = "
+foo =
+  @display: |self| 'Hello from @display'
+  @type: 'Foo'
+print foo
+";
+        check_logged_output(
+            script,
+            "\
+Hello from @display
 ",
         );
     }


### PR DESCRIPTION
Adds `os.start_timer` and `os.time`.

- Relax the ExternalData trait requirements
- Call @display when printing out result values in the REPL
- Fix bug with temporary results being lost when calling overloaded ops
- Add time utilities to the os module
