### PR TITLE
Add a 'module imported' callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ The Koto project adheres to
 - Internals
   - A 'module imported' callback has been added to `KotoSettings` to aid in
     keeping track of a script's module dependencies.
+  - `Koto::clear_module_cache()` has been added to allow for reloading scripts
+    when one of the script's dependencies has changed.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,8 @@ The Koto project adheres to
   string and that override @display.
 - Fixed a panic that could occur when skipping past the end of an iterator and
   then calling a 'to X' function.
-
+- Fixed unexpected shaky behaviour when compiling expressions that assign to the
+  same name more than once in the expression, e.g. `x = x = 1`.
 
 ## [0.10.0] 2021.12.02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,8 @@ The Koto project adheres to
     x, _unused, z = 1, 2, 3
     ```
 - Internals
-  - `Koto::for_each_module_path` has been added to provide access to the paths
-    of a script's module dependencies.
+  - A 'module imported' callback has been added to `KotoSettings` to aid in
+    keeping track of a script's module dependencies.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ version = "0.10.0"
 dependencies = [
  "dunce",
  "koto_parser",
+ "rustc-hash",
  "smallvec",
 ]
 

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -8,7 +8,7 @@ use {
 };
 
 pub fn make_module() -> ValueMap {
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("new", {
         |vm, args| match vm.get_args(args) {

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -52,15 +52,15 @@ impl fmt::Display for OutputCapture {
 pub fn compile_and_run(input: &str) -> String {
     let output = Rc::new(RefCell::new(String::new()));
 
-    let mut koto = Koto::with_settings(KotoSettings {
-        stdout: Rc::new(OutputCapture {
-            output: output.clone(),
-        }),
-        stderr: Rc::new(OutputCapture {
-            output: output.clone(),
-        }),
-        ..Default::default()
-    });
+    let mut koto = Koto::with_settings(
+        KotoSettings::default()
+            .with_stdout(OutputCapture {
+                output: output.clone(),
+            })
+            .with_stderr(OutputCapture {
+                output: output.clone(),
+            }),
+    );
 
     match koto.compile(input) {
         Ok(_) => match koto.run() {

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -16,11 +16,12 @@ If a string is used for the imported name, then the imported module isn't automa
 brought into scope, and it needs to be assigned to a local value.
 -#
 
+import test_module
+
 @tests =
   @test import_module: ||
     # The test_module module being imported here is defined in the neighbouring
     # test_module directory, with test_module/main.koto as its entry point.
-    import test_module
     assert_eq (koto.type test_module), "Map"
     assert_eq test_module.foo, 42
     assert_eq (test_module.square 9), 81

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -1,5 +1,7 @@
 # A simple test module, used by ../import.koto
 
+local_value = 123
+
 export foo = 42
 export bar = -1
 
@@ -17,3 +19,6 @@ export tests_were_run = false
 @tests =
   @test run_tests: ||
     export tests_were_run = true
+
+  @test local_value_unmodified_by_import: ||
+    assert_eq local_value, 123

--- a/libs/json/src/lib.rs
+++ b/libs/json/src/lib.rs
@@ -31,7 +31,7 @@ pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<Value, Stri
             }
         }
         JsonValue::Object(o) => {
-            let mut map = ValueMap::with_capacity(o.len());
+            let map = ValueMap::with_capacity(o.len());
             for (key, value) in o.iter() {
                 map.add_value(key, json_value_to_koto_value(value)?);
             }
@@ -45,7 +45,7 @@ pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<Value, Stri
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("from_string", |vm, args| match vm.get_args(args) {
         [Str(s)] => match serde_json::from_str(s) {

--- a/libs/lib_tests/tests/lib_tests.rs
+++ b/libs/lib_tests/tests/lib_tests.rs
@@ -10,7 +10,7 @@ fn run_script(script: &str, path: Option<PathBuf>, should_fail_at_runtime: bool)
     });
     koto.set_script_path(path);
 
-    let mut prelude = koto.prelude();
+    let prelude = koto.prelude();
     prelude.add_map("json", koto_json::make_module());
     prelude.add_map("random", koto_random::make_module());
     prelude.add_map("tempfile", koto_tempfile::make_module());

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -11,7 +11,7 @@ use {
 };
 
 pub fn make_module() -> ValueMap {
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("bool", |_, _| {
         THREAD_RNG.with(|rng| rng.borrow_mut().gen_bool())

--- a/libs/tempfile/src/lib.rs
+++ b/libs/tempfile/src/lib.rs
@@ -9,7 +9,7 @@ use {
 };
 
 pub fn make_module() -> ValueMap {
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("temp_file", {
         |_, _| match NamedTempFile::new().map_err(map_io_err) {

--- a/libs/toml/src/lib.rs
+++ b/libs/toml/src/lib.rs
@@ -25,7 +25,7 @@ pub fn toml_to_koto_value(value: &Toml) -> Result<Value, String> {
             }
         }
         Toml::Table(o) => {
-            let mut map = ValueMap::with_capacity(o.len());
+            let map = ValueMap::with_capacity(o.len());
             for (key, value) in o.iter() {
                 map.add_value(key, toml_to_koto_value(value)?);
             }
@@ -40,7 +40,7 @@ pub fn toml_to_koto_value(value: &Toml) -> Result<Value, String> {
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("from_string", |vm, args| match vm.get_args(args) {
         [Str(s)] => match toml::from_str(s) {

--- a/libs/yaml/src/lib.rs
+++ b/libs/yaml/src/lib.rs
@@ -31,7 +31,7 @@ pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, Stri
             }
         }
         YamlValue::Mapping(mapping) => {
-            let mut map = ValueMap::with_capacity(mapping.len());
+            let map = ValueMap::with_capacity(mapping.len());
             for (key, value) in mapping.iter() {
                 let key_as_koto_value = yaml_value_to_koto_value(key)?;
                 if !key_as_koto_value.is_immutable() {
@@ -52,7 +52,7 @@ pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, Stri
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("from_string", |vm, args| match vm.get_args(args) {
         [Str(s)] => match serde_yaml::from_str(s) {

--- a/src/bytecode/Cargo.toml
+++ b/src/bytecode/Cargo.toml
@@ -15,4 +15,5 @@ keywords = ["scripting", "language", "koto"]
 koto_parser = { path = "../parser", version = "^0.10.0"}
 
 dunce = "1.0.2" # Normalize Windows paths to the most compatible format, avoiding UNC where possible
+rustc-hash = "1.1.0"
 smallvec = "1.2.0"

--- a/src/bytecode/src/chunk.rs
+++ b/src/bytecode/src/chunk.rs
@@ -1,7 +1,7 @@
 use {
     crate::InstructionReader,
     koto_parser::{ConstantPool, Span},
-    std::{path::PathBuf, rc::Rc},
+    std::{fmt, path::PathBuf, rc::Rc},
 };
 
 /// Debug information for a Koto program
@@ -47,7 +47,7 @@ impl DebugInfo {
 }
 
 /// A compiled chunk of bytecode, along with its associated constants and metadata
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
 pub struct Chunk {
     /// The bytes representing the chunk's bytecode
     pub bytes: Vec<u8>,
@@ -141,5 +141,11 @@ impl Chunk {
         }
 
         result
+    }
+}
+
+impl fmt::Debug for Chunk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "Chunk ({:p})", self)
     }
 }

--- a/src/bytecode/src/loader.rs
+++ b/src/bytecode/src/loader.rs
@@ -2,9 +2,11 @@ use {
     crate::{Chunk, Compiler, CompilerError, CompilerSettings},
     dunce::canonicalize,
     koto_parser::{format_error_with_excerpt, Parser, ParserError},
+    rustc_hash::FxHasher,
     std::{
         collections::{hash_map::Keys, HashMap},
         error, fmt,
+        hash::BuildHasherDefault,
         path::{Path, PathBuf},
         rc::Rc,
     },
@@ -110,7 +112,7 @@ impl error::Error for LoaderError {}
 /// Helper for loading, compiling, and caching Koto modules
 #[derive(Clone, Default)]
 pub struct Loader {
-    chunks: HashMap<PathBuf, Rc<Chunk>>,
+    chunks: HashMap<PathBuf, Rc<Chunk>, BuildHasherDefault<FxHasher>>,
 }
 
 impl Loader {

--- a/src/bytecode/src/loader.rs
+++ b/src/bytecode/src/loader.rs
@@ -163,7 +163,7 @@ impl Loader {
         load_from_path: Option<PathBuf>,
     ) -> Result<(Rc<Chunk>, PathBuf), LoaderError> {
         // Get either the directory of the provided path, or the current working directory
-        let path = match &load_from_path {
+        let search_folder = match &load_from_path {
             Some(path) => match canonicalize(path) {
                 Ok(canonicalized) if canonicalized.is_file() => match canonicalized.parent() {
                     Some(parent_dir) => parent_dir.to_path_buf(),
@@ -212,7 +212,7 @@ impl Loader {
         };
 
         let extension = "koto";
-        let named_path = path.join(name);
+        let named_path = search_folder.join(name);
 
         // First, check for a neighbouring file with a matching name.
         let module_path = named_path.with_extension(extension);

--- a/src/bytecode/src/loader.rs
+++ b/src/bytecode/src/loader.rs
@@ -3,13 +3,7 @@ use {
     dunce::canonicalize,
     koto_parser::{format_error_with_excerpt, Parser, ParserError},
     rustc_hash::FxHasher,
-    std::{
-        collections::{hash_map::Keys, HashMap},
-        error, fmt,
-        hash::BuildHasherDefault,
-        path::{Path, PathBuf},
-        rc::Rc,
-    },
+    std::{collections::HashMap, error, fmt, hash::BuildHasherDefault, path::PathBuf, rc::Rc},
 };
 
 /// Errors that can be returned from [Loader] operations
@@ -231,33 +225,5 @@ impl Loader {
                 )))
             }
         }
-    }
-
-    /// Provides the paths that have been loaded by the loader
-    pub fn module_paths(&self) -> ModulePathIter {
-        ModulePathIter::new(self)
-    }
-}
-
-/// An iterator that provides the paths of the modules that have been loaded by a `Loader`
-///
-/// Returned from `Loader::module_paths`.
-pub struct ModulePathIter<'a> {
-    keys: Keys<'a, PathBuf, Rc<Chunk>>,
-}
-
-impl<'a> ModulePathIter<'a> {
-    fn new(loader: &'a Loader) -> Self {
-        Self {
-            keys: loader.chunks.keys(),
-        }
-    }
-}
-
-impl<'a> Iterator for ModulePathIter<'a> {
-    type Item = &'a Path;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.keys.next().map(|path| path.as_path())
     }
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -158,7 +158,7 @@ fn run() -> Result<(), ()> {
         let mut koto = Koto::with_settings(koto_settings);
         koto.set_script_path(script_path.map(|path| path.into()));
 
-        let mut prelude = koto.prelude();
+        let prelude = koto.prelude();
         prelude.add_map("json", koto_json::make_module());
         prelude.add_map("random", koto_random::make_module());
         prelude.add_map("tempfile", koto_tempfile::make_module());

--- a/src/cli/src/repl.rs
+++ b/src/cli/src/repl.rs
@@ -46,7 +46,7 @@ impl Repl {
 
         let koto = Koto::with_settings(koto_settings);
 
-        let mut prelude = koto.prelude();
+        let prelude = koto.prelude();
         prelude.add_map("json", koto_json::make_module());
         prelude.add_map("random", koto_random::make_module());
         prelude.add_map("tempfile", koto_tempfile::make_module());

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -188,13 +188,7 @@ impl Koto {
             Ok(result)
         } else {
             if self.settings.run_tests {
-                let maybe_tests = self
-                    .runtime
-                    .context()
-                    .exports
-                    .meta()
-                    .get(&MetaKey::Tests)
-                    .cloned();
+                let maybe_tests = self.runtime.exports().meta().get(&MetaKey::Tests).cloned();
                 match maybe_tests {
                     Some(Value::Map(tests)) => {
                         self.runtime.run_tests(tests)?;
@@ -206,13 +200,7 @@ impl Koto {
                 }
             }
 
-            let maybe_main = self
-                .runtime
-                .context()
-                .exports
-                .meta()
-                .get(&MetaKey::Main)
-                .cloned();
+            let maybe_main = self.runtime.exports().meta().get(&MetaKey::Main).cloned();
             if let Some(main) = maybe_main {
                 self.runtime
                     .run_function(main, CallArgs::None)
@@ -247,7 +235,7 @@ impl Koto {
     }
 
     pub fn exports(&self) -> ValueMap {
-        self.runtime.context().exports.clone()
+        self.runtime.exports().clone()
     }
 
     /// Calls the provided callback with the path of each module that has been loaded by the runtime

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -292,12 +292,12 @@ impl Koto {
             .map_err(|e| e.into())
     }
 
-    pub fn prelude(&self) -> ValueMap {
+    pub fn prelude(&self) -> &ValueMap {
         self.runtime.prelude()
     }
 
-    pub fn exports(&self) -> ValueMap {
-        self.runtime.exports().clone()
+    pub fn exports(&self) -> &ValueMap {
+        self.runtime.exports()
     }
 
     pub fn set_args(&mut self, args: &[String]) {

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -148,7 +148,7 @@ impl Default for KotoSettings {
 /// Example
 pub struct Koto {
     runtime: Vm,
-    pub settings: KotoSettings, // TODO make private, needs enable / disable tests methods
+    settings: KotoSettings,
     script_path: Option<PathBuf>,
     loader: Loader,
     chunk: Option<Rc<Chunk>>,
@@ -210,7 +210,15 @@ impl Koto {
         }
     }
 
-    pub fn run_chunk(&mut self, chunk: Rc<Chunk>) -> KotoResult {
+    /// Enables or disables the `run_tests` setting
+    ///
+    /// Currently this is only used when running benchmarks where tests are run once during setup,
+    /// and then disabled for repeated runs.
+    pub fn set_run_tests(&mut self, enabled: bool) {
+        self.settings.run_tests = enabled;
+    }
+
+    fn run_chunk(&mut self, chunk: Rc<Chunk>) -> KotoResult {
         let result = self.runtime.run(chunk)?;
 
         if self.settings.repl_mode {

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -40,7 +40,8 @@ fn run_script(script: &str, script_path: Option<PathBuf>, expected_module_paths:
                 // Check that the loaded module paths are correct
                 assert_eq!(
                     loaded_module_paths.borrow().len(),
-                    expected_module_paths.len()
+                    expected_module_paths.len(),
+                    "Mismatch in number of imported module paths"
                 );
             }
             Err(error) => {

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -21,7 +21,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::{Bool, Empty, Str};
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("create", {
         move |vm, args| match vm.get_args(args) {

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -13,7 +13,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("all", |vm, args| match vm.get_args(args) {
         [iterable, predicate] if iterable.is_iterable() && predicate.is_callable() => {

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -7,9 +7,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_value("args", Tuple(ValueTuple::default()));
 
-    result.add_fn("exports", |vm, _| {
-        Ok(Value::Map(vm.context_mut().exports.clone()))
-    });
+    result.add_fn("exports", |vm, _| Ok(Value::Map(vm.exports().clone())));
 
     result.add_value("script_dir", Empty);
     result.add_value("script_path", Empty);

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -3,7 +3,7 @@ use crate::{unexpected_type_error_with_slice, Value, ValueMap, ValueTuple};
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_value("args", Tuple(ValueTuple::default()));
 

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -10,7 +10,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("clear", |vm, args| match vm.get_args(args) {
         [List(l)] => {

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -10,7 +10,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("clear", |vm, args| match vm.get_args(args) {
         [Map(m)] => {

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -10,7 +10,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("length", |vm, args| match vm.get_args(args) {
         [Num2(n)] => Ok(Number(n.length().into())),

--- a/src/runtime/src/core/num4.rs
+++ b/src/runtime/src/core/num4.rs
@@ -10,7 +10,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("length", |vm, args| match vm.get_args(args) {
         [Num4(n)] => Ok(Number(n.length().into())),

--- a/src/runtime/src/core/number.rs
+++ b/src/runtime/src/core/number.rs
@@ -3,7 +3,7 @@ use crate::{unexpected_type_error_with_slice, Value, ValueMap, ValueNumber};
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     macro_rules! number_fn {
         ($fn:ident) => {

--- a/src/runtime/src/core/os.rs
+++ b/src/runtime/src/core/os.rs
@@ -13,7 +13,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::Number;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("name", |_, _| Ok(std::env::consts::OS.into()));
 

--- a/src/runtime/src/core/range.rs
+++ b/src/runtime/src/core/range.rs
@@ -3,7 +3,7 @@ use crate::{unexpected_type_error_with_slice, IntRange, Value, ValueMap};
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("contains", |vm, args| match vm.get_args(args) {
         [Range(r), Number(n)] => Ok(Bool(*n >= r.start && n.ceil() < r.end)),

--- a/src/runtime/src/core/string.rs
+++ b/src/runtime/src/core/string.rs
@@ -15,7 +15,7 @@ use {
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("bytes", |vm, args| match vm.get_args(args) {
         [Str(s)] => {

--- a/src/runtime/src/core/test.rs
+++ b/src/runtime/src/core/test.rs
@@ -5,7 +5,7 @@ use crate::{
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("assert", |vm, args| {
         for value in vm.get_args(args).iter() {

--- a/src/runtime/src/core/test.rs
+++ b/src/runtime/src/core/test.rs
@@ -123,7 +123,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("run_tests", |vm, args| match vm.get_args(args) {
         [Map(tests)] => {
             let tests = tests.clone();
-            let mut vm = vm.spawn_shared_vm();
+            let mut vm = vm.spawn_shared_vm(); // TODO is spawning a VM still necessary?
             vm.run_tests(tests)
         }
         unexpected => {

--- a/src/runtime/src/core/tuple.rs
+++ b/src/runtime/src/core/tuple.rs
@@ -6,7 +6,7 @@ use crate::{
 pub fn make_module() -> ValueMap {
     use Value::*;
 
-    let mut result = ValueMap::new();
+    let result = ValueMap::new();
 
     result.add_fn("contains", |vm, args| match vm.get_args(args) {
         [Tuple(t), value] => {

--- a/src/runtime/src/frame.rs
+++ b/src/runtime/src/frame.rs
@@ -14,8 +14,11 @@ pub(crate) struct Frame {
     // A stack of catch points for handling errors
     pub catch_stack: Vec<(u8, usize)>, // catch error register, catch ip
     // True if the frame should prevent execution from continuing after the frame is exited.
-    // e.g. when an overloaded operator is being executed as a result of a regular instruction,
-    //      or when an external function is calling back into the VM with a functor,
+    // e.g.
+    //   - a function is being called externally from the VM
+    //   - an overloaded operator is being executed as a result of a regular instruction
+    //   - an external function is calling back into the VM with a functor
+    //   - a module is being imported
     pub execution_barrier: bool,
 }
 

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -166,7 +166,7 @@ impl ValueMap {
     }
 
     #[inline]
-    pub fn insert(&mut self, key: ValueKey, value: Value) {
+    pub fn insert(&self, key: ValueKey, value: Value) {
         self.data_mut().insert(key, value);
     }
 
@@ -181,31 +181,27 @@ impl ValueMap {
     }
 
     #[inline]
-    pub fn add_fn(&mut self, id: &str, f: impl Fn(&mut Vm, &Args) -> RuntimeResult + 'static) {
+    pub fn add_fn(&self, id: &str, f: impl Fn(&mut Vm, &Args) -> RuntimeResult + 'static) {
         self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, false)));
     }
 
     #[inline]
-    pub fn add_instance_fn(
-        &mut self,
-        id: &str,
-        f: impl Fn(&mut Vm, &Args) -> RuntimeResult + 'static,
-    ) {
+    pub fn add_instance_fn(&self, id: &str, f: impl Fn(&mut Vm, &Args) -> RuntimeResult + 'static) {
         self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, true)));
     }
 
     #[inline]
-    pub fn add_list(&mut self, id: &str, list: ValueList) {
+    pub fn add_list(&self, id: &str, list: ValueList) {
         self.add_value(id, Value::List(list));
     }
 
     #[inline]
-    pub fn add_map(&mut self, id: &str, map: ValueMap) {
+    pub fn add_map(&self, id: &str, map: ValueMap) {
         self.add_value(id, Value::Map(map));
     }
 
     #[inline]
-    pub fn add_value(&mut self, id: &str, value: Value) {
+    pub fn add_value(&self, id: &str, value: Value) {
         self.insert(id.into(), value);
     }
 }

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -142,7 +142,7 @@ pub struct VmSettings {
     ///
     /// This allows you to track the runtime's dependencies, which might be useful if you want to
     /// reload the script when one of its dependencies has changed.
-    pub module_imported_callback: Option<Rc<dyn Fn(&Path)>>,
+    pub module_imported_callback: Option<Box<dyn Fn(&Path)>>,
     /// The runtime's stdin
     pub stdin: Rc<dyn KotoFile>,
     /// The runtime's stdout

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -59,7 +59,7 @@ pub type InstructionResult = Result<(), RuntimeError>;
 fn setup_core_lib_and_prelude() -> (CoreLib, ValueMap) {
     let core_lib = CoreLib::default();
 
-    let mut prelude = ValueMap::default();
+    let prelude = ValueMap::default();
     prelude.add_map("io", core_lib.io.clone());
     prelude.add_map("iterator", core_lib.iterator.clone());
     prelude.add_map("koto", core_lib.koto.clone());
@@ -211,8 +211,8 @@ impl Vm {
     }
 
     /// The prelude, containing items that can be imported within all modules
-    pub fn prelude(&self) -> ValueMap {
-        self.context.prelude.clone()
+    pub fn prelude(&self) -> &ValueMap {
+        &self.context.prelude
     }
 
     /// The active module's exports map

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -14,10 +14,12 @@ use {
     },
     koto_bytecode::{Chunk, Instruction, InstructionReader, TypeId},
     koto_parser::{ConstantIndex, MetaKeyId},
+    rustc_hash::FxHasher,
     std::{
         cell::{Ref, RefCell, RefMut},
         collections::HashMap,
         fmt,
+        hash::BuildHasherDefault,
         path::{Path, PathBuf},
         rc::Rc,
     },
@@ -3245,4 +3247,4 @@ pub enum CallArgs<'a> {
 // A cache of the export maps of imported modules
 //
 // The ValueMap is optional to prevent recursive imports (see Vm::run_import).
-type ModuleCache = HashMap<PathBuf, Option<ValueMap>>;
+type ModuleCache = HashMap<PathBuf, Option<ValueMap>, BuildHasherDefault<FxHasher>>;

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -174,7 +174,7 @@ mod external_values {
 
     fn test_script_with_external_value(script: &str, expected_output: Value) {
         let vm = Vm::default();
-        let mut prelude = vm.prelude();
+        let prelude = vm.prelude();
 
         prelude.add_fn("make_external", |vm, args| match vm.get_args(args) {
             [Value::Number(x)] => Ok(ExternalValue::with_shared_meta_map(

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -743,7 +743,7 @@ x
 
         fn test_script_with_prelude(script: &str, expected_output: Value) {
             let vm = Vm::default();
-            let mut prelude = vm.prelude();
+            let prelude = vm.prelude();
 
             prelude.add_value("test_value", 42.into());
             prelude.add_fn("assert", |vm, args| {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2633,6 +2633,19 @@ a.x + a.y # The meta map's y entry is hidden by the data entry
         }
     }
 
+    mod import {
+        use super::*;
+
+        #[test]
+        fn import_after_local_assignment() {
+            let script = "
+x = 123
+y = import test.assert
+x";
+            test_script(script, 123.into());
+        }
+    }
+
     mod export {
         use super::*;
 

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -92,6 +92,15 @@ a + 1";
         }
 
         #[test]
+        fn repeated_assignment() {
+            let script = "
+x = x = 1
+y = y = 2
+";
+            test_script(script, 2.into());
+        }
+
+        #[test]
         fn negation() {
             let script = "
 a = 99
@@ -2643,6 +2652,15 @@ x = 123
 y = import test.assert
 x";
             test_script(script, 123.into());
+        }
+
+        #[test]
+        fn import_with_same_local_name() {
+            let script = "
+x = 0
+pi = number.pi
+pi != x and pi == pi";
+            test_script(script, true.into());
         }
     }
 


### PR DESCRIPTION
This PR includes various cleanups and replaces the 'for each module path' mechanism added in #142 with a callback that gets called whenever a module is imported, which will be simpler to use for clients that need to keep track of a script's dependencies. 

The PR also includes `clear_module_cache`, which is useful when reloading scripts when dependencies have changed.