### PR TITLE
Switch to using the 2021 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ The Koto project adheres to
 - Internals
   - `ExternalIterator` has been renamed to `KotoIterator`.
   - `ValueIterator::make_external` has been renamed to `ValueIterator::new`.
+  - Koto now uses the Rust 2021 edition.
 
 ### Removed
 

--- a/examples/poetry/Cargo.toml
+++ b/examples/poetry/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_poetry"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 autobins = false
 publish = false
 

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -26,8 +26,11 @@ pub fn make_module() -> ValueMap {
     result
 }
 
-thread_local!(
-static POETRY_BINDINGS: Rc<RefCell<MetaMap>> = {
+thread_local! {
+    static POETRY_BINDINGS: Rc<RefCell<MetaMap>> = make_poetry_meta_map();
+}
+
+fn make_poetry_meta_map() -> Rc<RefCell<MetaMap>> {
     use Value::{Empty, Iterator, Str};
 
     let mut bindings = MetaMap::with_type_name("Poetry");
@@ -39,9 +42,11 @@ static POETRY_BINDINGS: Rc<RefCell<MetaMap>> = {
                 poetry.0.add_source_material(text);
                 Ok(Empty)
             }
-            unexpected => {
-                unexpected_type_error_with_slice("poetry.add_source_material", "a String as argument", unexpected)
-            }
+            unexpected => unexpected_type_error_with_slice(
+                "poetry.add_source_material",
+                "a String as argument",
+                unexpected,
+            ),
         },
     );
 
@@ -61,7 +66,7 @@ static POETRY_BINDINGS: Rc<RefCell<MetaMap>> = {
     });
 
     Rc::new(RefCell::new(bindings))
-});
+}
 
 #[derive(Clone)]
 struct PoetryIter {

--- a/examples/poetry/src/main.rs
+++ b/examples/poetry/src/main.rs
@@ -122,8 +122,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             .watch(&args.script, move |event: Event| {
                 match event {
                     Event::Create(script_path) | Event::Write(script_path) => {
-                        if let Err(e) = compile_and_run(&mut koto, &script_path) {
-                            eprintln!("{}", e);
+                        if let Err(error) = compile_and_run(&mut koto, &script_path) {
+                            eprintln!("{error}");
                         }
                     }
                     _ => {}
@@ -136,8 +136,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     } else {
         match compile_and_run(&mut koto, &script_path) {
             Ok(_) => Ok(()),
-            Err(e) => {
-                eprintln!("{}", e);
+            Err(error) => {
+                eprintln!("{error}");
                 std::process::exit(1);
             }
         }

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_wasm"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -65,8 +65,8 @@ pub fn compile_and_run(input: &str) -> String {
     match koto.compile(input) {
         Ok(_) => match koto.run() {
             Ok(_) => std::mem::take(&mut output.borrow_mut()),
-            Err(e) => format!("Runtime error: {}", e),
+            Err(error) => format!("Runtime error: {error}"),
         },
-        Err(e) => format!("Compilation error: {}", e),
+        Err(error) => format!("Compilation error: {error}"),
     }
 }

--- a/libs/json/Cargo.toml
+++ b/libs/json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_json"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "A Koto library for working with JSON data"
 homepage = "https://github.com/koto-lang/koto"

--- a/libs/lib_tests/Cargo.toml
+++ b/libs/lib_tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lib_tests"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "MIT"
 description = "A test runner for the standard Koto libraries"

--- a/libs/random/Cargo.toml
+++ b/libs/random/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_random"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "A Koto library for working with random numbers"
 homepage = "https://github.com/koto-lang/koto"

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -57,20 +57,22 @@ pub fn make_module() -> ValueMap {
 }
 
 thread_local! {
-    static RNG_META: Rc<RefCell<MetaMap>> = {
-        let mut meta = MetaMap::with_type_name("Rng");
-
-        meta.add_named_instance_fn_mut("bool", |rng: &mut ChaChaRng, _, _| rng.gen_bool());
-        meta.add_named_instance_fn_mut("number", |rng: &mut ChaChaRng, _, _| rng.gen_number());
-        meta.add_named_instance_fn_mut("num2", |rng: &mut ChaChaRng, _, _| rng.gen_num2());
-        meta.add_named_instance_fn_mut("num4", |rng: &mut ChaChaRng, _, _| rng.gen_num4());
-        meta.add_named_instance_fn_mut("pick", |rng: &mut ChaChaRng, _, args| rng.pick(args));
-        meta.add_named_instance_fn_mut("seed", |rng: &mut ChaChaRng, _, args| rng.seed(args));
-
-        Rc::new(RefCell::new(meta))
-    };
+    static RNG_META: Rc<RefCell<MetaMap>> = make_rng_meta_map();
 
     static THREAD_RNG: RefCell<ChaChaRng> = RefCell::new(ChaChaRng(ChaCha8Rng::from_entropy()));
+}
+
+fn make_rng_meta_map() -> Rc<RefCell<MetaMap>> {
+    let mut meta = MetaMap::with_type_name("Rng");
+
+    meta.add_named_instance_fn_mut("bool", |rng: &mut ChaChaRng, _, _| rng.gen_bool());
+    meta.add_named_instance_fn_mut("number", |rng: &mut ChaChaRng, _, _| rng.gen_number());
+    meta.add_named_instance_fn_mut("num2", |rng: &mut ChaChaRng, _, _| rng.gen_num2());
+    meta.add_named_instance_fn_mut("num4", |rng: &mut ChaChaRng, _, _| rng.gen_num4());
+    meta.add_named_instance_fn_mut("pick", |rng: &mut ChaChaRng, _, args| rng.pick(args));
+    meta.add_named_instance_fn_mut("seed", |rng: &mut ChaChaRng, _, args| rng.seed(args));
+
+    Rc::new(RefCell::new(meta))
 }
 
 #[derive(Debug)]

--- a/libs/tempfile/Cargo.toml
+++ b/libs/tempfile/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_tempfile"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "A Koto library for working with temporary files"
 homepage = "https://github.com/koto-lang/koto"

--- a/libs/toml/Cargo.toml
+++ b/libs/toml/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_toml"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "A Koto library for working with TOML data"
 homepage = "https://github.com/koto-lang/koto"

--- a/libs/yaml/Cargo.toml
+++ b/libs/yaml/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_yaml"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "A Koto library for working with YAML data"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/bytecode/Cargo.toml
+++ b/src/bytecode/Cargo.toml
@@ -3,6 +3,7 @@ name = "koto_bytecode"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
 edition = "2021"
+rust-version = "1.58"
 license = "MIT"
 description = "The bytecode compiler used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/bytecode/Cargo.toml
+++ b/src/bytecode/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_bytecode"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "The bytecode compiler used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/bytecode/src/chunk.rs
+++ b/src/bytecode/src/chunk.rs
@@ -83,7 +83,7 @@ impl Chunk {
         'outer: loop {
             for i in 1..=16 {
                 match iter.next() {
-                    Some(byte) => result += &format!("{:02x}", byte),
+                    Some(byte) => result += &format!("{byte:02x}"),
                     None => break 'outer,
                 }
                 if i < 16 {
@@ -132,11 +132,11 @@ impl Chunk {
                     .line
                     .min(source_lines.len() as u32)
                     .max(1) as usize;
-                result += &format!("|{}| {}\n", line, source_lines[line - 1]);
+                result += &format!("|{line}| {}\n", source_lines[line - 1]);
                 span = Some(instruction_span);
             }
 
-            result += &format!("{}\t{:?}\n", ip, &instruction);
+            result += &format!("{ip}\t{instruction:?}\n");
             ip = reader.ip;
         }
 
@@ -146,6 +146,6 @@ impl Chunk {
 
 impl fmt::Debug for Chunk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "Chunk ({:p})", self)
+        write!(f, "Chunk ({self:p})")
     }
 }

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -6,7 +6,7 @@ use {
         MetaKeyId, Node, Scope, Span, StringNode, SwitchArm,
     },
     smallvec::SmallVec,
-    std::{collections::HashSet, convert::TryFrom, error, fmt},
+    std::{collections::HashSet, error, fmt},
 };
 
 /// The error type used to report errors during compilation

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -498,61 +498,51 @@ impl fmt::Debug for Instruction {
         use Instruction::*;
         match self {
             Error { message } => unreachable!(message),
-            Copy { target, source } => write!(f, "Copy\t\tresult: {}\tsource: {}", target, source),
-            SetEmpty { register } => write!(f, "SetEmpty\tresult: {}", register),
+            Copy { target, source } => write!(f, "Copy\t\tresult: {target}\tsource: {source}"),
+            SetEmpty { register } => write!(f, "SetEmpty\tresult: {register}"),
             SetBool { register, value } => {
-                write!(f, "SetBool\t\tresult: {}\tvalue: {}", register, value)
+                write!(f, "SetBool\t\tresult: {register}\tvalue: {value}")
             }
             SetNumber { register, value } => {
-                write!(f, "SetNumber\tresult: {}\tvalue: {}", register, value)
+                write!(f, "SetNumber\tresult: {register}\tvalue: {value}")
             }
             LoadFloat { register, constant } => {
-                write!(f, "LoadFloat\tresult: {}\tconstant: {}", register, constant)
+                write!(f, "LoadFloat\tresult: {register}\tconstant: {constant}")
             }
             LoadInt { register, constant } => {
-                write!(f, "LoadInt\t\tresult: {}\tconstant: {}", register, constant)
+                write!(f, "LoadInt\t\tresult: {register}\tconstant: {constant}")
             }
-            LoadString { register, constant } => write!(
-                f,
-                "LoadString\tresult: {}\tconstant: {}",
-                register, constant
-            ),
-            LoadNonLocal { register, constant } => write!(
-                f,
-                "LoadNonLocal\tresult: {}\tconstant: {}",
-                register, constant
-            ),
+            LoadString { register, constant } => {
+                write!(f, "LoadString\tresult: {register}\tconstant: {constant}",)
+            }
+            LoadNonLocal { register, constant } => {
+                write!(f, "LoadNonLocal\tresult: {register}\tconstant: {constant}",)
+            }
             ValueExport { name, value } => {
-                write!(f, "ValueExport\tname: {}\t\tvalue: {}", name, value)
+                write!(f, "ValueExport\tname: {name}\t\tvalue: {value}")
             }
-            Import { register } => write!(f, "Import\t\tregister: {}", register),
+            Import { register } => write!(f, "Import\t\tregister: {register}"),
             MakeTempTuple {
                 register,
                 start,
                 count,
             } => write!(
                 f,
-                "MakeTempTuple\tresult: {}\tstart: {}\tcount: {}",
-                register, start, count
+                "MakeTempTuple\tresult: {register}\tstart: {start}\tcount: {count}"
             ),
             MakeMap {
                 register,
                 size_hint,
-            } => write!(
-                f,
-                "MakeMap\t\tresult: {}\tsize_hint: {}",
-                register, size_hint
-            ),
+            } => write!(f, "MakeMap\t\tresult: {register}\tsize_hint: {size_hint}"),
             SequenceStart {
                 register,
                 size_hint,
             } => write!(
                 f,
-                "SequenceStart\tresult: {}\tsize_hint: {}",
-                register, size_hint
+                "SequenceStart\tresult: {register}\tsize_hint: {size_hint}"
             ),
             SequencePush { sequence, value } => {
-                write!(f, "SequencePush\tsequence: {}\tvalue: {}", sequence, value)
+                write!(f, "SequencePush\tsequence: {sequence}\tvalue: {value}")
             }
             SequencePushN {
                 sequence,
@@ -560,50 +550,41 @@ impl fmt::Debug for Instruction {
                 count,
             } => write!(
                 f,
-                "SequencePushN\tsequence: {}\tstart: {}\tcount: {}",
-                sequence, start, count
+                "SequencePushN\tsequence: {sequence}\tstart: {start}\tcount: {count}",
             ),
-            SequenceToList { sequence } => write!(f, "SequenceToList\tsequence: {}", sequence),
-            SequenceToTuple { sequence } => write!(f, "SequenceToTuple\tsequence: {}", sequence),
+            SequenceToList { sequence } => write!(f, "SequenceToList\tsequence: {sequence}"),
+            SequenceToTuple { sequence } => write!(f, "SequenceToTuple\tsequence: {sequence}"),
             Range {
                 register,
                 start,
                 end,
-            } => write!(
-                f,
-                "Range\t\tresult: {}\tstart: {}\tend: {}",
-                register, start, end
-            ),
+            } => write!(f, "Range\t\tresult: {register}\tstart: {start}\tend: {end}",),
             RangeInclusive {
                 register,
                 start,
                 end,
             } => write!(
                 f,
-                "RangeInclusive\tresult: {}\tstart: {}\tend: {}",
-                register, start, end
+                "RangeInclusive\tresult: {register}\tstart: {start}\tend: {end}",
             ),
-            RangeTo { register, end } => write!(f, "RangeTo\t\tresult: {}\tend: {}", register, end),
+            RangeTo { register, end } => write!(f, "RangeTo\t\tresult: {register}\tend: {end}"),
             RangeToInclusive { register, end } => {
-                write!(f, "RangeToIncl\tresult: {}\tend: {}", register, end)
+                write!(f, "RangeToIncl\tresult: {register}\tend: {end}")
             }
             RangeFrom { register, start } => {
-                write!(f, "RangeFrom\tresult: {}\tstart: {}", register, start)
+                write!(f, "RangeFrom\tresult: {register}\tstart: {start}")
             }
-            RangeFull { register } => write!(f, "RangeFull\tresult: {}", register),
-            MakeIterator { register, iterable } => write!(
-                f,
-                "MakeIterator\tresult: {}\titerable: {}",
-                register, iterable
-            ),
+            RangeFull { register } => write!(f, "RangeFull\tresult: {register}"),
+            MakeIterator { register, iterable } => {
+                write!(f, "MakeIterator\tresult: {register}\titerable: {iterable}",)
+            }
             SimpleFunction {
                 register,
                 arg_count,
                 size,
             } => write!(
                 f,
-                "SimpleFunction\tresult: {}\targs: {}\t\tsize: {}",
-                register, arg_count, size,
+                "SimpleFunction\tresult: {register}\targs: {arg_count}\t\tsize: {size}",
             ),
             Function {
                 register,
@@ -616,17 +597,10 @@ impl fmt::Debug for Instruction {
                 size,
             } => write!(
                 f,
-                "Function\tresult: {}\targs: {}\t\tcaptures: {}\tsize: {}
-                 \t\t\tinstance: {}\tgenerator: {}
-                 \t\t\tvariadic: {}\targ_is_unpacked_tuple: {}",
-                register,
-                arg_count,
-                capture_count,
-                size,
-                instance_function,
-                generator,
-                variadic,
-                arg_is_unpacked_tuple,
+                "Function\tresult: {register}\targs: {arg_count}\
+                 \t\tcaptures: {capture_count}\tsize: {size}
+                 \t\t\tinstance: {instance_function}\tgenerator: {generator}
+                 \t\t\tvariadic: {variadic}\targ_is_unpacked_tuple: {arg_is_unpacked_tuple}",
             ),
             Capture {
                 function,
@@ -634,81 +608,60 @@ impl fmt::Debug for Instruction {
                 source,
             } => write!(
                 f,
-                "Capture\t\tfunction: {}\ttarget: {}\tsource: {}",
-                function, target, source
+                "Capture\t\tfunction: {function}\ttarget: {target}\tsource: {source}",
             ),
             Negate { register, value } => {
-                write!(f, "Negate\t\tresult: {}\tsource: {}", register, value)
+                write!(f, "Negate\t\tresult: {register}\tsource: {value}")
             }
             Not { register, value } => {
-                write!(f, "Not\t\tresult: {}\tsource: {}", register, value)
+                write!(f, "Not\t\tresult: {register}\tsource: {value}")
             }
-            Add { register, lhs, rhs } => write!(
-                f,
-                "Add\t\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
-            Subtract { register, lhs, rhs } => write!(
-                f,
-                "Subtract\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
-            Multiply { register, lhs, rhs } => write!(
-                f,
-                "Multiply\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
-            Divide { register, lhs, rhs } => write!(
-                f,
-                "Divide\t\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
-            Modulo { register, lhs, rhs } => write!(
-                f,
-                "Modulo\t\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
-            Less { register, lhs, rhs } => write!(
-                f,
-                "Less\t\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
+            Add { register, lhs, rhs } => {
+                write!(f, "Add\t\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
+            Subtract { register, lhs, rhs } => {
+                write!(f, "Subtract\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
+            Multiply { register, lhs, rhs } => {
+                write!(f, "Multiply\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
+            Divide { register, lhs, rhs } => {
+                write!(f, "Divide\t\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
+            Modulo { register, lhs, rhs } => {
+                write!(f, "Modulo\t\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
+            Less { register, lhs, rhs } => {
+                write!(f, "Less\t\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
             LessOrEqual { register, lhs, rhs } => write!(
                 f,
-                "LessOrEqual\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
+                "LessOrEqual\tresult: {register}\tlhs: {lhs}\t\trhs: {}",
+                rhs
             ),
-            Greater { register, lhs, rhs } => write!(
-                f,
-                "Greater\t\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
+            Greater { register, lhs, rhs } => {
+                write!(f, "Greater\t\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
             GreaterOrEqual { register, lhs, rhs } => write!(
                 f,
-                "GreaterOrEqual\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
+                "GreaterOrEqual\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}",
             ),
-            Equal { register, lhs, rhs } => write!(
-                f,
-                "Equal\t\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
-            NotEqual { register, lhs, rhs } => write!(
-                f,
-                "NotEqual\tresult: {}\tlhs: {}\t\trhs: {}",
-                register, lhs, rhs
-            ),
-            Jump { offset } => write!(f, "Jump\t\toffset: {}", offset),
+            Equal { register, lhs, rhs } => {
+                write!(f, "Equal\t\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
+            NotEqual { register, lhs, rhs } => {
+                write!(f, "NotEqual\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
+            }
+            Jump { offset } => write!(f, "Jump\t\toffset: {offset}"),
             JumpIf {
                 register,
                 offset,
                 jump_condition,
             } => write!(
                 f,
-                "JumpIf\t\tresult: {}\toffset: {}\tcondition: {}",
-                register, offset, jump_condition
+                "JumpIf\t\tresult: {register}\toffset: {offset}\tcondition: {jump_condition}",
             ),
-            JumpBack { offset } => write!(f, "JumpBack\toffset: {}", offset),
+            JumpBack { offset } => write!(f, "JumpBack\toffset: {offset}"),
             Call {
                 result,
                 function,
@@ -716,8 +669,8 @@ impl fmt::Debug for Instruction {
                 arg_count,
             } => write!(
                 f,
-                "Call\t\tresult: {}\tfunction: {}\tframe base: {}\targs: {}",
-                result, function, frame_base, arg_count
+                "Call\t\tresult: {result}\tfunction: {function}\t\
+                 frame base: {frame_base}\targs: {arg_count}",
             ),
             CallInstance {
                 result,
@@ -727,22 +680,20 @@ impl fmt::Debug for Instruction {
                 instance,
             } => write!(
                 f,
-                "CallInstance\tresult: {}\tfunction: {}\tframe_base: {}
-                 \t\t\targs: {}\t\tinstance: {}",
-                result, function, frame_base, arg_count, instance
+                "CallInstance\tresult: {result}\tfunction: {function}\tframe_base: {frame_base}
+                 \t\t\targs: {arg_count}\t\tinstance: {instance}",
             ),
-            Return { register } => write!(f, "Return\t\tresult: {}", register),
-            Yield { register } => write!(f, "Yield\t\tresult: {}", register),
-            Throw { register } => write!(f, "Throw\t\tresult: {}", register),
-            Size { register, value } => write!(f, "Size\t\tresult: {}\tvalue: {}", register, value),
+            Return { register } => write!(f, "Return\t\tresult: {register}"),
+            Yield { register } => write!(f, "Yield\t\tresult: {register}"),
+            Throw { register } => write!(f, "Throw\t\tresult: {register}"),
+            Size { register, value } => write!(f, "Size\t\tresult: {register}\tvalue: {value}"),
             IterNext {
                 register,
                 iterator,
                 jump_offset,
             } => write!(
                 f,
-                "IterNext\tresult: {}\titerator: {}\tjump offset: {}",
-                register, iterator, jump_offset
+                "IterNext\tresult: {register}\titerator: {iterator}\tjump offset: {jump_offset}",
             ),
             IterNextTemp {
                 register,
@@ -750,16 +701,15 @@ impl fmt::Debug for Instruction {
                 jump_offset,
             } => write!(
                 f,
-                "IterNextTemp\tresult: {}\titerator: {}\tjump offset: {}",
-                register, iterator, jump_offset
+                "IterNextTemp\tresult: {register}\
+                 \titerator: {iterator}\tjump offset: {jump_offset}",
             ),
             IterNextQuiet {
                 iterator,
                 jump_offset,
             } => write!(
                 f,
-                "IterNextQuiet\titerator: {}\tjump offset: {}",
-                iterator, jump_offset
+                "IterNextQuiet\titerator: {iterator}\tjump offset: {jump_offset}",
             ),
             TempIndex {
                 register,
@@ -767,8 +717,7 @@ impl fmt::Debug for Instruction {
                 index,
             } => write!(
                 f,
-                "TempIndex\tresult: {}\tvalue: {}\tindex: {}",
-                register, value, index
+                "TempIndex\tresult: {register}\tvalue: {value}\tindex: {index}",
             ),
             SliceFrom {
                 register,
@@ -776,8 +725,7 @@ impl fmt::Debug for Instruction {
                 index,
             } => write!(
                 f,
-                "SliceFrom\tresult: {}\tvalue: {}\tindex: {}",
-                register, value, index
+                "SliceFrom\tresult: {register}\tvalue: {value}\tindex: {index}",
             ),
             SliceTo {
                 register,
@@ -785,14 +733,13 @@ impl fmt::Debug for Instruction {
                 index,
             } => write!(
                 f,
-                "SliceTo\t\tresult: {}\tvalue: {}\tindex: {}",
-                register, value, index
+                "SliceTo\t\tresult: {register}\tvalue: {value}\tindex: {index}"
             ),
             IsTuple { register, value } => {
-                write!(f, "IsTuple\t\tresult: {}\tvalue: {}", register, value)
+                write!(f, "IsTuple\t\tresult: {register}\tvalue: {value}")
             }
             IsList { register, value } => {
-                write!(f, "IsList\t\tresult: {}\tvalue: {}", register, value)
+                write!(f, "IsList\t\tresult: {register}\tvalue: {value}")
             }
             Index {
                 register,
@@ -800,8 +747,7 @@ impl fmt::Debug for Instruction {
                 index,
             } => write!(
                 f,
-                "Index\t\tresult: {}\tvalue: {}\tindex: {}",
-                register, value, index
+                "Index\t\tresult: {register}\tvalue: {value}\tindex: {index}"
             ),
             SetIndex {
                 register,
@@ -809,8 +755,7 @@ impl fmt::Debug for Instruction {
                 value,
             } => write!(
                 f,
-                "SetIndex\tregister: {}\tindex: {}\tvalue: {}",
-                register, index, value
+                "SetIndex\tregister: {register}\tindex: {index}\tvalue: {value}"
             ),
             MapInsert {
                 register,
@@ -818,8 +763,7 @@ impl fmt::Debug for Instruction {
                 key,
             } => write!(
                 f,
-                "MapInsert\tmap: {}\t\tvalue: {}\tkey: {}",
-                register, value, key
+                "MapInsert\tmap: {register}\t\tvalue: {value}\tkey: {key}"
             ),
             MetaInsert {
                 register,
@@ -827,8 +771,7 @@ impl fmt::Debug for Instruction {
                 id,
             } => write!(
                 f,
-                "MetaInsert\tmap: {}\t\tid: {:?}\tvalue: {}",
-                register, id, value
+                "MetaInsert\tmap: {register}\t\tid: {id:?}\tvalue: {value}",
             ),
             MetaInsertNamed {
                 register,
@@ -837,14 +780,12 @@ impl fmt::Debug for Instruction {
                 value,
             } => write!(
                 f,
-                "MetaInsertNamed\tmap: {}\t\tid: {:?}\tname: {}\t\tvalue: {}",
-                register, id, name, value
+                "MetaInsertNamed\tmap: {register}\t\tid: {id:?}\tname: {name}\t\tvalue: {value}",
             ),
-            MetaExport { id, value } => write!(f, "MetaExport\tid: {:?}\tvalue: {}", id, value),
+            MetaExport { id, value } => write!(f, "MetaExport\tid: {id:?}\tvalue: {value}"),
             MetaExportNamed { id, name, value } => write!(
                 f,
-                "MetaExportNamed\tid: {:?}\tname: {}\tvalue: {}",
-                id, name, value,
+                "MetaExportNamed\tid: {id:?}\tname: {name}\tvalue: {value}",
             ),
             Access {
                 register,
@@ -852,8 +793,7 @@ impl fmt::Debug for Instruction {
                 key,
             } => write!(
                 f,
-                "Access\t\tresult: {}\tvalue: {}\tkey: {}",
-                register, value, key
+                "Access\t\tresult: {register}\tvalue: {value}\tkey: {key}"
             ),
             AccessString {
                 register,
@@ -861,26 +801,24 @@ impl fmt::Debug for Instruction {
                 key,
             } => write!(
                 f,
-                "AccessString\tresult: {}\tvalue: {}\tkey: {}",
-                register, value, key
+                "AccessString\tresult: {register}\tvalue: {value}\tkey: {key}"
             ),
             TryStart {
                 arg_register,
                 catch_offset,
             } => write!(
                 f,
-                "TryStart\targ register: {}\tcatch offset: {}",
-                arg_register, catch_offset
+                "TryStart\targ register: {arg_register}\tcatch offset: {catch_offset}",
             ),
             TryEnd => write!(f, "TryEnd"),
             Debug { register, constant } => {
-                write!(f, "Debug\t\tregister: {}\tconstant: {}", register, constant)
+                write!(f, "Debug\t\tregister: {register}\tconstant: {constant}")
             }
             CheckType { register, type_id } => {
-                write!(f, "CheckType\tregister: {}\ttype: {:?}", register, type_id)
+                write!(f, "CheckType\tregister: {register}\ttype: {type_id:?}")
             }
             CheckSize { register, size } => {
-                write!(f, "CheckSize\tregister: {}\tsize: {}", register, size)
+                write!(f, "CheckSize\tregister: {register}\tsize: {size}")
             }
             StringStart {
                 register,
@@ -888,15 +826,14 @@ impl fmt::Debug for Instruction {
             } => {
                 write!(
                     f,
-                    "StringStart\tregister: {}\tsize hint: {}",
-                    register, size_hint
+                    "StringStart\tregister: {register}\tsize hint: {size_hint}"
                 )
             }
             StringPush { register, value } => {
-                write!(f, "StringPush\tregister: {}\tvalue: {}", register, value)
+                write!(f, "StringPush\tregister: {register}\tvalue: {value}")
             }
             StringFinish { register } => {
-                write!(f, "StringFinish\tregister: {}", register)
+                write!(f, "StringFinish\tregister: {register}")
             }
         }
     }
@@ -1437,8 +1374,7 @@ impl Iterator for InstructionReader {
                 } else {
                     Some(Error {
                         message: format!(
-                            "Unexpected meta id {} found at instruction {}",
-                            meta_id, op_ip
+                            "Unexpected meta id {meta_id} found at instruction {op_ip}",
                         ),
                     })
                 }
@@ -1451,8 +1387,7 @@ impl Iterator for InstructionReader {
                 } else {
                     Some(Error {
                         message: format!(
-                            "Unexpected meta id {} found at instruction {}",
-                            meta_id, op_ip
+                            "Unexpected meta id {meta_id} found at instruction {op_ip}",
                         ),
                     })
                 }
@@ -1466,8 +1401,7 @@ impl Iterator for InstructionReader {
                 } else {
                     Some(Error {
                         message: format!(
-                            "Unexpected meta id {} found at instruction {}",
-                            meta_id, op_ip
+                            "Unexpected meta id {meta_id} found at instruction {op_ip}",
                         ),
                     })
                 }
@@ -1506,7 +1440,7 @@ impl Iterator for InstructionReader {
                 match TypeId::from_byte(get_u8!()) {
                     Ok(type_id) => Some(CheckType { register, type_id }),
                     Err(byte) => Some(Error {
-                        message: format!("Unexpected value for CheckType id: {}", byte),
+                        message: format!("Unexpected value for CheckType id: {byte}"),
                     }),
                 }
             }
@@ -1530,7 +1464,7 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
             }),
             _ => Some(Error {
-                message: format!("Unexpected opcode {:?} found at instruction {}", op, op_ip),
+                message: format!("Unexpected opcode {op:?} found at instruction {op_ip}"),
             }),
         }
     }

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -1,7 +1,7 @@
 use {
     crate::{Chunk, Op},
     koto_parser::{ConstantIndex, MetaKeyId},
-    std::{convert::TryInto, fmt, rc::Rc},
+    std::{fmt, rc::Rc},
 };
 
 #[derive(Debug)]

--- a/src/bytecode/src/loader.rs
+++ b/src/bytecode/src/loader.rs
@@ -179,9 +179,8 @@ impl Loader {
         let mut load_module_from_path = |module_path: PathBuf| {
             let module_path = module_path.canonicalize().map_err(|error| {
                 LoaderError::io_error(format!(
-                    "Failed to canonicalize path: '{}' - ({})",
+                    "Failed to canonicalize path: '{}' - ({error})",
                     module_path.to_string_lossy(),
-                    error
                 ))
             })?;
             match self.chunks.get(&module_path) {
@@ -228,8 +227,7 @@ impl Loader {
                 load_module_from_path(module_path)
             } else {
                 Err(LoaderError::io_error(format!(
-                    "Unable to find module '{}'",
-                    name
+                    "Unable to find module '{name}'"
                 )))
             }
         }

--- a/src/bytecode/tests/compile_failures.rs
+++ b/src/bytecode/tests/compile_failures.rs
@@ -8,11 +8,11 @@ mod bytecode {
         match Parser::parse(source) {
             Ok(ast) => {
                 if Compiler::compile(&ast, CompilerSettings::default()).is_ok() {
-                    panic!("\nUnexpected success while compiling: {}", source,);
+                    panic!("\nUnexpected success while compiling: {source}");
                 }
             }
             Err(parser_error) => {
-                panic!("Failure while parsing:\n{}\n{}", source, parser_error);
+                panic!("Failure while parsing:\n{source}\n{parser_error}");
             }
         }
     }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_cli"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "A CLI and script runner for the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/cli/src/help.rs
+++ b/src/cli/src/help.rs
@@ -276,7 +276,6 @@ fn consume_help_section<'a>(
         parser.next();
     }
 
-    let result = result.replace("\n", &format!("\n{}", indent));
-
+    let result = result.replace('\n', &format!("\n{}", indent));
     (section_name, result)
 }

--- a/src/cli/src/help.rs
+++ b/src/cli/src/help.rs
@@ -86,7 +86,7 @@ impl Help {
                             .collect::<Vec<_>>();
 
                         match matches.as_slice() {
-                            [] => format!("  No matches for '{}' found.", search),
+                            [] => format!("  No matches for '{search}' found."),
                             [(only_match, _)] => self.get_help(Some(only_match)),
                             _ => {
                                 let mut help = String::new();
@@ -237,7 +237,7 @@ fn consume_help_section<'a>(
             Text(text) => {
                 if section_name.is_empty() {
                     if let Some(module_name) = module_name {
-                        section_name = format!("{}.{}", module_name, text);
+                        section_name = format!("{module_name}.{text}");
                     } else {
                         section_name = text.to_string();
                     }
@@ -258,7 +258,7 @@ fn consume_help_section<'a>(
                 result.push('`');
                 if section_name.is_empty() {
                     if let Some(module_name) = module_name {
-                        section_name = format!("{}.{}", module_name, code);
+                        section_name = format!("{module_name}.{code}");
                     } else {
                         section_name = code.to_string();
                     }
@@ -276,6 +276,6 @@ fn consume_help_section<'a>(
         parser.next();
     }
 
-    let result = result.replace('\n', &format!("\n{}", indent));
+    let result = result.replace('\n', &format!("\n{indent}"));
     (section_name, result)
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -181,14 +181,14 @@ fn run() -> Result<(), ()> {
                 }
                 match koto.run_with_args(&args.script_args) {
                     Ok(_) => {}
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
+                    Err(error) => {
+                        eprintln!("Error: {error}");
                         return Err(());
                     }
                 }
             }
-            Err(e) => {
-                eprintln!("Error: {}", e);
+            Err(error) => {
+                eprintln!("Error: {error}");
                 return Err(());
             }
         }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -78,7 +78,7 @@ fn parse_arguments() -> Result<KotoArgs, String> {
                 pico_args::Error::UnusedArgsLeft(unused) => {
                     format!("Unsupported argument: {}", unused.first().unwrap())
                 }
-                other => format!("Error while parsing arguments: {}", other),
+                other => format!("Error while parsing arguments: {other}"),
             })
         }
     };

--- a/src/cli/src/repl.rs
+++ b/src/cli/src/repl.rs
@@ -362,11 +362,11 @@ impl Repl {
                 ResetColor,
                 Print(": "),
                 SetAttribute(Attribute::Bold),
-                Print(format!("{:#}\n\n", error)),
+                Print(format!("{error:#}\n\n")),
                 SetAttribute(Attribute::Reset),
             )
         } else {
-            writeln!(stdout, "{:#}", error)
+            writeln!(stdout, "{error:#}")
         }
     }
 }

--- a/src/cli/src/repl.rs
+++ b/src/cli/src/repl.rs
@@ -63,7 +63,7 @@ impl Repl {
     pub fn run(&mut self) -> Result<()> {
         let mut stdout = io::stdout();
 
-        write!(stdout, "Welcome to Koto v{}\r\n{}", VERSION, PROMPT).unwrap();
+        write!(stdout, "Welcome to Koto v{VERSION}\r\n{PROMPT}").unwrap();
         stdout.flush().unwrap();
 
         loop {
@@ -255,7 +255,7 @@ impl Repl {
                     }
                     match self.koto.run() {
                         Ok(result) => match self.koto.value_to_string(result.clone()) {
-                            Ok(result_string) => writeln!(stdout, "{}\n", result_string).unwrap(),
+                            Ok(result_string) => writeln!(stdout, "{result_string}\n").unwrap(),
                             Err(e) => {
                                 writeln!(
                                     stdout,

--- a/src/koto/Cargo.toml
+++ b/src/koto/Cargo.toml
@@ -3,6 +3,7 @@ name = "koto"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
 edition = "2021"
+rust-version = "1.58"
 license = "MIT"
 description = "A simple, expressive, embeddable programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/koto/Cargo.toml
+++ b/src/koto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "A simple, expressive, embeddable programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/koto/benches/koto_benchmark.rs
+++ b/src/koto/benches/koto_benchmark.rs
@@ -27,10 +27,10 @@ impl BenchmarkRunner {
         match runtime.compile(&script) {
             Ok(_) => {
                 if let Err(error) = runtime.run_with_args(args) {
-                    panic!("{}", error);
+                    panic!("{error}");
                 }
             }
-            Err(error) => panic!("{}", error),
+            Err(error) => panic!("{error}"),
         }
 
         runtime.set_run_tests(false);
@@ -43,7 +43,7 @@ impl BenchmarkRunner {
 
     fn run(&mut self) {
         if let Err(error) = self.runtime.run_with_args(&self.args) {
-            panic!("{}", error);
+            panic!("{error}");
         }
     }
 }

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -119,6 +119,7 @@ pub struct KotoSettings {
 
 impl KotoSettings {
     /// Helper for conveniently defining a custom stdin implementation
+    #[must_use]
     pub fn with_stdin(self, stdin: impl KotoFile + 'static) -> Self {
         Self {
             stdin: Rc::new(stdin),
@@ -127,6 +128,7 @@ impl KotoSettings {
     }
 
     /// Helper for conveniently defining a custom stdout implementation
+    #[must_use]
     pub fn with_stdout(self, stdout: impl KotoFile + 'static) -> Self {
         Self {
             stdout: Rc::new(stdout),
@@ -135,6 +137,7 @@ impl KotoSettings {
     }
 
     /// Helper for conveniently defining a custom stderr implementation
+    #[must_use]
     pub fn with_stderr(self, stderr: impl KotoFile + 'static) -> Self {
         Self {
             stderr: Rc::new(stderr),
@@ -143,6 +146,7 @@ impl KotoSettings {
     }
 
     /// Convenience function for declaring the 'module imported' callback
+    #[must_use]
     pub fn with_module_imported_callback(self, callback: impl Fn(&Path) + 'static) -> Self {
         Self {
             module_imported_callback: Some(Box::new(callback)),

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -13,15 +13,15 @@
 //! match koto.compile("1 + 2") {
 //!     Ok(_) => match koto.run() {
 //!         Ok(result) => match result {
-//!             Value::Number(n) => println!("{}", n), // 3.0
+//!             Value::Number(n) => println!("{n}"), // 3.0
 //!             other => panic!("Unexpected result: {}", other),
 //!         },
 //!         Err(runtime_error) => {
-//!             panic!("Runtime error: {}", runtime_error);
+//!             panic!("Runtime error: {runtime_error}");
 //!         }
 //!     },
 //!     Err(compiler_error) => {
-//!         panic!("Compiler error: {}", compiler_error);
+//!         panic!("Compiler error: {compiler_error}");
 //!     }
 //! }
 //! ```
@@ -71,10 +71,10 @@ impl fmt::Display for KotoError {
                 f.write_str("Missing compiled chunk, call compile() before calling run()")
             }
             InvalidTestsType(t) => {
-                write!(f, "Expected a Map for the exported 'tests', found '{}'", t)
+                write!(f, "Expected a Map for the exported 'tests', found '{t}'")
             }
             FunctionNotFound(name) => {
-                write!(f, "Function '{}' not found", name)
+                write!(f, "Function '{name}' not found")
             }
         }
     }

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -45,11 +45,11 @@ fn run_script(script: &str, script_path: Option<PathBuf>, expected_module_paths:
                 );
             }
             Err(error) => {
-                panic!("{}", error);
+                panic!("{error}");
             }
         },
         Err(error) => {
-            panic!("{}", error);
+            panic!("{error}");
         }
     }
 }

--- a/src/koto/tests/one_plus_two.rs
+++ b/src/koto/tests/one_plus_two.rs
@@ -9,14 +9,14 @@ fn one_plus_two() {
         Ok(_) => match koto.run() {
             Ok(result) => match result {
                 Value::Number(n) => assert_eq!(n, 3.0),
-                other => panic!("Unexpected result: {}", other),
+                other => panic!("Unexpected result: {other}"),
             },
             Err(runtime_error) => {
-                panic!("Runtime error: {}", runtime_error);
+                panic!("Runtime error: {runtime_error}");
             }
         },
         Err(compiler_error) => {
-            panic!("Compiler error: {}", compiler_error);
+            panic!("Compiler error: {compiler_error}");
         }
     }
 }

--- a/src/koto/tests/repl_mode_tests.rs
+++ b/src/koto/tests/repl_mode_tests.rs
@@ -31,7 +31,7 @@ fn run_repl_mode_test(inputs_and_expected_outputs: &[(&str, &str)]) {
 
         if let Err(error) = koto.run() {
             for (input, chunk) in chunks.iter() {
-                println!("\n--------\n{}\n--------\n", input);
+                println!("\n--------\n{input}\n--------\n");
                 println!("Constants\n---------\n{}\n", chunk.constants);
                 println!(
                     "Instructions\n------------\n{}",
@@ -39,7 +39,7 @@ fn run_repl_mode_test(inputs_and_expected_outputs: &[(&str, &str)]) {
                 );
             }
 
-            panic!("{}", error);
+            panic!("{error}");
         }
 
         assert_eq!(&output.borrow().trim(), &expected_output.trim());

--- a/src/lexer/Cargo.toml
+++ b/src/lexer/Cargo.toml
@@ -3,6 +3,7 @@ name = "koto_lexer"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
 edition = "2021"
+rust-version = "1.58"
 license = "MIT"
 description = "The lexer used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/lexer/Cargo.toml
+++ b/src/lexer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_lexer"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "The lexer used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -887,15 +887,14 @@ mod tests {
                 match lex.next().expect("Expected token") {
                     Whitespace => continue,
                     output => {
-                        assert_eq!(&output, token, "Token mismatch at position {}", i);
+                        assert_eq!(&output, token, "Token mismatch at position {i}");
                         if let Some(slice) = maybe_slice {
-                            assert_eq!(&lex.slice(), slice, "Slice mismatch at position {}", i);
+                            assert_eq!(&lex.slice(), slice, "Slice mismatch at position {i}");
                         }
                         assert_eq!(
                             lex.line_number() as u32,
                             *line_number,
-                            "Line number mismatch at position {}",
-                            i
+                            "Line number mismatch at position {i}",
                         );
                         break;
                     }
@@ -914,20 +913,18 @@ mod tests {
                 match lex.next().expect("Expected token") {
                     Whitespace => continue,
                     output => {
-                        assert_eq!(&output, token, "Mismatch at token {}", i);
+                        assert_eq!(&output, token, "Mismatch at token {i}");
                         if let Some(slice) = maybe_slice {
-                            assert_eq!(&lex.slice(), slice, "Mismatch at token {}", i);
+                            assert_eq!(&lex.slice(), slice, "Mismatch at token {i}");
                         }
                         assert_eq!(
                             lex.line_number() as u32,
                             *line_number,
-                            "Line number - expected: {}, actual: {} - (token {} - {:?})",
+                            "Line number - expected: {}, actual: {} - (token {i} - {token:?})",
                             *line_number,
                             lex.line_number(),
-                            i,
-                            token
                         );
-                        assert_eq!(lex.current_indent() as u32, *indent, "Indent (token {})", i);
+                        assert_eq!(lex.current_indent() as u32, *indent, "Indent (token {i})");
                         break;
                     }
                 }

--- a/src/parser/Cargo.toml
+++ b/src/parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_parser"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "The parser used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/parser/Cargo.toml
+++ b/src/parser/Cargo.toml
@@ -3,6 +3,7 @@ name = "koto_parser"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
 edition = "2021"
+rust-version = "1.58"
 license = "MIT"
 description = "The parser used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/parser/src/ast.rs
+++ b/src/parser/src/ast.rs
@@ -1,7 +1,6 @@
 use {
     crate::{error::*, ConstantPool, Node},
     koto_lexer::Span,
-    std::convert::TryFrom,
 };
 
 /// The index type used by nodes in the [Ast]

--- a/src/parser/src/constant_index.rs
+++ b/src/parser/src/constant_index.rs
@@ -93,7 +93,7 @@ pub struct ConstantIndexTryFromOutOfRange();
 
 impl fmt::Display for ConstantIndexTryFromOutOfRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/parser/src/constant_index.rs
+++ b/src/parser/src/constant_index.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, fmt};
+use std::fmt;
 
 const CONSTANT_INDEX_MAX: usize = 2_usize.pow(24) - 1;
 

--- a/src/parser/src/constant_pool.rs
+++ b/src/parser/src/constant_pool.rs
@@ -2,7 +2,6 @@ use {
     crate::{ConstantIndex, ConstantIndexTryFromOutOfRange},
     std::{
         collections::{hash_map::DefaultHasher, HashMap},
-        convert::TryFrom,
         fmt,
         hash::{Hash, Hasher},
         ops::Range,

--- a/src/parser/src/constant_pool.rs
+++ b/src/parser/src/constant_pool.rs
@@ -152,9 +152,9 @@ impl fmt::Display for ConstantPool {
         for (i, constant) in self.iter().enumerate() {
             write!(f, "{}\t", i)?;
             match constant {
-                Constant::F64(n) => write!(f, "Float\t{}", n)?,
-                Constant::I64(n) => write!(f, "Int\t{}", n)?,
-                Constant::Str(s) => write!(f, "String\t{}", s)?,
+                Constant::F64(n) => write!(f, "Float\t{n}")?,
+                Constant::I64(n) => write!(f, "Int\t{n}")?,
+                Constant::Str(s) => write!(f, "String\t{s}")?,
             }
             writeln!(f)?;
         }

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -380,15 +380,13 @@ pub fn format_error_with_excerpt(
 
         if start_pos.line == end_pos.line {
             let mut excerpt = format!(
-                " {:>width$} | {}\n",
+                " {:>number_width$} | {}\n",
                 line_numbers.first().unwrap(),
                 excerpt_lines.first().unwrap(),
-                width = number_width
             );
 
             excerpt += &format!(
-                "{}|{}{}",
-                padding,
+                "{padding}|{}{}",
                 " ".repeat(start_pos.column as usize),
                 "^".repeat((end_pos.column - start_pos.column) as usize)
             );
@@ -398,12 +396,7 @@ pub fn format_error_with_excerpt(
             let mut excerpt = String::new();
 
             for (excerpt_line, line_number) in excerpt_lines.iter().zip(line_numbers.iter()) {
-                excerpt += &format!(
-                    " {:>width$} | {}\n",
-                    line_number,
-                    excerpt_line,
-                    width = number_width
-                );
+                excerpt += &format!(" {line_number:>number_width$} | {excerpt_line}\n",);
             }
 
             (excerpt, padding)
@@ -421,7 +414,7 @@ pub fn format_error_with_excerpt(
             path.display()
         };
 
-        format!("{} - {}:{}", display_path, start_pos.line, start_pos.column)
+        format!("{display_path} - {}:{}", start_pos.line, start_pos.column)
     } else {
         format!("{}:{}", start_pos.line, start_pos.column)
     };

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -429,8 +429,5 @@ pub fn format_error_with_excerpt(
     format!(
         "{message}\n --- {position_info}\n{padding}|\n{excerpt}",
         message = message.unwrap_or(""),
-        position_info = position_info,
-        padding = padding,
-        excerpt = excerpt,
     )
 }

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -1,6 +1,6 @@
 use {
     crate::{ast::AstIndex, ConstantIndex},
-    std::{convert::TryFrom, fmt},
+    std::fmt,
 };
 
 /// A parsed node that can be included in the [AST](crate::Ast).

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -17,7 +17,7 @@ macro_rules! internal_error {
         let error = make_internal_error!($error, $parser);
 
         #[cfg(feature = "panic_on_parser_error")]
-        panic!("{}", error);
+        panic!("{error}");
 
         #[cfg(not(feature = "panic_on_parser_error"))]
         Err(error)
@@ -29,7 +29,7 @@ macro_rules! parser_error {
         let error = ParserError::new($error_type::$error.into(), $parser.current_span());
 
         #[cfg(feature = "panic_on_parser_error")]
-        panic!("{}", error);
+        panic!("{error}");
 
         #[cfg(not(feature = "panic_on_parser_error"))]
         Err(error)

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -3,7 +3,7 @@
 use {
     crate::{constant_pool::ConstantPoolBuilder, error::*, *},
     koto_lexer::{Lexer, Span, Token},
-    std::{collections::HashSet, iter::FromIterator, str::FromStr},
+    std::{collections::HashSet, str::FromStr},
 };
 
 macro_rules! make_internal_error {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -9,7 +9,7 @@ mod parser {
                 for (i, (ast_node, expected_node)) in
                     ast.nodes().iter().zip(expected_ast.iter()).enumerate()
                 {
-                    assert_eq!(ast_node.node, *expected_node, "Mismatch at position {}", i);
+                    assert_eq!(ast_node.node, *expected_node, "Mismatch at position {i}");
                 }
                 assert_eq!(
                     ast.nodes().len(),
@@ -30,7 +30,7 @@ mod parser {
                     );
                 }
             }
-            Err(error) => panic!("{} - {}", error, error.span.start),
+            Err(error) => panic!("{error} - {}", error.span.start),
         }
     }
 

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -7,8 +7,7 @@ mod parser {
 
         if let Ok(Ok(ast)) = catch_result {
             panic!(
-                "Unexpected success while parsing:\n{}\n{:#?}",
-                source,
+                "Unexpected success while parsing:\n{source}\n{:#?}",
                 ast.nodes()
             );
         }
@@ -18,8 +17,7 @@ mod parser {
     fn check_parsing_fails(source: &str) {
         if let Ok(ast) = Parser::parse(source) {
             panic!(
-                "Unexpected success while parsing:\n{}\n{:#?}",
-                source,
+                "Unexpected success while parsing:\n{source}\n{:#?}",
                 ast.nodes()
             );
         }

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_runtime"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "The runtime used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "koto_runtime"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
 edition = "2021"
+rust-version = "1.58"
 license = "MIT"
 description = "The runtime used by the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -175,88 +175,90 @@ pub fn make_module() -> ValueMap {
     result
 }
 
-thread_local!(
-    pub static FILE_META: Rc<RefCell<MetaMap>> = {
-        use Value::{Empty, Number, Str};
+thread_local! {
+    pub static FILE_META: Rc<RefCell<MetaMap>> = make_file_meta_map();
+}
 
-        let mut meta = MetaMap::with_type_name("File");
+fn make_file_meta_map() -> Rc<RefCell<MetaMap>> {
+    use Value::{Empty, Number, Str};
 
-        meta.add_named_instance_fn_mut("flush", |file: &mut File, _, _| match file.flush() {
-            Ok(_) => Ok(Empty),
-            Err(e) => Err(e.with_prefix("File.flush")),
-        });
+    let mut meta = MetaMap::with_type_name("File");
 
-        meta.add_named_instance_fn("path", |file: &File, _, _| match file.path() {
-            Ok(path) => Ok(Str(path.into())),
-            Err(e) => Err(e.with_prefix("File.path")),
-        });
+    meta.add_named_instance_fn_mut("flush", |file: &mut File, _, _| match file.flush() {
+        Ok(_) => Ok(Empty),
+        Err(e) => Err(e.with_prefix("File.flush")),
+    });
 
-        meta.add_named_instance_fn_mut("read_line", |file: &mut File, _, _| {
-            match file.read_line() {
-                Ok(Some(result)) => {
-                    let newline_bytes = if result.ends_with("\r\n") { 2 } else { 1 };
-                    Ok(result[..result.len() - newline_bytes].into())
-                }
-                Ok(None) => Ok(Empty),
-                Err(e) => Err(e.with_prefix("File.read_line")),
+    meta.add_named_instance_fn("path", |file: &File, _, _| match file.path() {
+        Ok(path) => Ok(Str(path.into())),
+        Err(e) => Err(e.with_prefix("File.path")),
+    });
+
+    meta.add_named_instance_fn_mut("read_line", |file: &mut File, _, _| {
+        match file.read_line() {
+            Ok(Some(result)) => {
+                let newline_bytes = if result.ends_with("\r\n") { 2 } else { 1 };
+                Ok(result[..result.len() - newline_bytes].into())
             }
-        });
+            Ok(None) => Ok(Empty),
+            Err(e) => Err(e.with_prefix("File.read_line")),
+        }
+    });
 
-        meta.add_named_instance_fn_mut("read_to_string", |file: &mut File, _, _| {
-            match file.read_to_string() {
-                Ok(result) => Ok(result.into()),
-                Err(e) => Err(e.with_prefix("File.read_to_string")),
+    meta.add_named_instance_fn_mut("read_to_string", |file: &mut File, _, _| {
+        match file.read_to_string() {
+            Ok(result) => Ok(result.into()),
+            Err(e) => Err(e.with_prefix("File.read_to_string")),
+        }
+    });
+
+    meta.add_named_instance_fn_mut("seek", |file: &mut File, _, args| match args {
+        [Number(n)] => {
+            if *n < 0.0 {
+                return runtime_error!("File.seek: Negative seek positions not allowed");
             }
-        });
-
-        meta.add_named_instance_fn_mut("seek", |file: &mut File, _, args| match args {
-            [Number(n)] => {
-                if *n < 0.0 {
-                    return runtime_error!("File.seek: Negative seek positions not allowed");
-                }
-                match file.seek(n.into()) {
-                    Ok(_) => Ok(Value::Empty),
-                    Err(e) => Err(e.with_prefix("File.seek")),
-                }
-            }
-            unexpected => unexpected_type_error_with_slice(
-                "File.seek",
-                "a non-negative Number as the seek position",
-                unexpected,
-            ),
-        });
-
-        meta.add_named_instance_fn_mut("write", |file: &mut File, _, args| match args {
-            [value] => match file.write(value.to_string().as_bytes()) {
+            match file.seek(n.into()) {
                 Ok(_) => Ok(Value::Empty),
-                Err(e) => Err(e.with_prefix("File.write")),
-            },
-            unexpected => unexpected_type_error_with_slice(
-                "File.write",
-                "a single argument",
-                unexpected,
-            ),
-        });
+                Err(e) => Err(e.with_prefix("File.seek")),
+            }
+        }
+        unexpected => unexpected_type_error_with_slice(
+            "File.seek",
+            "a non-negative Number as the seek position",
+            unexpected,
+        ),
+    });
 
-        meta.add_named_instance_fn_mut("write_line", |file: &mut File, _, args| {
-            let line = match args {
-                [] => "\n".to_string(),
-                [value] => format!("{}\n", value),
-                unexpected => return unexpected_type_error_with_slice(
+    meta.add_named_instance_fn_mut("write", |file: &mut File, _, args| match args {
+        [value] => match file.write(value.to_string().as_bytes()) {
+            Ok(_) => Ok(Value::Empty),
+            Err(e) => Err(e.with_prefix("File.write")),
+        },
+        unexpected => {
+            unexpected_type_error_with_slice("File.write", "a single argument", unexpected)
+        }
+    });
+
+    meta.add_named_instance_fn_mut("write_line", |file: &mut File, _, args| {
+        let line = match args {
+            [] => "\n".to_string(),
+            [value] => format!("{}\n", value),
+            unexpected => {
+                return unexpected_type_error_with_slice(
                     "File.write_line",
                     "a single argument",
                     unexpected,
-                ),
-            };
-            match file.write(line.as_bytes()) {
-                Ok(_) => Ok(Value::Empty),
-                Err(e) => Err(e.with_prefix("File.write_line")),
+                )
             }
-        });
+        };
+        match file.write(line.as_bytes()) {
+            Ok(_) => Ok(Value::Empty),
+            Err(e) => Err(e.with_prefix("File.write_line")),
+        }
+    });
 
-        Rc::new(RefCell::new(meta))
-    }
-);
+    Rc::new(RefCell::new(meta))
+}
 
 /// The File type used in the io module
 pub struct File(Rc<dyn KotoFile>);

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -148,16 +148,14 @@ pub fn make_module() -> ValueMap {
             let iterable = iterable.clone();
             let f = f.clone();
             for output in vm.make_iterator(iterable)? {
-                let run_result = match output {
-                    Output::Value(value) => vm.run_function(f.clone(), CallArgs::Single(value)),
+                match output {
+                    Output::Value(value) => {
+                        vm.run_function(f.clone(), CallArgs::Single(value))?;
+                    }
                     Output::ValuePair(a, b) => {
-                        vm.run_function(f.clone(), CallArgs::AsTuple(&[a, b]))
+                        vm.run_function(f.clone(), CallArgs::AsTuple(&[a, b]))?;
                     }
                     Output::Error(error) => return Err(error),
-                };
-
-                if run_result.is_err() {
-                    return run_result;
                 }
             }
             Ok(Empty)

--- a/src/runtime/src/core/iterator/adaptors.rs
+++ b/src/runtime/src/core/iterator/adaptors.rs
@@ -596,9 +596,8 @@ impl Iterator for Keep {
                 Ok(Value::Bool(false)) => continue,
                 Ok(Value::Bool(true)) => output,
                 Ok(unexpected) => Output::Error(make_runtime_error!(format!(
-                    "iterator.keep: Expected a Bool to be returned from the \
-                             predicate, found '{}'",
-                    unexpected.type_as_string(),
+                    "iterator.keep: Expected a Bool to be returned from the predicate, found '{}'",
+                    unexpected.type_as_string()
                 ))),
                 Err(error) => Output::Error(error),
             };
@@ -751,7 +750,7 @@ impl fmt::Display for ReversedError {
 
 impl fmt::Debug for ReversedError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -167,8 +167,7 @@ pub fn make_module() -> ValueMap {
             if index >= l.data().len() {
                 return runtime_error!(
                     "list.remove: Index out of bounds - \
-                     the index is {} but the List only has {} elements",
-                    index,
+                     the index is {index} but the List only has {} elements",
                     l.data().len(),
                 );
             }

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -68,7 +68,7 @@ pub fn make_module() -> ValueMap {
             match usize::from(i) {
                 0 => result.0 = value.into(),
                 1 => result.1 = value.into(),
-                other => return runtime_error!("num2.with: invalid index '{}'", other),
+                other => return runtime_error!("num2.with: invalid index '{other}'"),
             }
             Ok(Num2(result))
         }

--- a/src/runtime/src/core/num4.rs
+++ b/src/runtime/src/core/num4.rs
@@ -82,7 +82,7 @@ pub fn make_module() -> ValueMap {
                 1 => result.1 = value.into(),
                 2 => result.2 = value.into(),
                 3 => result.3 = value.into(),
-                other => return runtime_error!("num4.with: invalid index '{}'", other),
+                other => return runtime_error!("num4.with: invalid index '{other}'"),
             }
             Ok(Num4(result))
         }

--- a/src/runtime/src/core/os.rs
+++ b/src/runtime/src/core/os.rs
@@ -53,7 +53,7 @@ impl DateTime {
         let offset = match maybe_offset {
             Some(offset) => match FixedOffset::east_opt(offset as i32) {
                 Some(offset) => offset,
-                None => return runtime_error!("time offset is out of range: {}", offset),
+                None => return runtime_error!("time offset is out of range: {offset}"),
             },
             None => *Local::now().offset(),
         };
@@ -61,7 +61,7 @@ impl DateTime {
             Some(utc) => Ok(Self::with_chrono_datetime(
                 chrono::DateTime::<Local>::from_utc(utc, offset),
             )),
-            None => return runtime_error!("timestamp in seconds is out of range: {}", seconds),
+            None => return runtime_error!("timestamp in seconds is out of range: {seconds}"),
         }
     }
 

--- a/src/runtime/src/core/os.rs
+++ b/src/runtime/src/core/os.rs
@@ -72,59 +72,49 @@ impl DateTime {
 
 impl ExternalData for DateTime {}
 
-thread_local!(
-    pub static SYSTEM_TIME_META: Rc<RefCell<MetaMap>> = {
-        let mut meta = MetaMap::with_type_name("DateTime");
+thread_local! {
+    pub static SYSTEM_TIME_META: Rc<RefCell<MetaMap>> = make_system_time_meta_map();
+}
 
-        meta.add_unary_op(UnaryOp::Display, |data: &DateTime, _| {
-            Ok(data.0.format("%F %T").to_string().into())
-        });
+fn make_system_time_meta_map() -> Rc<RefCell<MetaMap>> {
+    let mut meta = MetaMap::with_type_name("DateTime");
 
-        meta.add_named_instance_fn("day", |data: &DateTime, _, _| {
-            Ok(data.0.day().into())
-        });
+    meta.add_unary_op(UnaryOp::Display, |data: &DateTime, _| {
+        Ok(data.0.format("%F %T").to_string().into())
+    });
 
-        meta.add_named_instance_fn("hour", |data: &DateTime, _, _| {
-            Ok(data.0.hour().into())
-        });
+    meta.add_named_instance_fn("day", |data: &DateTime, _, _| Ok(data.0.day().into()));
 
-        meta.add_named_instance_fn("minute", |data: &DateTime, _, _| {
-            Ok(data.0.minute().into())
-        });
+    meta.add_named_instance_fn("hour", |data: &DateTime, _, _| Ok(data.0.hour().into()));
 
-        meta.add_named_instance_fn("month", |data: &DateTime, _, _| {
-            Ok(data.0.month().into())
-        });
+    meta.add_named_instance_fn("minute", |data: &DateTime, _, _| Ok(data.0.minute().into()));
 
-        meta.add_named_instance_fn("second", |data: &DateTime, _, _| {
-            Ok(data.0.second().into())
-        });
+    meta.add_named_instance_fn("month", |data: &DateTime, _, _| Ok(data.0.month().into()));
 
-        meta.add_named_instance_fn("nanosecond", |data: &DateTime, _, _| {
-            Ok(data.0.nanosecond().into())
-        });
+    meta.add_named_instance_fn("second", |data: &DateTime, _, _| Ok(data.0.second().into()));
 
-        meta.add_named_instance_fn("timestamp", |data: &DateTime, _, _| {
-            let seconds = data.0.timestamp() as f64;
-            let sub_nanos = data.0.timestamp_subsec_nanos();
-            Ok((seconds + sub_nanos as f64 / 1.0e9).into())
-        });
+    meta.add_named_instance_fn("nanosecond", |data: &DateTime, _, _| {
+        Ok(data.0.nanosecond().into())
+    });
 
-        meta.add_named_instance_fn("timezone_offset", |data: &DateTime, _, _| {
-            Ok(data.0.offset().local_minus_utc().into())
-        });
+    meta.add_named_instance_fn("timestamp", |data: &DateTime, _, _| {
+        let seconds = data.0.timestamp() as f64;
+        let sub_nanos = data.0.timestamp_subsec_nanos();
+        Ok((seconds + sub_nanos as f64 / 1.0e9).into())
+    });
 
-        meta.add_named_instance_fn("timezone_string", |data: &DateTime, _, _| {
-            Ok(data.0.format("%z").to_string().into())
-        });
+    meta.add_named_instance_fn("timezone_offset", |data: &DateTime, _, _| {
+        Ok(data.0.offset().local_minus_utc().into())
+    });
 
-        meta.add_named_instance_fn("year", |data: &DateTime, _, _| {
-            Ok(data.0.year().into())
-        });
+    meta.add_named_instance_fn("timezone_string", |data: &DateTime, _, _| {
+        Ok(data.0.format("%z").to_string().into())
+    });
 
-        Rc::new(RefCell::new(meta))
-    }
-);
+    meta.add_named_instance_fn("year", |data: &DateTime, _, _| Ok(data.0.year().into()));
+
+    Rc::new(RefCell::new(meta))
+}
 
 pub struct Timer(Instant);
 
@@ -138,30 +128,29 @@ impl Timer {
 
 impl ExternalData for Timer {}
 
-thread_local!(
-    pub static TIMER_META: Rc<RefCell<MetaMap>> = {
-        let mut meta = MetaMap::with_type_name("Timer");
+thread_local! {
+    pub static TIMER_META: Rc<RefCell<MetaMap>> = make_timer_meta_map();
+}
 
-        meta.add_unary_op(UnaryOp::Display, |data: &Timer, _| {
-            Ok(format!("Timer({:.3}s)", data.0.elapsed().as_secs_f64()).into())
-        });
+fn make_timer_meta_map() -> Rc<RefCell<MetaMap>> {
+    let mut meta = MetaMap::with_type_name("Timer");
 
-        meta.add_binary_op(
-            BinaryOp::Subtract,
-            |a: &Timer, b, _, _| {
-                let result = if a.0 >= b.0 {
-                     a.0.duration_since(b.0).as_secs_f64()
-                } else {
-                    -(b.0.duration_since(a.0).as_secs_f64())
-                };
-                Ok(result.into())
-            },
-        );
+    meta.add_unary_op(UnaryOp::Display, |data: &Timer, _| {
+        Ok(format!("Timer({:.3}s)", data.0.elapsed().as_secs_f64()).into())
+    });
 
-        meta.add_named_instance_fn("elapsed", |instant: &Timer, _, _| {
-            Ok(instant.0.elapsed().as_secs_f64().into())
-        });
+    meta.add_binary_op(BinaryOp::Subtract, |a: &Timer, b, _, _| {
+        let result = if a.0 >= b.0 {
+            a.0.duration_since(b.0).as_secs_f64()
+        } else {
+            -(b.0.duration_since(a.0).as_secs_f64())
+        };
+        Ok(result.into())
+    });
 
-        Rc::new(RefCell::new(meta))
-    }
-);
+    meta.add_named_instance_fn("elapsed", |instant: &Timer, _, _| {
+        Ok(instant.0.elapsed().as_secs_f64().into())
+    });
+
+    Rc::new(RefCell::new(meta))
+}

--- a/src/runtime/src/core/string.rs
+++ b/src/runtime/src/core/string.rs
@@ -78,8 +78,7 @@ pub fn make_module() -> ValueMap {
                         Ok(byte) => bytes.push(byte),
                         Err(_) => {
                             return runtime_error!(
-                                "string.from_bytes: '{}' is out of the valid byte range",
-                                n
+                                "string.from_bytes: '{n}' is out of the valid byte range"
                             )
                         }
                     },
@@ -197,7 +196,7 @@ pub fn make_module() -> ValueMap {
             Err(_) => match s.parse::<f64>() {
                 Ok(n) => Ok(Number(n.into())),
                 Err(_) => {
-                    runtime_error!("string.to_number: Failed to convert '{}'", s)
+                    runtime_error!("string.to_number: Failed to convert '{s}'")
                 }
             },
         },
@@ -232,7 +231,7 @@ pub fn make_module() -> ValueMap {
 
 fn expected_string_error(name: &str, unexpected: &[Value]) -> RuntimeResult {
     unexpected_type_error_with_slice(
-        &format!("string.{}", name),
+        &format!("string.{name}"),
         "a String as argument",
         unexpected,
     )
@@ -240,7 +239,7 @@ fn expected_string_error(name: &str, unexpected: &[Value]) -> RuntimeResult {
 
 fn expected_two_strings_error(name: &str, unexpected: &[Value]) -> RuntimeResult {
     unexpected_type_error_with_slice(
-        &format!("string.{}", name),
+        &format!("string.{name}"),
         "two Strings as arguments",
         unexpected,
     )

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -91,7 +91,7 @@ impl<'a> FormatLexer<'a> {
                 self.position += 1;
                 Ok(result)
             }
-            Some(other) => Err(format!("Expected '}}', found '{}'", other)),
+            Some(other) => Err(format!("Expected '}}', found '{other}'")),
             None => Err("Expected '}}'".to_string()),
         }
     }
@@ -112,10 +112,10 @@ impl<'a> FormatLexer<'a> {
                 if n <= u32::MAX as u32 {
                     Ok(n as u32)
                 } else {
-                    Err(format!("{} exceeds the maximum of {}", n, u32::MAX))
+                    Err(format!("{n} exceeds the maximum of {}", u32::MAX))
                 }
             }
-            Some(other) => Err(format!("Expected digit, found '{}'", other)),
+            Some(other) => Err(format!("Expected digit, found '{other}'")),
             None => Err("Expected digit".into()),
         }
     }
@@ -174,8 +174,7 @@ impl<'a> Iterator for FormatLexer<'a> {
                                         }
                                         Some(other) => {
                                             return Some(Error(format!(
-                                                "Unexpected character '{}'",
-                                                other
+                                                "Unexpected character '{other}'",
                                             )))
                                         }
                                         None => {
@@ -216,8 +215,7 @@ impl<'a> Iterator for FormatLexer<'a> {
                                         }
                                         other => {
                                             return Some(Error(format!(
-                                                "Unexpected character '{}'",
-                                                other
+                                                "Unexpected character '{other}'",
                                             )))
                                         }
                                     }
@@ -235,9 +233,7 @@ impl<'a> Iterator for FormatLexer<'a> {
                                     Err(error) => Some(Error(error)),
                                 }
                             }
-                            Some(other) => {
-                                Some(Error(format!("Unexpected character - '{}'", other)))
-                            }
+                            Some(other) => Some(Error(format!("Unexpected character - '{other}'"))),
                             None => Some(Error("Unexpected end, missing '}}'".into())),
                         }
                     }
@@ -311,12 +307,12 @@ pub fn format_string(
             },
             FormatToken::Positional(n, format_spec) => match format_args.get(n as usize) {
                 Some(arg) => result.push_str(&value_to_string(vm, arg, format_spec)?),
-                None => return runtime_error!("Missing argument for index {}", n),
+                None => return runtime_error!("Missing argument for index {n}"),
             },
             FormatToken::Identifier(id, format_spec) => match format_args.first() {
                 Some(Value::Map(map)) => match map.data().get_with_string(id) {
                     Some(value) => result.push_str(&value_to_string(vm, value, format_spec)?),
-                    None => return runtime_error!("Key '{}' not found in map", id),
+                    None => return runtime_error!("Key '{id}' not found in map"),
                 },
                 Some(other) => {
                     return runtime_error!(
@@ -326,7 +322,7 @@ pub fn format_string(
                 }
                 None => return runtime_error!("Expected map as first argument"),
             },
-            FormatToken::Error(error) => return runtime_error!("Invalid format string: {}", error),
+            FormatToken::Error(error) => return runtime_error!("Invalid format string: {error}"),
         }
     }
 
@@ -436,12 +432,11 @@ mod tests {
                     Some(output) => {
                         assert_eq!(
                             &output, token,
-                            "mismatch at position {}, expected: {:?}, actual: {:?}",
-                            i, token, output
+                            "mismatch at position {i}, expected: {token:?}, actual: {output:?}",
                         );
                     }
                     None => {
-                        panic!("Lexer stopped providing output at position {}", i);
+                        panic!("Lexer stopped providing output at position {i}");
                     }
                 }
             }

--- a/src/runtime/src/core/test.rs
+++ b/src/runtime/src/core/test.rs
@@ -35,7 +35,7 @@ pub fn make_module() -> ValueMap {
             match result {
                 Ok(Bool(true)) => Ok(Empty),
                 Ok(Bool(false)) => {
-                    runtime_error!("Assertion failed, '{}' is not equal to '{}'", a, b)
+                    runtime_error!("Assertion failed, '{a}' is not equal to '{b}'")
                 }
                 Ok(unexpected) => unexpected_type_error_with_slice(
                     "test.assert_eq",
@@ -56,7 +56,7 @@ pub fn make_module() -> ValueMap {
             match result {
                 Ok(Bool(true)) => Ok(Empty),
                 Ok(Bool(false)) => {
-                    runtime_error!("Assertion failed, '{}' should not be equal to '{}'", a, b)
+                    runtime_error!("Assertion failed, '{a}' should not be equal to '{b}'")
                 }
                 Ok(unexpected) => unexpected_type_error_with_slice(
                     "test.assert_ne",
@@ -75,10 +75,7 @@ pub fn make_module() -> ValueMap {
                 Ok(Empty)
             } else {
                 runtime_error!(
-                    "Assertion failed, '{}' and '{}' are not within {} of each other",
-                    a,
-                    b,
-                    allowed_diff,
+                    "Assertion failed, '{a}' and '{b}' are not within {allowed_diff} of each other"
                 )
             }
         }
@@ -88,10 +85,7 @@ pub fn make_module() -> ValueMap {
                 Ok(Empty)
             } else {
                 runtime_error!(
-                    "Assertion failed, '{}' and '{}' are not within {} of each other",
-                    a,
-                    b,
-                    allowed_diff,
+                    "Assertion failed, '{a}' and '{b}' are not within {allowed_diff} of each other"
                 )
             }
         }
@@ -105,10 +99,7 @@ pub fn make_module() -> ValueMap {
                 Ok(Empty)
             } else {
                 runtime_error!(
-                    "Assertion failed, '{}' and '{}' are not within {} of each other",
-                    a,
-                    b,
-                    allowed_diff,
+                    "Assertion failed, '{a}' and '{b}' are not within {allowed_diff} of each other"
                 )
             }
         }

--- a/src/runtime/src/core/tuple.rs
+++ b/src/runtime/src/core/tuple.rs
@@ -100,9 +100,5 @@ pub fn make_module() -> ValueMap {
 }
 
 fn expected_tuple_error(name: &str, unexpected: &[Value]) -> RuntimeResult {
-    unexpected_type_error_with_slice(
-        &format!("tuple.{}", name),
-        "a Tuple as argument",
-        unexpected,
-    )
+    unexpected_type_error_with_slice(&format!("tuple.{name}"), "a Tuple as argument", unexpected)
 }

--- a/src/runtime/src/error.rs
+++ b/src/runtime/src/error.rs
@@ -130,8 +130,8 @@ impl fmt::Display for RuntimeError {
                     ))?,
                     None => write!(
                         f,
-                        "Runtime error at instruction {}: {}",
-                        frame.instruction, message
+                        "Runtime error at instruction {}: {message}",
+                        frame.instruction,
                     )?,
                 };
             }
@@ -170,8 +170,7 @@ macro_rules! runtime_error {
 
 pub fn unexpected_type_error<T>(expected_str: &str, unexpected: &Value) -> Result<T, RuntimeError> {
     runtime_error!(
-        "Expected {}, found {}.",
-        expected_str,
+        "Expected {expected_str}, found {}.",
         unexpected.type_as_string()
     )
 }
@@ -197,5 +196,5 @@ pub fn unexpected_type_error_with_slice<T>(
             types
         }
     };
-    runtime_error!("{prefix} - expected {expected_str}, but found {}.", message)
+    runtime_error!("{prefix} - expected {expected_str}, but found {message}.")
 }

--- a/src/runtime/src/error.rs
+++ b/src/runtime/src/error.rs
@@ -60,6 +60,7 @@ impl RuntimeError {
     }
 
     /// Modifies string errors to include the given prefix
+    #[must_use]
     pub fn with_prefix(mut self, prefix: &str) -> Self {
         use RuntimeErrorType::StringError;
 

--- a/src/runtime/src/error.rs
+++ b/src/runtime/src/error.rs
@@ -157,10 +157,13 @@ macro_rules! make_runtime_error {
 
 #[macro_export]
 macro_rules! runtime_error {
+    ($error:literal) => {
+        Err($crate::make_runtime_error!(format!($error)))
+    };
     ($error:expr) => {
         Err($crate::make_runtime_error!($error))
     };
-    ($error:expr, $($y:expr),+ $(,)?) => {
+    ($error:literal, $($y:expr),+ $(,)?) => {
         Err($crate::make_runtime_error!(format!($error, $($y),+)))
     };
 }
@@ -194,10 +197,5 @@ pub fn unexpected_type_error_with_slice<T>(
             types
         }
     };
-    runtime_error!(
-        "{} - expected {}, but found {}.",
-        prefix,
-        expected_str,
-        message
-    )
+    runtime_error!("{prefix} - expected {expected_str}, but found {}.", message)
 }

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -56,6 +56,7 @@ impl ExternalValue {
         }
     }
 
+    #[must_use]
     pub fn with_new_data(&self, data: impl ExternalData) -> Self {
         Self {
             data: Rc::new(RefCell::new(data)),

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -111,13 +111,12 @@ impl fmt::Debug for ExternalFunction {
         let raw = Rc::into_raw(self.function.clone());
         write!(
             f,
-            "external {}function: {:?}",
+            "external {}function: {raw:?}",
             if self.is_instance_function {
                 "instance "
             } else {
                 ""
             },
-            raw
         )
     }
 }

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -98,9 +98,7 @@ impl MetaMap {
                     match instance_value.data().downcast_ref::<T>() {
                         Some(instance_data) => f(instance_data, instance_value, extra_args),
                         None => runtime_error!(
-                            "{}.{} - Unexpected external data type: {}",
-                            type_name,
-                            fn_name,
+                            "{type_name}.{fn_name} - Unexpected external data type: {}",
                             instance_value.data().value_type(),
                         ),
                     }
@@ -148,9 +146,7 @@ impl MetaMap {
                     match instance_value.data_mut().downcast_mut::<T>() {
                         Some(instance_data) => f(instance_data, instance_value, extra_args),
                         None => runtime_error!(
-                            "{}.{} - Unexpected external data type: {}",
-                            type_name,
-                            fn_name,
+                            "{type_name}.{fn_name} - Unexpected external data type: {}",
                             instance_value.data().value_type(),
                         ),
                     }
@@ -299,9 +295,7 @@ impl MetaMap {
             [ExternalValue(value_a), value_b] => match value_a.data().downcast_ref::<T>() {
                 Some(data_a) => f(data_a, value_a, value_b),
                 _ => runtime_error!(
-                    "{}.{} - Unexpected external data type: {}",
-                    type_name,
-                    op,
+                    "{type_name}.{op} - Unexpected external data type: {}",
                     value_a.data().value_type(),
                 ),
             },

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -105,11 +105,7 @@ impl MetaMap {
                         ),
                     }
                 }
-                _ => runtime_error!(format!(
-                    "{type_name}.{fn_name} - Expected {type_name} as argument",
-                    type_name = type_name,
-                    fn_name = fn_name
-                )),
+                _ => runtime_error!("{type_name}.{fn_name} - Expected {type_name} as argument"),
             },
         );
     }
@@ -159,11 +155,7 @@ impl MetaMap {
                         ),
                     }
                 }
-                _ => runtime_error!(format!(
-                    "{type_name}.{fn_name} - Expected {type_name} as argument",
-                    type_name = type_name,
-                    fn_name = fn_name
-                )),
+                _ => runtime_error!("{type_name}.{fn_name} - Expected {type_name} as argument"),
             },
         );
     }
@@ -204,11 +196,7 @@ impl MetaMap {
                     ),
                 }
             }
-            _ => runtime_error!(format!(
-                "{type_name}.@{op} - Expected {type_name} as argument",
-                type_name = type_name,
-                op = op
-            )),
+            _ => runtime_error!("{type_name}.@{op} - Expected {type_name} as argument"),
         });
     }
 
@@ -262,11 +250,7 @@ impl MetaMap {
                     ),
                 }
             }
-            _ => runtime_error!(format!(
-                "{type_name}.@{op} - Expected two '{type_name}'s as arguments",
-                type_name = type_name,
-                op = op
-            )),
+            _ => runtime_error!("{type_name}.@{op} - Expected two '{type_name}'s as arguments"),
         });
     }
 
@@ -321,11 +305,9 @@ impl MetaMap {
                     value_a.data().value_type(),
                 ),
             },
-            _ => runtime_error!(format!(
-                "{type_name}.@{op} - Expected '{type_name}' and a Value as arguments",
-                type_name = type_name,
-                op = op
-            )),
+            _ => runtime_error!(
+                "{type_name}.@{op} - Expected '{type_name}' and a Value as arguments"
+            ),
         });
     }
 

--- a/src/runtime/src/num2.rs
+++ b/src/runtime/src/num2.rs
@@ -11,6 +11,7 @@ use {
 pub struct Num2(pub f64, pub f64);
 
 impl Num2 {
+    #[must_use]
     pub fn abs(&self) -> Self {
         Num2(self.0.abs(), self.1.abs())
     }
@@ -19,6 +20,7 @@ impl Num2 {
         (self.0 * self.0 + self.1 * self.1).sqrt()
     }
 
+    #[must_use]
     pub fn normalize(&self) -> Self {
         *self / self.length()
     }

--- a/src/runtime/src/num4.rs
+++ b/src/runtime/src/num4.rs
@@ -11,6 +11,7 @@ use {
 pub struct Num4(pub f32, pub f32, pub f32, pub f32);
 
 impl Num4 {
+    #[must_use]
     pub fn abs(&self) -> Self {
         Self(self.0.abs(), self.1.abs(), self.2.abs(), self.3.abs())
     }
@@ -23,6 +24,7 @@ impl Num4 {
         (x * x + y * y + z * z + w * w).sqrt()
     }
 
+    #[must_use]
     pub fn normalize(&self) -> Self {
         *self / self.length()
     }

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -223,27 +223,27 @@ impl fmt::Display for Value {
         use Value::*;
         match self {
             Empty => f.write_str("()"),
-            Bool(b) => write!(f, "{}", b),
-            Number(n) => write!(f, "{}", n),
-            Num2(n) => write!(f, "{}", n),
-            Num4(n) => write!(f, "{}", n),
+            Bool(b) => write!(f, "{b}"),
+            Number(n) => write!(f, "{n}"),
+            Num2(n) => write!(f, "{n}"),
+            Num4(n) => write!(f, "{n}"),
             Str(s) => {
                 if f.alternate() {
-                    write!(f, "{:#}", s)
+                    write!(f, "{s:#}")
                 } else {
-                    write!(f, "{}", s)
+                    write!(f, "{s}")
                 }
             }
-            List(l) => write!(f, "{}", l),
-            Tuple(t) => write!(f, "{}", t),
+            List(l) => write!(f, "{l}"),
+            Tuple(t) => write!(f, "{t}"),
             Map(m) => {
                 if f.alternate() {
-                    write!(f, "{:#}", m)
+                    write!(f, "{m:#}")
                 } else {
-                    write!(f, "{}", m)
+                    write!(f, "{m}")
                 }
             }
-            Range(IntRange { start, end }) => write!(f, "{}..{}", start, end),
+            Range(IntRange { start, end }) => write!(f, "{start}..{end}"),
             SimpleFunction(_) | Function(_) => write!(f, "||"),
             Generator(_) => write!(f, "Generator"),
             Iterator(_) => write!(f, "Iterator"),
@@ -251,10 +251,10 @@ impl fmt::Display for Value {
             ExternalValue(_) | ExternalData(_) => f.write_str(&self.type_as_string()),
             IndexRange(self::IndexRange { .. }) => f.write_str("IndexRange"),
             TemporaryTuple(RegisterSlice { start, count }) => {
-                write!(f, "TemporaryTuple [{}..{}]", start, start + count)
+                write!(f, "TemporaryTuple [{start}..{}]", start + count)
             }
             SequenceBuilder(_) => write!(f, "SequenceBuilder"),
-            StringBuilder(s) => write!(f, "StringBuilder({})", s),
+            StringBuilder(s) => write!(f, "StringBuilder({s})"),
         }
     }
 }

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -104,6 +104,7 @@ impl Value {
         }
     }
 
+    #[must_use]
     pub fn deep_copy(&self) -> Value {
         use Value::*;
 

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -89,6 +89,7 @@ impl ValueIterator {
         Self::new(GeneratorIterator::new(vm))
     }
 
+    #[must_use]
     pub fn make_copy(&self) -> Self {
         self.0.borrow().make_copy()
     }

--- a/src/runtime/src/value_list.rs
+++ b/src/runtime/src/value_list.rs
@@ -58,7 +58,7 @@ impl fmt::Display for ValueList {
             if i > 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "{:#}", value)?;
+            write!(f, "{value:#}")?;
         }
         write!(f, "]")
     }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -214,7 +214,7 @@ impl fmt::Display for ValueMap {
             if !first {
                 write!(f, ", ")?;
             }
-            write!(f, "{}: {:#}", key.value(), value)?;
+            write!(f, "{}: {value:#}", key.value())?;
             first = false;
         }
         write!(f, "}}")

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -10,7 +10,7 @@ use {
         cell::{Ref, RefCell, RefMut},
         fmt,
         hash::BuildHasherDefault,
-        iter::{FromIterator, IntoIterator},
+        iter::IntoIterator,
         ops::{Deref, DerefMut},
         rc::Rc,
     },

--- a/src/runtime/src/value_number.rs
+++ b/src/runtime/src/value_number.rs
@@ -93,8 +93,8 @@ impl ValueNumber {
 impl fmt::Debug for ValueNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ValueNumber::F64(n) => write!(f, "Float({})", n),
-            ValueNumber::I64(n) => write!(f, "Int({})", n),
+            ValueNumber::F64(n) => write!(f, "Float({n})"),
+            ValueNumber::I64(n) => write!(f, "Int({n})"),
         }
     }
 }
@@ -104,12 +104,12 @@ impl fmt::Display for ValueNumber {
         match self {
             ValueNumber::F64(n) => {
                 if n.fract() > 0.0 {
-                    write!(f, "{}", n)
+                    write!(f, "{n}")
                 } else {
-                    write!(f, "{:.1}", n)
+                    write!(f, "{n:.1}")
                 }
             }
-            ValueNumber::I64(n) => write!(f, "{}", n),
+            ValueNumber::I64(n) => write!(f, "{n}"),
         }
     }
 }

--- a/src/runtime/src/value_number.rs
+++ b/src/runtime/src/value_number.rs
@@ -15,6 +15,7 @@ pub enum ValueNumber {
 }
 
 impl ValueNumber {
+    #[must_use]
     pub fn abs(self) -> Self {
         match self {
             Self::F64(n) => Self::F64(n.abs()),
@@ -22,6 +23,7 @@ impl ValueNumber {
         }
     }
 
+    #[must_use]
     pub fn ceil(self) -> Self {
         match self {
             Self::F64(n) => Self::I64(n.ceil() as i64),
@@ -29,10 +31,12 @@ impl ValueNumber {
         }
     }
 
+    #[must_use]
     pub fn floor(self) -> Self {
         Self::I64(self.as_i64())
     }
 
+    #[must_use]
     pub fn round(self) -> Self {
         match self {
             Self::F64(n) => Self::I64(n.round() as i64),
@@ -59,6 +63,7 @@ impl ValueNumber {
         }
     }
 
+    #[must_use]
     pub fn pow(self, other: Self) -> Self {
         use ValueNumber::*;
 

--- a/src/runtime/src/value_tuple.rs
+++ b/src/runtime/src/value_tuple.rs
@@ -26,7 +26,7 @@ impl fmt::Display for ValueTuple {
             if i > 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "{:#}", value)?;
+            write!(f, "{value:#}")?;
         }
         write!(f, ")")
     }

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -546,7 +546,7 @@ impl Vm {
             match meta_entry {
                 Some((MetaKey::Test(test_name), test)) if test.is_callable() => {
                     let make_test_error = |error: RuntimeError, message: &str| {
-                        Err(error.with_prefix(&format!("{} '{}'", message, test_name)))
+                        Err(error.with_prefix(&format!("{message} '{test_name}'")))
                     };
 
                     if let Some(pre_test) = &pre_test {
@@ -673,9 +673,7 @@ impl Vm {
         let mut control_flow = ControlFlow::Continue;
 
         match instruction {
-            Instruction::Error { message } => {
-                runtime_error!("{}", message)
-            }
+            Instruction::Error { message } => runtime_error!(message),
             Instruction::Copy { target, source } => {
                 self.set_register(target, self.clone_register(source));
                 Ok(())
@@ -1023,7 +1021,7 @@ impl Vm {
             self.set_register(register, non_local);
             Ok(())
         } else {
-            runtime_error!("'{}' not found", name)
+            runtime_error!("'{name}' not found")
         }
     }
 
@@ -1064,10 +1062,7 @@ impl Vm {
             }
             (None, Some(Number(end))) => {
                 if *end < 0.0 {
-                    return runtime_error!(
-                        "RangeTo: negative numbers not allowed, found '{}'",
-                        end
-                    );
+                    return runtime_error!("RangeTo: negative numbers not allowed, found '{end}'");
                 }
                 let end = if inclusive {
                     usize::from(end) + 1
@@ -1082,8 +1077,7 @@ impl Vm {
             (Some(Number(start)), None) => {
                 if *start < 0.0 {
                     return runtime_error!(
-                        "RangeFrom: negative numbers not allowed, found '{}'",
-                        start
+                        "RangeFrom: negative numbers not allowed, found '{start}'"
                     );
                 }
                 IndexRange(value::IndexRange {
@@ -1348,20 +1342,18 @@ impl Vm {
 
             match capture_list {
                 Some(capture_list) => {
-                    capture_list.data_mut()[capture_index as usize] = self.clone_register(value)
+                    capture_list.data_mut()[capture_index as usize] = self.clone_register(value);
+                    Ok(())
                 }
-                None => return runtime_error!("Missing capture list for function"),
+                None => runtime_error!("Missing capture list for function"),
             }
         } else {
             // e.g. x = (1..10).find |n| n == x
             // The function was temporary and has been removed from the value stack,
             // but the capture of `x` is still attempted. It would be cleaner for the compiler to
             // detect this case but for now a runtime error will have to do.
-            return runtime_error!(
-                "Attempting to capture a reserved value in a temporary function"
-            );
+            runtime_error!("Attempting to capture a reserved value in a temporary function")
         }
-        Ok(())
     }
 
     fn run_negate(&mut self, result: u8, value: u8) -> InstructionResult {
@@ -2009,7 +2001,7 @@ impl Vm {
             .compile_module(&import_name, source_path)
         {
             Ok(result) => result,
-            Err(e) => return runtime_error!("Failed to import '{}': {}", import_name, e),
+            Err(error) => return runtime_error!("Failed to import '{import_name}': {error}"),
         };
 
         // Has the module been loaded previously?
@@ -2023,7 +2015,7 @@ impl Vm {
             Some(None) => {
                 // If the cache contains a None placeholder entry for the module path,
                 // then we're in a recursive import (see below).
-                return runtime_error!("Recursive import of module '{}'", import_name);
+                return runtime_error!("Recursive import of module '{import_name}'");
             }
             Some(Some(cached_exports)) if compile_result.loaded_from_cache => {
                 self.set_register(import_register, Value::Map(cached_exports));
@@ -2062,8 +2054,7 @@ impl Vm {
                         }
                         Some(other) => {
                             return runtime_error!(
-                                "Expected map for tests in module '{}', found '{}'",
-                                import_name,
+                                "Expected map for tests in module '{import_name}', found '{}'",
                                 other.type_as_string()
                             )
                         }
@@ -2133,7 +2124,7 @@ impl Vm {
                         if index >= 0.0 && u_index < list_len {
                             list.data_mut()[u_index] = value;
                         } else {
-                            return runtime_error!("Index '{}' not in List", index);
+                            return runtime_error!("Index '{index}' not in List");
                         }
                     }
                     Range(IntRange { start, end }) => {
@@ -2166,10 +2157,10 @@ impl Vm {
         let index = usize::from(n);
 
         if n < 0.0 {
-            return runtime_error!("Negative indices aren't allowed ('{}')", n);
+            return runtime_error!("Negative indices aren't allowed ('{n}')");
         } else if let Some(size) = size {
             if index >= size {
-                return runtime_error!("Index out of bounds - index: {}, size: {}", n, size);
+                return runtime_error!("Index out of bounds - index: {n}, size: {size}");
             }
         }
 
@@ -2187,23 +2178,16 @@ impl Vm {
 
         if start < 0 || end < 0 {
             return runtime_error!(
-                "Indexing with negative indices isn't supported, start: {}, end: {}",
-                start,
-                end
+                "Indexing with negative indices isn't supported, start: {start}, end: {end}"
             );
         } else if start > end {
             return runtime_error!(
-                "Indexing with a descending range isn't supported, start: {}, end: {}",
-                start,
-                end
+                "Indexing with a descending range isn't supported, start: {start}, end: {end}"
             );
         } else if let Some(size) = size {
             if ustart > size || uend > size {
                 return runtime_error!(
-                    "Index out of bounds, start: {}, end: {}, size: {}",
-                    start,
-                    end,
-                    size
+                    "Index out of bounds, start: {start}, end: {end}, size: {size}"
                 );
             }
         }
@@ -2214,17 +2198,10 @@ impl Vm {
     fn validate_index_range(&self, start: usize, end: usize, size: usize) -> InstructionResult {
         if start > end {
             runtime_error!(
-                "Indexing with a descending range isn't supported, start: {}, end: {}",
-                start,
-                end
+                "Indexing with a descending range isn't supported, start: {start}, end: {end}"
             )
         } else if start > size || end > size {
-            runtime_error!(
-                "Index out of bounds, start: {}, end: {}, size: {}",
-                start,
-                end,
-                size
-            )
+            runtime_error!("Index out of bounds, start: {start}, end: {end}, size: {size}")
         } else {
             Ok(())
         }
@@ -2281,8 +2258,7 @@ impl Vm {
                     self.set_register(result_register, Str(result));
                 } else {
                     return runtime_error!(
-                        "Index out of bounds - index: {}, size: {}",
-                        index,
+                        "Index out of bounds - index: {index}, size: {}",
                         s.grapheme_count()
                     );
                 }
@@ -2294,9 +2270,7 @@ impl Vm {
                     self.set_register(result_register, Str(result));
                 } else {
                     return runtime_error!(
-                        "Index out of bounds for string - start: {}, end {}, size: {}",
-                        start,
-                        end,
+                        "Index out of bounds for string - start: {start}, end {end}, size: {}",
                         s.grapheme_count()
                     );
                 }
@@ -2310,10 +2284,9 @@ impl Vm {
                     self.set_register(result_register, Str(result));
                 } else {
                     return runtime_error!(
-                        "Index out of bounds for string - start: {}{}, size: {}",
-                        start,
+                        "Index out of bounds for string - start: {start}{}, size: {}",
                         if let Some(end_unwrapped) = end {
-                            format!(", {}", end_unwrapped)
+                            format!(", {end_unwrapped}")
                         } else {
                             "".to_string()
                         },
@@ -2325,14 +2298,14 @@ impl Vm {
                 let i = usize::from(i);
                 match i {
                     0 | 1 => self.set_register(result_register, Number(n[i].into())),
-                    other => return runtime_error!("Index out of bounds for Num2, {}", other),
+                    other => return runtime_error!("Index out of bounds for Num2, {other}"),
                 }
             }
             (Num4(n), Number(i)) => {
                 let i = usize::from(i);
                 match i {
                     0 | 1 | 2 | 3 => self.set_register(result_register, Number(n[i].into())),
-                    other => return runtime_error!("Index out of bounds for Num4, {}", other),
+                    other => return runtime_error!("Index out of bounds for Num4, {other}"),
                 }
             }
             (Map(m), index) => {
@@ -2384,7 +2357,7 @@ impl Vm {
         let value = self.clone_register(value);
         let meta_key = match meta_id_to_key(meta_id, None) {
             Ok(meta_key) => meta_key,
-            Err(error) => return runtime_error!("Error while preparing meta key: {}", error),
+            Err(error) => return runtime_error!("Error while preparing meta key: {error}"),
         };
 
         match self.get_register_mut(map_register) {
@@ -2408,7 +2381,7 @@ impl Vm {
         let meta_key = match self.clone_register(name_register) {
             Value::Str(name) => match meta_id_to_key(meta_id, Some(name)) {
                 Ok(key) => key,
-                Err(e) => return runtime_error!("Error while preparing meta key: {}", e),
+                Err(error) => return runtime_error!("Error while preparing meta key: {error}"),
             },
             other => return unexpected_type_error("String", &other),
         };
@@ -2426,7 +2399,7 @@ impl Vm {
         let value = self.clone_register(value);
         let meta_key = match meta_id_to_key(meta_id, None) {
             Ok(meta_key) => meta_key,
-            Err(error) => return runtime_error!("Error while preparing meta key: {}", error),
+            Err(error) => return runtime_error!("Error while preparing meta key: {error}"),
         };
 
         self.exports.meta_mut().insert(meta_key, value);
@@ -2444,7 +2417,7 @@ impl Vm {
         let meta_key = match self.clone_register(name_register) {
             Value::Str(name) => match meta_id_to_key(meta_id, Some(name)) {
                 Ok(key) => key,
-                Err(e) => return runtime_error!("Error while preparing meta key: {}", e),
+                Err(error) => return runtime_error!("Error while preparing meta key: {error}"),
             },
             other => return unexpected_type_error("String", &other),
         };
@@ -2502,8 +2475,7 @@ impl Vm {
                 }
                 None => {
                     return runtime_error!(
-                        "'{}' not found in '{}'",
-                        key_string,
+                        "'{key_string}' not found in '{}'",
                         accessed_value.type_as_string()
                     );
                 }
@@ -2579,7 +2551,7 @@ impl Vm {
             },
             None => {
                 use std::ops::Deref;
-                return runtime_error!("'{}' not found in '{}'", key.deref(), module_name);
+                return runtime_error!("'{}' not found in '{module_name}'", key.deref());
             }
         };
 
@@ -2911,10 +2883,8 @@ impl Vm {
 
         let expression_string = self.get_constant_str(expression_constant);
 
-        self.stdout().write_line(&format!(
-            "{}{}: {}",
-            prefix, expression_string, value_string
-        ))
+        self.stdout()
+            .write_line(&format!("{prefix}{expression_string}: {value_string}",))
     }
 
     fn run_check_type(&self, register: u8, type_id: TypeId) -> InstructionResult {
@@ -2940,11 +2910,7 @@ impl Vm {
         if value_size == expected_size {
             Ok(())
         } else {
-            runtime_error!(
-                "Value has a size of '{}', expected '{}'",
-                value_size,
-                expected_size
-            )
+            runtime_error!("Value has a size of '{value_size}', expected '{expected_size}'")
         }
     }
 
@@ -3188,8 +3154,7 @@ impl Vm {
 
     fn binary_op_error(&self, lhs: &Value, rhs: &Value, op: &str) -> InstructionResult {
         runtime_error!(
-            "Unable to perform operation '{}' with '{}' and '{}'",
-            op,
+            "Unable to perform operation '{op}' with '{}' and '{}'",
             lhs.type_as_string(),
             rhs.type_as_string(),
         )

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -199,6 +199,7 @@ impl Vm {
     ///   - An iterator spawns a shared VM that can be used to execute functors
     ///   - A generator function spawns a shared VM to yield incremental results
     ///   - Thrown errors spawn a shared VM to display an error from a custom error type
+    #[must_use]
     pub fn spawn_shared_vm(&self) -> Self {
         Self {
             exports: self.exports.clone(),

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -42,8 +42,7 @@ mod external_values {
                                 Ok(Empty)
                             }
                             None => runtime_error!(
-                                "{} - unexpected other type: {}",
-                                fn_name,
+                                "{fn_name} - unexpected other type: {}",
                                 other.data().value_type(),
                             ),
                         }

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -16,161 +16,163 @@ mod external_values {
 
     impl ExternalData for TestExternalData {}
 
-    thread_local!(
-        static EXTERNAL_META: Rc<RefCell<MetaMap>> = {
-            use Value::{Bool, Empty, Number};
+    thread_local! {
+        static EXTERNAL_META: Rc<RefCell<MetaMap>> = make_external_value_meta_map();
+    }
 
-            let mut meta = MetaMap::with_type_name("TestExternalData");
+    fn make_external_value_meta_map() -> Rc<RefCell<MetaMap>> {
+        use Value::{Bool, Empty, Number};
 
-            meta.add_named_instance_fn("to_number", |data: &TestExternalData, _, _| {
-                Ok(Number(data.x.into()))
-            });
+        let mut meta = MetaMap::with_type_name("TestExternalData");
 
-            meta.add_named_instance_fn_mut(
-                "set_all_instances",
-                |data: &mut TestExternalData, _, extra_args| {
-                    let fn_name = "TestExternalData.set_all_instances";
+        meta.add_named_instance_fn("to_number", |data: &TestExternalData, _, _| {
+            Ok(Number(data.x.into()))
+        });
 
-                    match extra_args {
-                        [Value::ExternalValue(other)] => {
-                            match other.data().downcast_ref::<TestExternalData>() {
-                                Some(other_data) => {
-                                    data.x = other_data.x;
-                                    Ok(Empty)
-                                }
-                                None => runtime_error!(
-                                    "{} - unexpected other type: {}",
-                                    fn_name,
-                                    other.data().value_type(),
-                                ),
+        meta.add_named_instance_fn_mut(
+            "set_all_instances",
+            |data: &mut TestExternalData, _, extra_args| {
+                let fn_name = "TestExternalData.set_all_instances";
+
+                match extra_args {
+                    [Value::ExternalValue(other)] => {
+                        match other.data().downcast_ref::<TestExternalData>() {
+                            Some(other_data) => {
+                                data.x = other_data.x;
+                                Ok(Empty)
                             }
-                        }
-                        _ => {
-                            runtime_error!("{} - expected two ExternalData arguments", fn_name)
+                            None => runtime_error!(
+                                "{} - unexpected other type: {}",
+                                fn_name,
+                                other.data().value_type(),
+                            ),
                         }
                     }
-                },
-                );
+                    _ => {
+                        runtime_error!("{} - expected two ExternalData arguments", fn_name)
+                    }
+                }
+            },
+        );
 
-            meta.add_named_instance_fn(
-                "get_data",
-                |_data: &TestExternalData, value: &ExternalValue, _| {
-                    Ok(Value::ExternalData(value.data.clone()))
-                },
-            );
+        meta.add_named_instance_fn(
+            "get_data",
+            |_data: &TestExternalData, value: &ExternalValue, _| {
+                Ok(Value::ExternalData(value.data.clone()))
+            },
+        );
 
-            meta.add_unary_op(UnaryOp::Display, |data: &TestExternalData, _| {
-                Ok(format!("TestExternalData: {}", data.x).into())
-            });
+        meta.add_unary_op(UnaryOp::Display, |data: &TestExternalData, _| {
+            Ok(format!("TestExternalData: {}", data.x).into())
+        });
 
-            meta.add_unary_op(UnaryOp::Negate, |data: &TestExternalData, value| {
-                let result = value.with_new_data(TestExternalData { x: -data.x });
+        meta.add_unary_op(UnaryOp::Negate, |data: &TestExternalData, value| {
+            let result = value.with_new_data(TestExternalData { x: -data.x });
+            Ok(result.into())
+        });
+
+        meta.add_binary_op(
+            BinaryOp::Add,
+            |data_a: &TestExternalData, data_b, value_a, _| {
+                let result = value_a.with_new_data(TestExternalData {
+                    x: data_a.x + data_b.x,
+                });
                 Ok(result.into())
-            });
+            },
+        );
 
-            meta.add_binary_op(
-                BinaryOp::Add,
-                |data_a: &TestExternalData, data_b, value_a, _| {
-                    let result = value_a.with_new_data(TestExternalData {
-                        x: data_a.x + data_b.x,
-                    });
-                    Ok(result.into())
-                },
-            );
+        meta.add_binary_op(
+            BinaryOp::Subtract,
+            |data_a: &TestExternalData, data_b, value_a, _| {
+                let result = value_a.with_new_data(TestExternalData {
+                    x: data_a.x - data_b.x,
+                });
+                Ok(result.into())
+            },
+        );
 
-            meta.add_binary_op(
-                BinaryOp::Subtract,
-                |data_a: &TestExternalData, data_b, value_a, _| {
-                    let result = value_a.with_new_data(TestExternalData {
-                        x: data_a.x - data_b.x,
-                    });
-                    Ok(result.into())
-                },
-            );
+        meta.add_binary_op(
+            BinaryOp::Multiply,
+            |data_a: &TestExternalData, data_b, value_a, _| {
+                let result = value_a.with_new_data(TestExternalData {
+                    x: data_a.x * data_b.x,
+                });
+                Ok(result.into())
+            },
+        );
 
-            meta.add_binary_op(
-                BinaryOp::Multiply,
-                |data_a: &TestExternalData, data_b, value_a, _| {
-                    let result = value_a.with_new_data(TestExternalData {
-                        x: data_a.x * data_b.x,
-                    });
-                    Ok(result.into())
-                },
-            );
+        meta.add_binary_op(
+            BinaryOp::Divide,
+            |data_a: &TestExternalData, data_b, value_a, _| {
+                let result = value_a.with_new_data(TestExternalData {
+                    x: data_a.x / data_b.x,
+                });
+                Ok(result.into())
+            },
+        );
 
-            meta.add_binary_op(
-                BinaryOp::Divide,
-                |data_a: &TestExternalData, data_b, value_a, _| {
-                    let result = value_a.with_new_data(TestExternalData {
-                        x: data_a.x / data_b.x,
-                    });
-                    Ok(result.into())
-                },
-            );
+        meta.add_binary_op(
+            BinaryOp::Modulo,
+            |data_a: &TestExternalData, data_b, value_a, _| {
+                let result = value_a.with_new_data(TestExternalData {
+                    x: data_a.x % data_b.x,
+                });
+                Ok(result.into())
+            },
+        );
 
-            meta.add_binary_op(
-                BinaryOp::Modulo,
-                |data_a: &TestExternalData, data_b, value_a, _| {
-                    let result = value_a.with_new_data(TestExternalData {
-                        x: data_a.x % data_b.x,
-                    });
-                    Ok(result.into())
-                },
-            );
+        meta.add_binary_op(BinaryOp::Less, |data_a: &TestExternalData, data_b, _, _| {
+            Ok(Bool(data_a.x < data_b.x))
+        });
 
-            meta.add_binary_op(BinaryOp::Less, |data_a: &TestExternalData, data_b, _, _| {
-                Ok(Bool(data_a.x < data_b.x))
-            });
+        meta.add_binary_op(
+            BinaryOp::LessOrEqual,
+            |data_a: &TestExternalData, data_b, _, _| Ok(Bool(data_a.x <= data_b.x)),
+        );
 
-            meta.add_binary_op(
-                BinaryOp::LessOrEqual,
-                |data_a: &TestExternalData, data_b, _, _| Ok(Bool(data_a.x <= data_b.x)),
-            );
+        meta.add_binary_op(
+            BinaryOp::Greater,
+            |data_a: &TestExternalData, data_b, _, _| Ok(Bool(data_a.x > data_b.x)),
+        );
 
-            meta.add_binary_op(
-                BinaryOp::Greater,
-                |data_a: &TestExternalData, data_b, _, _| Ok(Bool(data_a.x > data_b.x)),
-            );
+        meta.add_binary_op(
+            BinaryOp::GreaterOrEqual,
+            |data_a: &TestExternalData, data_b, _, _| Ok(Bool(data_a.x >= data_b.x)),
+        );
 
-            meta.add_binary_op(
-                BinaryOp::GreaterOrEqual,
-                |data_a: &TestExternalData, data_b, _, _| Ok(Bool(data_a.x >= data_b.x)),
-            );
+        meta.add_binary_op(
+            BinaryOp::Equal,
+            |data_a: &TestExternalData, data_b, _, _| {
+                #[allow(clippy::float_cmp)]
+                Ok(Bool(data_a.x == data_b.x))
+            },
+        );
 
-            meta.add_binary_op(
-                BinaryOp::Equal,
-                |data_a: &TestExternalData, data_b, _, _| {
-                    #[allow(clippy::float_cmp)]
-                    Ok(Bool(data_a.x == data_b.x))
-                },
-            );
+        meta.add_binary_op(
+            BinaryOp::NotEqual,
+            |data_a: &TestExternalData, data_b, _, _| {
+                #[allow(clippy::float_cmp)]
+                Ok(Bool(data_a.x != data_b.x))
+            },
+        );
 
-            meta.add_binary_op(
-                BinaryOp::NotEqual,
-                |data_a: &TestExternalData, data_b, _, _| {
-                    #[allow(clippy::float_cmp)]
-                    Ok(Bool(data_a.x != data_b.x))
-                },
-            );
+        meta.add_binary_op_with_any_rhs(
+            BinaryOp::Index,
+            |data_a: &TestExternalData, _, value_b| match value_b {
+                Number(index) => {
+                    let index = usize::from(index);
+                    let result = data_a.x + index as f64;
+                    Ok(Number(result.into()))
+                }
+                unexpected => runtime_error!(
+                    "ExternalValue.@Index - Expected Number as argument, found {}",
+                    unexpected.type_as_string()
+                ),
+            },
+        );
 
-            meta.add_binary_op_with_any_rhs(
-                BinaryOp::Index,
-                |data_a: &TestExternalData, _, value_b| match value_b {
-                    Number(index) => {
-                        let index = usize::from(index);
-                        let result = data_a.x + index as f64;
-                        Ok(Number(result.into()))
-                    }
-                    unexpected => runtime_error!(
-                        "ExternalValue.@Index - Expected Number as argument, found {}",
-                        unexpected.type_as_string()
-                    ),
-                },
-            );
-
-            Rc::new(RefCell::new(meta))
-        }
-    );
+        Rc::new(RefCell::new(meta))
+    }
 
     fn test_script_with_external_value(script: &str, expected_output: Value) {
         let vm = Vm::default();

--- a/src/serialize/Cargo.toml
+++ b/src/serialize/Cargo.toml
@@ -2,7 +2,7 @@
 name = "koto_serialize"
 version = "0.10.0"
 authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "Serde serialization support for the Koto programming language"
 homepage = "https://github.com/koto-lang/koto"


### PR DESCRIPTION
- Switch to using the 2021 edition
- Remove imports of items in the 2021 prelude
- Listen to clippy
- Specify Rust 1.58 as the minimum version
