### PR TITLE
Always attempt to access IDs, even when no result is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,10 @@ The Koto project adheres to
     import bar.baz # <-- Previously this would cause a runtime error
     debug baz
     ```
+- Accessing an ID without side effects would previously be optimized away,
+  which led to the confusing situation where a missing ID could be accessed in a
+  script without triggering an error.
+
 
 ## [0.10.0] 2021.12.02
 

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -1206,7 +1206,11 @@ impl Compiler {
                     self.compile_load_non_local(result.register, id);
                     Some(result)
                 }
-                None => None,
+                None => {
+                    let register = self.push_register()?;
+                    self.compile_load_non_local(register, id);
+                    Some(CompileResult::with_temporary(register))
+                }
             }
         };
 

--- a/src/runtime/tests/runtime_failures.rs
+++ b/src/runtime/tests/runtime_failures.rs
@@ -69,6 +69,20 @@ assert_near 1, 2, 0.1
             }
         }
 
+        mod missing_values {
+            use super::*;
+
+            #[test]
+            fn missing_identifier_before_last_expression() {
+                let script = "
+x = 123
+y
+x
+";
+                check_script_fails(script);
+            }
+        }
+
         mod iterators {
             use super::*;
 


### PR DESCRIPTION
Accessing an ID without side effects would previously be optimized away,l which led to the confusing situation where a missing ID could be accessed in a  script without triggering an error.

e.g. 

```coffee
x = 123
y # <-- The compiler would previously optimize this away, so no runtime error would be thrown
debug x
```