### PR TITLE
Avoid panics in the Koto API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ The Koto project adheres to
   - `ExternalIterator` has been renamed to `KotoIterator`.
   - `ValueIterator::make_external` has been renamed to `ValueIterator::new`.
   - Koto now uses the Rust 2021 edition.
+  - `Koto::set_script_path` and `set_args` now return `Result`s.
 
 ### Removed
 

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -65,7 +65,7 @@ fn make_poetry_meta_map() -> Rc<RefCell<MetaMap>> {
         Ok(result)
     });
 
-    Rc::new(RefCell::new(bindings))
+    bindings.into()
 }
 
 #[derive(Clone)]

--- a/examples/poetry/src/main.rs
+++ b/examples/poetry/src/main.rs
@@ -109,7 +109,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     koto.prelude().add_map("random", koto_random::make_module());
 
     let script_path = PathBuf::from_str(&args.script).expect("Failed to parse script path");
-    koto.set_script_path(Some(script_path.clone()));
+    koto.set_script_path(Some(script_path.clone()))
+        .expect("Failed to set script path");
 
     if args.watch {
         if let Err(e) = compile_and_run(&mut koto, &script_path) {

--- a/libs/lib_tests/tests/lib_tests.rs
+++ b/libs/lib_tests/tests/lib_tests.rs
@@ -8,7 +8,7 @@ fn run_script(script: &str, path: Option<PathBuf>, should_fail_at_runtime: bool)
         run_tests: true,
         ..Default::default()
     });
-    koto.set_script_path(path);
+    koto.set_script_path(path).unwrap();
 
     let prelude = koto.prelude();
     prelude.add_map("json", koto_json::make_module());

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -72,7 +72,7 @@ fn make_rng_meta_map() -> Rc<RefCell<MetaMap>> {
     meta.add_named_instance_fn_mut("pick", |rng: &mut ChaChaRng, _, args| rng.pick(args));
     meta.add_named_instance_fn_mut("seed", |rng: &mut ChaChaRng, _, args| rng.seed(args));
 
-    Rc::new(RefCell::new(meta))
+    meta.into()
 }
 
 #[derive(Debug)]

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -156,7 +156,10 @@ fn run() -> Result<(), ()> {
 
     if let Some(script) = script {
         let mut koto = Koto::with_settings(koto_settings);
-        koto.set_script_path(script_path.map(|path| path.into()));
+        if let Err(error) = koto.set_script_path(script_path.map(|path| path.into())) {
+            eprintln!("{error}");
+            return Err(());
+        }
 
         let prelude = koto.prelude();
         prelude.add_map("json", koto_json::make_module());

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -21,7 +21,7 @@ fn run_script(script: &str, script_path: Option<PathBuf>, expected_module_paths:
             move |path: &Path| loaded_module_paths.borrow_mut().push(path.to_path_buf())
         }),
     );
-    koto.set_script_path(script_path);
+    koto.set_script_path(script_path).unwrap();
 
     match koto.compile(script) {
         Ok(_) => match koto.run() {

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -258,7 +258,7 @@ fn make_file_meta_map() -> Rc<RefCell<MetaMap>> {
         }
     });
 
-    Rc::new(RefCell::new(meta))
+    meta.into()
 }
 
 /// The File type used in the io module

--- a/src/runtime/src/core/os.rs
+++ b/src/runtime/src/core/os.rs
@@ -113,7 +113,7 @@ fn make_system_time_meta_map() -> Rc<RefCell<MetaMap>> {
 
     meta.add_named_instance_fn("year", |data: &DateTime, _, _| Ok(data.0.year().into()));
 
-    Rc::new(RefCell::new(meta))
+    meta.into()
 }
 
 pub struct Timer(Instant);

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{RuntimeResult, Vm},
+    crate::{MetaMap, RuntimeResult, Vm},
     downcast_rs::impl_downcast,
     std::{
         cell::{Ref, RefCell, RefMut},
@@ -10,8 +10,6 @@ use {
 };
 
 pub use downcast_rs::Downcast;
-
-use crate::MetaMap;
 
 /// A trait for external data
 pub trait ExternalData: Downcast {

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -8,9 +8,11 @@ use {
     rustc_hash::FxHasher,
     std::{
         borrow::Borrow,
+        cell::RefCell,
         fmt,
         hash::{BuildHasherDefault, Hash, Hasher},
         ops::{Deref, DerefMut},
+        rc::Rc,
     },
 };
 
@@ -324,6 +326,12 @@ impl Deref for MetaMap {
 impl DerefMut for MetaMap {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl From<MetaMap> for Rc<RefCell<MetaMap>> {
+    fn from(m: MetaMap) -> Self {
+        Rc::new(RefCell::new(m))
     }
 }
 

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -170,7 +170,7 @@ mod external_values {
             },
         );
 
-        Rc::new(RefCell::new(meta))
+        meta.into()
     }
 
     fn test_script_with_external_value(script: &str, expected_output: Value) {


### PR DESCRIPTION
- Avoid panics in the top-level Koto wrapper
- Add From<MetaMap> impl for Rc<RefCell<MetaMap>>
- Clean up a few things in MetaMap
