### PR TITLE
Error message improvements

### DIFF
--- a/src/parser/src/ast.rs
+++ b/src/parser/src/ast.rs
@@ -55,24 +55,6 @@ impl Ast {
             .map_err(|_| ParserError::new(InternalError::AstCapacityOverflow.into(), span))
     }
 
-    /// Pushes a node onto the tree, associating it with an existing span
-    pub fn push_with_span_index(
-        &mut self,
-        node: Node,
-        span_index: AstIndex,
-    ) -> Result<AstIndex, ParserError> {
-        self.nodes.push(AstNode {
-            node,
-            span: span_index,
-        });
-        AstIndex::try_from(self.nodes.len() - 1).map_err(|_| {
-            ParserError::new(
-                InternalError::AstCapacityOverflow.into(),
-                *self.span(span_index),
-            )
-        })
-    }
-
     /// Returns a node for a given node index
     pub fn node(&self, index: AstIndex) -> &AstNode {
         &self.nodes[index as usize]

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -31,6 +31,7 @@ pub enum InternalError {
 #[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub enum ExpectedIndentation {
+    AssignmentExpression,
     CatchBody,
     ElseBlock,
     ElseIfBlock,
@@ -225,6 +226,7 @@ impl fmt::Display for ExpectedIndentation {
         use ExpectedIndentation::*;
 
         match self {
+            AssignmentExpression => f.write_str("Expected expression after assignment operator"),
             CatchBody => f.write_str("Expected indented block for catch expression"),
             ElseBlock => f.write_str("Expected indented block for 'else'."),
             ElseIfBlock => f.write_str("Expected indented block for 'else if'."),

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -228,19 +228,19 @@ impl fmt::Display for ExpectedIndentation {
             CatchBody => f.write_str("Expected indented block for catch expression"),
             ElseBlock => f.write_str("Expected indented block for 'else'."),
             ElseIfBlock => f.write_str("Expected indented block for 'else if'."),
-            ForBody => f.write_str("Expected indented block in for loop"),
+            ForBody => f.write_str("Expected indented block as for loop body"),
             FinallyBody => f.write_str("Expected indented block for finally expression"),
             FunctionBody => f.write_str("Expected function body"),
-            LoopBody => f.write_str("Expected indented block in loop"),
+            LoopBody => f.write_str("Expected indented block as loop body"),
             MatchArm => f.write_str("Expected indented arm for match expression"),
             SwitchArm => f.write_str("Expected indented arm for switch expression"),
-            RhsExpression => f.write_str("Expected expression"),
+            RhsExpression => f.write_str("Expected expression after binary operator"),
             ThenKeywordOrBlock => f.write_str(
                 "Error parsing if expression, expected 'then' keyword or indented block.",
             ),
             TryBody => f.write_str("Expected indented block for try expression"),
-            UntilBody => f.write_str("Expected indented block in until loop"),
-            WhileBody => f.write_str("Expected indented block in while loop"),
+            UntilBody => f.write_str("Expected indented block as until loop body"),
+            WhileBody => f.write_str("Expected indented block as while loop body"),
         }
     }
 }
@@ -259,7 +259,7 @@ impl fmt::Display for SyntaxError {
             ExpectedCatchArgument => f.write_str("Expected argument for catch expression"),
             ExpectedCatch => f.write_str("Expected catch expression after try"),
             ExpectedCloseParen => f.write_str("Expected closing parenthesis ')'"),
-            ExpectedElseExpression => f.write_str("Expected 'else' expression."),
+            ExpectedElseExpression => f.write_str("Expected expression after 'else'."),
             ExpectedElseIfCondition => f.write_str("Expected condition for 'else if'."),
             ExpectedEndOfLine => f.write_str("Expected end of line"),
             ExpectedExportExpression => f.write_str("Expected ID to export"),
@@ -281,7 +281,7 @@ impl fmt::Display for SyntaxError {
             ExpectedIndexExpression => f.write_str("Expected index expression"),
             ExpectedListEnd => f.write_str("Expected List end ']'"),
             ExpectedMapColon => f.write_str("Expected ':' after map key"),
-            ExpectedMapEnd => f.write_str("Unexpected token in Map, expected '}'"),
+            ExpectedMapEnd => f.write_str("Expected '}' at end of map declaration"),
             ExpectedMapEntry => f.write_str("Expected map entry"),
             ExpectedMapKey => f.write_str("Expected key after '.' in Map access"),
             ExpectedMapValue => f.write_str("Expected value after ':' in Map"),
@@ -303,7 +303,7 @@ impl fmt::Display for SyntaxError {
                 f.write_str("Expected expression after then in switch arm")
             }
             ExpectedTestName => f.write_str("Expected a test name"),
-            ExpectedThenExpression => f.write_str("Expected 'then' expression."),
+            ExpectedThenExpression => f.write_str("Expected expression after 'then'."),
             ExpectedUntilCondition => f.write_str("Expected condition in until loop"),
             ExpectedWhileCondition => f.write_str("Expected condition in while loop"),
             IfBlockNotAllowedInThisContext => {


### PR DESCRIPTION
- Remove unused function
- Improve the span placement for binary operations
- Improve the wording of some error messages
- Replace parser error macros and place some error spans more clearly
