### PR TITLE
Advent of Code Day 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,16 @@ The Koto project adheres to
     # After
     assert_eq x == y, true
     ```
+- Functions that access a value that was exported prior to the function being
+  created, will capture the value rather than access it from exports.
+  - e.g.
+    ```koto
+    export x = 123
+    f = || x
+    # Re-exporting x doesn't affect the value of x captured when f was created
+    export x = 99
+    f()
+    ```
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The Koto project adheres to
     - `os.start_timer`
       - Provides a timer that can be used for measuring the duration between
         moments in time.
+    - `string.from_bytes`
   - The following items are now imported by default into the top level of the
     prelude:
     - `io.print`, `koto.type`, `test.assert`, `test.assert_eq`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ The Koto project adheres to
   displayed more consistently in calling functions.
 - `io.print` now correctly prints values that are printed without a format
   string and that override @display.
+- Fixed a panic that could occur when skipping past the end of an iterator and
+  then calling a 'to X' function.
 
 ## [0.10.0] 2021.12.02
 

--- a/docs/reference/core_lib/iterator.md
+++ b/docs/reference/core_lib/iterator.md
@@ -298,6 +298,7 @@ If no match is found then `()` is returned.
 ### See Also
 
 - [`iterator.find`](#find)
+
 ## fold
 
 `|Iterable, Value, |Value, Value| -> Value| -> Value`

--- a/docs/reference/core_lib/string.md
+++ b/docs/reference/core_lib/string.md
@@ -74,6 +74,7 @@ escape code, then it can be escaped with an additional `\`.
 - [ends_with](#ends_with)
 - [escape](#escape)
 - [format](#format)
+- [from_bytes](#from_bytes)
 - [is_empty](#is_empty)
 - [lines](#lines)
 - [size](#size)
@@ -95,9 +96,13 @@ contained in the string data.
 ### Example
 
 ```koto
-"Hëy".bytes().to_tuple()
-# (72, 195, 171, 121)
+"Hëy!".bytes().to_tuple()
+# (72, 195, 171, 121, 33)
 ```
+
+### See Also
+
+- [`string.from_bytes`](#from_bytes)
 
 ## chars
 
@@ -275,6 +280,25 @@ Returns `true` if the string contains no characters.
 "".is_empty()
 # true
 ```
+
+## from_bytes
+
+`|Iterable| -> String`
+
+Returns a string containing the bytes that are produced by the input iterable.
+The iterable output must contain only Numbers in the `0..=255` range.
+The resulting sequence of bytes must contain UTF-8 data.
+
+### Example
+
+```koto
+string.from_bytes (72, 195, 171, 121, 33)
+# Hëy!
+```
+
+### See Also
+
+- [`string.bytes`](#bytes)
 
 ## lines
 

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -43,6 +43,12 @@
     # Unicode characters
     assert_eq '\u{1f98b}', '🦋'
 
+  @test escaped_newlines: ||
+    x = "foo \
+         bar \
+         baz"
+    assert_eq x, "foo bar baz"
+
   @test bytes: ||
     assert_eq "Hëy".bytes().to_tuple(), (72, 195, 171, 121)
 
@@ -78,6 +84,9 @@
 
     assert_eq "👋".escape(), "\\u{1f44b}"
 
+  @test from_bytes: ||
+    assert_eq (string.from_bytes (72, 195, 171, 121)), "Hëy"
+
   @test is_empty: ||
     assert "".is_empty()
     assert not "abc".is_empty()
@@ -98,12 +107,6 @@ zzz
 
     x3 = "foo\nbar\nbaz"
     assert_eq x3.lines().to_tuple(), ("foo", "bar", "baz")
-
-  @test escaped_newlines: ||
-    x = "foo \
-         bar \
-         baz"
-    assert_eq x, "foo bar baz"
 
   @test size: ||
     # size returns the number of unicode graphemes in the string,

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -715,7 +715,7 @@ pub fn make_module() -> ValueMap {
     result
 }
 
-fn collect_pair(iterator_output: Output) -> Output {
+pub(crate) fn collect_pair(iterator_output: Output) -> Output {
     match iterator_output {
         Output::ValuePair(first, second) => Output::Value(Value::Tuple(vec![first, second].into())),
         _ => iterator_output,

--- a/src/runtime/src/core/iterator/adaptors.rs
+++ b/src/runtime/src/core/iterator/adaptors.rs
@@ -106,7 +106,7 @@ impl Iterator for Each {
             };
             match functor_result {
                 Ok(result) => Output::Value(result),
-                Err(error) => Output::Error(error.with_prefix("iterator.each")),
+                Err(error) => Output::Error(error),
             }
         })
     }
@@ -404,7 +404,7 @@ impl Iterator for Keep {
                              predicate, found '{}'",
                     unexpected.type_as_string(),
                 ))),
-                Err(error) => Output::Error(error.with_prefix("iterator.keep")),
+                Err(error) => Output::Error(error),
             };
 
             return Some(result);

--- a/src/runtime/src/core/iterator/adaptors.rs
+++ b/src/runtime/src/core/iterator/adaptors.rs
@@ -1,7 +1,10 @@
-use crate::{
-    make_runtime_error,
-    value_iterator::{ExternalIterator, ValueIterator, ValueIteratorOutput as Output},
-    CallArgs, Value, Vm,
+use {
+    super::collect_pair,
+    crate::{
+        make_runtime_error,
+        value_iterator::{ExternalIterator, ValueIterator, ValueIteratorOutput as Output},
+        CallArgs, Value, Vm,
+    },
 };
 
 /// An iterator that links the output of two iterators together in a chained sequence
@@ -580,13 +583,6 @@ impl Iterator for PairSecond {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
-    }
-}
-
-fn collect_pair(iterator_output: Output) -> Output {
-    match iterator_output {
-        Output::ValuePair(first, second) => Output::Value(Value::Tuple(vec![first, second].into())),
-        _ => iterator_output,
     }
 }
 

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -251,7 +251,7 @@ impl Iterator for ValueIterator {
             External(external_iterator) => return external_iterator.borrow().size_hint(),
         };
 
-        let remaining = iterable_size - index;
+        let remaining = iterable_size.saturating_sub(index);
 
         (remaining, Some(remaining))
     }

--- a/src/runtime/src/value_number.rs
+++ b/src/runtime/src/value_number.rs
@@ -30,10 +30,7 @@ impl ValueNumber {
     }
 
     pub fn floor(self) -> Self {
-        match self {
-            Self::F64(n) => Self::I64(n.floor() as i64),
-            Self::I64(n) => Self::I64(n),
-        }
+        Self::I64(self.as_i64())
     }
 
     pub fn round(self) -> Self {
@@ -77,6 +74,13 @@ impl ValueNumber {
         match self {
             Self::F64(n) => n.to_bits(),
             Self::I64(n) => n as u64,
+        }
+    }
+
+    pub fn as_i64(self) -> i64 {
+        match self {
+            Self::F64(n) => n.floor() as i64,
+            Self::I64(n) => n,
         }
     }
 }

--- a/src/runtime/tests/iterator_tests.rs
+++ b/src/runtime/tests/iterator_tests.rs
@@ -136,6 +136,18 @@ y.next()
         }
     }
 
+    mod skip {
+        use super::*;
+
+        #[test]
+        fn skip_past_end_then_collect_shouldnt_panic() {
+            let script = "
+[].skip(1).to_tuple()
+";
+            test_script(script, value_tuple(&[]));
+        }
+    }
+
     mod take {
         use super::*;
 

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1124,16 +1124,6 @@ f [1, 2]";
         }
 
         #[test]
-        fn export_assignment() {
-            let script = "
-f = ||
-  export x = 42
-f()
-x";
-            test_script(script, 42.into());
-        }
-
-        #[test]
         fn multi_assignment_of_function_results() {
             let script = "
 f = |n| n
@@ -2616,6 +2606,39 @@ a = foo 10
 a.x + a.y # The meta map's y entry is hidden by the data entry
 ";
             test_script(script, 110.into());
+        }
+    }
+
+    mod export {
+        use super::*;
+
+        #[test]
+        fn export_in_function() {
+            let script = "
+f = || export x = 42
+f()
+x";
+            test_script(script, 42.into());
+        }
+
+        #[test]
+        fn accessing_value_exported_after_function_creation() {
+            let script = "
+f = || x
+export x = 99
+f()";
+            test_script(script, 99.into());
+        }
+
+        #[test]
+        fn capture_of_value_exported_before_function_creation() {
+            let script = "
+export x = 123
+f = || x
+# Re-exporting x doesn't affect the value captured when f was created
+export x = 99
+f()";
+            test_script(script, 123.into());
         }
     }
 }


### PR DESCRIPTION
Various improvements that came up while working on Advent of Code Day 14.

- Fix a 'subtract with overflow' error that can occur when using `iterator.skip`
- Add `string.from_bytes`
- Remove unnecessary error prefixes in iterator adaptors
- Change functions so that they capture previously exported values
