### PR TITLE
Null improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,56 +10,32 @@ The Koto project adheres to
 
 ### Added
 
-- Core Library
-  - New additions:
-    - `iterator`
-      - `chunks`, `find`, `flatten`, `generate`, `repeat`, `reversed`,
-        `to_num2`, `to_num4`, `windows`
-    - `list.resize_with`
-    - `number`
-      - `acosh`, `asinh`, `atanh`, `atan2`, `lerp`
-      - `pi_2`, `pi_4`
-    - `num2`
-      - `lerp`, `make_num2`, `with`
-      - `x`, `y`
-      - `angle`
-    - `num4`
-      - `lerp`, `make_num4`, `with`
-      - `r`, `g`, `b`, `a`, `x`, `y`, `z`, `w`
-    - `os`
-      - `time`
-        - Provides information about the current date and time.
-      - `start_timer`
-        - Provides a timer that can be used for measuring the duration between
-          moments in time.
-    - `string.from_bytes`
-  - The following items are now imported by default into the top level of the
-    prelude:
-    - `io.print`, `koto.type`, `num2.make_num2`, `num4.make_num4`,
-      `test.assert`, `test.assert_eq`, `test.assert_ne`, `test.assert_near`
-  - List operations that modify the list but previously returned Empty,
-    now return the modified list.
+#### Language
+
+- The `null` keyword has been introduced, which is a more explicit way of
+  declaring a non-value than `()`.
+  - A consequence of this addition is that formatted JSON is now valid Koto.
     - e.g.
       ```koto
-      x = [1, 2, 3]
-
-      # Before
-      x.push 4
-      # ()
-
-      # After
-      x.push 4
-      # [1, 2, 3, 4]
+      data = {
+        "empty": null,
+        "nested": {
+          "number": 123,
+          "string": "hello"
+        }
+      }
+      data.nested.number
+      # 123
       ```
-  - `iterator.consume` now accepts an optional function that will be called
-    for each iterator output value.
-    - e.g.
-      ```koto
-      (1, 2, 3).consume |n| io.print n
-      # 1
-      # 2
-      # 3
-      ```
+- Koto values now coerce to Bool in boolean contexts, with `false` and `null`
+  evaluating to `false`, with all other values evaluating to `true`.
+  - e.g.
+    ```koto
+    x = null
+    y = x or 42
+    y
+    # 42
+    ```
 - Maps can now implement `@iterator`, which allows you to define custom
   iteration behaviour.
   - e.g.
@@ -73,8 +49,8 @@ The Koto project adheres to
 - Num2 and Num4 values can now be iterated over in a for loop.
 - Empty tuples can be declared by including a trailing comma in parentheses,
   e.g. `(,)`.
-- Wildcard arguments (declared with `_`) can now optionally have names following
-  the underscore.
+- Wildcard arguments (declared with `_`) can now optionally have names
+  following the underscore.
   - e.g.
     ```koto
     # Before
@@ -82,13 +58,55 @@ The Koto project adheres to
     # After
     x, _unused, z = 1, 2, 3
     ```
-- Internals
-  - A 'module imported' callback has been added to `KotoSettings` to aid in
-    keeping track of a script's module dependencies.
-  - `Koto::clear_module_cache()` has been added to allow for reloading scripts
-    when one of the script's dependencies has changed.
+
+#### Core Library
+
+- New additions:
+  - `iterator`
+    - `chunks`, `find`, `flatten`, `generate`, `repeat`, `reversed`,
+      `to_num2`, `to_num4`, `windows`
+  - `list.resize_with`
+  - `number`
+    - `acosh`, `asinh`, `atanh`, `atan2`, `lerp`
+    - `pi_2`, `pi_4`
+  - `num2`
+    - `lerp`, `make_num2`, `with`
+    - `x`, `y`
+    - `angle`
+  - `num4`
+    - `lerp`, `make_num4`, `with`
+    - `r`, `g`, `b`, `a`, `x`, `y`, `z`, `w`
+  - `os`
+    - `time`
+      - Provides information about the current date and time.
+    - `start_timer`
+      - Provides a timer that can be used for measuring the duration between
+        moments in time.
+  - `string.from_bytes`
+- The following items are now imported by default into the top level of the
+  prelude:
+  - `io.print`, `koto.type`, `num2.make_num2`, `num4.make_num4`,
+    `test.assert`, `test.assert_eq`, `test.assert_ne`, `test.assert_near`
+- `iterator.consume` now accepts an optional function that will be called
+  for each iterator output value.
+  - e.g.
+    ```koto
+    (1, 2, 3).consume |n| io.print n
+    # 1
+    # 2
+    # 3
+    ```
+
+#### Internals
+
+- A 'module imported' callback has been added to `KotoSettings` to aid in
+  keeping track of a script's module dependencies.
+- `Koto::clear_module_cache()` has been added to allow for reloading scripts
+  when one of the script's dependencies has changed.
 
 ### Changed
+
+#### Language
 
 - Assigning to a module's meta map has been reworked
   - The `export` keyword is no longer needed to assign to a meta key, as meta
@@ -114,31 +132,6 @@ The Koto project adheres to
       @main = ||
         ...
       ```
-- Core Library
-  - The `num2` and `num4` keywords have been removed in favour of the new
-    `make_num2`, `make_num4`, `iterator.to_num2`, and `iterator.to_num4`
-    functions.
-  - The value provided to `list.resize` is now optional, with `()` being
-    inserted when growing the list.
-  - `list.get`, `tuple.get`, and `map.get_index` will now return `()` when a
-    negative number is used as the index, rather than throwing an error.
-- Random Library
-  - The default generator functions can now be used directly.
-    Previously they had to be used as instance functions.
-    - e.g.
-      ```koto
-      # Before
-      if random.bool() then do_x()
-      # After
-      rng_bool = import random.bool
-      if rng_bool() then do_x()
-      ```
-  - The `number2` and `number4` functions have been renamed to
-    `num2` and `num4`.
-  - The number of rounds used by the generator (ChaCha) has been reduced from
-    20 to 8.
-  - The random module is provided as a `ValueMap` rather than a `Value`,
-    meaning that its now added to the prelude via `add_map` like other modules.
 - Map equality comparisons now don't rely on maps having keys in the same order.
   - e.g.
     ```koto
@@ -172,11 +165,57 @@ The Koto project adheres to
         , 3
         ]
     ```
-- Internals
-  - `ExternalIterator` has been renamed to `KotoIterator`.
-  - `ValueIterator::make_external` has been renamed to `ValueIterator::new`.
-  - Koto now uses the Rust 2021 edition.
-  - `Koto::set_script_path` and `set_args` now return `Result`s.
+
+#### Core Library
+
+- The `num2` and `num4` keywords have been removed in favour of the new
+  `make_num2`, `make_num4`, `iterator.to_num2`, and `iterator.to_num4`
+  functions.
+- The value provided to `list.resize` is now optional, with `null` being
+  inserted when growing the list.
+- `list.get`, `tuple.get`, and `map.get_index` will now return `null` when a
+  negative number is used as the index, rather than throwing an error.
+- List operations that modify the list but previously returned `null`,
+  now return the modified list.
+  - e.g.
+    ```koto
+    x = [1, 2, 3]
+
+    # Before
+    x.push 4
+    # Null
+
+    # After
+    x.push 4
+    # [1, 2, 3, 4]
+    ```
+
+#### Random Library
+
+- The default generator functions can now be used directly.
+  Previously they had to be used as instance functions.
+  - e.g.
+    ```koto
+    # Before
+    if random.bool() then do_x()
+    # After
+    rng_bool = import random.bool
+    if rng_bool() then do_x()
+    ```
+- The `number2` and `number4` functions have been renamed to
+  `num2` and `num4`.
+- The number of rounds used by the generator (ChaCha) has been reduced from
+  20 to 8.
+- The random module is provided as a `ValueMap` rather than a `Value`,
+  meaning that its now added to the prelude via `add_map` like other modules.
+
+#### Internals
+
+- Koto now uses the Rust 2021 edition.
+- `Value::Empty` has been renamed to `Null`.
+- `ExternalIterator` has been renamed to `KotoIterator`.
+- `ValueIterator::make_external` has been renamed to `ValueIterator::new`.
+- `Koto::set_script_path` and `set_args` now return `Result`s.
 
 ### Removed
 

--- a/docs/reference/core_lib/io.md
+++ b/docs/reference/core_lib/io.md
@@ -49,7 +49,7 @@ f.read_to_string()
 
 `|| -> String`
 
-Returns the current working directory as a String, or Empty if the current
+Returns the current working directory as a String, or Null if the current
 directory can't be retrieved.
 
 ## exists
@@ -109,8 +109,8 @@ f.exists()
 
 ## print
 
-`|Value| -> ()`
-`|String, Value...| -> ()`
+`|Value| -> Null`
+`|String, Value...| -> Null`
 
 Prints a formatted string to the active logger,
 by default this is the standard output.
@@ -143,7 +143,7 @@ io.read_to_string "foo.temp"
 
 ## remove_file
 
-`|String| -> ()`
+`|String| -> Null`
 
 Removes the file at the given path.
 
@@ -233,7 +233,7 @@ A map that wraps a file handle, returned from functions in `io`.
 
 ## File.flush
 
-`|File| -> ()`
+`|File| -> Null`
 
 Ensures that any buffered changes to the file have been written.
 
@@ -250,11 +250,11 @@ Returns the file's path.
 
 ## File.read_line
 
-`|File| -> String or Empty`
+`|File| -> String or Null`
 
 Reads a line of output from the file as a string, not including the newline.
 
-When the end of the file is reached, Empty will be returned.
+When the end of the file is reached, Null will be returned.
 
 ### Errors
 
@@ -272,18 +272,18 @@ An error is thrown if the file doesn't contain valid UTF-8 data.
 
 ## File.seek
 
-`|File, Number| -> ()`
+`|File, Number| -> Null`
 
 Seeks within the file to the specified position in bytes.
 
 ## File.write
 
-`|File, Value| -> ()`
+`|File, Value| -> Null`
 
 Writes the formatted value as a string to the file.
 
 ## File.write_line
 
-`|File, Value| -> ()`
+`|File, Value| -> Null`
 
 Writes the formatted value as a string, with a newline, to the file.

--- a/docs/reference/core_lib/iterator.md
+++ b/docs/reference/core_lib/iterator.md
@@ -1,8 +1,7 @@
 # iterator
 
 Iterators in Koto provide access to sequences of data, yielding values via
-`.next()`, until the end of the sequence is reached and the empty value `()`
-is returned.
+`.next()`, until the end of the sequence is reached and Null is returned.
 
 ## Iterable Values
 
@@ -170,11 +169,11 @@ e.g. a List or a String (i.e. not an adapted iterator or a generator).
 
 ## consume
 
-`|Iterable| -> ()`
+`|Iterable| -> Null`
 
 Consumes the output of the iterator.
 
-`|Iterable, Function| -> ()`
+`|Iterable, Function| -> Null`
 
 Consumes the output of the iterator, calling the provided function with each
 iterator output value.
@@ -310,7 +309,7 @@ if the value is a match, or `false` if it's not.
 
 The first matching value will cause iteration to stop.
 
-If no match is found then `()` is returned.
+If no match is found then Null is returned.
 
 ### Example
 
@@ -319,7 +318,7 @@ If no match is found then `()` is returned.
 # 15
 
 (10..20).find |x| x > 100
-# ()
+# Null
 ```
 
 ## flatten
@@ -479,7 +478,7 @@ Consumes the iterator, returning the last yielded value.
 # 5
 
 (0..0).last()
-# ()
+# Null
 ```
 
 ## max
@@ -577,7 +576,7 @@ x.next()
 x.next()
 # 2
 x.next()
-# ()
+# Null
 ```
 
 ## position
@@ -593,7 +592,7 @@ if the value is a match, or `false` if it's not.
 The first matching value will cause iteration to stop, and the number of
 steps taken to reach the matched value is returned as the result.
 
-If no match is found then `()` is returned.
+If no match is found then Null is returned.
 
 ### Example
 
@@ -602,7 +601,7 @@ If no match is found then `()` is returned.
 # 5
 
 (10..20).position |x| x == 99
-# ()
+# Null
 ```
 
 ### See Also
@@ -731,7 +730,7 @@ If a value is a tuple, then the first element in the tuple will be inserted as
 the key for the map entry, and the second element will be inserted as the value.
 
 If the value is anything other than a tuple, then it will be inserted as the map
-key, with `()` as the entry's value.
+key, with Null as the entry's value.
 
 ### Example
 

--- a/docs/reference/core_lib/koto.md
+++ b/docs/reference/core_lib/koto.md
@@ -43,17 +43,17 @@ it can be useful to export items programatically.
 
 ## script_dir
 
-`String or Empty`
+`String or Null`
 
 If a script is being executed then `script_dir` provides the directory that the
-current script is contained in as a String, otherwise `script_dir` is Empty.
+current script is contained in as a String, otherwise `script_dir` is Null.
 
 ## script_path
 
-`String or Empty`
+`String or Null`
 
 If a script is being executed then `script_path` provides the path of the
-current script as a String, otherwise `script_path` is Empty.
+current script as a String, otherwise `script_path` is Null.
 
 ## type
 

--- a/docs/reference/core_lib/list.md
+++ b/docs/reference/core_lib/list.md
@@ -155,7 +155,7 @@ x
 
 `|List| -> Value`
 
-Returns the first value in the list, or `()` if the list is empty.
+Returns the first value in the list, or Null if the list is empty.
 
 ### Example
 
@@ -164,7 +164,7 @@ Returns the first value in the list, or `()` if the list is empty.
 # 99
 
 [].first()
-# ()
+# Null
 ```
 
 ### See also
@@ -179,7 +179,7 @@ Returns the first value in the list, or `()` if the list is empty.
 
 Gets the Nth value in the list.
 If the list doesn't contain a value at that position then the provided default
-value is returned. If no default value is provided then `()` is returned.
+value is returned. If no default value is provided then Null is returned.
 
 ### Example
 
@@ -190,7 +190,7 @@ x.get 1
 # -1
 
 x.get -1
-# ()
+# Null
 
 x.get 5, 123
 # 123
@@ -244,7 +244,7 @@ Returns `true` if the list has a size of zero, and `false` otherwise.
 
 `|List| -> Value`
 
-Returns the last value in the list, or `()` if the list is empty.
+Returns the last value in the list, or Null if the list is empty.
 
 ### Example
 
@@ -253,7 +253,7 @@ Returns the last value in the list, or `()` if the list is empty.
 # 42
 
 [].first()
-# ()
+# Null
 ```
 
 ### See also
@@ -267,7 +267,7 @@ Returns the last value in the list, or `()` if the list is empty.
 
 Removes the last value from the list and returns it.
 
-If the list is empty then `()` is returned.
+If the list is empty then Null is returned.
 
 ### Example
 
@@ -280,7 +280,7 @@ x
 # [99, -1]
 
 [].pop()
-# ()
+# Null
 ```
 
 ### See also
@@ -328,11 +328,11 @@ Throws an error if the position isn't a valid index in the list.
 
 ## resize
 
-`|List, Number| -> ()`
-`|List, Number, Value| -> ()`
+`|List, Number| -> Null`
+`|List, Number, Value| -> Null`
 
 Grows or shrinks the list to the specified size.
-If the new size is larger, then copies of the provided value (or `()` if no
+If the new size is larger, then copies of the provided value (or Null if no
 value is provided) are used to fill the new space.
 
 ### Example
@@ -354,7 +354,7 @@ x
 
 ## resize_with
 
-`|List, Number, || -> Value| -> ()`
+`|List, Number, || -> Value| -> Null`
 
 Grows or shrinks the list to the specified size.
 If the new size is larger, then the provided function will be called repeatedly
@@ -490,7 +490,7 @@ x # x remains untouched
 
 ## swap
 
-`|List, List| -> ()`
+`|List, List| -> Null`
 
 Swaps the contents of the two input lists.
 

--- a/docs/reference/core_lib/list.md
+++ b/docs/reference/core_lib/list.md
@@ -349,7 +349,7 @@ x
 
 x.resize 4
 x
-# [1, 2, "x", ()]
+# [1, 2, "x", null]
 ```
 
 ## resize_with

--- a/docs/reference/core_lib/map.md
+++ b/docs/reference/core_lib/map.md
@@ -201,7 +201,7 @@ Tests are also stored in the meta map, see [test.md](test.md) for info.
 
 ## clear
 
-`|Map| -> ()`
+`|Map| -> Null`
 
 Clears the map by removing all of its elements.
 
@@ -284,7 +284,7 @@ x.bar.baz # a deep copy has been made, so x is unaffected by the change to y
 Returns the value corresponding to the given key, or the provided default value
 if the map doesn't contain the key.
 
-If no default value is provided then `()` is returned.
+If no default value is provided then Null is returned.
 
 ### Example
 
@@ -294,7 +294,7 @@ x.get "hello"
 # -1
 
 x.get "goodbye"
-# ()
+# Null
 
 x.get "goodbye", "byeeee"
 # "byeeee"
@@ -316,7 +316,7 @@ x.get 99
 Returns the entry at the given index as a key/value tuple, or the provided
 default value if the map doesn't contain an entry at that index.
 
-If no default value is provided then `()` is returned.
+If no default value is provided then Null is returned.
 
 ### Example
 
@@ -326,7 +326,7 @@ x.get_index 1
 # (bar, -2)
 
 x.get_index -99
-# ()
+# Null
 
 x.get_index 99, "xyz"
 # "xyz"
@@ -340,14 +340,14 @@ x.get_index 99, "xyz"
 
 `|Map, Key| -> Value`
 
-Inserts `()` into the map with the given key.
+Inserts Null into the map with the given key.
 
 `|Map, Key, Value| -> Value`
 
 Inserts a value into the map with the given key.
 
 If the key already existed in the map, then the old value is returned.
-If the key didn't already exist, then `()` is returned.
+If the key didn't already exist, then Null is returned.
 
 ### Example
 
@@ -360,7 +360,7 @@ x.hello # hello is now 99
 # 99
 
 x.insert "goodbye", 123 # No existing value at `goodbye`, so () is returned
-# ()
+# Null
 
 x.goodbye
 # 123
@@ -413,7 +413,7 @@ x.next()
 # "goodbye"
 
 x.next()
-# ()
+# Null
 ```
 
 ### See also
@@ -426,7 +426,7 @@ x.next()
 
 Removes the entry that matches the given key.
 
-If the entry existed then its value is returned, otherwise `()` is returned.
+If the entry existed then its value is returned, otherwise Null is returned.
 
 ### Example
 
@@ -439,7 +439,7 @@ x.remove "hello"
 # -1
 
 x.remove "xyz"
-# ()
+# Null
 
 x.remove "goodbye"
 # 99
@@ -474,11 +474,11 @@ Returns the number of entries contained in the map.
 
 ## sort
 
-`|Map| -> ()`
+`|Map| -> Null`
 
 Sorts the map's entries by key.
 
-`|Map, |Value, Value| -> Value| -> ()`
+`|Map, |Value, Value| -> Value| -> Null`
 
 Sorts the map's entries, based on the output of calling a 'key' function for
 each entry. The entry's key and value are passed into the function as separate
@@ -511,7 +511,7 @@ x
 `|Map, Key, |Value| -> Value| -> Value`
 
 Updates the value associated with a given key by calling a function with either
-the existing value, or `()` if there isn't a matching entry.
+the existing value, or Null if there isn't a matching entry.
 
 The result of the function will either replace an existing value, or if no value
 existed then an entry will be inserted into the map with the given key and the
@@ -568,7 +568,7 @@ x.next()
 # 99
 
 x.next()
-# ()
+# Null
 ```
 
 ### See also

--- a/docs/reference/core_lib/string.md
+++ b/docs/reference/core_lib/string.md
@@ -357,7 +357,7 @@ starting at the first index and ending at the second number.
 
 ### Note
 
-Invalid start indices return Empty.
+Invalid start indices return Null.
 
 ### Example
 
@@ -369,7 +369,7 @@ Invalid start indices return Empty.
 # "cd"
 
 "abcdef".slice 100, 110
-# ()
+# Null
 ```
 
 ## split

--- a/docs/reference/core_lib/test.md
+++ b/docs/reference/core_lib/test.md
@@ -28,7 +28,7 @@ first argument, then the `@tests` Map itself will be passed in as `self`.
 
   # '@post_test' will be run after each test
   @post_test: |self|
-    self.test_data = ()
+    self.test_data = null
 
   # Functions that are tagged with @test are automatically run as tests
   @test basic_assertions: ||
@@ -74,7 +74,7 @@ Tests can be run from a Koto script by calling [`test.run_tests`](#run_tests).
 
 ## assert
 
-`|Bool| -> ()`
+`|Bool| -> Null`
 
 Throws a runtime error if the argument if false.
 
@@ -91,7 +91,7 @@ assert 1 > 2
 
 ## assert_eq
 
-`|Value, Value| -> ()`
+`|Value, Value| -> Null`
 
 Checks the two input values for equality and throws an error if they're not
 equal.
@@ -109,7 +109,7 @@ assert_eq 2 + 2, 5
 
 ## assert_ne
 
-`|Value, Value| -> ()`
+`|Value, Value| -> Null`
 
 Checks the two input values for inequality and throws an error if they're equal.
 
@@ -126,11 +126,11 @@ assert_ne 2 + 2, 4
 
 ## assert_near
 
-`|Number, Number, Number| -> ()`
+`|Number, Number, Number| -> Null`
 
-`|Num2, Num2, Number| -> ()`
+`|Num2, Num2, Number| -> Null`
 
-`|Num4, Num4, Number| -> ()`
+`|Num4, Num4, Number| -> Null`
 
 Checks that the two input numbers are equal, within an allowed margin of error.
 
@@ -151,7 +151,7 @@ assert_near 1.3, 1.32, allowed_error
 
 ## run_tests
 
-`|Map| -> ()`
+`|Map| -> Null`
 
 Runs the tests contained in the map.
 

--- a/docs/reference/core_lib/test.md
+++ b/docs/reference/core_lib/test.md
@@ -160,7 +160,7 @@ Runs the tests contained in the map.
 ```koto
 my_tests =
   @pre_test: |self| self.test_data = 1, 2, 3
-  @post_test: |self| self.test_data = ()
+  @post_test: |self| self.test_data = null
 
   @test data_size: |self| assert_eq self.test_data.size(), 3
   @test failure: |self| assert not self.test_data.is_empty()

--- a/docs/reference/core_lib/tuple.md
+++ b/docs/reference/core_lib/tuple.md
@@ -68,7 +68,7 @@ Matching is performed with the `==` equality operator.
 
 `|Tuple| -> Value`
 
-Returns the first value in the tuple, or `()` if the tuple is empty.
+Returns the first value in the tuple, or Null if the tuple is empty.
 
 ### Example
 
@@ -78,7 +78,7 @@ x.first()
 # 99
 
 [].to_tuple().first()
-# ()
+# Null
 ```
 
 ## get
@@ -88,7 +88,7 @@ x.first()
 
 Gets the Nth value in the tuple.
 If the tuple doesn't contain a value at that position then the provided default
-value is returned. If no default value is provided then `()` is returned.
+value is returned. If no default value is provided then Null is returned.
 
 ### Example
 
@@ -99,7 +99,7 @@ x.get 1
 # -1
 
 x.get -1
-# ()
+# Null
 
 x.get 5, "abc"
 # abc
@@ -109,7 +109,7 @@ x.get 5, "abc"
 
 `|Tuple| -> Value`
 
-Returns the last value in the tuple, or `()` if the tuple is empty.
+Returns the last value in the tuple, or Null if the tuple is empty.
 
 ### Example
 
@@ -119,7 +119,7 @@ x.last()
 # 42
 
 [].to_tuple().last()
-# ()
+# Null
 ```
 
 ## size

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -31,7 +31,7 @@ thread_local! {
 }
 
 fn make_poetry_meta_map() -> Rc<RefCell<MetaMap>> {
-    use Value::{Empty, Iterator, Str};
+    use Value::{Iterator, Null, Str};
 
     let mut bindings = MetaMap::with_type_name("Poetry");
 
@@ -40,7 +40,7 @@ fn make_poetry_meta_map() -> Rc<RefCell<MetaMap>> {
         |poetry: &mut KotoPoetry, _, args| match args {
             [Str(text)] => {
                 poetry.0.add_source_material(text);
-                Ok(Empty)
+                Ok(Null)
             }
             unexpected => unexpected_type_error_with_slice(
                 "poetry.add_source_material",
@@ -60,7 +60,7 @@ fn make_poetry_meta_map() -> Rc<RefCell<MetaMap>> {
     bindings.add_named_instance_fn_mut("next_word", |poetry: &mut KotoPoetry, _, _| {
         let result = match poetry.0.next_word() {
             Some(word) => Str(word.as_ref().into()),
-            None => Empty,
+            None => Null,
         };
         Ok(result)
     });
@@ -87,13 +87,13 @@ impl Iterator for PoetryIter {
     type Item = ValueIteratorOutput;
 
     fn next(&mut self) -> Option<Self::Item> {
-        use Value::{Empty, Str};
+        use Value::{Null, Str};
 
         match self.poetry.data.borrow_mut().downcast_mut::<KotoPoetry>() {
             Some(poetry) => {
                 let result = match poetry.0.next_word() {
                     Some(word) => Str(word.as_ref().into()),
-                    None => Empty,
+                    None => Null,
                 };
                 Some(ValueIteratorOutput::Value(result))
             }

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -1,6 +1,6 @@
 @main = ||
   n = match koto.args.get 0
-    () then 10
+    null then 10
     arg then arg.to_number()
 
   a = []

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -61,7 +61,7 @@ fannkuch = |n|
 
 @main = ||
   n = match koto.args.get 0
-    () then 4
+    null then 4
     arg then arg.to_number()
 
   sum, flips = fannkuch n

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -6,7 +6,7 @@ fib = |n|
 
 @main = ||
   n = match koto.args.get 0
-    () then 8
+    null then 8
     arg then arg.to_number()
 
   fib n

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -118,7 +118,7 @@ run_nbody = |n|
 
 @main = ||
   n = match koto.args.get 0
-    () then 100
+    null then 100
     arg then arg.to_number()
 
   initial_energy, end_energy = run_nbody n

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -46,7 +46,7 @@ spectral_norm = |n|
 
 @main = ||
   n = match koto.args.get 0
-    () then 4
+    null then 4
     arg then arg.to_number()
 
   result = spectral_norm n

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -29,7 +29,7 @@ number_to_english = |n|
 
 @main = ||
   n = match koto.args.get 0
-    () then 50
+    null then 50
     arg then arg.to_number()
 
   result = -n..n

--- a/koto/tests/assignment.koto
+++ b/koto/tests/assignment.koto
@@ -52,7 +52,10 @@
     assert_eq b, 2
     assert_eq c, 3
 
-  @test assign_empty: ||
-    a = ()
-    assert_eq a, ()
-    assert_ne 1, ()
+  @test assign_null: ||
+    a = null
+    assert_eq a, null
+    assert_ne 1, null
+
+    b = () # Empty parentheses resolve to null
+    assert_eq a, b

--- a/koto/tests/function_closures.koto
+++ b/koto/tests/function_closures.koto
@@ -16,6 +16,6 @@
         inner2 = |x|
           x + b + c
         inner2 a
-      b, c = (), () # inner and inner2 have captured their own copies of b and c
+      b, c = null, null # inner and inner2 have captured their own copies of b and c
       inner()
     assert_eq (capture_test 1, 2, 3), 6

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -36,8 +36,8 @@
 
   @test missing_args_set_to_empty: ||
     foo = |a, b|
-      a = if a == null then 100 else a
-      b = if b == null then 42 else b
+      a = a or 100
+      b = b or 42
       a + b
 
     assert_eq foo(), 142

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -36,8 +36,8 @@
 
   @test missing_args_set_to_empty: ||
     foo = |a, b|
-      a = if a == () then 100 else a
-      b = if b == () then 42 else b
+      a = if a == null then 100 else a
+      b = if b == null then 42 else b
       a + b
 
     assert_eq foo(), 142

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -33,7 +33,7 @@ ccc
     assert_eq file.read_line(), "aaa"
     assert_eq file.read_line(), "bbb"
     assert_eq file.read_line(), "ccc"
-    assert_eq file.read_line(), ()
+    assert_eq file.read_line(), null
 
   @test file_read_to_string: ||
     file = io.open test_path

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -10,7 +10,7 @@ make_foo = |x|
     assert_eq i.next(), 1
     assert_eq i.next(), 2
     assert_eq i.next(), 3
-    assert_eq i.next(), ()
+    assert_eq i.next(), null
 
   @test to_list: ||
     assert_eq (1..=3).to_list(), [1, 2, 3]
@@ -169,7 +169,7 @@ make_foo = |x|
       (1, 3, 5, 7, 9)
 
   @test last: ||
-    assert_eq (101..101).take(5).last(), ()
+    assert_eq (101..101).take(5).last(), null
     assert_eq (101..1000).take(5).last(), 105
 
   @test max: ||
@@ -297,7 +297,7 @@ make_foo = |x|
       n = 0
       loop
         match iter.next()
-          () then return
+          null then return
           value if n % 2 == 0 then yield value
         n += 1
 

--- a/koto/tests/libs/json.koto
+++ b/koto/tests/libs/json.koto
@@ -15,7 +15,7 @@ from test import assert, assert_eq
       io.stderr().write_line "Error reading decoding json data: $error"
       assert false
 
-    assert_eq data.empty, ()
+    assert_eq data.empty, null
     assert_eq data.number, 99
     assert_eq data.bool, true
     assert_eq data.string, "O_o"

--- a/koto/tests/libs/tempfile.koto
+++ b/koto/tests/libs/tempfile.koto
@@ -16,5 +16,5 @@ from test import assert, assert_eq
     assert_eq (io.read_to_string temp_path), temp.read_to_string()
 
     # Temp files are deleted when they're no longer used
-    temp = ()
+    temp = null
     assert not io.exists temp_path

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -53,8 +53,8 @@ make_foo = |x|
 
   @test first_last: ||
     z = []
-    assert_eq z.first(), ()
-    assert_eq z.last(), ()
+    assert_eq z.first(), null
+    assert_eq z.last(), null
 
     z = [99]
     assert_eq z.first(), 99
@@ -80,8 +80,8 @@ make_foo = |x|
   @test get: ||
     x = (0..10).to_list()
     assert_eq (x.get 5), 5
-    assert_eq (x.get 15), ()
-    assert_eq (x.get -1), ()
+    assert_eq (x.get 15), null
+    assert_eq (x.get -1), null
 
   @test fill: ||
     a = [1, 2, 3]
@@ -91,13 +91,13 @@ make_foo = |x|
   @test resize: ||
     z = [42]
     z.resize 4
-    assert_eq z, [42, (), (), ()]
+    assert_eq z, [42, null, null, null]
     z.resize 2
-    assert_eq z, [42, ()]
+    assert_eq z, [42, null]
     z.resize 4, 99
-    assert_eq z, [42, (), 99, 99]
+    assert_eq z, [42, null, 99, 99]
     z.resize 2, -1
-    assert_eq z, [42, ()]
+    assert_eq z, [42, null]
 
   @test resize_with: ||
     z = [42]

--- a/koto/tests/lists.koto
+++ b/koto/tests/lists.koto
@@ -29,7 +29,7 @@
     a, b, c = [10, 20], [30, 40]
     assert_eq a, [10, 20]
     assert_eq b, [30, 40]
-    assert_eq c, ()
+    assert_eq c, null
 
   @test list_shared_data: ||
     a = [0, 1, 2]

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -38,7 +38,7 @@ make_foo = |x|
   @test insert_without_value: ||
     m = foo: 42
     m.insert "foo"
-    assert_eq m.foo, ()
+    assert_eq m.foo, null
 
   @test insert_non_string_key: ||
     m = {}
@@ -54,7 +54,7 @@ make_foo = |x|
   @test get: ||
     m = foo: 42
     assert_eq (m.get "foo"), 42
-    assert_eq (m.get "bar"), ()
+    assert_eq (m.get "bar"), null
 
     # A default value can also be provided
     assert_eq (m.get "bar", 99), 99
@@ -63,13 +63,13 @@ make_foo = |x|
     m = {}
     m.insert 1, "O_o"
     assert_eq (m.get 1), "O_o"
-    assert_eq (m.get make_num2 1, 2), ()
+    assert_eq (m.get make_num2 1, 2), null
 
   @test get_index: ||
     m = foo: 42, bar: 99, baz: 123
     assert_eq (m.get_index 1), ("bar", 99)
     assert_eq (m.get_index 2), ("baz", 123)
-    assert_eq (m.get_index 5), (),
+    assert_eq (m.get_index 5), null
 
     # A default value can also be provided
     assert_eq (m.get_index 5, ("not found", -1)), ("not found", -1)
@@ -85,7 +85,7 @@ make_foo = |x|
     assert_eq (m.remove "foo"), 42
     assert_eq m.keys().to_tuple(), ("bar", "baz")
     assert_eq (m.remove "bar"), 99
-    assert_eq (m.remove "foo"), ()
+    assert_eq (m.remove "foo"), null
 
   @test size: ||
     assert_eq {}.size(), 0

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -19,8 +19,8 @@
   @test map_iteration: ||
     m = foo: 42, bar: -1
     for key, value in m
-      assert_ne key, ()
-      assert_ne value, ()
+      assert_ne key, null
+      assert_ne value, null
 
   @test map_string_keys: ||
     # Strings can be used for keys that would otherwise be disallowed

--- a/koto/tests/num2_4.koto
+++ b/koto/tests/num2_4.koto
@@ -92,7 +92,7 @@ from number import pi, pi_4
     a, b, c = x
     assert_eq a, 1
     assert_eq b, 2
-    assert_eq c, ()
+    assert_eq c, null
 
   @test element_unpacking_num4: ||
     x = make_num4 5, 6, 7, 8
@@ -101,7 +101,7 @@ from number import pi, pi_4
     assert_eq b, 6
     assert_eq c, 7
     assert_eq d, 8
-    assert_eq e, ()
+    assert_eq e, null
 
   @test iterator_ops_num2: ||
     x = make_num2 1, 2
@@ -110,7 +110,7 @@ from number import pi, pi_4
     i = x.iter()
     assert_eq i.next(), 1
     assert_eq i.next(), 2
-    assert_eq i.next(), ()
+    assert_eq i.next(), null
 
   @test iterator_ops_num4: ||
     x = make_num4 5, 6, 7, 8
@@ -120,4 +120,4 @@ from number import pi, pi_4
     i.skip(2)
     assert_eq i.next(), 7
     assert_eq i.next(), 8
-    assert_eq i.next(), ()
+    assert_eq i.next(), null

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -121,7 +121,7 @@ zzz
     x = "abcdef".slice 2 # end index is optional
     assert_eq x, "cdef"
     assert_eq (x.slice 1, 3), "de"
-    assert_eq (x.slice 10, 13), ()
+    assert_eq (x.slice 10, 13), null
 
   @test split: ||
     assert_eq "a,b,c".split(",").to_tuple(), ("a", "b", "c")

--- a/koto/tests/test_module/baz.koto
+++ b/koto/tests/test_module/baz.koto
@@ -3,7 +3,7 @@
 import number.pi, test.assert_eq
 assert_eq pi, pi
 
-export qux = ()
+export qux = null
 
 @main = ||
   # Redefine qux to check that main has been called

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -7,7 +7,7 @@
 
   # '@post_test' will be run after each test
   @post_test: |self|
-    self.test_data = ()
+    self.test_data = null
 
   # Functions with that are tagged with @test will be automatically run as tests
   @test size: |self|

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -41,13 +41,13 @@ make_foo = |x|
 
   @test first: ||
     assert_eq (1, 2, 3).first(), 1
-    assert_eq [].to_tuple().first(), ()
+    assert_eq [].to_tuple().first(), null
 
   @test get: ||
     x = 1, 2, 3
     assert_eq (x.get 0), 1
     assert_eq (x.get 2), 3
-    assert_eq (x.get 4), ()
+    assert_eq (x.get 4), null
 
   @test indexing: ||
     x = 1, 2, 3
@@ -67,7 +67,7 @@ make_foo = |x|
 
   @test last: ||
     assert_eq (1, 2, 3).last(), 3
-    assert_eq [].to_tuple().last(), ()
+    assert_eq [].to_tuple().last(), null
 
   @test size: ||
     assert_eq (1, 2).size(), 2

--- a/libs/json/src/lib.rs
+++ b/libs/json/src/lib.rs
@@ -10,7 +10,7 @@ use {
 
 pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<Value, String> {
     let result = match value {
-        JsonValue::Null => Value::Empty,
+        JsonValue::Null => Value::Null,
         JsonValue::Bool(b) => Value::Bool(*b),
         JsonValue::Number(n) => match n.as_i64() {
             Some(n64) => Value::Number(n64.into()),

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -154,7 +154,7 @@ impl ChaChaRng {
         match args {
             [Number(n)] => {
                 self.0 = ChaCha8Rng::seed_from_u64(n.to_bits());
-                Ok(Empty)
+                Ok(Null)
             }
             unexpected => {
                 unexpected_type_error_with_slice("random.seed", "a Number as argument", unexpected)

--- a/libs/yaml/src/lib.rs
+++ b/libs/yaml/src/lib.rs
@@ -10,7 +10,7 @@ use {
 
 pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, String> {
     let result = match value {
-        YamlValue::Null => Value::Empty,
+        YamlValue::Null => Value::Null,
         YamlValue::Bool(b) => Value::Bool(*b),
         YamlValue::Number(n) => match n.as_i64() {
             Some(n64) => Value::Number(n64.into()),

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -413,10 +413,10 @@ impl Compiler {
         self.span_stack.push(*ast.span(node.span));
 
         let result = match &node.node {
-            Node::Empty => {
+            Node::Null => {
                 let result = self.get_result_register(result_register)?;
                 if let Some(result) = result {
-                    self.push_op(SetEmpty, &[result.register]);
+                    self.push_op(SetNull, &[result.register]);
                 }
                 result
             }
@@ -622,7 +622,7 @@ impl Compiler {
 
                 let result = self.get_result_register(result_register)?;
                 if let Some(result) = result {
-                    self.push_op(SetEmpty, &[result.register]);
+                    self.push_op(SetNull, &[result.register]);
                 }
                 result
             }
@@ -631,19 +631,19 @@ impl Compiler {
 
                 let result = self.get_result_register(result_register)?;
                 if let Some(result) = result {
-                    self.push_op(SetEmpty, &[result.register]);
+                    self.push_op(SetNull, &[result.register]);
                 }
                 result
             }
             Node::Return(None) => match self.get_result_register(result_register)? {
                 Some(result) => {
-                    self.push_op(SetEmpty, &[result.register]);
+                    self.push_op(SetNull, &[result.register]);
                     self.push_op(Return, &[result.register]);
                     Some(result)
                 }
                 None => {
                     let register = self.push_register()?;
-                    self.push_op(SetEmpty, &[register]);
+                    self.push_op(SetNull, &[register]);
                     self.push_op(Return, &[register]);
                     self.pop_register()?;
                     None
@@ -807,7 +807,7 @@ impl Compiler {
             }
         } else {
             let register = self.push_register()?;
-            self.push_op(Op::SetEmpty, &[register]);
+            self.push_op(Op::SetNull, &[register]);
             self.push_op_without_span(Op::Return, &[register]);
             self.pop_register()?;
         }
@@ -930,18 +930,18 @@ impl Compiler {
         expressions: &[AstIndex],
         ast: &Ast,
     ) -> CompileNodeResult {
-        use Op::SetEmpty;
+        use Op::SetNull;
 
         let result = match expressions {
             [] => match self.get_result_register(result_register)? {
                 Some(result) => {
-                    self.push_op(SetEmpty, &[result.register]);
+                    self.push_op(SetNull, &[result.register]);
                     Some(result)
                 }
                 None => {
                     // TODO Under what conditions do we get into this branch?
                     let register = self.push_register()?;
-                    self.push_op(SetEmpty, &[register]);
+                    self.push_op(SetNull, &[register]);
                     Some(CompileResult::with_temporary(register))
                 }
             },
@@ -2866,7 +2866,7 @@ impl Compiler {
         if let Some(else_node) = else_node {
             self.compile_node(expression_result_register, ast.node(*else_node), ast)?;
         } else if let Some(result) = result {
-            self.push_op_without_span(SetEmpty, &[result.register]);
+            self.push_op_without_span(SetNull, &[result.register]);
         }
 
         // We're at the end, so update the if and else if jump placeholders
@@ -3145,7 +3145,7 @@ impl Compiler {
             let pattern_node = ast.node(*pattern);
 
             match &pattern_node.node {
-                Node::Empty
+                Node::Null
                 | Node::BoolTrue
                 | Node::BoolFalse
                 | Node::Number0
@@ -3415,7 +3415,7 @@ impl Compiler {
 
         let result = self.get_result_register(result_register)?;
         if let Some(result) = result {
-            self.push_op(SetEmpty, &[result.register]);
+            self.push_op(SetNull, &[result.register]);
         }
 
         let stack_count = self.frame().register_stack.len();

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -87,7 +87,7 @@ pub enum Instruction {
         target: u8,
         source: u8,
     },
-    SetEmpty {
+    SetNull {
         register: u8,
     },
     SetBool {
@@ -420,7 +420,7 @@ impl fmt::Display for Instruction {
         match self {
             Error { message } => unreachable!("{message}"),
             Copy { .. } => write!(f, "Copy"),
-            SetEmpty { .. } => write!(f, "SetEmpty"),
+            SetNull { .. } => write!(f, "SetNull"),
             SetBool { .. } => write!(f, "SetBool"),
             SetNumber { .. } => write!(f, "SetNumber"),
             LoadFloat { .. } => write!(f, "LoadFloat"),
@@ -504,7 +504,7 @@ impl fmt::Debug for Instruction {
         match self {
             Error { message } => unreachable!("{message}"),
             Copy { target, source } => write!(f, "Copy\t\tresult: {target}\tsource: {source}"),
-            SetEmpty { register } => write!(f, "SetEmpty\tresult: {register}"),
+            SetNull { register } => write!(f, "SetNull\t\tresult: {register}"),
             SetBool { register, value } => {
                 write!(f, "SetBool\t\tresult: {register}\tvalue: {value}")
             }
@@ -1014,7 +1014,7 @@ impl Iterator for InstructionReader {
                 target: get_u8!(),
                 source: get_u8!(),
             }),
-            Op::SetEmpty => Some(SetEmpty {
+            Op::SetNull => Some(SetNull {
                 register: get_u8!(),
             }),
             Op::SetFalse => Some(SetBool {

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -268,12 +268,15 @@ pub enum Instruction {
     Jump {
         offset: usize,
     },
-    JumpIf {
+    JumpBack {
+        offset: usize,
+    },
+    JumpIfTrue {
         register: u8,
         offset: usize,
-        jump_condition: bool,
     },
-    JumpBack {
+    JumpIfFalse {
+        register: u8,
         offset: usize,
     },
     Call {
@@ -464,8 +467,9 @@ impl fmt::Display for Instruction {
             Equal { .. } => write!(f, "Equal"),
             NotEqual { .. } => write!(f, "NotEqual"),
             Jump { .. } => write!(f, "Jump"),
-            JumpIf { .. } => write!(f, "JumpIf"),
             JumpBack { .. } => write!(f, "JumpBack"),
+            JumpIfTrue { .. } => write!(f, "JumpIfTrue"),
+            JumpIfFalse { .. } => write!(f, "JumpIfFalse"),
             Call { .. } => write!(f, "Call"),
             CallInstance { .. } => write!(f, "CallInstance"),
             Return { .. } => write!(f, "Return"),
@@ -661,15 +665,13 @@ impl fmt::Debug for Instruction {
                 write!(f, "NotEqual\tresult: {register}\tlhs: {lhs}\t\trhs: {rhs}")
             }
             Jump { offset } => write!(f, "Jump\t\toffset: {offset}"),
-            JumpIf {
-                register,
-                offset,
-                jump_condition,
-            } => write!(
-                f,
-                "JumpIf\t\tresult: {register}\toffset: {offset}\tcondition: {jump_condition}",
-            ),
             JumpBack { offset } => write!(f, "JumpBack\toffset: {offset}"),
+            JumpIfTrue { register, offset } => {
+                write!(f, "JumpIfTrue\tresult: {register}\toffset: {offset}")
+            }
+            JumpIfFalse { register, offset } => {
+                write!(f, "JumpIfFalse\tresult: {register}\toffset: {offset}")
+            }
             Call {
                 result,
                 function,
@@ -1261,17 +1263,15 @@ impl Iterator for InstructionReader {
             Op::Jump => Some(Jump {
                 offset: get_u16!() as usize,
             }),
-            Op::JumpTrue => Some(JumpIf {
-                register: get_u8!(),
-                offset: get_u16!() as usize,
-                jump_condition: true,
-            }),
-            Op::JumpFalse => Some(JumpIf {
-                register: get_u8!(),
-                offset: get_u16!() as usize,
-                jump_condition: false,
-            }),
             Op::JumpBack => Some(JumpBack {
+                offset: get_u16!() as usize,
+            }),
+            Op::JumpIfTrue => Some(JumpIfTrue {
+                register: get_u8!(),
+                offset: get_u16!() as usize,
+            }),
+            Op::JumpIfFalse => Some(JumpIfFalse {
+                register: get_u8!(),
                 offset: get_u16!() as usize,
             }),
             Op::Call => Some(Call {

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -15,10 +15,10 @@ pub enum Op {
     /// `[Copy, *target, *source]`
     Copy,
 
-    /// Sets a register to contain Empty
+    /// Sets a register to contain Null
     ///
     /// `[*target]`
-    SetEmpty,
+    SetNull,
 
     /// Sets a register to contain Bool(false)
     ///

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -323,20 +323,20 @@ pub enum Op {
     /// `[offset[2]]`
     Jump,
 
-    /// Causes the instruction pointer to jump forward, if a condition is true
-    ///
-    /// `[*condition, offset[2]]`
-    JumpTrue,
-
-    /// Causes the instruction pointer to jump forward, if a condition is false
-    ///
-    /// `[*condition, offset[2]]`
-    JumpFalse,
-
     /// Causes the instruction pointer to jump back by a number of bytes
     ///
     /// `[offset[2]]`
     JumpBack,
+
+    /// Causes the instruction pointer to jump forward, if a condition is true
+    ///
+    /// `[*condition, offset[2]]`
+    JumpIfTrue,
+
+    /// Causes the instruction pointer to jump forward, if a condition is false
+    ///
+    /// `[*condition, offset[2]]`
+    JumpIfFalse,
 
     /// Calls a function
     ///

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -341,7 +341,7 @@ impl Koto {
     }
 
     pub fn set_script_path(&mut self, path: Option<PathBuf>) -> Result<(), KotoError> {
-        use Value::{Empty, Map, Str};
+        use Value::{Map, Null, Str};
 
         let (script_dir, script_path) = match &path {
             Some(path) => {
@@ -354,12 +354,12 @@ impl Koto {
                         let s = p.to_string_lossy();
                         Str(s.into_owned().into())
                     })
-                    .unwrap_or(Empty);
+                    .unwrap_or(Null);
                 let script_path = Str(path.display().to_string().into());
 
                 (script_dir, script_path)
             }
-            None => (Empty, Empty),
+            None => (Null, Null),
         };
 
         self.script_path = path;

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -82,6 +82,7 @@ pub enum Token {
     Loop,
     Match,
     Not,
+    Null,
     Or,
     Return,
     Switch,
@@ -481,6 +482,7 @@ impl<'a> TokenLexer<'a> {
             check_keyword!("loop", Loop);
             check_keyword!("match", Match);
             check_keyword!("not", Not);
+            check_keyword!("null", Null);
             check_keyword!("or", Or);
             check_keyword!("return", Return);
             check_keyword!("switch", Switch);

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -8,8 +8,8 @@ use {
 /// Nodes refer to each other via [AstIndex]s, see [AstNode](crate::AstNode).
 #[derive(Clone, Debug, PartialEq)]
 pub enum Node {
-    /// An Empty node, used for `()` empty expressions
-    Empty,
+    /// The `null` keyword
+    Null,
 
     /// A single expression wrapped in parentheses
     Nested(AstIndex),
@@ -266,7 +266,7 @@ pub enum Node {
 
 impl Default for Node {
     fn default() -> Self {
-        Node::Empty
+        Node::Null
     }
 }
 
@@ -274,7 +274,7 @@ impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Node::*;
         match self {
-            Empty => write!(f, "Empty"),
+            Null => write!(f, "Null"),
             Nested(_) => write!(f, "Nested"),
             Id(_) => write!(f, "Id"),
             Meta(_, _) => write!(f, "Meta"),

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1358,6 +1358,10 @@ impl<'source> Parser<'source> {
         let start_indent = self.current_indent();
         if let Some(peeked) = self.peek_next_token(context) {
             let result = match peeked.token {
+                Token::Null => {
+                    self.consume_next_token(context);
+                    self.push_node(Empty)
+                }
                 Token::True => {
                     self.consume_next_token(context);
                     self.push_node(BoolTrue)
@@ -2219,7 +2223,7 @@ impl<'source> Parser<'source> {
 
         let result = match self.peek_next_token(&pattern_context) {
             Some(peeked) => match peeked.token {
-                True | False | Number | SingleQuote | DoubleQuote | Subtract => {
+                True | False | Null | Number | SingleQuote | DoubleQuote | Subtract => {
                     return self.parse_term(&mut pattern_context)
                 }
                 Id => match self.parse_id(&mut pattern_context)? {

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1360,7 +1360,7 @@ impl<'source> Parser<'source> {
             let result = match peeked.token {
                 Token::Null => {
                     self.consume_next_token(context);
-                    self.push_node(Empty)
+                    self.push_node(Null)
                 }
                 Token::True => {
                     self.consume_next_token(context);
@@ -2268,7 +2268,7 @@ impl<'source> Parser<'source> {
 
                     if self.peek_token() == Some(RoundClose) {
                         self.consume_token();
-                        Some(self.push_node(Node::Empty)?)
+                        Some(self.push_node(Node::Null)?)
                     } else {
                         let tuple_patterns = self.parse_nested_match_patterns()?;
 
@@ -2523,7 +2523,7 @@ impl<'source> Parser<'source> {
 
     // Parses expressions contained in round parentheses
     // The result may be:
-    //   - Empty
+    //   - Null
     //   - A single value
     //   - A comma-separated tuple
     fn parse_nested_expressions(
@@ -2576,7 +2576,7 @@ impl<'source> Parser<'source> {
         }
 
         let expressions_node = match expressions.as_slice() {
-            [] if !last_token_was_a_comma => self.push_node(Node::Empty)?,
+            [] if !last_token_was_a_comma => self.push_node(Node::Null)?,
             [single_expression] if !last_token_was_a_comma => {
                 self.push_node_with_start_span(Node::Nested(*single_expression), start_span)?
             }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -86,7 +86,7 @@ null"#;
                     string_literal(1, QuotationMark::Double),
                     string_literal(2, QuotationMark::Single),
                     Id(constant(3)),
-                    Empty,
+                    Null,
                     MainBlock {
                         body: vec![0, 1, 2, 3, 4, 5, 6, 7],
                         local_count: 0,
@@ -989,7 +989,7 @@ min..max
             check_ast(
                 source,
                 &[
-                    Empty,
+                    Null,
                     MainBlock {
                         body: vec![0],
                         local_count: 0,
@@ -4798,7 +4798,7 @@ match x, y
                     Id(constant(4)),
                     Number0, // 10
                     Id(constant(5)),
-                    Empty,
+                    Null,
                     TempTuple(vec![11, 12]),
                     Id(constant(5)),
                     Number0, // 15
@@ -4859,7 +4859,7 @@ match x.foo 42
                     )),
                     Lookup((LookupNode::Id(constant(1)), Some(2))),
                     Lookup((LookupNode::Root(0), Some(3))),
-                    Empty, // 5
+                    Null, // 5
                     Number0,
                     Number1,
                     Match {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -75,7 +75,7 @@ false
 "hello"
 'world'
 a
-()"#;
+null"#;
             check_ast(
                 source,
                 &[
@@ -974,6 +974,22 @@ min..max
                 source,
                 &[
                     Tuple(vec![]),
+                    MainBlock {
+                        body: vec![0],
+                        local_count: 0,
+                    },
+                ],
+                None,
+            )
+        }
+
+        #[test]
+        fn empty_parentheses_without_comma() {
+            let source = "()";
+            check_ast(
+                source,
+                &[
+                    Empty,
                     MainBlock {
                         body: vec![0],
                         local_count: 0,
@@ -4826,7 +4842,7 @@ match x, y
         fn match_expression_is_lookup_call() {
             let source = "
 match x.foo 42
-  () then 0
+  null then 0
   else 1
 ";
             check_ast(

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -19,7 +19,7 @@ use {
 };
 
 pub fn make_module() -> ValueMap {
-    use Value::{Bool, Empty, Str};
+    use Value::{Bool, Null, Str};
 
     let result = ValueMap::new();
 
@@ -45,7 +45,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("current_dir", |_, _| {
         let result = match std::env::current_dir() {
             Ok(path) => Str(path.to_string_lossy().to_string().into()),
-            Err(_) => Empty,
+            Err(_) => Null,
         };
         Ok(result)
     });
@@ -126,7 +126,7 @@ pub fn make_module() -> ValueMap {
         };
 
         match result {
-            Ok(_) => Ok(Empty),
+            Ok(_) => Ok(Null),
             Err(e) => Err(e.with_prefix("io.print")),
         }
     });
@@ -150,7 +150,7 @@ pub fn make_module() -> ValueMap {
             [Str(path)] => {
                 let path = Path::new(path.as_str());
                 match fs::remove_file(&path) {
-                    Ok(_) => Ok(Value::Empty),
+                    Ok(_) => Ok(Value::Null),
                     Err(error) => runtime_error!(
                         "io.remove_file: Error while removing file '{}': {error}",
                         path.to_string_lossy(),
@@ -181,12 +181,12 @@ thread_local! {
 }
 
 fn make_file_meta_map() -> Rc<RefCell<MetaMap>> {
-    use Value::{Empty, Number, Str};
+    use Value::{Null, Number, Str};
 
     let mut meta = MetaMap::with_type_name("File");
 
     meta.add_named_instance_fn_mut("flush", |file: &mut File, _, _| match file.flush() {
-        Ok(_) => Ok(Empty),
+        Ok(_) => Ok(Null),
         Err(e) => Err(e.with_prefix("File.flush")),
     });
 
@@ -201,7 +201,7 @@ fn make_file_meta_map() -> Rc<RefCell<MetaMap>> {
                 let newline_bytes = if result.ends_with("\r\n") { 2 } else { 1 };
                 Ok(result[..result.len() - newline_bytes].into())
             }
-            Ok(None) => Ok(Empty),
+            Ok(None) => Ok(Null),
             Err(e) => Err(e.with_prefix("File.read_line")),
         }
     });
@@ -219,7 +219,7 @@ fn make_file_meta_map() -> Rc<RefCell<MetaMap>> {
                 return runtime_error!("File.seek: Negative seek positions not allowed");
             }
             match file.seek(n.into()) {
-                Ok(_) => Ok(Value::Empty),
+                Ok(_) => Ok(Value::Null),
                 Err(e) => Err(e.with_prefix("File.seek")),
             }
         }
@@ -232,7 +232,7 @@ fn make_file_meta_map() -> Rc<RefCell<MetaMap>> {
 
     meta.add_named_instance_fn_mut("write", |file: &mut File, _, args| match args {
         [value] => match file.write(value.to_string().as_bytes()) {
-            Ok(_) => Ok(Value::Empty),
+            Ok(_) => Ok(Value::Null),
             Err(e) => Err(e.with_prefix("File.write")),
         },
         unexpected => {
@@ -253,7 +253,7 @@ fn make_file_meta_map() -> Rc<RefCell<MetaMap>> {
             }
         };
         match file.write(line.as_bytes()) {
-            Ok(_) => Ok(Value::Empty),
+            Ok(_) => Ok(Value::Null),
             Err(e) => Err(e.with_prefix("File.write_line")),
         }
     });

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -143,7 +143,7 @@ pub fn make_module() -> ValueMap {
                     return Err(error);
                 }
             }
-            Ok(Empty)
+            Ok(Null)
         }
         [iterable, f] if iterable.is_iterable() && f.is_callable() => {
             let iterable = iterable.clone();
@@ -159,7 +159,7 @@ pub fn make_module() -> ValueMap {
                     Output::Error(error) => return Err(error),
                 }
             }
-            Ok(Empty)
+            Ok(Null)
         }
         unexpected => unexpected_type_error_with_slice(
             "iterator.consume",
@@ -265,7 +265,7 @@ pub fn make_module() -> ValueMap {
                 }
             }
 
-            Ok(Empty)
+            Ok(Null)
         }
         unexpected => unexpected_type_error_with_slice(
             "iterator.find",
@@ -409,7 +409,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("last", |vm, args| match vm.get_args(args) {
         [iterable] if iterable.is_iterable() => {
             let iterable = iterable.clone();
-            let mut result = Empty;
+            let mut result = Null;
 
             let mut iter = vm.make_iterator(iterable)?.map(collect_pair);
             for output in &mut iter {
@@ -490,7 +490,7 @@ pub fn make_module() -> ValueMap {
                 }
             }
 
-            Ok(result.map_or(Empty, |(min, max)| Tuple(vec![min, max].into())))
+            Ok(result.map_or(Null, |(min, max)| Tuple(vec![min, max].into())))
         }
         [iterable, key_fn] if iterable.is_iterable() && key_fn.is_callable() => {
             let iterable = iterable.clone();
@@ -529,7 +529,7 @@ pub fn make_module() -> ValueMap {
                 }
             }
 
-            Ok(result.map_or(Empty, |((min, _), (max, _))| Tuple(vec![min, max].into())))
+            Ok(result.map_or(Null, |((min, _), (max, _))| Tuple(vec![min, max].into())))
         }
         unexpected => unexpected_type_error_with_slice(
             "iterator.min_max",
@@ -542,7 +542,7 @@ pub fn make_module() -> ValueMap {
         [Iterator(i)] => match i.clone().next().map(collect_pair) {
             Some(Output::Value(value)) => Ok(value),
             Some(Output::Error(error)) => Err(error),
-            None => Ok(Value::Empty),
+            None => Ok(Value::Null),
             _ => unreachable!(),
         },
         unexpected => {
@@ -583,7 +583,7 @@ pub fn make_module() -> ValueMap {
                 }
             }
 
-            Ok(Empty)
+            Ok(Null)
         }
         unexpected => unexpected_type_error_with_slice(
             "iterator.position",
@@ -738,7 +738,7 @@ pub fn make_module() -> ValueMap {
                         result.insert(key.into(), value);
                     }
                     Output::Value(value) => {
-                        result.insert(value.into(), Value::Empty);
+                        result.insert(value.into(), Value::Null);
                     }
                     Output::Error(error) => return Err(error),
                 }
@@ -942,7 +942,7 @@ fn run_iterator_comparison_by_key(
         }
     }
 
-    Ok(result_and_key.map_or(Value::Empty, |(value, _)| value))
+    Ok(result_and_key.map_or(Value::Null, |(value, _)| value))
 }
 
 // Compares two values using BinaryOp::Less

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -9,8 +9,8 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("exports", |vm, _| Ok(Value::Map(vm.exports().clone())));
 
-    result.add_value("script_dir", Empty);
-    result.add_value("script_path", Empty);
+    result.add_value("script_dir", Null);
+    result.add_value("script_path", Null);
 
     result.add_fn("type", |vm, args| match vm.get_args(args) {
         [value] => Ok(Str(value.type_as_string().into())),

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -79,7 +79,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("first", |vm, args| match vm.get_args(args) {
         [List(l)] => match l.data().first() {
             Some(value) => Ok(value.clone()),
-            None => Ok(Empty),
+            None => Ok(Null),
         },
         unexpected => {
             unexpected_type_error_with_slice("list.first", "a List as argument", unexpected)
@@ -88,7 +88,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("get", |vm, args| {
         let (list, index, default) = match vm.get_args(args) {
-            [List(list), Number(n)] => (list, n, &Empty),
+            [List(list), Number(n)] => (list, n, &Null),
             [List(list), Number(n), default] => (list, n, default),
             unexpected => {
                 return unexpected_type_error_with_slice(
@@ -132,7 +132,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("last", |vm, args| match vm.get_args(args) {
         [List(l)] => match l.data().last() {
             Some(value) => Ok(value.clone()),
-            None => Ok(Empty),
+            None => Ok(Null),
         },
         unexpected => {
             unexpected_type_error_with_slice("list.last", "a List as argument", unexpected)
@@ -142,7 +142,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("pop", |vm, args| match vm.get_args(args) {
         [List(l)] => match l.data_mut().pop() {
             Some(value) => Ok(value),
-            None => Ok(Empty),
+            None => Ok(Null),
         },
         unexpected => {
             unexpected_type_error_with_slice("list.pop", "a List as argument", unexpected)
@@ -183,12 +183,12 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("resize", |vm, args| match vm.get_args(args) {
         [List(l), Number(n)] if *n >= 0.0 => {
-            l.data_mut().resize(n.into(), Empty);
-            Ok(Empty)
+            l.data_mut().resize(n.into(), Null);
+            Ok(Null)
         }
         [List(l), Number(n), value] if *n >= 0.0 => {
             l.data_mut().resize(n.into(), value.clone());
-            Ok(Empty)
+            Ok(Null)
         }
         unexpected => unexpected_type_error_with_slice(
             "list.resize",
@@ -216,7 +216,7 @@ pub fn make_module() -> ValueMap {
                 Ordering::Equal => {}
             }
 
-            Ok(Empty)
+            Ok(Null)
         }
         unexpected => unexpected_type_error_with_slice(
             "list.resize_with",
@@ -251,7 +251,7 @@ pub fn make_module() -> ValueMap {
                         Err(error) => return Err(error.with_prefix("list.retain")),
                     }
                 }
-                l.data_mut().resize(write_index, Empty);
+                l.data_mut().resize(write_index, Null);
                 l
             }
             [List(l), value] => {
@@ -385,7 +385,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("swap", |vm, args| match vm.get_args(args) {
         [List(a), List(b)] => {
             std::mem::swap(a.data_mut().deref_mut(), b.data_mut().deref_mut());
-            Ok(Empty)
+            Ok(Null)
         }
         unexpected => {
             unexpected_type_error_with_slice("list.swap", "two Lists as arguments", unexpected)

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -15,7 +15,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("clear", |vm, args| match vm.get_args(args) {
         [Map(m)] => {
             m.data_mut().clear();
-            Ok(Empty)
+            Ok(Null)
         }
         unexpected => {
             unexpected_type_error_with_slice("map.clear", "a Map as argument", unexpected)
@@ -47,7 +47,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("get", |vm, args| {
         let (map, key, default) = match vm.get_args(args) {
-            [Map(map), key] if key.is_immutable() => (map, key, &Empty),
+            [Map(map), key] if key.is_immutable() => (map, key, &Null),
             [Map(map), key, default] if key.is_immutable() => (map, key, default),
             unexpected => {
                 return unexpected_type_error_with_slice(
@@ -66,7 +66,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("get_index", |vm, args| {
         let (map, index, default) = match vm.get_args(args) {
-            [Map(map), Number(n)] => (map, n, &Empty),
+            [Map(map), Number(n)] => (map, n, &Null),
             [Map(map), Number(n), default] => (map, n, default),
             unexpected => {
                 return unexpected_type_error_with_slice(
@@ -85,15 +85,15 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("insert", |vm, args| match vm.get_args(args) {
         [Map(m), key] if key.is_immutable() => {
-            match m.data_mut().insert(key.clone().into(), Empty) {
+            match m.data_mut().insert(key.clone().into(), Null) {
                 Some(old_value) => Ok(old_value),
-                None => Ok(Empty),
+                None => Ok(Null),
             }
         }
         [Map(m), key, value] if key.is_immutable() => {
             match m.data_mut().insert(key.clone().into(), value.clone()) {
                 Some(old_value) => Ok(old_value),
-                None => Ok(Empty),
+                None => Ok(Null),
             }
         }
         unexpected => unexpected_type_error_with_slice(
@@ -122,7 +122,7 @@ pub fn make_module() -> ValueMap {
         [Map(m), key] if key.is_immutable() => {
             match m.data_mut().shift_remove(&ValueKey::from(key.clone())) {
                 Some(old_value) => Ok(old_value),
-                None => Ok(Empty),
+                None => Ok(Null),
             }
         }
         unexpected => {
@@ -138,7 +138,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("sort", |vm, args| match vm.get_args(args) {
         [Map(m)] => {
             m.data_mut().sort_keys();
-            Ok(Empty)
+            Ok(Null)
         }
         [Map(l), f] if f.is_callable() => {
             let m = l.clone();
@@ -167,7 +167,7 @@ pub fn make_module() -> ValueMap {
                         Ok(val) => val,
                         Err(e) => {
                             error.get_or_insert(Err(e.with_prefix("map.sort")));
-                            Empty
+                            Null
                         }
                     },
                 };
@@ -177,7 +177,7 @@ pub fn make_module() -> ValueMap {
                         Ok(val) => val,
                         Err(e) => {
                             error.get_or_insert(Err(e.with_prefix("map.sort")));
-                            Empty
+                            Null
                         }
                     },
                 };
@@ -194,7 +194,7 @@ pub fn make_module() -> ValueMap {
             if let Some(error) = error {
                 error
             } else {
-                Ok(Empty)
+                Ok(Null)
             }
         }
         unexpected => unexpected_type_error_with_slice(
@@ -206,7 +206,7 @@ pub fn make_module() -> ValueMap {
 
     result.add_fn("update", |vm, args| match vm.get_args(args) {
         [Map(m), key, f] if key.is_immutable() && f.is_callable() => {
-            do_map_update(m.clone(), key.clone().into(), Empty, f.clone(), vm)
+            do_map_update(m.clone(), key.clone().into(), Null, f.clone(), vm)
         }
         [Map(m), key, default, f] if key.is_immutable() && f.is_callable() => do_map_update(
             m.clone(),

--- a/src/runtime/src/core/string.rs
+++ b/src/runtime/src/core/string.rs
@@ -129,7 +129,7 @@ pub fn make_module() -> ValueMap {
             let bounds = usize::from(*from)..input.len();
             let result = match input.with_bounds(bounds) {
                 Some(result) => Str(result),
-                None => Empty,
+                None => Null,
             };
             Ok(result)
         }
@@ -137,7 +137,7 @@ pub fn make_module() -> ValueMap {
             let bounds = usize::from(*from)..usize::from(*to);
             let result = match input.with_bounds(bounds) {
                 Some(result) => Str(result),
-                None => Empty,
+                None => Null,
             };
             Ok(result)
         }

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -554,8 +554,8 @@ mod tests {
             check_format_output("{} foo {0}", &[Value::Number(1.into())], "1 foo 1");
             check_format_output(
                 "{1} - {0} {} - {}",
-                &[Value::Number(2.into()), Value::Empty],
-                "() - 2 2 - ()",
+                &[Value::Number(2.into()), Value::Null],
+                "null - 2 2 - null",
             );
         }
 

--- a/src/runtime/src/core/test.rs
+++ b/src/runtime/src/core/test.rs
@@ -24,7 +24,7 @@ pub fn make_module() -> ValueMap {
                 }
             }
         }
-        Ok(Empty)
+        Ok(Null)
     });
 
     result.add_fn("assert_eq", |vm, args| match vm.get_args(args) {
@@ -33,7 +33,7 @@ pub fn make_module() -> ValueMap {
             let b = b.clone();
             let result = vm.run_binary_op(BinaryOp::Equal, a.clone(), b.clone());
             match result {
-                Ok(Bool(true)) => Ok(Empty),
+                Ok(Bool(true)) => Ok(Null),
                 Ok(Bool(false)) => {
                     runtime_error!("Assertion failed, '{a}' is not equal to '{b}'")
                 }
@@ -54,7 +54,7 @@ pub fn make_module() -> ValueMap {
             let b = b.clone();
             let result = vm.run_binary_op(BinaryOp::NotEqual, a.clone(), b.clone());
             match result {
-                Ok(Bool(true)) => Ok(Empty),
+                Ok(Bool(true)) => Ok(Null),
                 Ok(Bool(false)) => {
                     runtime_error!("Assertion failed, '{a}' should not be equal to '{b}'")
                 }
@@ -72,7 +72,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("assert_near", |vm, args| match vm.get_args(args) {
         [Number(a), Number(b), Number(allowed_diff)] => {
             if number_near(*a, *b, *allowed_diff) {
-                Ok(Empty)
+                Ok(Null)
             } else {
                 runtime_error!(
                     "Assertion failed, '{a}' and '{b}' are not within {allowed_diff} of each other"
@@ -82,7 +82,7 @@ pub fn make_module() -> ValueMap {
         [Num2(a), Num2(b), Number(allowed_diff)] => {
             let allowed_diff: f64 = allowed_diff.into();
             if f64_near(a.0, b.0, allowed_diff) && f64_near(a.1, b.1, allowed_diff) {
-                Ok(Empty)
+                Ok(Null)
             } else {
                 runtime_error!(
                     "Assertion failed, '{a}' and '{b}' are not within {allowed_diff} of each other"
@@ -96,7 +96,7 @@ pub fn make_module() -> ValueMap {
                 && f32_near(a.2, b.2, allowed_diff)
                 && f32_near(a.3, b.3, allowed_diff)
             {
-                Ok(Empty)
+                Ok(Null)
             } else {
                 runtime_error!(
                     "Assertion failed, '{a}' and '{b}' are not within {allowed_diff} of each other"

--- a/src/runtime/src/core/tuple.rs
+++ b/src/runtime/src/core/tuple.rs
@@ -43,14 +43,14 @@ pub fn make_module() -> ValueMap {
     result.add_fn("first", |vm, args| match vm.get_args(args) {
         [Tuple(t)] => match t.data().first() {
             Some(value) => Ok(value.clone()),
-            None => Ok(Empty),
+            None => Ok(Null),
         },
         unexpected => expected_tuple_error("first", unexpected),
     });
 
     result.add_fn("get", |vm, args| {
         let (tuple, index, default) = match vm.get_args(args) {
-            [Tuple(tuple), Number(n)] => (tuple, n, &Empty),
+            [Tuple(tuple), Number(n)] => (tuple, n, &Null),
             [Tuple(tuple), Number(n), default] => (tuple, n, default),
             unexpected => {
                 return unexpected_type_error_with_slice(
@@ -70,7 +70,7 @@ pub fn make_module() -> ValueMap {
     result.add_fn("last", |vm, args| match vm.get_args(args) {
         [Tuple(t)] => match t.data().last() {
             Some(value) => Ok(value.clone()),
-            None => Ok(Empty),
+            None => Ok(Null),
         },
         unexpected => expected_tuple_error("last", unexpected),
     });

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -131,7 +131,7 @@ impl MetaMap {
     ///     "set_to_zero",
     ///     |data: &mut FooData, _value, _extra_args| {
     ///         data.x = 0;
-    ///         Ok(Value::Empty),
+    ///         Ok(Value::Null),
     ///     }
     /// );
     pub fn add_named_instance_fn_mut<T, F>(&mut self, fn_name: &str, f: F)

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -12,7 +12,7 @@ use {
 #[derive(Clone, Debug)]
 pub enum Value {
     /// The default type representing the absence of a value
-    Empty,
+    Null,
 
     /// A boolean, can be either true or false
     Bool(bool),
@@ -93,7 +93,7 @@ impl Value {
     #[inline]
     pub(crate) fn as_ref(&self) -> ValueRef {
         match &self {
-            Value::Empty => ValueRef::Empty,
+            Value::Null => ValueRef::Null,
             Value::Bool(b) => ValueRef::Bool(b),
             Value::Number(n) => ValueRef::Number(n),
             Value::Num2(n) => ValueRef::Num2(n),
@@ -140,7 +140,7 @@ impl Value {
         use Value::*;
         matches!(
             self,
-            Empty | Bool(_) | Number(_) | Num2(_) | Num4(_) | Range(_) | Str(_)
+            Null | Bool(_) | Number(_) | Num2(_) | Num4(_) | Range(_) | Str(_)
         )
     }
 
@@ -178,7 +178,7 @@ impl Value {
     pub fn type_as_string(&self) -> String {
         use Value::*;
         match &self {
-            Empty => "Empty".to_string(),
+            Null => "Null".to_string(),
             Bool(_) => "Bool".to_string(),
             Number(ValueNumber::F64(_)) => "Float".to_string(),
             Number(ValueNumber::I64(_)) => "Int".to_string(),
@@ -214,7 +214,7 @@ impl Value {
 
 impl Default for Value {
     fn default() -> Self {
-        Value::Empty
+        Value::Null
     }
 }
 
@@ -222,7 +222,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Value::*;
         match self {
-            Empty => f.write_str("()"),
+            Null => f.write_str("null"),
             Bool(b) => write!(f, "{b}"),
             Number(n) => write!(f, "{n}"),
             Num2(n) => write!(f, "{n}"),

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -636,7 +636,7 @@ impl Iterator for GeneratorIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.vm.continue_running() {
-            Ok(Value::Empty) => None,
+            Ok(Value::Null) => None,
             Ok(Value::TemporaryTuple(_)) => {
                 unreachable!("Yield shouldn't produce temporary tuples")
             }

--- a/src/runtime/src/value_key.rs
+++ b/src/runtime/src/value_key.rs
@@ -31,7 +31,7 @@ impl PartialEq for ValueKey {
             (Bool(a), Bool(b)) => a == b,
             (Str(a), Str(b)) => a == b,
             (Range(a), Range(b)) => a == b,
-            (Empty, Empty) => true,
+            (Null, Null) => true,
             _ => false,
         }
     }
@@ -84,9 +84,9 @@ impl PartialOrd for ValueKey {
         use Value::*;
 
         match (&self.0, &other.0) {
-            (Empty, Empty) => Some(Ordering::Equal),
-            (Empty, _) => Some(Ordering::Less),
-            (_, Empty) => Some(Ordering::Greater),
+            (Null, Null) => Some(Ordering::Equal),
+            (Null, _) => Some(Ordering::Less),
+            (_, Null) => Some(Ordering::Greater),
             (Number(a), Number(b)) => a.partial_cmp(b),
             (Num2(a), Num2(b)) => a.partial_cmp(b),
             (Num4(a), Num4(b)) => a.partial_cmp(b),
@@ -101,9 +101,9 @@ impl Ord for ValueKey {
         use Value::*;
 
         match (&self.0, &other.0) {
-            (Empty, Empty) => Ordering::Equal,
-            (Empty, _) => Ordering::Less,
-            (_, Empty) => Ordering::Greater,
+            (Null, Null) => Ordering::Equal,
+            (Null, _) => Ordering::Less,
+            (_, Null) => Ordering::Greater,
             (Number(a), Number(b)) => a.cmp(b),
             (Str(a), Str(b)) => a.cmp(b),
             _ => Ordering::Less,
@@ -116,7 +116,7 @@ impl Eq for ValueKey {}
 // Currently only used to support DataMap::get_with_string()
 #[derive(Clone, Debug)]
 pub(crate) enum ValueRef<'a> {
-    Empty,
+    Null,
     Bool(&'a bool),
     Number(&'a ValueNumber),
     Num2(&'a num2::Num2),
@@ -128,7 +128,7 @@ pub(crate) enum ValueRef<'a> {
 impl<'a> From<&'a Value> for ValueRef<'a> {
     fn from(value: &'a Value) -> Self {
         match value {
-            Value::Empty => ValueRef::Empty,
+            Value::Null => ValueRef::Null,
             Value::Bool(b) => ValueRef::Bool(b),
             Value::Number(n) => ValueRef::Number(n),
             Value::Num2(n) => ValueRef::Num2(n),
@@ -151,7 +151,7 @@ impl<'a> PartialEq for ValueRef<'a> {
             (Bool(a), Bool(b)) => a == b,
             (Str(a), Str(b)) => a == b,
             (Range(a), Range(b)) => a == b,
-            (Empty, Empty) => true,
+            (Null, Null) => true,
             _ => false,
         }
     }
@@ -166,7 +166,7 @@ impl<'a> Hash for ValueRef<'a> {
         std::mem::discriminant(self).hash(state);
 
         match self {
-            Empty => {}
+            Null => {}
             Bool(b) => b.hash(state),
             Number(n) => n.hash(state),
             Num2(n) => n.hash(state),

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -237,12 +237,9 @@ mod tests {
         let mut data = m.data_mut();
 
         assert!(data.get_with_string("test").is_none());
-        data.add_value("test", Value::Empty);
+        data.add_value("test", Value::Null);
         assert!(data.get_with_string("test").is_some());
-        assert!(matches!(
-            data.remove_with_string("test"),
-            Some(Value::Empty)
-        ));
+        assert!(matches!(data.remove_with_string("test"), Some(Value::Null)));
         assert!(data.get_with_string("test").is_none());
     }
 }

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -21,7 +21,7 @@ mod external_values {
     }
 
     fn make_external_value_meta_map() -> Rc<RefCell<MetaMap>> {
-        use Value::{Bool, Empty, Number};
+        use Value::{Bool, Null, Number};
 
         let mut meta = MetaMap::with_type_name("TestExternalData");
 
@@ -39,7 +39,7 @@ mod external_values {
                         match other.data().downcast_ref::<TestExternalData>() {
                             Some(other_data) => {
                                 data.x = other_data.x;
-                                Ok(Empty)
+                                Ok(Null)
                             }
                             None => runtime_error!(
                                 "{fn_name} - unexpected other type: {}",

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1737,10 +1737,10 @@ foo min..max, 20
         }
 
         #[test]
-        fn missing_arg_set_to_empty() {
+        fn missing_arg_set_to_null() {
             let script = "
 foo = |a, b|
-  if b == ()
+  if b == null
     99
   else
     -1
@@ -1750,10 +1750,10 @@ foo 42
         }
 
         #[test]
-        fn missing_arg_set_to_empty_with_list_as_first_arg() {
+        fn missing_arg_set_to_null_with_list_as_first_arg() {
             let script = "
 foo = |a, b|
-  if b == ()
+  if b == null
     99
   else
     -1
@@ -1763,11 +1763,11 @@ foo [42]
         }
 
         #[test]
-        fn missing_arg_set_to_empty_with_list_as_first_arg_and_capture() {
+        fn missing_arg_set_to_null_with_list_as_first_arg_and_capture() {
             let script = "
 x = 123
 foo = |a, b|
-  if b == ()
+  if b == null
     x
   else
     -1
@@ -1777,10 +1777,10 @@ foo [42]
         }
 
         #[test]
-        fn missing_arg_set_to_empty_with_list_as_first_arg_for_generator() {
+        fn missing_arg_set_to_null_with_list_as_first_arg_for_generator() {
             let script = "
 foo = |a, b|
-  if b == ()
+  if b == null
     yield 123
   else
     yield -1
@@ -1854,7 +1854,7 @@ gen(1..=5).to_tuple()";
         fn generator_with_missing_arg() {
             let script = "
 gen = |xs|
-  xs = if xs == () then (1, 2, 3) else xs
+  xs = if xs == null then (1, 2, 3) else xs
   for x in xs
     yield x
 gen().to_tuple()";
@@ -1899,7 +1899,7 @@ gen().to_tuple()
             let script = "
 x = 1, 2, 3
 gen = |offset, bar...|
-  offset = if offset == () then 10 else offset
+  offset = if offset == null then 10 else offset
   for y in x
     yield y + offset
 gen().to_tuple()

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -43,7 +43,7 @@ mod vm {
         }
     }
 
-    mod operators {
+    mod arithmetic {
         use super::*;
 
         #[test]
@@ -60,6 +60,18 @@ mod vm {
         fn subtract_divide_modulo() {
             test_script("(20 - 2) / 3 % 4", 2.into());
         }
+
+        #[test]
+        fn negation() {
+            let script = "
+a = 99
+-a";
+            test_script(script, number(-99));
+        }
+    }
+
+    mod logic {
+        use super::*;
 
         #[test]
         fn comparison() {
@@ -85,6 +97,36 @@ mod vm {
         }
 
         #[test]
+        fn not_coerced_null() {
+            test_script("not null", true.into());
+        }
+
+        #[test]
+        fn not_coerced_value() {
+            test_script("not 42", false.into());
+        }
+
+        #[test]
+        fn or_with_coerced_null() {
+            let script = "
+x = null
+x or 42";
+            test_script(script, 42.into());
+        }
+
+        #[test]
+        fn or_with_coerced_value() {
+            let script = "
+x = 99
+x or 42";
+            test_script(script, 99.into());
+        }
+    }
+
+    mod assignment {
+        use super::*;
+
+        #[test]
         fn assignment() {
             let script = "
 a = 1 * 3
@@ -99,14 +141,6 @@ x = x = 1
 y = y = 2
 ";
             test_script(script, 2.into());
-        }
-
-        #[test]
-        fn negation() {
-            let script = "
-a = 99
--a";
-            test_script(script, number(-99));
         }
     }
 
@@ -1855,7 +1889,7 @@ gen(1..=5).to_tuple()";
         fn generator_with_missing_arg() {
             let script = "
 gen = |xs|
-  xs = if xs == null then (1, 2, 3) else xs
+  xs = xs or (1, 2, 3)
   for x in xs
     yield x
 gen().to_tuple()";
@@ -1900,7 +1934,7 @@ gen().to_tuple()
             let script = "
 x = 1, 2, 3
 gen = |offset, bar...|
-  offset = if offset == null then 10 else offset
+  offset = offset or 10
   for y in x
     yield y + offset
 gen().to_tuple()

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -17,8 +17,9 @@ mod vm {
         use super::*;
 
         #[test]
-        fn empty() {
-            test_script("()", Empty);
+        fn null() {
+            test_script("null", Null);
+            test_script("()", Null);
         }
 
         #[test]
@@ -360,7 +361,7 @@ x";
             let script = "
 a, b, c = [7, 8]
 a, b, c";
-            test_script(script, value_tuple(&[7.into(), 8.into(), Empty]));
+            test_script(script, value_tuple(&[7.into(), 8.into(), Null]));
         }
 
         #[test]
@@ -370,7 +371,7 @@ a, b, c = [1, 2], [3, 4]
 a, b, c";
             test_script(
                 script,
-                value_tuple(&[number_list(&[1, 2]), number_list(&[3, 4]), Empty]),
+                value_tuple(&[number_list(&[1, 2]), number_list(&[3, 4]), Null]),
             );
         }
 
@@ -441,7 +442,7 @@ x";
 if 5 < 4
   42
 ";
-            test_script(script, Empty);
+            test_script(script, Null);
         }
 
         #[test]
@@ -454,7 +455,7 @@ else if 2 == 3
 else if false
   99
 ";
-            test_script(script, Empty);
+            test_script(script, Null);
         }
 
         #[test]
@@ -784,7 +785,7 @@ x
                         }
                     }
                 }
-                Ok(Empty)
+                Ok(Null)
             });
 
             test_script_with_vm(vm, script, expected_output);
@@ -799,13 +800,13 @@ x
         #[test]
         fn function() {
             let script = "assert 1 + 1 == 2";
-            test_script_with_prelude(script, Empty);
+            test_script_with_prelude(script, Null);
         }
 
         #[test]
         fn function_two_args() {
             let script = "assert 1 + 1 == 2, 2 < 3";
-            test_script_with_prelude(script, Empty);
+            test_script_with_prelude(script, Null);
         }
     }
 
@@ -852,7 +853,7 @@ add(5, 6)";
 foo = |a, b| b
 foo 42
 ";
-            test_script(script, Empty);
+            test_script(script, Null);
         }
 
         #[test]
@@ -969,7 +970,7 @@ f 5, 10, 20, 30";
             let script = "
 f = |a, b...| b
 f()";
-            test_script(script, Empty);
+            test_script(script, Null);
         }
 
         #[test]
@@ -1046,7 +1047,7 @@ f = |x|
     return
   x
 f -42";
-            test_script(script, Empty);
+            test_script(script, Null);
         }
 
         #[test]

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -9,7 +9,7 @@ mod vm {
         koto_runtime::{
             runtime_error, DataMap, IntRange,
             Value::{self, *},
-            ValueList, ValueMap, Vm,
+            ValueList, ValueMap, ValueTuple, Vm,
         },
     };
 
@@ -129,6 +129,11 @@ a = 99
 
     mod tuples {
         use super::*;
+
+        #[test]
+        fn empty() {
+            test_script("(,)", Tuple(ValueTuple::default()));
+        }
 
         #[test]
         fn one_entry() {

--- a/src/serialize/src/lib.rs
+++ b/src/serialize/src/lib.rs
@@ -13,7 +13,7 @@ impl<'a> Serialize for SerializableValue<'a> {
         S: Serializer,
     {
         match self.0 {
-            Value::Empty => s.serialize_unit(),
+            Value::Null => s.serialize_unit(),
             Value::Bool(b) => s.serialize_bool(*b),
             Value::Number(n) => {
                 if n.is_f64() {


### PR DESCRIPTION
This PR introduces a `null` keyword as the preferred alternative to the existing `()` syntax for creating non-values. The code and documentation now refer to `null` / `Null` instead of `()` / `Empty`.

Additionally, bool coercions have been introduced, following the Lua pattern `null` coercing to `false`, and all other values coercing to `true`.

This allows for using `or` as a [null coalescing operator](https://en.wikipedia.org/wiki/Null_coalescing_operator) in Koto, rather than introducing a new keyword or operator.

e.g.
```coffee
foo = |x|
  x = x or 42 # Previously you would need to write `x = if x == null then 42 else x`
  print x

foo()
# 42
```
