### PR TITLE
Build with Rust 1.59

### DIFF
--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -418,7 +418,7 @@ impl fmt::Display for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Instruction::*;
         match self {
-            Error { message } => unreachable!(message),
+            Error { message } => unreachable!("{message}"),
             Copy { .. } => write!(f, "Copy"),
             SetEmpty { .. } => write!(f, "SetEmpty"),
             SetBool { .. } => write!(f, "SetBool"),
@@ -502,7 +502,7 @@ impl fmt::Debug for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Instruction::*;
         match self {
-            Error { message } => unreachable!(message),
+            Error { message } => unreachable!("{message}"),
             Copy { target, source } => write!(f, "Copy\t\tresult: {target}\tsource: {source}"),
             SetEmpty { register } => write!(f, "SetEmpty\tresult: {register}"),
             SetBool { register, value } => {

--- a/src/runtime/src/core/string/iterators.rs
+++ b/src/runtime/src/core/string/iterators.rs
@@ -239,7 +239,7 @@ impl Iterator for SplitWith {
                 }
             }
 
-            let end = end.unwrap_or_else(|| self.input.len());
+            let end = end.unwrap_or(self.input.len());
             let output = Str(self.input.with_bounds(start..end).unwrap());
             self.start = end + grapheme_len;
 

--- a/src/runtime/src/value_string.rs
+++ b/src/runtime/src/value_string.rs
@@ -48,7 +48,7 @@ impl ValueString {
     }
 
     pub fn with_grapheme_indices(&self, start: usize, end: Option<usize>) -> Option<Self> {
-        let end_unwrapped = end.unwrap_or_else(|| self.len());
+        let end_unwrapped = end.unwrap_or(self.len());
         debug_assert!(start <= end_unwrapped);
 
         let mut result_start = if start == 0 { Some(0) } else { None };

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -2609,7 +2609,7 @@ impl Vm {
             frame_base + 1
         };
 
-        let result = (&*function)(
+        let result = (*function)(
             self,
             &Args {
                 register: adjusted_frame_base,


### PR DESCRIPTION
- The first argument to unreachable must be a string literal
- Listen to clippy
