### PR TITLE
Syntax improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,8 +141,8 @@ The Koto project adheres to
 - Map equality comparisons now don't rely on maps having keys in the same order.
   - e.g.
     ```koto
-    x = foo: 42, bar: 99
-    y = bar: 99, foo: 42
+    x = {foo: 42, bar: 99}
+    y = {bar: 99, foo: 42}
     # Before
     assert_eq x != y, true
     # After
@@ -162,7 +162,7 @@ The Koto project adheres to
   bodies need to use `then`.
   - This reverts a change made in `0.9.0`, in practice it's less distracting to
     have `then` required in all arms.
-- Parsing of multi-line containers is now more flexible.
+- Parsing of multi-line braced expressions is now more flexible.
   - e.g.
     ```koto
     # The following style of list declaration was previously disallowed
@@ -171,6 +171,9 @@ The Koto project adheres to
         , 3
         ]
     ```
+- Curly braces are now required when declaring a Map with inline syntax.
+  - This reverts a change made in 0.9 which created too many ambiguous parsing 
+    situations in practice.
 
 #### Core Library
 

--- a/examples/poetry/scripts/reference.koto
+++ b/examples/poetry/scripts/reference.koto
@@ -1,6 +1,6 @@
 @main = ||
-  input_file = io.extend_path koto.script_dir, "..", "..", "..",
-    "docs", "reference", "core_lib", "string.md"
+  input_file = io.extend_path 
+    koto.script_dir, "..", "..", "..", "docs", "reference", "core_lib", "string.md"
   generator = poetry.new io.read_to_string input_file
 
   separator = "==================================================="

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -144,7 +144,7 @@ make_foo = |x|
 
   @test generate: ||
     import iterator.generate
-    state = x: 0
+    state = {x: 0}
     f = || state.x += 1
     assert_eq generate(f).take(3).to_tuple(), (1, 2, 3)
     assert_eq generate(5, f).to_tuple(), (4, 5, 6, 7, 8)
@@ -178,7 +178,7 @@ make_foo = |x|
     assert_eq ("hello", "goodbye").max(), "hello"
 
     # A key function can be used to convert values before the max comparison is performed
-    x = foo: 42, bar: 99
+    x = {foo: 42, bar: 99}
     assert_eq x.max(|(key, value)| value), ("bar", 99)
 
     x = [[1], [2, 3], [4, 5, 6]]

--- a/koto/tests/line_breaks.koto
+++ b/koto/tests/line_breaks.koto
@@ -1,3 +1,46 @@
+m = {
+  foo:
+    42,
+  bar:
+    -1,
+}
+assert_eq m.bar, -1
+
+x = [
+  42,
+  99,
+]
+assert_eq x[1], 99
+
+y = 
+  [ 42
+  , 99
+  ]
+assert_eq x, y
+
+x = (
+  1, # indentation is flexible inside braced expressions
+2, 
+    3, 4,
+  5,
+)
+assert_eq x.last(), 5
+
+# Linebreaks before operators
+a = 1
+  + 2 + #- inline comment -# 3
+    # Another comment
+    + 4
+assert_eq a, 10
+
+# Linebreaks after operators
+a = 1 +
+    # Indentation can increase between operators
+      2 + #- inline comment -# 3 +
+        # Another comment
+        4
+
+assert_eq a, 10
 a = make_num4
   0, 1, 2, 3
 b = make_num4
@@ -53,36 +96,3 @@ assert_equal
   1234,
   1234
 
-m = {
-  foo:
-    42,
-  bar:
-    -1,
-}
-assert_eq m.bar, -1
-
-x = [
-  42,
-  99,
-]
-assert_eq x[1], 99
-
-y = [ 42
-    , 99
-    ]
-assert_eq x, y
-
-# Linebreaks before operators
-a = 1
-  + 2 + #- inline comment -# 3
-    # Another comment
-    + 4
-assert_eq a, 10
-
-# Linebreaks after operators
-a = 1 +
-    # Indentation can increase between operators
-      2 + #- inline comment -# 3 +
-        # Another comment
-        4
-assert_eq a, 10

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -6,12 +6,12 @@ make_foo = |x|
 
 @tests =
   @test clear: ||
-    m = foo: 42, bar: 99
+    m = {foo: 42, bar: 99}
     m.clear()
     assert_eq m, {}
 
   @test contains_key: ||
-    m = foo: 42, bar: 99
+    m = {foo: 42, bar: 99}
     assert m.contains_key "foo"
     assert m.contains_key "bar"
     assert not m.contains_key "baz"
@@ -23,7 +23,7 @@ make_foo = |x|
     assert_eq m2.bar.baz, 99
 
   @test insert: ||
-    m = foo: 42
+    m = {foo: 42}
     old_value = m.insert "foo", 99
     assert_eq m.foo, 99
     assert_eq old_value, 42
@@ -31,12 +31,12 @@ make_foo = |x|
   @test insert_via_map_module: ||
     # map ops are also available in the map module,
     # which allows access to ops when a key might have a matching name.
-    m = foo: 42
+    m = {foo: 42}
     map.insert m, "foo", -1
     assert_eq m.foo, -1
 
   @test insert_without_value: ||
-    m = foo: 42
+    m = {foo: 42}
     m.insert "foo"
     assert_eq m.foo, null
 
@@ -52,7 +52,7 @@ make_foo = |x|
     assert not {foo: 42}.is_empty()
 
   @test get: ||
-    m = foo: 42
+    m = {foo: 42}
     assert_eq (m.get "foo"), 42
     assert_eq (m.get "bar"), null
 
@@ -66,7 +66,7 @@ make_foo = |x|
     assert_eq (m.get make_num2 1, 2), null
 
   @test get_index: ||
-    m = foo: 42, bar: 99, baz: 123
+    m = {foo: 42, bar: 99, baz: 123}
     assert_eq (m.get_index 1), ("bar", 99)
     assert_eq (m.get_index 2), ("baz", 123)
     assert_eq (m.get_index 5), null
@@ -81,7 +81,7 @@ make_foo = |x|
     assert_eq m.keys().to_tuple(), ("foo", 0)
 
   @test remove: ||
-    m = foo: 42, bar: 99, baz: -1
+    m = {foo: 42, bar: 99, baz: -1}
     assert_eq (m.remove "foo"), 42
     assert_eq m.keys().to_tuple(), ("bar", "baz")
     assert_eq (m.remove "bar"), 99
@@ -92,7 +92,7 @@ make_foo = |x|
     assert_eq {foo: 42}.size(), 1
 
   @test sort: ||
-    m = foo: 42, bar: 99
+    m = {foo: 42, bar: 99}
     assert_eq m.keys().to_tuple(), ("foo", "bar")
 
     m.sort()
@@ -113,7 +113,7 @@ make_foo = |x|
     assert_eq m.keys().to_tuple(), ("baz", "foo", "bar")
 
   @test update: ||
-    m = foo: 42
+    m = {foo: 42}
 
     # update takes a function that receives the entry's current value,
     # which is then replaced with the function's result.
@@ -127,5 +127,5 @@ make_foo = |x|
     assert_eq m.xyz, 50
 
   @test values: ||
-    m = foo: 42, bar: "O_o"
+    m = {foo: 42, bar: "O_o"}
     assert_eq m.values().to_tuple(), (42, "O_o")

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -1,15 +1,16 @@
 @tests =
   @test access_by_key: ||
-    m = key: "value", another_key: "another_value"
+    m = {key: "value", another_key: "another_value"}
     assert_eq m.key, "value"
     assert_eq m.another_key, "another_value"
 
   @test assign_by_key: ||
-    m = key: -1
+    m = {key: -1}
     m.key = 42
     assert_eq m.key, 42
 
   @test implict_key_values: ||
+    # Map values can be automatically inserted when using {} syntax  
     foo, baz = 42, -1
     m = {foo, bar: 99, baz}
     assert_eq m.foo, 42
@@ -17,14 +18,14 @@
     assert_eq m.baz, -1
 
   @test map_iteration: ||
-    m = foo: 42, bar: -1
+    m = {foo: 42, bar: -1}
     for key, value in m
       assert_ne key, null
       assert_ne value, null
 
   @test map_string_keys: ||
     # Strings can be used for keys that would otherwise be disallowed
-    x = "for": -1, 'while': 99, "20": "twenty"
+    x = {"for": -1, 'while': 99, "20": "twenty"}
     assert_eq x."for", -1
     assert_eq x."while", 99
     assert_eq x."20", "twenty"
@@ -60,7 +61,7 @@
     assert_eq sum, 861
 
   @test equality_and_shared_data: ||
-    m = foo: 42, bar: -1
+    m = {foo: 42, bar: -1}
     m2 = m
     assert_eq m, m2
     m2.foo = -1
@@ -80,10 +81,10 @@
     assert_eq m.baz.child_foo, 99
 
   @test addition: ||
-    m = foo: 42
-    m2 = m + bar: -1
+    m = {foo: 42}
+    m2 = m + {bar: -1}
     assert_eq m2.bar, -1
-    m2 += extra: 99
+    m2 += {extra: 99}
     assert_eq m2.extra, 99
 
   @test value_mutation: ||
@@ -136,9 +137,6 @@
     deep.a.b.c.d.e.f = 99
     assert_eq deep.a.b.c.d.e.f, 99
 
-    #... and without curly braces
-    deep2 = a: b: c: d: e: f: 99
-    assert_eq deep, deep2
 
   @test nested_block: ||
     deep =

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -91,6 +91,7 @@ pub enum SyntaxError {
     ExpectedMetaKey,
     ExpectedMetaId,
     ExpectedNegatableExpression,
+    ExpectedLineBreakBeforeMapBlock,
     ExpectedSwitchArmExpression,
     ExpectedSwitchArmExpressionAfterThen,
     ExpectedStringPlaceholderEnd,
@@ -297,6 +298,9 @@ impl fmt::Display for SyntaxError {
             ExpectedMetaKey => f.write_str("Expected meta key after @"),
             ExpectedMetaId => f.write_str("Expected id after @meta"),
             ExpectedNegatableExpression => f.write_str("Expected negatable expression"),
+            ExpectedLineBreakBeforeMapBlock => {
+                f.write_str("Expected a line break before starting a map block")
+            }
             ExpectedStringPlaceholderEnd => {
                 f.write_str("Expected '}' at end of string placeholder")
             }

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -492,44 +492,6 @@ x =
         }
 
         #[test]
-        fn map_inline_without_braces() {
-            let source = "
-x = foo: 42, bar: 'hello'
-";
-            check_ast(
-                source,
-                &[
-                    Id(constant(0)), // x
-                    Int(constant(2)),
-                    string_literal(4, QuotationMark::Single),
-                    Map(vec![
-                        (MapKey::Id(constant(1)), Some(1)),
-                        (MapKey::Id(constant(3)), Some(2)),
-                    ]),
-                    Assign {
-                        target: AssignTarget {
-                            target_index: 0,
-                            scope: Scope::Local,
-                        },
-                        op: AssignOp::Equal,
-                        expression: 3,
-                    },
-                    MainBlock {
-                        body: vec![4],
-                        local_count: 1,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("x"),
-                    Constant::Str("foo"),
-                    Constant::I64(42),
-                    Constant::Str("bar"),
-                    Constant::Str("hello"),
-                ]),
-            )
-        }
-
-        #[test]
         fn map_inline_multiline() {
             let source = r#"
 {

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -165,6 +165,14 @@ x .foo
             use super::*;
 
             #[test]
+            fn block_starting_on_same_line_as_assignment_single_entry() {
+                let source = "
+x = foo: 42
+";
+                check_parsing_fails(source);
+            }
+
+            #[test]
             fn block_starting_on_same_line_as_assignment() {
                 let source = "
 x = foo: 42
@@ -190,6 +198,15 @@ x =
 x =
   foo: 42
   bar: 1, 2, 3
+  baz: 99
+";
+                check_parsing_fails(source);
+            }
+
+            #[test]
+            fn inline_map_without_braces() {
+                let source = "
+x = foo: 42, bar: 99,
   baz: 99
 ";
                 check_parsing_fails(source);

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -222,6 +222,13 @@ x = foo: 42, bar: 99,
 
                 check_parsing_fails(source);
             }
+
+            #[test]
+            fn space_separated_function_call_in_list() {
+                let source = "x = [1, 2, f y, 4]";
+
+                check_parsing_fails(source);
+            }
         }
 
         mod tuples {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1562,7 +1562,7 @@ m = {foo: -1, bar: 42} + {foo: 99}
         #[test]
         fn equality() {
             let script = "
-m = foo: 42, bar: 'abc'
+m = {foo: 42, bar: 'abc'}
 m2 = m.copy()
 m == m2";
             test_script(script, true.into());
@@ -1571,8 +1571,8 @@ m == m2";
         #[test]
         fn equality_different_key_order() {
             let script = "
-m = foo: 42, bar: 'abc'
-m2 = bar: 'abc', foo: 42
+m = {foo: 42, bar: 'abc'}
+m2 = {bar: 'abc', foo: 42}
 m == m2";
             test_script(script, true.into());
         }
@@ -1580,8 +1580,8 @@ m == m2";
         #[test]
         fn inequality() {
             let script = "
-m = foo: 42, bar: 'xyz'
-m2 = foo: 42, bar: 'abc'
+m = {foo: 42, bar: 'xyz'}
+m2 = {foo: 42, bar: 'abc'}
 m != m2";
             test_script(script, true.into());
         }


### PR DESCRIPTION
- Reintroduce mandatory curly braces for comma-separated map definitions
- Allow comma-separated values inside braces to have flexible indentation
