### PR TITLE
Further import improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,13 @@ The Koto project adheres to
   then calling a 'to X' function.
 - Fixed unexpected shaky behaviour when compiling expressions that assign to the
   same name more than once in the expression, e.g. `x = x = 1`.
+- Import expressions now work with previously-imported maps.
+  - e.g.
+    ```koto
+    import foo.bar
+    import bar.baz # <-- Previously this would cause a runtime error
+    debug baz
+    ```
 
 ## [0.10.0] 2021.12.02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ The Koto project adheres to
     functions.
   - The value provided to `list.resize` is now optional, with `()` being
     inserted when growing the list.
+  - `list.get`, `tuple.get`, and `map.get_index` will now return `()` when a
+    negative number is used as the index, rather than throwing an error.
 - Random Library
   - The default generator functions can now be used directly.
     Previously they had to be used as instance functions.

--- a/docs/reference/core_lib/list.md
+++ b/docs/reference/core_lib/list.md
@@ -185,13 +185,15 @@ value is returned. If no default value is provided then `()` is returned.
 ### Example
 
 ```koto
-[99, -1, 42].get 1
+x = [99, -1, 42]
+
+x.get 1
 # -1
 
-[99, -1, 42].get 5
+x.get -1
 # ()
 
-[99, -1, 42].get 5, 123
+x.get 5, 123
 # 123
 ```
 

--- a/docs/reference/core_lib/map.md
+++ b/docs/reference/core_lib/map.md
@@ -318,8 +318,6 @@ default value if the map doesn't contain an entry at that index.
 
 If no default value is provided then `()` is returned.
 
-An error will be thrown if a negative index is provided.
-
 ### Example
 
 ```koto
@@ -327,7 +325,7 @@ x = foo: -1, bar: -2
 x.get_index 1
 # (bar, -2)
 
-x.get_index 99
+x.get_index -99
 # ()
 
 x.get_index 99, "xyz"

--- a/docs/reference/core_lib/tuple.md
+++ b/docs/reference/core_lib/tuple.md
@@ -93,11 +93,16 @@ value is returned. If no default value is provided then `()` is returned.
 ### Example
 
 ```koto
-(99, -1, 42).get 1
+x = 99, -1, 42
+
+x.get 1
 # -1
 
-(99, -1, 42).get 5
+x.get -1
 # ()
+
+x.get 5, "abc"
+# abc
 ```
 
 ## last

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -22,7 +22,7 @@ import test_module
   @test import_module: ||
     # The test_module module being imported here is defined in the neighbouring
     # test_module directory, with test_module/main.koto as its entry point.
-    assert_eq (koto.type test_module), "Map"
+    assert_eq (type test_module), "Map"
     assert_eq test_module.foo, 42
     assert_eq (test_module.square 9), 81
 
@@ -31,8 +31,14 @@ import test_module
     assert_eq bar, -1
     assert_eq x, bar
 
-  @test import_nested_item: ||
+  @test import_nested_item_directly: ||
     import test_module.baz.qux
+    assert_eq qux, "O_o"
+
+  @test import_nested_item_indirectly: ||
+    import test_module
+    import test_module.baz
+    import baz.qux
     assert_eq qux, "O_o"
 
   @test import_multiple_items: ||

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -81,6 +81,7 @@ make_foo = |x|
     x = (0..10).to_list()
     assert_eq (x.get 5), 5
     assert_eq (x.get 15), ()
+    assert_eq (x.get -1), ()
 
   @test fill: ||
     a = [1, 2, 3]

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -87,16 +87,17 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("get", |vm, args| {
-        let (list, index, default) =
-            match vm.get_args(args) {
-                [List(list), Number(n)] if *n >= 0.0 => (list, n, &Empty),
-                [List(list), Number(n), default] if *n >= 0.0 => (list, n, default),
-                unexpected => return unexpected_type_error_with_slice(
+        let (list, index, default) = match vm.get_args(args) {
+            [List(list), Number(n)] => (list, n, &Empty),
+            [List(list), Number(n), default] => (list, n, default),
+            unexpected => {
+                return unexpected_type_error_with_slice(
                     "list.get",
-                    "a List and a non-negative Number (with optional default value) as arguments",
+                    "a List and a Number (with optional default value) as arguments",
                     unexpected,
-                ),
-            };
+                )
+            }
+        };
 
         match list.data().get::<usize>(index.into()) {
             Some(value) => Ok(value.clone()),

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -66,12 +66,12 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("get_index", |vm, args| {
         let (map, index, default) = match vm.get_args(args) {
-            [Map(map), Number(n)] if *n >= 0.0 => (map, n, &Empty),
-            [Map(map), Number(n), default] if *n >= 0.0 => (map, n, default),
+            [Map(map), Number(n)] => (map, n, &Empty),
+            [Map(map), Number(n), default] => (map, n, default),
             unexpected => {
                 return unexpected_type_error_with_slice(
                     "map.get_index",
-                    "a Map and non-negative Number as arguments",
+                    "a Map and Number as arguments",
                     unexpected,
                 )
             }

--- a/src/runtime/src/core/tuple.rs
+++ b/src/runtime/src/core/tuple.rs
@@ -49,16 +49,17 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("get", |vm, args| {
-        let (tuple, index, default) =
-            match vm.get_args(args) {
-                [Tuple(tuple), Number(n)] if *n >= 0.0 => (tuple, n, &Empty),
-                [Tuple(tuple), Number(n), default] if *n >= 0.0 => (tuple, n, default),
-                unexpected => return unexpected_type_error_with_slice(
+        let (tuple, index, default) = match vm.get_args(args) {
+            [Tuple(tuple), Number(n)] => (tuple, n, &Empty),
+            [Tuple(tuple), Number(n), default] => (tuple, n, default),
+            unexpected => {
+                return unexpected_type_error_with_slice(
                     "tuple.get",
-                    "a Tuple and non-negative Number (with optional default Value) as arguments",
+                    "a Tuple and Number (with optional default Value) as arguments",
                     unexpected,
-                ),
-            };
+                )
+            }
+        };
 
         match tuple.data().get::<usize>(index.into()) {
             Some(value) => Ok(value.clone()),

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1968,10 +1968,15 @@ impl Vm {
     }
 
     fn run_import(&mut self, import_register: u8) -> InstructionResult {
-        // The import name string will have been placed in the import register
-        let import_name = match self.get_register(import_register) {
-            Value::Str(s) => s.clone(),
-            other => return unexpected_type_error("import id or string", other),
+        let import_name = match self.clone_register(import_register) {
+            Value::Str(s) => s,
+            value @ Value::Map(_) | value @ Value::ExternalValue(_) => {
+                self.set_register(import_register, value);
+                return Ok(());
+            }
+            other => {
+                return unexpected_type_error("import id or string, or accessible value", &other)
+            }
         };
 
         // Is the import in the exports?

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -2465,8 +2465,12 @@ impl Vm {
 
         macro_rules! core_op {
             ($module:ident, $iterator_fallback:expr) => {{
-                let op =
-                    self.get_core_op(&key, &self.context.core_lib.$module, $iterator_fallback)?;
+                let op = self.get_core_op(
+                    &key,
+                    &self.context.core_lib.$module,
+                    $iterator_fallback,
+                    stringify!($module),
+                )?;
                 self.set_register(result_register, op);
             }};
         }
@@ -2516,6 +2520,7 @@ impl Vm {
         key: &ValueKey,
         module: &ValueMap,
         iterator_fallback: bool,
+        module_name: &str,
     ) -> RuntimeResult {
         use Value::*;
 
@@ -2573,7 +2578,7 @@ impl Vm {
             },
             None => {
                 use std::ops::Deref;
-                return runtime_error!("'{}' not found", key.deref());
+                return runtime_error!("'{}' not found in '{}'", key.deref(), module_name);
             }
         };
 


### PR DESCRIPTION
- Allow import to work with previously-imported maps
- Accept negative numbers in list.get, tuple.get, and map.get_index
- Rework run_import to ensure cleanup is followed in all cases
- Make the core op 'not found' error message more helpful
