### PR TITLE
Prepare for Rust 1.62

### DIFF
--- a/src/bytecode/src/chunk.rs
+++ b/src/bytecode/src/chunk.rs
@@ -1,7 +1,11 @@
 use {
     crate::InstructionReader,
     koto_parser::{ConstantPool, Span},
-    std::{fmt, path::PathBuf, rc::Rc},
+    std::{
+        fmt::{self, Write},
+        path::PathBuf,
+        rc::Rc,
+    },
 };
 
 /// Debug information for a Koto program
@@ -83,9 +87,10 @@ impl Chunk {
         'outer: loop {
             for i in 1..=16 {
                 match iter.next() {
-                    Some(byte) => result += &format!("{byte:02x}"),
+                    Some(byte) => write!(result, "{byte:02x}").ok(),
                     None => break 'outer,
-                }
+                };
+
                 if i < 16 {
                     result += " ";
 
@@ -132,11 +137,11 @@ impl Chunk {
                     .line
                     .min(source_lines.len() as u32)
                     .max(1) as usize;
-                result += &format!("|{line}| {}\n", source_lines[line - 1]);
+                writeln!(result, "|{line}| {}", source_lines[line - 1]).ok();
                 span = Some(instruction_span);
             }
 
-            result += &format!("{ip}\t{instruction:?}\n");
+            writeln!(result, "{ip}\t{instruction:?}").ok();
             ip = reader.ip;
         }
 

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -1,6 +1,10 @@
 use {
     koto_lexer::{Position, Span},
-    std::{error, fmt, path::PathBuf},
+    std::{
+        error,
+        fmt::{self, Write},
+        path::PathBuf,
+    },
 };
 
 /// An error that represents a problem with the Parser's internal logic, rather than a user error
@@ -389,18 +393,20 @@ pub fn format_error_with_excerpt(
                 excerpt_lines.first().unwrap(),
             );
 
-            excerpt += &format!(
+            write!(
+                excerpt,
                 "{padding}|{}{}",
                 " ".repeat(start_pos.column as usize),
                 "^".repeat((end_pos.column - start_pos.column) as usize)
-            );
+            )
+            .ok();
 
             (excerpt, padding)
         } else {
             let mut excerpt = String::new();
 
             for (excerpt_line, line_number) in excerpt_lines.iter().zip(line_numbers.iter()) {
-                excerpt += &format!(" {line_number:>number_width$} | {excerpt_line}\n",);
+                writeln!(excerpt, " {line_number:>number_width$} | {excerpt_line}").ok();
             }
 
             (excerpt, padding)

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1226,7 +1226,7 @@ impl Vm {
             }
             TemporaryTuple(RegisterSlice { start, count }) => {
                 let count = *count;
-                if (index.abs() as u8) < count {
+                if index.unsigned_abs() < count {
                     let index = signed_index_to_unsigned(index, count as usize);
                     self.clone_register(start + index as u8)
                 } else {
@@ -3199,7 +3199,7 @@ impl fmt::Debug for Vm {
 
 fn signed_index_to_unsigned(index: i8, size: usize) -> usize {
     if index < 0 {
-        size - (index.abs() as usize).min(size)
+        size - (index as isize).unsigned_abs().min(size)
     } else {
         index as usize
     }


### PR DESCRIPTION
This PR fixes a couple of clippy lints that show up in the current 1.62 beta.

- Prefer write! & writeln! over appending the result of format! to strings
- Prefer unsigned_abs() over casting abs() to unsigned
