### PR TITLE
Improvements to parsing Lists, Maps, and Tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ The Koto project adheres to
     # (1, 2, 3)
     ```
 - Num2 and Num4 values can now be iterated over in a for loop.
+- Empty tuples can be declared by including a trailing comma in parentheses,
+  e.g. `(,)`.
 
 ### Changed
 
@@ -147,6 +149,15 @@ The Koto project adheres to
   bodies need to use `then`.
   - This reverts a change made in `0.9.0`, in practice it's less distracting to
     have `then` required in all arms.
+- Parsing of multi-line containers is now more flexible.
+  - e.g.
+    ```koto
+    # The following style of list declaration was previously disallowed
+    x = [ 1
+        , 2
+        , 3
+        ]
+    ```
 - Internals
   - `ExternalIterator` has been renamed to `KotoIterator`.
   - `ValueIterator::make_external` has been renamed to `ValueIterator::new`.

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -14,7 +14,7 @@ make_foo = |x|
 
   @test to_list: ||
     assert_eq (1..=3).to_list(), [1, 2, 3]
-    assert_eq [2,, 4, 6].to_list(), [2, 4, 6]
+    assert_eq [2, 4, 6].to_list(), [2, 4, 6]
     assert_eq
       {foo: 42, bar: 99}.to_list(),
       [("foo", 42), ("bar", 99)]

--- a/koto/tests/line_breaks.koto
+++ b/koto/tests/line_breaks.koto
@@ -67,6 +67,11 @@ x = [
 ]
 assert_eq x[1], 99
 
+y = [ 42
+    , 99
+    ]
+assert_eq x, y
+
 # Linebreaks before operators
 a = 1
   + 2 + #- inline comment -# 3

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -260,7 +260,7 @@ impl fmt::Display for SyntaxError {
             ExpectedAssignmentAfterMetaKey => f.write_str("Expected '=' assignment after meta key"),
             ExpectedCatchArgument => f.write_str("Expected argument for catch expression"),
             ExpectedCatch => f.write_str("Expected catch expression after try"),
-            ExpectedCloseParen => f.write_str("Expected closing parenthesis"),
+            ExpectedCloseParen => f.write_str("Expected closing parenthesis ')'"),
             ExpectedElseExpression => f.write_str("Expected 'else' expression."),
             ExpectedElseIfCondition => f.write_str("Expected condition for 'else if'."),
             ExpectedEndOfLine => f.write_str("Expected end of line"),

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -279,9 +279,9 @@ impl fmt::Display for SyntaxError {
             ExpectedIndentedLookupContinuation => {
                 f.write_str("Expected indented lookup continuation")
             }
-            ExpectedIndexEnd => f.write_str("Unexpected token while indexing a List, expected ']'"),
+            ExpectedIndexEnd => f.write_str("Expected index end ']'"),
             ExpectedIndexExpression => f.write_str("Expected index expression"),
-            ExpectedListEnd => f.write_str("Unexpected token while in List, expected ']'"),
+            ExpectedListEnd => f.write_str("Expected List end ']'"),
             ExpectedMapColon => f.write_str("Expected ':' after map key"),
             ExpectedMapEnd => f.write_str("Unexpected token in Map, expected '}'"),
             ExpectedMapEntry => f.write_str("Expected map entry"),

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1575,7 +1575,7 @@ impl<'source> Parser<'source> {
         ) {
             self.consume_until_next_token(&mut entry_context);
 
-            if let Some(entry) = self.parse_expression(&mut ExpressionContext::inline())? {
+            if let Some(entry) = self.parse_expression(&mut ExpressionContext::permissive())? {
                 entries.push(entry);
             }
 

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -2583,7 +2583,7 @@ impl<'source> Parser<'source> {
         }
 
         let expressions_node = match expressions.as_slice() {
-            [] => self.push_node(Node::Empty)?,
+            [] if !encountered_comma => self.push_node(Node::Empty)?,
             [single_expression] if !encountered_comma => {
                 self.push_node_with_start_span(Node::Nested(*single_expression), start_span)?
             }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -969,9 +969,24 @@ min..max
 
         #[test]
         fn tuple_in_parens() {
-            let source = "(0, 1, 0)";
-            check_ast(
-                source,
+            let sources = [
+                "(0, 1, 0)",
+                "
+( 0,
+  1,
+  0
+)
+",
+                "
+( 0
+  , 1
+  , 0
+  )
+",
+            ];
+
+            check_ast_for_equivalent_sources(
+                &sources,
                 &[
                     Number0,
                     Number1,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -308,9 +308,13 @@ a
                 Some(&[Constant::F64(-12.0), Constant::Str("a"), Constant::Str("x")]),
             )
         }
+    }
+
+    mod lists {
+        use super::*;
 
         #[test]
-        fn list() {
+        fn basic_lists() {
             let source = r#"
 [0, n, "test", n, -1]
 []
@@ -335,7 +339,7 @@ a
         }
 
         #[test]
-        fn list_nested() {
+        fn nested_list() {
             let source = r#"
 [0, [1, -1], 2]
 "#;
@@ -391,6 +395,10 @@ x = [
                 Some(&[Constant::Str("x")]),
             )
         }
+    }
+
+    mod maps {
+        use super::*;
 
         #[test]
         fn map_inline() {
@@ -689,6 +697,10 @@ x =
                 Some(&[Constant::Str("foo")]),
             )
         }
+    }
+
+    mod ranges {
+        use super::*;
 
         #[test]
         fn ranges_from_literals() {
@@ -836,7 +848,7 @@ min..max
         }
 
         #[test]
-        fn lists_from_ranges() {
+        fn ranges_in_lists() {
             let source = "\
 [0..1]
 [0..10, 10..=0]";
@@ -874,6 +886,10 @@ min..max
                 Some(&[Constant::I64(10)]),
             )
         }
+    }
+
+    mod tuples {
+        use super::*;
 
         #[test]
         fn tuple() {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -968,6 +968,22 @@ min..max
         }
 
         #[test]
+        fn empty_tuple() {
+            let source = "(,)";
+            check_ast(
+                source,
+                &[
+                    Tuple(vec![]),
+                    MainBlock {
+                        body: vec![0],
+                        local_count: 0,
+                    },
+                ],
+                None,
+            )
+        }
+
+        #[test]
         fn tuple_in_parens() {
             let sources = [
                 "(0, 1, 0)",

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3498,9 +3498,26 @@ x.foo
 
         #[test]
         fn map_lookup_in_list() {
-            let source = "[m.foo, m.bar]";
-            check_ast(
-                source,
+            let sources = [
+                "[my_map.foo, my_map.bar]",
+                "
+[
+  my_map
+    .foo
+  ,
+  my_map
+    .bar
+]
+",
+                "
+[ my_map.foo,
+  my_map
+    .bar
+]
+",
+            ];
+            check_ast_for_equivalent_sources(
+                &sources,
                 &[
                     Id(constant(0)),
                     Lookup((LookupNode::Id(constant(1)), None)),
@@ -3515,7 +3532,7 @@ x.foo
                     },
                 ],
                 Some(&[
-                    Constant::Str("m"),
+                    Constant::Str("my_map"),
                     Constant::Str("foo"),
                     Constant::Str("bar"),
                 ]),

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -363,14 +363,42 @@ a
 
         #[test]
         fn list_with_line_breaks() {
-            let source = "\
+            let sources = [
+                "
 x = [
   0,
-  1, 0, 1,
+  1,
+  0,
+  1,
   0
-]";
-            check_ast(
-                source,
+]
+",
+                "
+x = [
+  0, 1,
+  0, 1,
+  0
+]
+",
+                "
+x = [ 0
+    , 1
+    , 0
+    , 1
+    , 0
+    ]
+",
+                "
+x = [
+  0 ,
+  1
+  , 0 , 1
+  , 0]
+",
+            ];
+
+            check_ast_for_equivalent_sources(
+                &sources,
                 &[
                     Id(constant(0)),
                     Number0,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -430,28 +430,57 @@ x = [
 
         #[test]
         fn map_inline() {
-            let source = r#"
+            let sources = [
+                "
 {}
-{"foo": 42, bar, baz: "hello", @+: 99}"#;
-            check_ast(
-                source,
+x = {'foo': 42, bar, baz: 'hello', @+: 99}",
+                "
+{
+}
+x = { 'foo': 42
+  , bar
+  , baz: 'hello'
+  , @+: 99
+}
+",
+                "
+{ }
+x =
+  { 'foo': 42, bar
+    , baz: 'hello'
+    , @+: 99
+    }
+",
+            ];
+            check_ast_for_equivalent_sources(
+                &sources,
                 &[
                     Map(vec![]),
-                    Int(constant(1)),
-                    string_literal(4, QuotationMark::Double),
-                    Int(constant(5)),
+                    Id(constant(0)),
+                    Int(constant(2)),
+                    string_literal(5, QuotationMark::Single),
+                    Int(constant(6)),
                     Map(vec![
-                        (string_literal_map_key(0, QuotationMark::Double), Some(1)),
-                        (MapKey::Id(constant(2)), None),
-                        (MapKey::Id(constant(3)), Some(2)),
-                        (MapKey::Meta(MetaKeyId::Add, None), Some(3)),
-                    ]),
+                        (string_literal_map_key(1, QuotationMark::Single), Some(2)),
+                        (MapKey::Id(constant(3)), None),
+                        (MapKey::Id(constant(4)), Some(3)),
+                        (MapKey::Meta(MetaKeyId::Add, None), Some(4)),
+                    ]), // 5
+                    Assign {
+                        target: AssignTarget {
+                            target_index: 1,
+                            scope: Scope::Local,
+                        },
+                        op: AssignOp::Equal,
+                        expression: 5,
+                    },
                     MainBlock {
-                        body: vec![0, 4],
-                        local_count: 0,
+                        body: vec![0, 6],
+                        local_count: 1,
                     },
                 ],
                 Some(&[
+                    Constant::Str("x"),
                     Constant::Str("foo"),
                     Constant::I64(42),
                     Constant::Str("bar"),

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -60,34 +60,12 @@ mod parser {
             }
 
             #[test]
-            fn list_end_with_incorrect_indentation() {
-                let source = "
-x = [
-  1,
-  2,
-    ]
-";
-                check_parsing_fails(source);
-            }
-
-            #[test]
             fn map_end_with_incorrect_indentation() {
                 let source = "
 x = {
   foo: 42,
   bar: 99
     }
-";
-                check_parsing_fails(source);
-            }
-
-            #[test]
-            fn function_end_with_incorrect_indentation() {
-                let source = "
-x = |
-  x
-  y
-    | x + y
 ";
                 check_parsing_fails(source);
             }

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -60,17 +60,6 @@ mod parser {
             }
 
             #[test]
-            fn map_end_with_incorrect_indentation() {
-                let source = "
-x = {
-  foo: 42,
-  bar: 99
-    }
-";
-                check_parsing_fails(source);
-            }
-
-            #[test]
             fn else_at_same_indentation_as_if_body() {
                 let source = "
 if f x

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -198,6 +198,28 @@ x =
             }
         }
 
+        mod lists {
+            use super::*;
+
+            #[test]
+            fn double_comma() {
+                let source = "x = [1, 2, , 3]";
+
+                check_parsing_fails(source);
+            }
+        }
+
+        mod tuples {
+            use super::*;
+
+            #[test]
+            fn double_comma() {
+                let source = "x = (1, 2, , 3)";
+
+                check_parsing_fails(source);
+            }
+        }
+
         mod match_expressions {
             use super::*;
 


### PR DESCRIPTION
- Allow multi-line lists to be declared more flexibly
- Enable permissive expression parsing for list entries
- Allow multi-line maps with braces to be parsed more flexibly
- Allow multi-line tuples to be parsed more flexibly
- Allow empty tuples to be created with (,)
- Don't allow double commas in tuple or lists