### PR TITLE
`num2`/`num4` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,28 @@ The Koto project adheres to
 
 - Core Library
   - New additions:
-    - `iterator.find`
+    - `iterator`
+      - `find`
+      - `to_num2`
+      - `to_num4`
     - `number.round`
-    - `os.time`
-      - Provides information about the current date and time.
-    - `os.start_timer`
-      - Provides a timer that can be used for measuring the duration between
-        moments in time.
+    - `num2`
+      - `make_num2`,
+      - `x`, `y`
+    - `num4`
+      - `make_num4`,
+      - `r`, `g`, `b`, `a`, `x`, `y`, `z`, `w`
+    - `os`
+      - `time`
+        - Provides information about the current date and time.
+      - `start_timer`
+        - Provides a timer that can be used for measuring the duration between
+          moments in time.
     - `string.from_bytes`
   - The following items are now imported by default into the top level of the
     prelude:
-    - `io.print`, `koto.type`, `test.assert`, `test.assert_eq`,
-      `test.assert_ne`, `test.assert_near`
+    - `io.print`, `koto.type`, `num2.make_num2`, `num4.make_num4`,
+      `test.assert`, `test.assert_eq`, `test.assert_ne`, `test.assert_near`
   - List operations that modify the list but previously returned Empty,
     now return the modified list.
     - e.g.
@@ -81,6 +91,9 @@ The Koto project adheres to
       @main = ||
         ...
       ```
+- The `num2` and `num4` keywords have been removed in favour of the new
+  `make_num2`, `make_num4`, `iterator.to_num2`, and `iterator.to_num4`
+  functions.
 - Map equality comparisons now don't rely on maps having keys in the same order.
   - e.g.
     ```koto
@@ -102,6 +115,10 @@ The Koto project adheres to
     f()
     ```
 
+### Removed
+
+- The `num2` and `num4` keywords have been removed, see above.
+
 ### Fixed
 
 - Error traces have been made more reliable, with the correct positions being
@@ -110,6 +127,7 @@ The Koto project adheres to
   string and that override @display.
 - Fixed a panic that could occur when skipping past the end of an iterator and
   then calling a 'to X' function.
+
 
 ## [0.10.0] 2021.12.02
 

--- a/docs/reference/core_lib/iterator.md
+++ b/docs/reference/core_lib/iterator.md
@@ -72,6 +72,8 @@ for x in (2, 3, 4).each |n| n * 2
 - [take](#take)
 - [to_list](#to_list)
 - [to_map](#to_map)
+- [to_num2](#to_num2)
+- [to_num4](#to_num4)
 - [to_string](#to_string)
 - [to_tuple](#to_tuple)
 - [zip](#zip)
@@ -659,6 +661,44 @@ key, with `()` as the entry's value.
 - [`iterator.to_list`](#to_list)
 - [`iterator.to_string`](#to_string)
 - [`iterator.to_tuple`](#to_tuple)
+
+## to_num2
+
+`|Iterable| -> Num2`
+
+Consumes up to 2 values from the iterator and places them in a Num2.
+
+### Example
+
+```koto
+[1].to_num2()
+# num2(1, 0)
+(1..10).keep(|n| n % 2 == 0).to_num2()
+# num2(2, 4)
+```
+
+### See also
+
+- [`iterator.to_num4`](#to_num4)
+
+## to_num4
+
+`|Iterable| -> Num4`
+
+Consumes up to 4 values from the iterator and places them in a Num2.
+
+### Example
+
+```koto
+[1].to_num4()
+# num2(1, 0, 0, 0)
+(1..10).keep(|n| n % 2 == 0).to_num4()
+# num2(2, 4, 6, 8)
+```
+
+### See also
+
+- [`iterator.to_num4`](#to_num4)
 
 ## to_string
 

--- a/docs/reference/core_lib/num2.md
+++ b/docs/reference/core_lib/num2.md
@@ -10,8 +10,8 @@ while operations with Numbers apply the number to each element.
 ## Example
 
 ```koto
-x = num2 1, 2
-y = num2 3, 4
+x = make_num2 1, 2
+y = make_num2 3, 4
 x + y
 # num2(4, 6)
 
@@ -29,6 +29,7 @@ x
 # Reference
 
 - [length](#length)
+- [make_num2](#make_num2)
 - [max](#max)
 - [min](#min)
 - [normalize](#normalize)
@@ -44,9 +45,31 @@ Returns the length of the vector represented by the Num2's elements.
 ### Example
 
 ```koto
-x = num2(3, 4)
+x = make_num2 3, 4
 x.length()
 # 5
+```
+
+## make_num2
+
+`|Number| -> Num2`
+`|Number, Number| -> Num2`
+`|Num2| -> Num2`
+`|Iterable| -> Num2`
+
+Makes a Num2 from the provided values.
+
+### Example
+
+```koto
+make_num2 1
+# num2(1, 1)
+
+make_num2 3, 4
+# num2(3, 4)
+
+make_num2 [11, 12]
+# num2(11, 12)
 ```
 
 ## max
@@ -58,7 +81,7 @@ Returns the value of the largest element in the Num2.
 ### Example
 
 ```koto
-x = num2(10, 20)
+x = make_num2(10, 20)
 x.max()
 # 20
 ```
@@ -72,7 +95,7 @@ Returns the value of the smallest element in the Num2.
 ### Example
 
 ```koto
-x = num2(10, 20)
+x = make_num2(10, 20)
 x.min()
 # 10
 ```
@@ -87,7 +110,7 @@ with its length normalized to 1.
 ### Example
 
 ```koto
-x = num2(3, 4)
+x = make_num2(3, 4)
 x.normalize()
 # num2(0.6, 0.8)
 ```
@@ -101,7 +124,7 @@ Returns the result of multiplying the Num2's elements together.
 ### Example
 
 ```koto
-x = num2(10, 20)
+x = make_num2(10, 20)
 x.product()
 # 300
 ```
@@ -115,7 +138,7 @@ Returns the result of adding the Num2's elements together.
 ### Example
 
 ```koto
-x = num2(10, 20)
+x = make_num2(10, 20)
 x.sum()
 # 30
 ```

--- a/docs/reference/core_lib/num2.md
+++ b/docs/reference/core_lib/num2.md
@@ -35,6 +35,8 @@ x
 - [normalize](#normalize)
 - [product](#product)
 - [sum](#sum)
+- [x](#x)
+- [y](#y)
 
 ## length
 
@@ -141,4 +143,32 @@ Returns the result of adding the Num2's elements together.
 x = make_num2(10, 20)
 x.sum()
 # 30
+```
+
+## x
+
+`|Num2| -> Float`
+
+Returns the first element of the Num2.
+
+### Example
+
+```koto
+n = make_num2 10, 20
+n.x()
+# 10
+```
+
+## y
+
+`|Num2| -> Float`
+
+Returns the second element of the Num2.
+
+### Example
+
+```koto
+n = make_num2 10, 20
+n.y()
+# 20
 ```

--- a/docs/reference/core_lib/num4.md
+++ b/docs/reference/core_lib/num4.md
@@ -10,8 +10,8 @@ while operations with Numbers apply the number to each element.
 ## Example
 
 ```koto
-x = num4 1, 2, 3, 4
-y = num4 5, 6, 7, 8
+x = make_num4 1, 2, 3, 4
+y = make_num4 5, 6, 7, 8
 x + y
 # num4(6, 8, 10, 12)
 
@@ -29,6 +29,7 @@ x
 # Reference
 
 - [length](#length)
+- [make_num4](#make_num4)
 - [max](#max)
 - [min](#min)
 - [normalize](#normalize)
@@ -44,9 +45,37 @@ Returns the length of the vector represented by the Num4's elements.
 ### Example
 
 ```koto
-x = num4(2, -2, 2, -2)
+x = make_num4(2, -2, 2, -2)
 x.length()
 # 4
+```
+
+## make_num4
+
+`|Number| -> Num4`
+`|Number, Number| -> Num4`
+`|Number, Number, Number| -> Num4`
+`|Number, Number, Number, Number| -> Num4`
+`|Num2| -> Num4`
+`|Num4| -> Num4`
+`|Iterable| -> Num4`
+
+Makes a Num4 from the provided values.
+
+### Example
+
+```koto
+make_num4 1
+# num4(1, 1, 1, 1)
+
+make_num4 3, 4
+# num4(3, 4, 0, 0)
+
+make_num4 5, 6, 7, 8
+# num4(5, 6, 7, 8)
+
+make_num4 [11, 12, 13, 14]
+# num4(11, 12, 13, 14)
 ```
 
 ## max
@@ -58,7 +87,7 @@ Returns the value of the largest element in the Num4.
 ### Example
 
 ```koto
-x = num4(10, 20, -50, -10)
+x = make_num4(10, 20, -50, -10)
 x.max()
 # 20
 ```
@@ -72,7 +101,7 @@ Returns the value of the smallest element in the Num4.
 ### Example
 
 ```koto
-x = num4(10, 20, -50, -10)
+x = make_num4(10, 20, -50, -10)
 x.min()
 # -50
 ```
@@ -87,7 +116,7 @@ with its length normalized to 1.
 ### Example
 
 ```koto
-x = num4(2, -2, 2, -2)
+x = make_num4(2, -2, 2, -2)
 x.normalize()
 # num4(0.5, -0.5, 0.5, 0.5)
 ```
@@ -101,7 +130,7 @@ Returns the result of multiplying the Num4's elements together.
 ### Example
 
 ```koto
-x = num4(10, 20, -50, -10)
+x = make_num4(10, 20, -50, -10)
 x.product()
 # 100000
 ```
@@ -115,7 +144,7 @@ Returns the result of adding the Num4's elements together.
 ### Example
 
 ```koto
-x = num4(10, 20, 30, 40)
+x = make_num4(10, 20, 30, 40)
 x.sum()
 # 100
 ```

--- a/docs/reference/core_lib/num4.md
+++ b/docs/reference/core_lib/num4.md
@@ -35,6 +35,14 @@ x
 - [normalize](#normalize)
 - [product](#product)
 - [sum](#sum)
+- [r](#r)
+- [g](#g)
+- [b](#b)
+- [a](#a)
+- [x](#x)
+- [y](#y)
+- [z](#z)
+- [w](#w)
 
 ## length
 
@@ -147,4 +155,140 @@ Returns the result of adding the Num4's elements together.
 x = make_num4(10, 20, 30, 40)
 x.sum()
 # 100
+```
+
+## r
+
+`|Num4| -> Float`
+
+Returns the first element of the Num4.
+
+This can be useful when using a Num4 as a colour value, and want to access its
+'red' component.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.r()
+# 10
+```
+
+## g
+
+`|Num4| -> Float`
+
+Returns the second element of the Num4.
+
+This can be useful when using a Num4 as a colour value, and want to access its
+'green' component.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.g()
+# 20
+```
+
+## b
+
+`|Num4| -> Float`
+
+Returns the third element of the Num4.
+
+This can be useful when using a Num4 as a colour value, and want to access its
+'blue' component.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.b()
+# 30
+```
+
+## a
+
+`|Num4| -> Float`
+
+Returns the fourth element of the Num4.
+
+This can be useful when using a Num4 as a colour value, and want to access its
+'alpha' component.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.w()
+# 40
+```
+
+## x
+
+`|Num4| -> Float`
+
+Returns the first element of the Num4.
+
+This can be useful when using a Num4 as a 3D or 4D vector, and want to access
+its `x` component.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.x()
+# 10
+```
+
+## y
+
+`|Num4| -> Float`
+
+Returns the second element of the Num4.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.y()
+# 20
+```
+
+This can be useful when using a Num4 as a 3D or 4D vector, and want to access
+its `y` component.
+
+## z
+
+`|Num4| -> Float`
+
+Returns the third element of the Num4.
+
+This can be useful when using a Num4 as a 3D or 4D vector, and want to access
+its `z` component.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.z()
+# 30
+```
+
+## w
+
+`|Num4| -> Float`
+
+Returns the fourth element of the Num4.
+
+This can be useful when using a Num4 as a 4D vector, and want to access its `w`
+component.
+
+### Example
+
+```koto
+n = make_num4 10, 20, 30, 40
+n.w()
+# 40
 ```

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -17,53 +17,59 @@ sun, jupiter, saturn, uranus, neptune = {}, {}, {}, {}, {}
 
 
 init_bodies = ||
-  sun.pos = num4 0
-  sun.vel = num4 0
+  sun.pos = make_num4 0
+  sun.vel = make_num4 0
   sun.mass = solar_mass
 
   jupiter.pos =
-    num4 4.84143144246472090e+00,
-         -1.16032004402742839e+00,
-         -1.03622044471123109e-01
+    make_num4
+      4.84143144246472090e+00,
+      -1.16032004402742839e+00,
+      -1.03622044471123109e-01
   jupiter.vel =
-    num4 (1.66007664274403694e-03 * days_per_year),
-         (7.69901118419740425e-03 * days_per_year),
-         (-6.90460016972063023e-05 * days_per_year)
+    make_num4
+      (1.66007664274403694e-03 * days_per_year),
+      (7.69901118419740425e-03 * days_per_year),
+      (-6.90460016972063023e-05 * days_per_year)
   jupiter.mass = 9.54791938424326609e-04 * solar_mass
 
   saturn.pos =
-    num4 8.34336671824457987e+00,
-         4.12479856412430479e+00,
-         -4.03523417114321381e-01
+    make_num4
+      8.34336671824457987e+00,
+      4.12479856412430479e+00,
+      -4.03523417114321381e-01
   saturn.vel =
-    num4 (-2.76742510726862411e-03 * days_per_year),
-         (4.99852801234917238e-03 * days_per_year),
-         (2.30417297573763929e-05 * days_per_year)
+    make_num4
+      (-2.76742510726862411e-03 * days_per_year),
+      (4.99852801234917238e-03 * days_per_year),
+      (2.30417297573763929e-05 * days_per_year)
   saturn.mass = 2.85885980666130812e-04 * solar_mass
 
   uranus.pos =
-    num4 1.28943695621391310e+01,
-         -1.51111514016986312e+01,
-         -2.23307578892655734e-01
+    make_num4
+      1.28943695621391310e+01,
+      -1.51111514016986312e+01,
+      -2.23307578892655734e-01
   uranus.vel =
-    num4 (2.96460137564761618e-03 * days_per_year),
-         (2.37847173959480950e-03 * days_per_year),
-         (-2.96589568540237556e-05 * days_per_year)
+    make_num4
+      (2.96460137564761618e-03 * days_per_year),
+      (2.37847173959480950e-03 * days_per_year),
+      (-2.96589568540237556e-05 * days_per_year)
   uranus.mass = 4.36624404335156298e-05 * solar_mass
 
   neptune.pos =
-    num4 1.53796971148509165e+01,
-         -2.59193146099879641e+01,
-         1.79258772950371181e-01
+    make_num4
+      1.53796971148509165e+01,
+      -2.59193146099879641e+01,
+      1.79258772950371181e-01
   neptune.vel =
-    num4 (2.68067772490389322e-03 * days_per_year),
-         (1.62824170038242295e-03 * days_per_year),
-         (-9.51592254519715870e-05 * days_per_year)
+    make_num4
+      (2.68067772490389322e-03 * days_per_year),
+      (1.62824170038242295e-03 * days_per_year),
+      (-9.51592254519715870e-05 * days_per_year)
   neptune.mass = 5.15138902046611451e-05 * solar_mass
 
-
 bodies = [sun, jupiter, saturn, uranus, neptune]
-
 
 advance = |bodies, nbodies, dt|
   for i, bi in bodies.enumerate()
@@ -81,7 +87,6 @@ advance = |bodies, nbodies, dt|
     bi.vel = bi_vel
     bi.pos = bi.pos + dt * bi_vel
 
-
 get_energy = |bodies, nbody|
   energy = 0
   for i, bi in bodies.enumerate()
@@ -95,13 +100,11 @@ get_energy = |bodies, nbody|
       energy -= (bi_mass * bj.mass) / distance
   energy
 
-
 offset_momentum = |bodies, nbody|
-  pos = num4 0
+  pos = make_num4 0
   for body in bodies
     pos += body.vel * body.mass
   bodies[0].vel = -pos / solar_mass
-
 
 run_nbody = |n|
   init_bodies()
@@ -112,7 +115,6 @@ run_nbody = |n|
     advance bodies, nbody, 0.01
   end_energy = get_energy bodies, nbody
   initial_energy, end_energy
-
 
 @main = ||
   n = match koto.args.get 0

--- a/koto/benches/num4.koto
+++ b/koto/benches/num4.koto
@@ -4,18 +4,18 @@
     arg then arg.to_number()
 
   for _ in 0..n
-    assert_eq (num4 0), (num4 0, 0, 0, 0)
-    assert_eq (num4 1), (num4 1, 1, 1, 1)
-    assert_eq (num4 1, 1), (num4 1, 1, 0, 0)
-    assert_eq (num4 1, 1, 1), (num4 1, 1, 1, 0)
-    assert_eq (num4 1, 1, 1, 1), (num4 1, 1, 1, 1)
+    assert_eq (make_num4 0), (make_num4 0, 0, 0, 0)
+    assert_eq (make_num4 1), (make_num4 1, 1, 1, 1)
+    assert_eq (make_num4 1, 1), (make_num4 1, 1, 0, 0)
+    assert_eq (make_num4 1, 1, 1), (make_num4 1, 1, 1, 0)
+    assert_eq (make_num4 1, 1, 1, 1), (make_num4 1, 1, 1, 1)
 
-    assert_eq (num4 [-1, 1]), (num4 -1, 1, 0, 0)
-    assert_eq (num4 num4 1), (num4 1)
+    assert_eq (make_num4 [-1, 1]), (make_num4 -1, 1, 0, 0)
+    assert_eq (make_num4 make_num4 1), (make_num4 1)
 
-    assert_eq ((num4 1) + (num4 0.5)), (num4 1.5)
-    assert_eq ((num4 2, 4, 6, 8) - 1), (num4 1, 3, 5, 7)
+    assert_eq ((make_num4 1) + (make_num4 0.5)), (make_num4 1.5)
+    assert_eq ((make_num4 2, 4, 6, 8) - 1), (make_num4 1, 3, 5, 7)
 
-    assert_eq ((num4 2) * (num4 0.5)), (num4 1)
-    assert_eq ((num4 2, 4, 6, 8) * 0.5), (num4 1, 2, 3, 4)
-    assert_eq (8 / (num4 2, 4, 8, 16)), (num4 4, 2, 1, 0.5)
+    assert_eq ((make_num4 2) * (make_num4 0.5)), (make_num4 1)
+    assert_eq ((make_num4 2, 4, 6, 8) * 0.5), (make_num4 1, 2, 3, 4)
+    assert_eq (8 / (make_num4 2, 4, 8, 16)), (make_num4 4, 2, 1, 0.5)

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -39,6 +39,16 @@ make_foo = |x|
         .to_map(),
       {"entry 1": 1, "entry 2": 2, "entry 3": 3}
 
+  @test to_num2: ||
+    assert_eq (1, 2).to_num2(), (make_num2 1, 2)
+    assert_eq [1].to_num2(), (make_num2 1, 0)
+    assert_eq (1..10).keep(|n| n % 2 == 0).to_num2(), (make_num2 2, 4)
+
+  @test to_num4: ||
+    assert_eq (5, 6, 7, 8).to_num4(), (make_num4 5, 6, 7, 8)
+    assert_eq [-1, -2].to_num4(), (make_num4 -1, -2, 0, 0)
+    assert_eq (1..10).keep(|n| n % 2 == 0).to_num4(), (make_num4 2, 4, 6, 8)
+
   @test to_string: ||
     assert_eq ("a", "b", "c").to_string(), "abc"
     assert_eq ("a:", 1, " b:", 2).to_string(), "a:1 b:2"

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -192,7 +192,7 @@ make_foo = |x|
   @test product: ||
     assert_eq (1..=5).product(), 120
     # An initial value can be provided to override the default initial value of 0
-    assert_eq (2, 3, 4).product(num2 1, 2), (num2 24, 48)
+    assert_eq (2, 3, 4).product(make_num2 1, 2), (make_num2 24, 48)
 
   @test product_with_overloaded_multiply_operator: ||
     foo = |x|

--- a/koto/tests/libs/random.koto
+++ b/koto/tests/libs/random.koto
@@ -14,8 +14,8 @@ from test import assert, assert_eq, assert_ne, assert_near
     assert_near random.number(), 0.982, 0.001
 
   @test num2_num4: ||
-    assert_near random.number2(), (num2 0.024, 0.982), 0.001
-    assert_near random.number4(), (num4 0.006, 0.861, 0.823, 0.186), 0.001
+    assert_near random.number2(), (make_num2 0.024, 0.982), 0.001
+    assert_near random.number4(), (make_num4 0.006, 0.861, 0.823, 0.186), 0.001
 
   @test pick_list: ||
     x = ["foo", "bar", "baz"]

--- a/koto/tests/line_breaks.koto
+++ b/koto/tests/line_breaks.koto
@@ -1,15 +1,15 @@
-a = num4
+a = make_num4
   0, 1, 2, 3
-b = num4
+b = make_num4
   0, 1,
   2, 3
 assert_eq a, b
 
-a = num4(1,
+a = make_num4(1,
   2, 3,
   4
 )
-b = num4(
+b = make_num4(
   1,
   2, 3, # Comments can be included in the num4 construction
   4

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -96,7 +96,7 @@ make_foo = |x|
     assert_eq z, [42, 99]
 
   @test retain_value: ||
-    z = ["hello", 42, (num4 0), "hello"]
+    z = ["hello", 42, (make_num4 0), "hello"]
     z.retain "hello"
     assert_eq z, ["hello", "hello"]
 

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -63,7 +63,7 @@ make_foo = |x|
     m = {}
     m.insert 1, "O_o"
     assert_eq (m.get 1), "O_o"
-    assert_eq (m.get num2 1, 2), ()
+    assert_eq (m.get make_num2 1, 2), ()
 
   @test get_index: ||
     m = foo: 42, bar: 99, baz: 123

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -1,90 +1,90 @@
 @tests =
   @test creating: ||
-    assert_eq (num4 0), (num4 0, 0, 0, 0)
-    assert_eq (num2 1), (num2 1, 1)
-    assert_eq (num4 (num2 1)), (num4 1, 1, 0, 0)
+    assert_eq (make_num4 0), (make_num4 0, 0, 0, 0)
+    assert_eq (make_num2 1), (make_num2 1, 1)
+    assert_eq (make_num4 (make_num2 1)), (make_num4 1, 1, 0, 0)
 
   @test mutation_num2: ||
-    x = num2 10, 11
+    x = make_num2 10, 11
     x *= 2
-    assert_eq x, (num2 20, 22)
+    assert_eq x, (make_num2 20, 22)
     x %= 5
-    assert_eq x, (num2 0, 2)
-    x += num2 10
-    assert_eq x, (num2 10, 12)
+    assert_eq x, (make_num2 0, 2)
+    x += make_num2 10
+    assert_eq x, (make_num2 10, 12)
 
   @test mutation_num4: ||
-    x = num4 5, 6, 7, 8
+    x = make_num4 5, 6, 7, 8
     x *= 2
-    assert_eq x, (num4 10, 12, 14, 16)
+    assert_eq x, (make_num4 10, 12, 14, 16)
     x %= 5
-    assert_eq x, (num4 0, 2, 4, 1)
-    x += num4 10
-    assert_eq x, (num4 10, 12, 14, 11)
+    assert_eq x, (make_num4 0, 2, 4, 1)
+    x += make_num4 10
+    assert_eq x, (make_num4 10, 12, 14, 11)
 
   @test length: ||
-    assert_eq (num2 3, 4).length(), 5
-    assert_eq (num2 -3, -4).length(), 5
-    assert_eq (num4 2, -2, 2, -2).length(), 4
+    assert_eq (make_num2 3, 4).length(), 5
+    assert_eq (make_num2 -3, -4).length(), 5
+    assert_eq (make_num4 2, -2, 2, -2).length(), 4
 
   @test max: ||
-    assert_eq (num2 1, -1).max(), 1
-    assert_eq (num4 3, 4, 5, -123).max(), 5
+    assert_eq (make_num2 1, -1).max(), 1
+    assert_eq (make_num4 3, 4, 5, -123).max(), 5
 
   @test min: ||
-    assert_eq (num2 1, -1).min(), -1
-    assert_eq (num4 3, 4, 5, -123).min(), -123
+    assert_eq (make_num2 1, -1).min(), -1
+    assert_eq (make_num4 3, 4, 5, -123).min(), -123
 
   @test normalize: ||
-    assert_eq (num2 0, 1).normalize(), num2 0, 1
-    assert_eq (num2 3, 4).normalize(), num2 0.6, 0.8
-    assert_eq (num4 2, -2, 2, -2).normalize(), num4 0.5, -0.5, 0.5, -0.5
+    assert_eq (make_num2 0, 1).normalize(), make_num2 0, 1
+    assert_eq (make_num2 3, 4).normalize(), make_num2 0.6, 0.8
+    assert_eq (make_num4 2, -2, 2, -2).normalize(), make_num4 0.5, -0.5, 0.5, -0.5
 
   @test product: ||
-    assert_eq (num2 3, 4).product(), 12
-    assert_eq (num4 3, 4, 5, 6).product(), 360
+    assert_eq (make_num2 3, 4).product(), 12
+    assert_eq (make_num4 3, 4, 5, 6).product(), 360
 
   @test sum: ||
-    assert_eq (num2 1, 2).sum(), 3
-    assert_eq (num4 1, 2, 3, 4).sum(), 10
+    assert_eq (make_num2 1, 2).sum(), 3
+    assert_eq (make_num4 1, 2, 3, 4).sum(), 10
 
   @test element_access_num2: ||
-    x = num2 10, 20
+    x = make_num2 10, 20
     assert_eq x[0], 10
     assert_eq x[1], 20
 
   @test element_access_num4: ||
-    x = num4 2, 3, 4, 5
+    x = make_num4 2, 3, 4, 5
     assert_eq x[0], 2
     assert_eq x[3], 5
 
   @test element_mutation_num2: ||
-    x = num2 1, 2
+    x = make_num2 1, 2
 
     x[0] = 99
-    assert_eq x, (num2 99, 2)
+    assert_eq x, (make_num2 99, 2)
 
     x[..] = -1
-    assert_eq x, (num2 -1, -1)
+    assert_eq x, (make_num2 -1, -1)
 
   @test element_mutation_num4: ||
-    x = num4 1, 2, 3, 4
+    x = make_num4 1, 2, 3, 4
     x[0] = -1
     x[3] = 123
-    assert_eq x, (num4 -1, 2, 3, 123)
+    assert_eq x, (make_num4 -1, 2, 3, 123)
 
     x[2..] = 99
-    assert_eq x, (num4 -1, 2, 99, 99)
+    assert_eq x, (make_num4 -1, 2, 99, 99)
 
   @test element_unpacking_num2: ||
-    x = num2 1, 2
+    x = make_num2 1, 2
     a, b, c = x
     assert_eq a, 1
     assert_eq b, 2
     assert_eq c, ()
 
   @test element_unpacking_num4: ||
-    x = num4 5, 6, 7, 8
+    x = make_num4 5, 6, 7, 8
     a, b, c, d, e = x
     assert_eq a, 5
     assert_eq b, 6
@@ -93,7 +93,7 @@
     assert_eq e, ()
 
   @test iterator_ops_num2: ||
-    x = num2 1, 2
+    x = make_num2 1, 2
     assert_eq x.to_list(), [1, 2]
 
     i = x.iter()
@@ -102,7 +102,7 @@
     assert_eq i.next(), ()
 
   @test iterator_ops_num4: ||
-    x = num4 5, 6, 7, 8
+    x = make_num4 5, 6, 7, 8
     assert_eq x.to_tuple(), (5, 6, 7, 8)
 
     i = x.iter()

--- a/koto/tests/types.koto
+++ b/koto/tests/types.koto
@@ -6,8 +6,8 @@
     assert_eq (type {foo: 42}), "Map"
     assert_eq (type 0), "Int"
     assert_eq (type 0.0), "Float"
-    assert_eq (type (num2 0)), "Num2"
-    assert_eq (type (num4 0)), "Num4"
+    assert_eq (type (make_num2 0)), "Num2"
+    assert_eq (type (make_num4 0)), "Num4"
     assert_eq (type 0..10), "Range"
     assert_eq (type "foo"), "String"
 

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -472,8 +472,6 @@ impl Compiler {
                 result
             }
             Node::Str(string) => self.compile_string(result_register, &string.nodes, ast)?,
-            Node::Num2(elements) => self.compile_make_num2(result_register, elements, ast)?,
-            Node::Num4(elements) => self.compile_make_num4(result_register, elements, ast)?,
             Node::List(elements) => {
                 self.compile_make_sequence(result_register, elements, Op::SequenceToList, ast)?
             }
@@ -1872,112 +1870,6 @@ impl Compiler {
                 }
             }
         }
-
-        Ok(result)
-    }
-
-    fn compile_make_num2(
-        &mut self,
-        result_register: ResultRegister,
-        elements: &[AstIndex],
-        ast: &Ast,
-    ) -> CompileNodeResult {
-        if elements.is_empty() || elements.len() > 2 {
-            return compiler_error!(
-                self,
-                "compile_make_num2: unexpected number of elements: {}",
-                elements.len()
-            );
-        }
-
-        let result = match self.get_result_register(result_register)? {
-            Some(result) => {
-                let stack_count = self.frame().register_stack.len();
-
-                for element_node in elements.iter() {
-                    let element_register = self.push_register()?;
-                    self.compile_node(
-                        ResultRegister::Fixed(element_register),
-                        ast.node(*element_node),
-                        ast,
-                    )?;
-                }
-
-                let first_element_register = self.peek_register(elements.len() - 1)?;
-                self.push_op(
-                    Op::MakeNum2,
-                    &[
-                        result.register,
-                        first_element_register,
-                        elements.len() as u8,
-                    ],
-                );
-
-                self.truncate_register_stack(stack_count)?;
-                Some(result)
-            }
-            None => {
-                // Compile the element nodes for side-effects
-                for element_node in elements.iter() {
-                    self.compile_node(ResultRegister::None, ast.node(*element_node), ast)?;
-                }
-                None
-            }
-        };
-
-        Ok(result)
-    }
-
-    fn compile_make_num4(
-        &mut self,
-        result_register: ResultRegister,
-        elements: &[AstIndex],
-        ast: &Ast,
-    ) -> CompileNodeResult {
-        if elements.is_empty() || elements.len() > 4 {
-            return compiler_error!(
-                self,
-                "compile_make_num4: unexpected number of elements: {}",
-                elements.len()
-            );
-        }
-
-        let result = match self.get_result_register(result_register)? {
-            Some(result) => {
-                let stack_count = self.frame().register_stack.len();
-
-                for element_node in elements.iter() {
-                    let element_register = self.push_register()?;
-                    self.compile_node(
-                        ResultRegister::Fixed(element_register),
-                        ast.node(*element_node),
-                        ast,
-                    )?;
-                }
-
-                let first_element_register = self.peek_register(elements.len() - 1)?;
-                self.push_op(
-                    Op::MakeNum4,
-                    &[
-                        result.register,
-                        first_element_register,
-                        elements.len() as u8,
-                    ],
-                );
-
-                self.truncate_register_stack(stack_count)?;
-
-                Some(result)
-            }
-            None => {
-                // Compile the element nodes for side-effects
-                for element_node in elements.iter() {
-                    self.compile_node(ResultRegister::None, ast.node(*element_node), ast)?;
-                }
-
-                None
-            }
-        };
 
         Ok(result)
     }

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -130,16 +130,6 @@ pub enum Instruction {
         register: u8,
         size_hint: usize,
     },
-    MakeNum2 {
-        register: u8,
-        element_register: u8,
-        count: u8,
-    },
-    MakeNum4 {
-        register: u8,
-        element_register: u8,
-        count: u8,
-    },
     SequenceStart {
         register: u8,
         size_hint: usize,
@@ -437,8 +427,6 @@ impl fmt::Display for Instruction {
             Import { .. } => write!(f, "Import"),
             MakeTempTuple { .. } => write!(f, "MakeTempTuple"),
             MakeMap { .. } => write!(f, "MakeMap"),
-            MakeNum2 { .. } => write!(f, "MakeNum2"),
-            MakeNum4 { .. } => write!(f, "MakeNum4"),
             SequenceStart { .. } => write!(f, "SequenceStart"),
             SequencePush { .. } => write!(f, "SequencePush"),
             SequencePushN { .. } => write!(f, "SequencePushN"),
@@ -554,24 +542,6 @@ impl fmt::Debug for Instruction {
                 f,
                 "MakeMap\t\tresult: {}\tsize_hint: {}",
                 register, size_hint
-            ),
-            MakeNum2 {
-                register,
-                count,
-                element_register,
-            } => write!(
-                f,
-                "MakeNum2\tresult: {}\tcount: {}\telement reg: {}",
-                register, count, element_register
-            ),
-            MakeNum4 {
-                register,
-                count,
-                element_register,
-            } => write!(
-                f,
-                "MakeNum4\tresult: {}\tcount: {}\telement reg: {}",
-                register, count, element_register
             ),
             SequenceStart {
                 register,
@@ -1189,16 +1159,6 @@ impl Iterator for InstructionReader {
             Op::MakeMap32 => Some(MakeMap {
                 register: get_u8!(),
                 size_hint: get_u32!() as usize,
-            }),
-            Op::MakeNum2 => Some(MakeNum2 {
-                register: get_u8!(),
-                element_register: get_u8!(),
-                count: get_u8!(),
-            }),
-            Op::MakeNum4 => Some(MakeNum4 {
-                register: get_u8!(),
-                element_register: get_u8!(),
-                count: get_u8!(),
             }),
             Op::SequenceStart => Some(SequenceStart {
                 register: get_u8!(),

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -131,16 +131,6 @@ pub enum Op {
     /// `[*target, size hint[4]]`
     MakeMap32,
 
-    /// Makes a Num2 in the target register
-    ///
-    /// `[*target, *start, value count]`
-    MakeNum2,
-
-    /// Makes a Num4 in the target register
-    ///
-    /// `[*target, *start, value count]`
-    MakeNum4,
-
     /// Makes an Iterator out of an iterable value
     ///
     /// `[*target, *iterable]`
@@ -533,6 +523,8 @@ pub enum Op {
     CheckSize,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
+    Unused91,
+    Unused92,
     Unused93,
     Unused94,
     Unused95,

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -82,8 +82,6 @@ pub enum Token {
     Loop,
     Match,
     Not,
-    Num2,
-    Num4,
     Or,
     Return,
     Switch,
@@ -482,8 +480,6 @@ impl<'a> TokenLexer<'a> {
             check_keyword!("loop", Loop);
             check_keyword!("match", Match);
             check_keyword!("not", Not);
-            check_keyword!("num2", Num2);
-            check_keyword!("num4", Num4);
             check_keyword!("or", Or);
             check_keyword!("return", Return);
             check_keyword!("switch", Switch);
@@ -949,9 +945,9 @@ mod tests {
     fn indent() {
         let input = "\
 if true then
-  num4 1
+  make_num4 1
 
-num2 2
+make_num2 2
 x
 y";
         check_lexer_output_indented(
@@ -961,11 +957,11 @@ y";
                 (True, None, 1, 0),
                 (Then, None, 1, 0),
                 (NewLineIndented, None, 2, 2),
-                (Num4, None, 2, 2),
+                (Id, Some("make_num4"), 2, 2),
                 (Number, Some("1"), 2, 2),
                 (NewLine, None, 3, 0),
                 (NewLine, None, 4, 0),
-                (Num2, None, 4, 0),
+                (Id, Some("make_num2"), 4, 0),
                 (Number, Some("2"), 4, 0),
                 (NewLine, None, 5, 0),
                 (Id, Some("x"), 5, 0),

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -105,8 +105,6 @@ pub enum SyntaxError {
     MatchElseNotInLastArm,
     SelfArgNotInFirstPosition,
     SwitchElseNotInLastArm,
-    TooManyNum2Terms,
-    TooManyNum4Terms,
     UnexpectedCharInNumericEscapeCode,
     UnexpectedElseIndentation,
     UnexpectedElseIfIndentation,
@@ -327,8 +325,6 @@ impl fmt::Display for SyntaxError {
                 f.write_str("else can only be used in the last arm in a switch expression")
             }
             SelfArgNotInFirstPosition => f.write_str("self is only allowed as the first argument"),
-            TooManyNum2Terms => f.write_str("num2 only supports up to 2 terms"),
-            TooManyNum4Terms => f.write_str("num4 only supports up to 4 terms"),
             UnexpectedCharInNumericEscapeCode => {
                 f.write_str("Unexpected character in numeric escape code")
             }

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -54,16 +54,6 @@ pub enum Node {
     /// A string literal
     Str(AstString),
 
-    /// A `num2` expression
-    ///
-    /// e.g. `num2 1` or `num2 3, 4`
-    Num2(Vec<AstIndex>),
-
-    /// A `num4` expression
-    ///
-    /// e.g. `num4 1`, `num4 1, 2, 3, 4`, etc.
-    Num4(Vec<AstIndex>),
-
     /// A list literal
     ///
     /// e.g. `[foo, bar, 42]`
@@ -293,8 +283,6 @@ impl fmt::Display for Node {
             Number0 => write!(f, "Number0"),
             Number1 => write!(f, "Number1"),
             Str(_) => write!(f, "Str"),
-            Num2(_) => write!(f, "Num2"),
-            Num4(_) => write!(f, "Num4"),
             List(_) => write!(f, "List"),
             Tuple(_) => write!(f, "Tuple"),
             TempTuple(_) => write!(f, "TempTuple"),

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1399,44 +1399,6 @@ impl<'source> Parser<'source> {
                 }
                 Token::SquareOpen => self.parse_list(context)?,
                 Token::CurlyOpen => self.parse_map_inline(context)?,
-                Token::Num2 => {
-                    self.consume_next_token(context);
-                    let start_span = self.current_span();
-
-                    let args = if self.peek_token() == Some(Token::RoundOpen) {
-                        self.parse_parenthesized_args()?
-                    } else {
-                        self.parse_call_args(&mut ExpressionContext::permissive())?
-                    };
-
-                    if args.is_empty() {
-                        return syntax_error!(ExpectedExpression, self);
-                    } else if args.len() > 2 {
-                        return syntax_error!(TooManyNum2Terms, self);
-                    }
-
-                    let node = self.push_node_with_start_span(Num2(args), start_span)?;
-                    Some(self.check_for_lookup_after_node(node, context)?)
-                }
-                Token::Num4 => {
-                    self.consume_next_token(context);
-                    let start_span = self.current_span();
-
-                    let args = if self.peek_token() == Some(Token::RoundOpen) {
-                        self.parse_parenthesized_args()?
-                    } else {
-                        self.parse_call_args(&mut ExpressionContext::permissive())?
-                    };
-
-                    if args.is_empty() {
-                        return syntax_error!(ExpectedExpression, self);
-                    } else if args.len() > 4 {
-                        return syntax_error!(TooManyNum4Terms, self);
-                    }
-
-                    let node = self.push_node_with_start_span(Num4(args), start_span)?;
-                    Some(self.check_for_lookup_after_node(node, context)?)
-                }
                 Token::If => self.parse_if_expression(context)?,
                 Token::Match => self.parse_match_expression(context)?,
                 Token::Switch => self.parse_switch_expression(context)?,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -876,61 +876,6 @@ min..max
         }
 
         #[test]
-        fn num2() {
-            let source = "\
-num2 0
-num2
-  1,
-  x";
-            check_ast(
-                source,
-                &[
-                    Number0,
-                    Num2(vec![0]),
-                    Number1,
-                    Id(constant(0)),
-                    Num2(vec![2, 3]),
-                    MainBlock {
-                        body: vec![1, 4],
-                        local_count: 0,
-                    },
-                ],
-                Some(&[Constant::Str("x")]),
-            )
-        }
-
-        #[test]
-        fn num4() {
-            let source = "\
-num4 0
-num4 1, x
-num4(
-  x, 0,
-  1, x,
-)";
-            check_ast(
-                source,
-                &[
-                    Number0,
-                    Num4(vec![0]),
-                    Number1,
-                    Id(constant(0)),
-                    Num4(vec![2, 3]),
-                    Id(constant(0)), // 5
-                    Number0,
-                    Number1,
-                    Id(constant(0)),
-                    Num4(vec![5, 6, 7, 8]),
-                    MainBlock {
-                        body: vec![1, 4, 9],
-                        local_count: 0,
-                    },
-                ],
-                Some(&[Constant::Str("x")]),
-            )
-        }
-
-        #[test]
         fn tuple() {
             let source = "0, 1, 0";
             check_ast(
@@ -3715,58 +3660,6 @@ x.foo
                     },
                 ],
                 Some(&[Constant::Str("x"), Constant::Str("values")]),
-            )
-        }
-
-        #[test]
-        fn lookup_on_num2_with_parens() {
-            let source = "num2(1).sum()";
-            check_ast(
-                source,
-                &[
-                    Number1,
-                    Num2(vec![0]),
-                    Lookup((
-                        LookupNode::Call {
-                            args: vec![],
-                            with_parens: true,
-                        },
-                        None,
-                    )),
-                    Lookup((LookupNode::Id(constant(0)), Some(2))),
-                    Lookup((LookupNode::Root(1), Some(3))),
-                    MainBlock {
-                        body: vec![4],
-                        local_count: 0,
-                    },
-                ],
-                Some(&[Constant::Str("sum")]),
-            )
-        }
-
-        #[test]
-        fn lookup_on_num4_with_parens() {
-            let source = "num4(1).sum()";
-            check_ast(
-                source,
-                &[
-                    Number1,
-                    Num4(vec![0]),
-                    Lookup((
-                        LookupNode::Call {
-                            args: vec![],
-                            with_parens: true,
-                        },
-                        None,
-                    )),
-                    Lookup((LookupNode::Id(constant(0)), Some(2))),
-                    Lookup((LookupNode::Root(1), Some(3))),
-                    MainBlock {
-                        body: vec![4],
-                        local_count: 0,
-                    },
-                ],
-                Some(&[Constant::Str("sum")]),
             )
         }
 

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -1,10 +1,13 @@
 pub mod adaptors;
 
-use crate::{
-    runtime_error, unexpected_type_error_with_slice,
-    value_iterator::{make_iterator, ValueIterator, ValueIteratorOutput as Output},
-    BinaryOp, CallArgs, DataMap, RuntimeError, RuntimeResult, Value, ValueList, ValueMap, ValueVec,
-    Vm,
+use {
+    super::{num2::num2_from_iterator, num4::num4_from_iterator},
+    crate::{
+        runtime_error, unexpected_type_error_with_slice,
+        value_iterator::{make_iterator, ValueIterator, ValueIteratorOutput as Output},
+        BinaryOp, CallArgs, DataMap, RuntimeError, RuntimeResult, Value, ValueList, ValueMap,
+        ValueVec, Vm,
+    },
 };
 
 pub fn make_module() -> ValueMap {
@@ -645,6 +648,30 @@ pub fn make_module() -> ValueMap {
         }
         unexpected => unexpected_type_error_with_slice(
             "iterator.to_map",
+            "an iterable value as argument",
+            unexpected,
+        ),
+    });
+
+    result.add_fn("to_num2", |vm, args| match vm.get_args(args) {
+        [iterable] if iterable.is_iterable() => {
+            let iterator = make_iterator(iterable).unwrap();
+            Ok(Num2(num2_from_iterator(iterator, "iterator.to_num2")?))
+        }
+        unexpected => unexpected_type_error_with_slice(
+            "iterator.to_num2",
+            "an iterable value as argument",
+            unexpected,
+        ),
+    });
+
+    result.add_fn("to_num4", |vm, args| match vm.get_args(args) {
+        [iterable] if iterable.is_iterable() => {
+            let iterator = make_iterator(iterable).unwrap();
+            Ok(Num4(num4_from_iterator(iterator, "iterator.to_num4")?))
+        }
+        unexpected => unexpected_type_error_with_slice(
+            "iterator.to_num4",
             "an iterable value as argument",
             unexpected,
         ),

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -2,8 +2,8 @@ use {
     super::iterator::collect_pair,
     crate::{
         num2, unexpected_type_error_with_slice,
-        value_iterator::{make_iterator, ValueIteratorOutput as Output},
-        RuntimeResult, Value, ValueMap,
+        value_iterator::{make_iterator, ValueIterator, ValueIteratorOutput as Output},
+        RuntimeError, RuntimeResult, Value, ValueMap,
     },
 };
 
@@ -23,23 +23,7 @@ pub fn make_module() -> ValueMap {
             [Number(n1), Number(n2)] => num2::Num2(n1.into(), n2.into()),
             [Num2(n)] => *n,
             [iterable] if iterable.is_iterable() => {
-                let iterator = make_iterator(iterable).unwrap();
-                let mut result = num2::Num2::default();
-                for (i, value) in iterator.take(2).map(collect_pair).enumerate() {
-                    match value {
-                        Output::Value(Number(n)) => result[i] = n.into(),
-                        Output::Value(unexpected) => {
-                            return unexpected_type_error_with_slice(
-                                "num2.make_num2",
-                                "a Number",
-                                &[unexpected],
-                            )
-                        }
-                        Output::Error(e) => return Err(e),
-                        _ => unreachable!(), // ValuePairs collected in collect_pair
-                    }
-                }
-                result
+                num2_from_iterator(make_iterator(iterable).unwrap(), "num2.make_num2")?
             }
             unexpected => {
                 return unexpected_type_error_with_slice(
@@ -82,4 +66,22 @@ pub fn make_module() -> ValueMap {
 
 fn num2_error(name: &str, unexpected: &[Value]) -> RuntimeResult {
     unexpected_type_error_with_slice(&format!("num2.{}", name), "a Num2 as argument", unexpected)
+}
+
+pub(crate) fn num2_from_iterator(
+    iterator: ValueIterator,
+    error_prefix: &str,
+) -> Result<num2::Num2, RuntimeError> {
+    let mut result = num2::Num2::default();
+    for (i, value) in iterator.take(2).map(collect_pair).enumerate() {
+        match value {
+            Output::Value(Value::Number(n)) => result[i] = n.into(),
+            Output::Value(unexpected) => {
+                return unexpected_type_error_with_slice(error_prefix, "a Number", &[unexpected])
+            }
+            Output::Error(e) => return Err(e),
+            _ => unreachable!(), // ValuePairs collected in collect_pair
+        }
+    }
+    Ok(result)
 }

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -61,6 +61,16 @@ pub fn make_module() -> ValueMap {
         unexpected => num2_error("sum", unexpected),
     });
 
+    result.add_fn("x", |vm, args| match vm.get_args(args) {
+        [Num2(n)] => Ok(Number(n.0.into())),
+        unexpected => num2_error("x", unexpected),
+    });
+
+    result.add_fn("y", |vm, args| match vm.get_args(args) {
+        [Num2(n)] => Ok(Number(n.1.into())),
+        unexpected => num2_error("y", unexpected),
+    });
+
     result
 }
 

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -1,4 +1,11 @@
-use crate::{unexpected_type_error_with_slice, RuntimeResult, Value, ValueMap};
+use {
+    super::iterator::collect_pair,
+    crate::{
+        num2, unexpected_type_error_with_slice,
+        value_iterator::{make_iterator, ValueIteratorOutput as Output},
+        RuntimeResult, Value, ValueMap,
+    },
+};
 
 pub fn make_module() -> ValueMap {
     use Value::*;
@@ -8,6 +15,41 @@ pub fn make_module() -> ValueMap {
     result.add_fn("length", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Number(n.length().into())),
         unexpected => num2_error("length", unexpected),
+    });
+
+    result.add_fn("make_num2", |vm, args| {
+        let result = match vm.get_args(args) {
+            [Number(n)] => num2::Num2(n.into(), n.into()),
+            [Number(n1), Number(n2)] => num2::Num2(n1.into(), n2.into()),
+            [Num2(n)] => *n,
+            [iterable] if iterable.is_iterable() => {
+                let iterator = make_iterator(iterable).unwrap();
+                let mut result = num2::Num2::default();
+                for (i, value) in iterator.take(2).map(collect_pair).enumerate() {
+                    match value {
+                        Output::Value(Number(n)) => result[i] = n.into(),
+                        Output::Value(unexpected) => {
+                            return unexpected_type_error_with_slice(
+                                "num2.make_num2",
+                                "a Number",
+                                &[unexpected],
+                            )
+                        }
+                        Output::Error(e) => return Err(e),
+                        _ => unreachable!(), // ValuePairs collected in collect_pair
+                    }
+                }
+                result
+            }
+            unexpected => {
+                return unexpected_type_error_with_slice(
+                    "num2.make_num2",
+                    "Numbers or an iterable as arguments",
+                    unexpected,
+                )
+            }
+        };
+        Ok(Num2(result))
     });
 
     result.add_fn("max", |vm, args| match vm.get_args(args) {

--- a/src/runtime/src/core/num4.rs
+++ b/src/runtime/src/core/num4.rs
@@ -73,6 +73,46 @@ pub fn make_module() -> ValueMap {
         unexpected => num4_error("sum", unexpected),
     });
 
+    result.add_fn("r", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.0.into())),
+        unexpected => num4_error("r", unexpected),
+    });
+
+    result.add_fn("g", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.1.into())),
+        unexpected => num4_error("g", unexpected),
+    });
+
+    result.add_fn("b", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.2.into())),
+        unexpected => num4_error("b", unexpected),
+    });
+
+    result.add_fn("a", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.3.into())),
+        unexpected => num4_error("a", unexpected),
+    });
+
+    result.add_fn("x", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.0.into())),
+        unexpected => num4_error("x", unexpected),
+    });
+
+    result.add_fn("y", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.1.into())),
+        unexpected => num4_error("y", unexpected),
+    });
+
+    result.add_fn("z", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.2.into())),
+        unexpected => num4_error("z", unexpected),
+    });
+
+    result.add_fn("w", |vm, args| match vm.get_args(args) {
+        [Num4(n)] => Ok(Number(n.3.into())),
+        unexpected => num4_error("w", unexpected),
+    });
+
     result
 }
 

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -65,6 +65,8 @@ fn setup_core_lib_and_prelude() -> (CoreLib, ValueMap) {
     prelude.add_map("map", core_lib.map.clone());
     prelude.add_map("os", core_lib.os.clone());
     prelude.add_map("number", core_lib.number.clone());
+    prelude.add_map("num2", core_lib.num2.clone());
+    prelude.add_map("num4", core_lib.num4.clone());
     prelude.add_map("range", core_lib.range.clone());
     prelude.add_map("string", core_lib.string.clone());
     prelude.add_map("test", core_lib.test.clone());

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1838,48 +1838,48 @@ gen().to_tuple()
 
         #[test]
         fn with_1_arg_1() {
-            test_script("num2 1", num2(1.0, 1.0));
+            test_script("make_num2 1", num2(1.0, 1.0));
         }
 
         #[test]
         fn with_1_arg_2() {
-            test_script("num2 2", num2(2.0, 2.0));
+            test_script("make_num2 2", num2(2.0, 2.0));
         }
 
         #[test]
         fn with_2_args() {
-            test_script("num2 1, 2", num2(1.0, 2.0));
+            test_script("make_num2 1, 2", num2(1.0, 2.0));
         }
 
         #[test]
         fn from_list() {
-            test_script("num2 [-1]", num2(-1.0, 0.0));
+            test_script("make_num2 [-1]", num2(-1.0, 0.0));
         }
 
         #[test]
         fn from_num2() {
-            test_script("num2 (num2 1, 2)", num2(1.0, 2.0));
+            test_script("make_num2 (make_num2 1, 2)", num2(1.0, 2.0));
         }
 
         #[test]
         fn add_multiply() {
-            test_script("(num2 1) + (num2 0.5) * 3.0", num2(2.5, 2.5));
+            test_script("(make_num2 1) + (make_num2 0.5) * 3.0", num2(2.5, 2.5));
         }
 
         #[test]
         fn subtract_divide() {
-            test_script("((num2 10, 20) - (num2 2)) / 2.0", num2(4.0, 9.0));
+            test_script("((make_num2 10, 20) - (make_num2 2)) / 2.0", num2(4.0, 9.0));
         }
 
         #[test]
         fn modulo() {
-            test_script("(num2 15, 25) % (num2 10) % 4", num2(1.0, 1.0));
+            test_script("(make_num2 15, 25) % (make_num2 10) % 4", num2(1.0, 1.0));
         }
 
         #[test]
         fn negation() {
             let script = "
-x = num2 1, -2
+x = make_num2 1, -2
 -x";
             test_script(script, num2(-1.0, 2.0));
         }
@@ -1887,7 +1887,7 @@ x = num2 1, -2
         #[test]
         fn index() {
             let script = "
-x = num2 4, 5
+x = make_num2 4, 5
 x[1]";
             test_script(script, 5.into());
         }
@@ -1895,7 +1895,7 @@ x[1]";
         #[test]
         fn index_element_mutation() {
             let script = "
-x = num2 4, 5
+x = make_num2 4, 5
 x[1] = 99
 x[1]";
             test_script(script, 99.into());
@@ -1904,7 +1904,7 @@ x[1]";
         #[test]
         fn index_range_mutation() {
             let script = "
-x = num2 4, 5
+x = make_num2 4, 5
 x[0..2] = 1
 x[0] + x[1]";
             test_script(script, 2.into());
@@ -1913,7 +1913,7 @@ x[0] + x[1]";
         #[test]
         fn index_full_range_mutation() {
             let script = "
-x = num2 4, 5
+x = make_num2 4, 5
 x[..] = 2
 x";
             test_script(script, num2(2.0, 2.0));
@@ -1922,7 +1922,7 @@ x";
         #[test]
         fn iterator_ops() {
             let script = "
-num2(1, -1).keep(|n| n < 0).count()
+make_num2(1, -1).keep(|n| n < 0).count()
 ";
             test_script(script, 1.into());
         }
@@ -1933,53 +1933,56 @@ num2(1, -1).keep(|n| n < 0).count()
 
         #[test]
         fn with_1_arg_1() {
-            test_script("num4 1", num4(1.0, 1.0, 1.0, 1.0));
+            test_script("make_num4 1", num4(1.0, 1.0, 1.0, 1.0));
         }
 
         #[test]
         fn with_1_arg_2() {
-            test_script("num4 2", num4(2.0, 2.0, 2.0, 2.0));
+            test_script("make_num4 2", num4(2.0, 2.0, 2.0, 2.0));
         }
 
         #[test]
         fn with_2_args() {
-            test_script("num4 1, 2", num4(1.0, 2.0, 0.0, 0.0));
+            test_script("make_num4 1, 2", num4(1.0, 2.0, 0.0, 0.0));
         }
 
         #[test]
         fn with_3_args() {
-            test_script("num4 3, 2, 1", num4(3.0, 2.0, 1.0, 0.0));
+            test_script("make_num4 3, 2, 1", num4(3.0, 2.0, 1.0, 0.0));
         }
 
         #[test]
         fn with_4_args() {
-            test_script("num4 -1, 1, -2, 2", num4(-1.0, 1.0, -2.0, 2.0));
+            test_script("make_num4 -1, 1, -2, 2", num4(-1.0, 1.0, -2.0, 2.0));
         }
 
         #[test]
         fn from_list() {
-            test_script("num4 [-1, 1]", num4(-1.0, 1.0, 0.0, 0.0));
+            test_script("make_num4 [-1, 1]", num4(-1.0, 1.0, 0.0, 0.0));
         }
 
         #[test]
         fn from_num2() {
-            test_script("num4 (num2 1, 2)", num4(1.0, 2.0, 0.0, 0.0));
+            test_script("make_num4 (make_num2 1, 2)", num4(1.0, 2.0, 0.0, 0.0));
         }
 
         #[test]
         fn from_num4() {
-            test_script("num4 (num4 3, 4)", num4(3.0, 4.0, 0.0, 0.0));
+            test_script("make_num4 (make_num4 3, 4)", num4(3.0, 4.0, 0.0, 0.0));
         }
 
         #[test]
         fn add_multiply() {
-            test_script("(num4 1) + (num4 0.5) * 3.0", num4(2.5, 2.5, 2.5, 2.5));
+            test_script(
+                "(make_num4 1) + (make_num4 0.5) * 3.0",
+                num4(2.5, 2.5, 2.5, 2.5),
+            );
         }
 
         #[test]
         fn subtract_divide() {
             test_script(
-                "((num4 10, 20, 30, 40) - (num4 2)) / 2.0",
+                "((make_num4 10, 20, 30, 40) - (make_num4 2)) / 2.0",
                 num4(4.0, 9.0, 14.0, 19.0),
             );
         }
@@ -1987,7 +1990,7 @@ num2(1, -1).keep(|n| n < 0).count()
         #[test]
         fn modulo() {
             test_script(
-                "(num4 15, 25, 35, 45) % (num4 10) % 4",
+                "(make_num4 15, 25, 35, 45) % (make_num4 10) % 4",
                 num4(1.0, 1.0, 1.0, 1.0),
             );
         }
@@ -1995,7 +1998,7 @@ num2(1, -1).keep(|n| n < 0).count()
         #[test]
         fn negation() {
             let script = "
-x = num4 1, -2, 3, -4
+x = make_num4 1, -2, 3, -4
 -x";
             test_script(script, num4(-1.0, 2.0, -3.0, 4.0));
         }
@@ -2003,7 +2006,7 @@ x = num4 1, -2, 3, -4
         #[test]
         fn index() {
             let script = "
-x = num4 9, 8, 7, 6
+x = make_num4 9, 8, 7, 6
 x[3]";
             test_script(script, 6.into());
         }
@@ -2011,7 +2014,7 @@ x[3]";
         #[test]
         fn index_element_mutation() {
             let script = "
-x = num4 4, 5, 6, 7
+x = make_num4 4, 5, 6, 7
 x[2] = 99
 x[2]";
             test_script(script, 99.into());
@@ -2020,7 +2023,7 @@ x[2]";
         #[test]
         fn index_range_mutation() {
             let script = "
-x = num4 4, 5, 6, 7
+x = make_num4 4, 5, 6, 7
 x[1..=2] = 1
 x";
             test_script(script, num4(4.0, 1.0, 1.0, 7.0));
@@ -2029,7 +2032,7 @@ x";
         #[test]
         fn index_full_range_mutation() {
             let script = "
-x = num4 4, 5, 6, 7
+x = make_num4 4, 5, 6, 7
 x[..] = 2
 x.sum()";
             test_script(script, 8.into());
@@ -2038,7 +2041,7 @@ x.sum()";
         #[test]
         fn iterator_ops() {
             let script = "
-num4(1, -1, 2, -2).keep(|n| n > 0).count()
+make_num4(1, -1, 2, -2).keep(|n| n > 0).count()
 ";
             test_script(script, 2.into());
         }


### PR DESCRIPTION
Resolves #133.

- Replace num2/num4 keywords with core library functions
- Add iterator.to_num2 / to_num4
- Add x/y/z/w/r/g/b/a getters to num2 + num4
- Update the changelog
