### PR TITLE
Iterator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The Koto project adheres to
     foo(3).to_tuple()
     # (1, 2, 3)
     ```
+- Num2 and Num4 values can now be iterated over in a for loop.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ The Koto project adheres to
       # 2
       # 3
       ```
+- Maps can now implement `@iterator`, which allows you to define custom
+  iteration behaviour.
+  - e.g.
+    ```koto
+    foo = |n|
+      n: n
+      @iterator: |self| 1..=self.n
+    foo(3).to_tuple()
+    # (1, 2, 3)
+    ```
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The Koto project adheres to
     - `iterator`
       - `chunks`
       - `find`
+      - `flatten`
       - `to_num2`
       - `to_num4`
       - `windows`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The Koto project adheres to
 - Core Library
   - New additions:
     - `iterator`
+      - `chunks`
       - `find`
       - `to_num2`
       - `to_num4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The Koto project adheres to
       - `find`
       - `to_num2`
       - `to_num4`
+      - `windows`
     - `number.round`
     - `num2`
       - `make_num2`,

--- a/docs/reference/core_lib/iterator.md
+++ b/docs/reference/core_lib/iterator.md
@@ -77,6 +77,7 @@ for x in (2, 3, 4).each |n| n * 2
 - [to_num4](#to_num4)
 - [to_string](#to_string)
 - [to_tuple](#to_tuple)
+- [windows](#windows)
 - [zip](#zip)
 
 ## all
@@ -763,6 +764,26 @@ Consumes all values coming from the iterator and places them in a tuple.
 - [`iterator.to_list`](#to_list)
 - [`iterator.to_map`](#to_map)
 - [`iterator.to_string`](#to_string)
+
+## windows
+
+`|Iterable, Number| -> Iterator`
+
+Returns an iterator that splits up the input data into overlapping windows of
+size `N`, where each window is provided as an iterator over the chunk's
+elements.
+
+If the input has fewer than `N` elements then no windows will be produced.
+
+Note that the input value should be an iterable value that has a defined range,
+e.g. a List or a String (i.e. not an adapted iterator or a generator).
+
+### Example
+
+```koto
+(1..=5).windows(3).each(iterator.to_list).to_list(),
+# [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+```
 
 ## zip
 

--- a/docs/reference/core_lib/iterator.md
+++ b/docs/reference/core_lib/iterator.md
@@ -57,6 +57,7 @@ for x in (2, 3, 4).each |n| n * 2
 - [each](#each)
 - [enumerate](#enumerate)
 - [find](#find)
+- [flatten](#flatten)
 - [fold](#fold)
 - [intersperse](#intersperse)
 - [iter](#iter)
@@ -318,6 +319,23 @@ If no match is found then `()` is returned.
 
 (10..20).find |x| x > 100
 # ()
+```
+
+## flatten
+
+`|Iterable| -> Value`
+
+Returns the output of the input iterator, with any nested iterable values
+flattened out.
+
+Note that only one level of flattening is performed, so any double-nested
+containers will still be present in the output.
+
+### Example
+
+```koto
+[(2, 4), [6, 8, (10, 12)]].flatten().to_list()
+# [2, 4, 6, 8, (10, 12)]
 ```
 
 ### See Also

--- a/docs/reference/core_lib/iterator.md
+++ b/docs/reference/core_lib/iterator.md
@@ -49,6 +49,7 @@ for x in (2, 3, 4).each |n| n * 2
 - [all](#all)
 - [any](#any)
 - [chain](#chain)
+- [chunks](#chunks)
 - [consume](#consume)
 - [copy](#copy)
 - [count](#count)
@@ -141,6 +142,27 @@ followed by the output of the second iterator.
 ```koto
 [1, 2].chain([3, 4, 5]).to_tuple()
 # (1, 2, 3, 4, 5)
+```
+
+## chunks
+
+`|Iterable, Number| -> Iterator`
+
+Returns an iterator that splits up the input data into chunks of size `N`,
+where each chunk is provided as an iterator over the chunk's elements.
+The final chunk may have fewer than `N` elements.
+
+Note that the input value should be an iterable value that has a defined range,
+e.g. a List or a String (i.e. not an adapted iterator or a generator).
+
+### Example
+
+```koto
+(1..=10)
+  .chunks 3
+  .each |chunk| chunk.to_list()
+  .to_list()
+# [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]
 ```
 
 ## consume

--- a/docs/reference/core_lib/map.md
+++ b/docs/reference/core_lib/map.md
@@ -148,6 +148,10 @@ Additionally, the following meta functions can customize object behaviour:
 - `@index`
   - Overloads `[]` indexing:
     - `@index: |self, index| self.data + index`
+- `@iterator`
+  - Customizes how iterators will be made from the map. The function returns an
+    iterator that will be used in place of the default iteration behaviour.
+    - `@iterator: |self| 0..self.data`
 - `@display`
   - Customizes how the map will be displayed when formatted as a string:
     - `@display: |self| "X: {}".format self.data`

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -75,6 +75,12 @@ make_foo = |x|
       (1..10).chain(10..15).chain(15..20).to_tuple(),
       (1..20).to_tuple()
 
+  @test chunks: ||
+    assert_eq
+      (0..=10).chunks(3).each(iterator.to_tuple).to_tuple(),
+      ((0, 1, 2), (3, 4, 5), (6, 7, 8), (9, 10))
+    assert_eq (0..0).chunks(5).count(), 0
+
   @test consume: ||
     x = []
     (1..=5).each(|n| x.push n).consume()

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -246,6 +246,13 @@ make_foo = |x|
       ones().take(3).to_tuple(),
       (1, 1, 1)
 
+  @test windows: ||
+    assert_eq
+      (1..=5).windows(3).each(iterator.to_tuple).to_tuple(),
+      ((1, 2, 3), (2, 3, 4), (3, 4, 5))
+    # If there aren't enough values in the input, then no windows are produced.
+    assert_eq (1, 2).windows(3).count(), 0
+
   @test zip: ||
     assert_eq
       1..=3

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -135,6 +135,10 @@ make_foo = |x|
     assert_eq (1..10).find(|n| n > 4 and n < 6), 5
     assert_eq "heyNow".find(|c| c.to_uppercase() == c), "N"
 
+  @test flatten: ||
+    assert_eq [[1, 2, 3], {}, (4, [5, 6])].flatten().to_tuple(), (1, 2, 3, 4, [5, 6])
+    assert_eq (("a", "b", "c"), [], ("x", "y", "z")).flatten().to_string(), "abcxyz"
+
   @test fold: ||
     assert_eq (1..=5).fold(0, |sum, x| sum + x), 15
 

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -30,6 +30,8 @@ locals.foo_meta =
   # Indexing
   @[]: |self, index| self.x + index
 
+  @iterator: |self| 0..self.x
+
   # Formatting
   @display: |self| "Foo (${self.x})"
 
@@ -99,6 +101,10 @@ locals.foo_meta =
   @test index: ||
     assert_eq foo(10)[5], 15
     assert_eq foo(100)[-1], 99
+
+  @test iterator: ||
+    assert_eq foo(5).to_tuple(), (0, 1, 2, 3, 4)
+    assert_eq foo(-4).to_list(), [0, -1, -2, -3]
 
   @test display: ||
     assert_eq "${foo -1}", "Foo (-1)"

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -569,6 +569,8 @@ pub enum MetaKeyId {
 
     /// @display
     Display,
+    /// @iterator
+    Iterator,
     /// @negate
     Negate,
     /// @not

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -822,6 +822,7 @@ impl<'source> Parser<'source> {
             Some(Token::Not) => MetaKeyId::Not,
             Some(Token::Id) => match self.lexer.slice() {
                 "display" => MetaKeyId::Display,
+                "iterator" => MetaKeyId::Iterator,
                 "negate" => MetaKeyId::Negate,
                 "tests" => MetaKeyId::Tests,
                 "pre_test" => MetaKeyId::PreTest,

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -766,6 +766,21 @@ pub fn make_module() -> ValueMap {
         ),
     });
 
+    result.add_fn("windows", |vm, args| match vm.get_args(args) {
+        [iterable, Number(n)] if iterable.is_sequence() && *n >= 1 => {
+            let iterable = iterable.clone();
+            let n = *n;
+            let result = adaptors::Windows::new(vm.make_iterator(iterable)?, n.into());
+            Ok(Iterator(ValueIterator::make_external(result)))
+        }
+        unexpected => unexpected_type_error_with_slice(
+            "iterator.windows",
+            "a value with a range (like a List or String), \
+             and a chunk size greater than zero as arguments",
+            unexpected,
+        ),
+    });
+
     result.add_fn("zip", |vm, args| match vm.get_args(args) {
         [iterable_a, iterable_b] if iterable_a.is_iterable() && iterable_b.is_iterable() => {
             let iterable_a = iterable_a.clone();

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -117,6 +117,21 @@ pub fn make_module() -> ValueMap {
         ),
     });
 
+    result.add_fn("chunks", |vm, args| match vm.get_args(args) {
+        [iterable, Number(n)] if iterable.is_sequence() && *n >= 1 => {
+            let iterable = iterable.clone();
+            let n = *n;
+            let result = adaptors::Chunks::new(vm.make_iterator(iterable)?, n.into());
+            Ok(Iterator(ValueIterator::make_external(result)))
+        }
+        unexpected => unexpected_type_error_with_slice(
+            "iterator.chunks",
+            "a value with a range (like a List or String), \
+             and a chunk size greater than zero as arguments",
+            unexpected,
+        ),
+    });
+
     result.add_fn("consume", |vm, args| match vm.get_args(args) {
         [iterable] if iterable.is_iterable() => {
             let iterable = iterable.clone();

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -273,6 +273,20 @@ pub fn make_module() -> ValueMap {
         ),
     });
 
+    result.add_fn("flatten", |vm, args| match vm.get_args(args) {
+        [iterable] if iterable.is_iterable() => {
+            let iterable = iterable.clone();
+            let result = adaptors::Flatten::new(vm.make_iterator(iterable)?, vm.spawn_shared_vm());
+
+            Ok(Iterator(ValueIterator::make_external(result)))
+        }
+        unexpected => unexpected_type_error_with_slice(
+            "iterator.cycle",
+            "an iterable value as argument",
+            unexpected,
+        ),
+    });
+
     result.add_fn("fold", |vm, args| {
         match vm.get_args(args) {
             [iterable, result, f] if iterable.is_iterable() && f.is_callable() => {

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -2,7 +2,7 @@ use {
     super::iterator::collect_pair,
     crate::{
         num2, unexpected_type_error_with_slice,
-        value_iterator::{make_iterator, ValueIterator, ValueIteratorOutput as Output},
+        value_iterator::{ValueIterator, ValueIteratorOutput as Output},
         RuntimeError, RuntimeResult, Value, ValueMap,
     },
 };
@@ -23,7 +23,8 @@ pub fn make_module() -> ValueMap {
             [Number(n1), Number(n2)] => num2::Num2(n1.into(), n2.into()),
             [Num2(n)] => *n,
             [iterable] if iterable.is_iterable() => {
-                num2_from_iterator(make_iterator(iterable).unwrap(), "num2.make_num2")?
+                let iterable = iterable.clone();
+                num2_from_iterator(vm.make_iterator(iterable)?, "num2.make_num2")?
             }
             unexpected => {
                 return unexpected_type_error_with_slice(

--- a/src/runtime/src/core/num4.rs
+++ b/src/runtime/src/core/num4.rs
@@ -2,7 +2,7 @@ use {
     super::iterator::collect_pair,
     crate::{
         num4, unexpected_type_error_with_slice,
-        value_iterator::{make_iterator, ValueIterator, ValueIteratorOutput as Output},
+        value_iterator::{ValueIterator, ValueIteratorOutput as Output},
         RuntimeError, RuntimeResult, Value, ValueMap,
     },
 };
@@ -30,7 +30,8 @@ pub fn make_module() -> ValueMap {
             [Num2(n)] => num4::Num4(n[0] as f32, n[1] as f32, 0.0, 0.0),
             [Num4(n)] => *n,
             [iterable] if iterable.is_iterable() => {
-                let iterator = make_iterator(iterable).unwrap();
+                let iterable = iterable.clone();
+                let iterator = vm.make_iterator(iterable)?;
                 num4_from_iterator(iterator, "num4.make_num4")?
             }
             unexpected => {

--- a/src/runtime/src/core/string.rs
+++ b/src/runtime/src/core/string.rs
@@ -5,7 +5,7 @@ use {
     super::iterator::collect_pair,
     crate::{
         runtime_error, unexpected_type_error_with_slice,
-        value_iterator::{make_iterator, ValueIterator, ValueIteratorOutput as Output},
+        value_iterator::{ValueIterator, ValueIteratorOutput as Output},
         RuntimeResult, Value, ValueMap,
     },
     std::convert::TryFrom,
@@ -67,7 +67,8 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("from_bytes", |vm, args| match vm.get_args(args) {
         [iterable] if iterable.is_iterable() => {
-            let iterator = make_iterator(iterable).unwrap();
+            let iterable = iterable.clone();
+            let iterator = vm.make_iterator(iterable)?;
             let (size_hint, _) = iterator.size_hint();
             let mut bytes = Vec::<u8>::with_capacity(size_hint);
 

--- a/src/runtime/src/error.rs
+++ b/src/runtime/src/error.rs
@@ -157,7 +157,7 @@ macro_rules! runtime_error {
 
 pub fn unexpected_type_error<T>(expected_str: &str, unexpected: &Value) -> Result<T, RuntimeError> {
     runtime_error!(
-        "Expected {}, found {}",
+        "Expected {}, found {}.",
         expected_str,
         unexpected.type_as_string()
     )
@@ -185,7 +185,7 @@ pub fn unexpected_type_error_with_slice<T>(
         }
     };
     runtime_error!(
-        "{} - expected {}, but found {}",
+        "{} - expected {}, but found {}.",
         prefix,
         expected_str,
         message

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -435,9 +435,10 @@ impl fmt::Display for BinaryOp {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum UnaryOp {
+    Display,
+    Iterator,
     Negate,
     Not,
-    Display,
 }
 
 impl fmt::Display for UnaryOp {
@@ -448,9 +449,10 @@ impl fmt::Display for UnaryOp {
             f,
             "{}",
             match self {
+                Display => "display",
+                Iterator => "iterator",
                 Negate => "negate",
                 Not => "not",
-                Display => "display",
             }
         )
     }
@@ -472,6 +474,7 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKe
         MetaKeyId::Equal => MetaKey::BinaryOp(Equal),
         MetaKeyId::NotEqual => MetaKey::BinaryOp(NotEqual),
         MetaKeyId::Index => MetaKey::BinaryOp(Index),
+        MetaKeyId::Iterator => MetaKey::UnaryOp(Iterator),
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
         MetaKeyId::Not => MetaKey::UnaryOp(Not),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -144,10 +144,14 @@ impl Value {
     }
 
     pub fn is_iterable(&self) -> bool {
+        self.is_sequence() || matches!(self, Value::Iterator(_))
+    }
+
+    pub fn is_sequence(&self) -> bool {
         use Value::*;
         matches!(
             self,
-            Num2(_) | Num4(_) | Range(_) | List(_) | Tuple(_) | Map(_) | Str(_) | Iterator(_)
+            Num2(_) | Num4(_) | Range(_) | List(_) | Tuple(_) | Map(_) | Str(_)
         )
     }
 

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -262,19 +262,3 @@ impl fmt::Debug for ValueIterator {
         write!(f, "ValueIterator")
     }
 }
-
-pub fn make_iterator(value: &Value) -> Result<ValueIterator, ()> {
-    use Value::*;
-    let result = match value {
-        Range(r) => ValueIterator::with_range(*r),
-        Num2(n) => ValueIterator::with_num2(*n),
-        Num4(n) => ValueIterator::with_num4(*n),
-        List(l) => ValueIterator::with_list(l.clone()),
-        Tuple(t) => ValueIterator::with_tuple(t.clone()),
-        Map(m) => ValueIterator::with_map(m.clone()),
-        Str(s) => ValueIterator::with_string(s.clone()),
-        Iterator(i) => i.clone(),
-        _ => return Err(()),
-    };
-    Ok(result)
-}

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -24,7 +24,7 @@ impl IntRange {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ValueIteratorOutput {
     Value(Value),
     ValuePair(Value, Value),

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1128,6 +1128,8 @@ impl Vm {
                 List(list) => ValueIterator::with_list(list),
                 Tuple(tuple) => ValueIterator::with_tuple(tuple),
                 Str(s) => ValueIterator::with_string(s),
+                Num2(n) => ValueIterator::with_num2(n),
+                Num4(n) => ValueIterator::with_num4(n),
                 Map(map)
                     if map
                         .meta()

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1979,6 +1979,17 @@ make_num2(1, -1).keep(|n| n < 0).count()
 ";
             test_script(script, 1.into());
         }
+
+        #[test]
+        fn for_loop() {
+            let script = "
+x = 0
+for n in make_num2 4, 5
+  x += n
+x
+";
+            test_script(script, 9.into());
+        }
     }
 
     mod num4 {
@@ -2097,6 +2108,17 @@ x.sum()";
 make_num4(1, -1, 2, -2).keep(|n| n > 0).count()
 ";
             test_script(script, 2.into());
+        }
+
+        #[test]
+        fn for_loop() {
+            let script = "
+x = 0
+for n in make_num4 4, 5, 6, 7
+  x += n
+x
+";
+            test_script(script, 22.into());
         }
     }
 


### PR DESCRIPTION
Resolves #128.

- Allow maps to overload `@iterator`
- Allow num2/num4 values to be used in a for loop
- Add `iterator.chunks`
- Add `iterator.windows`
- Add `iterator.flatten`
