### PR TITLE
Guide followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ The Koto project adheres to
   - `list`
     - `extend`, `resize_with`
   - `map`
-    - `get_meta_map`, `with_meta_map`
+    - `extend`, `get_meta_map`, `with_meta_map`
   - `number`
     - `acosh`, `asinh`, `atanh`, `atan2`, `lerp`
     - `pi_2`, `pi_4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,8 @@ The Koto project adheres to
     print 'hello'
     #--#
     ```
+- The `+` operator is no longer implemented for Lists and Maps, 
+  `list.extend` and `map.extend` can be used as an alternative.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,8 @@ The Koto project adheres to
   - `iterator`
     - `chunks`, `find`, `flatten`, `generate`, `repeat`, `reversed`,
       `to_num2`, `to_num4`, `windows`
-  - `list.resize_with`
+  - `list`
+    - `extend`, `resize_with`
   - `map`
     - `get_meta_map`, `with_meta_map`
   - `number`

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -19,7 +19,7 @@ returned.
 print! (1..9).all |x| x > 0
 check! true
 
-print! ("", "", "foo").all string.is_empty
+print! ('', '', 'foo').all string.is_empty
 check! false
 
 print! [10, 20, 30]
@@ -46,7 +46,7 @@ if any of the values pass the test.
 print! (1..9).any |x| x == 5
 check! true
 
-print! ("", "", "foo").any string.is_empty
+print! ('', '', 'foo').any string.is_empty
 check! true
 
 print! [10, 20, 30]
@@ -235,8 +235,8 @@ Returns an iterator that provides each value along with an associated index.
 ### Example
 
 ```koto
-print! ("a", "b", "c").enumerate().to_list()
-check! [(0, "a"), (1, "b"), (2, "c")]
+print! ('a', 'b', 'c').enumerate().to_list()
+check! [(0, 'a'), (1, 'b'), (2, 'c')]
 ```
 
 ## find
@@ -310,7 +310,7 @@ This operation is also known in other languages as `reduce`, `accumulate`,
 ### Example
 
 ```koto
-print! ("a", "b", "c").fold "", |result, x| result += x + "-"
+print! ('a', 'b', 'c').fold '', |result, x| result += x + '-'
 check! a-b-c-
 ```
 
@@ -367,14 +367,14 @@ between each adjacent pair of output values.
 ### Example
 
 ```koto
-print! ("a", "b", "c").intersperse("-").to_string()
+print! ('a', 'b', 'c').intersperse('-').to_string()
 check! a-b-c
 
 separators = (1, 2, 3).iter()
-print! ("a", "b", "c")
+print! ('a', 'b', 'c')
   .intersperse || separators.next()
   .to_tuple(),
-check! ("a", 1, "b", 2, "c")
+check! ('a', 1, 'b', 2, 'c')
 ```
 
 ## iter
@@ -701,8 +701,8 @@ Consumes all values coming from the iterator and places them in a list.
 ### Example
 
 ```koto
-print! ("a", 42, (-1, -2)).to_list()
-check! ["a", 42, (-1, -2)]
+print! ('a', 42, (-1, -2)).to_list()
+check! ['a', 42, (-1, -2)]
 ```
 
 ### See also
@@ -728,10 +728,10 @@ key, with Null as the entry's value.
 ### Example
 
 ```koto
-print! ("a", "b", "c").to_map()
+print! ('a', 'b', 'c').to_map()
 check! {a: null, b: null, c: null}
 
-print! ("a", "bbb", "cc")
+print! ('a', 'bbb', 'cc')
   .each |x| x, x.size()
   .to_map()
 check! {a: 1, bbb: 3, cc: 2}
@@ -797,10 +797,10 @@ the formatted values.
 ### Example
 
 ```koto
-print! ("x", "y", "z").to_string()
+print! ('x', 'y', 'z').to_string()
 check! xyz
 
-print! (1, 2, 3).intersperse("-").to_string()
+print! (1, 2, 3).intersperse('-').to_string()
 check! 1-2-3
 ```
 
@@ -821,8 +821,8 @@ Consumes all values coming from the iterator and places them in a tuple.
 ### Example
 
 ```koto
-print! ("a", 42, (-1, -2)).to_list()
-check! ["a", 42, (-1, -2)]
+print! ('a', 42, (-1, -2)).to_list()
+check! ['a', 42, (-1, -2)]
 ```
 
 ### See also
@@ -865,6 +865,6 @@ corresponding pairs of values, one at a time from each input iterable.
 ### Example
 
 ```koto
-print! (1, 2, 3).zip(("a", "b", "c")).to_list()
-check! [(1, "a"), (2, "b"), (3, "c")]
+print! (1, 2, 3).zip(('a', 'b', 'c')).to_list()
+check! [(1, 'a'), (2, 'b'), (3, 'c')]
 ```

--- a/docs/core_lib/list.md
+++ b/docs/core_lib/list.md
@@ -92,6 +92,32 @@ check! [[1, 2], [3, [4, 5]]]
 
 - [`list.copy`](#copy)
 
+## extend
+
+```kototype
+|List, Iterable| -> List
+```
+
+Extends the list with the output of the iterator, and returns the list.
+
+### Example
+
+```koto
+x = [1, 2, 3]
+print! x.extend 'abc'
+check! [1, 2, 3, "a", "b", "c"]
+print! x.last()
+check! c
+print! x.extend [10, 20, 30]
+check! [1, 2, 3, "a", "b", "c", 10, 20, 30]
+print! x.last()
+check! 30
+```
+
+### See also
+
+- [`list.push`](#push)
+
 ## fill
 
 ```kototype

--- a/docs/core_lib/list.md
+++ b/docs/core_lib/list.md
@@ -29,7 +29,7 @@ Matching is performed with the `==` equality operator.
 ### Example
 
 ```koto
-print! [1, "hello", (99, -1)].contains "hello"
+print! [1, 'hello', (99, -1)].contains 'hello'
 check! true
 ```
 
@@ -48,16 +48,16 @@ any nested containers are also unique, use [`list.deep_copy`](#deep-copy).
 ### Example
 
 ```koto
-x = [1, 2, "hello"]
+x = [1, 2, 'hello']
 y = x
-y[0] = "abc" # x and y share the same internal list data
+y[0] = 'abc' # x and y share the same internal list data
 print! x
-check! ["abc", 2, "hello"]
+check! ['abc', 2, 'hello']
 
 z = x.copy()
 z[1] = -1 # z is a copy of x, so has unique internal data
 print! x # x remains unchanged after the modificaton of z
-check! ["abc", 2, "hello"]
+check! ['abc', 2, 'hello']
 ```
 
 ### See also
@@ -105,11 +105,11 @@ Extends the list with the output of the iterator, and returns the list.
 ```koto
 x = [1, 2, 3]
 print! x.extend 'abc'
-check! [1, 2, 3, "a", "b", "c"]
+check! [1, 2, 3, 'a', 'b', 'c']
 print! x.last()
 check! c
 print! x.extend [10, 20, 30]
-check! [1, 2, 3, "a", "b", "c", 10, 20, 30]
+check! [1, 2, 3, 'a', 'b', 'c', 10, 20, 30]
 print! x.last()
 check! 30
 ```
@@ -207,10 +207,10 @@ list.
 
 ```koto
 x = [99, -1, 42]
-print! x.insert 2, "hello"
-check! [99, -1, "hello", 42]
+print! x.insert 2, 'hello'
+check! [99, -1, 'hello', 42]
 print! x
-check! [99, -1, "hello", 42]
+check! [99, -1, 'hello', 42]
 ```
 
 ### See also
@@ -298,10 +298,10 @@ Adds the value to the end of the list, and returns the list.
 
 ```koto
 x = [99, -1]
-print! x.push "hello"
-check! [99, -1, "hello"]
+print! x.push 'hello'
+check! [99, -1, 'hello']
 print! x
-check! [99, -1, "hello"]
+check! [99, -1, 'hello']
 ```
 
 ### See also
@@ -346,14 +346,14 @@ value is provided) are used to fill the new space.
 
 ```koto
 x = [1, 2]
-print! x.resize 4, "x"
-check! [1, 2, "x", "x"]
+print! x.resize 4, 'x'
+check! [1, 2, 'x', 'x']
 
 print! x.resize 3
-check! [1, 2, "x"]
+check! [1, 2, 'x']
 
 print! x.resize 4
-check! [1, 2, "x", null]
+check! [1, 2, 'x', null]
 ```
 
 ## resize_with
@@ -423,11 +423,11 @@ Reverses the order of the list's contents, and returns the list.
 ### Example
 
 ```koto
-x = ["hello", -1, 99, "world"]
+x = ['hello', -1, 99, 'world']
 print! x.reverse()
-check! ["world", 99, -1, "hello"]
+check! ['world', 99, -1, 'hello']
 print! x
-check! ["world", 99, -1, "hello"]
+check! ['world', 99, -1, 'hello']
 ```
 
 ## size
@@ -474,11 +474,11 @@ check! [-1, 1, 42, 99]
 print! x
 check! [-1, 1, 42, 99]
 
-x = ["bb", "ccc", "a"]
+x = ['bb', 'ccc', 'a']
 print! x.sort string.size
-check! ["a", "bb", "ccc"]
+check! ['a', 'bb', 'ccc']
 print! x
-check! ["a", "bb", "ccc"]
+check! ['a', 'bb', 'ccc']
 
 x = [2, 1, 3]
 print! x.sort |n| -n
@@ -536,16 +536,16 @@ provided function, and then returns the list.
 ### Example
 
 ```koto
-x = ["aaa", "bb", "c"]
+x = ['aaa', 'bb', 'c']
 print! x.transform string.size
 check! [3, 2, 1]
 print! x
 check! [3, 2, 1]
 
-print! x.transform |n| "{}".format n
-check! ["3", "2", "1"]
+print! x.transform |n| '{}'.format n
+check! ['3', '2', '1']
 print! x
-check! ["3", "2", "1"]
+check! ['3', '2', '1']
 ```
 
 ## with_size
@@ -559,6 +559,6 @@ Returns a list containing `N` copies of a value.
 ### Example
 
 ```koto
-print! list.with_size 5, "!"
-check! ["!", "!", "!", "!", "!"]
+print! list.with_size 5, '!'
+check! ['!', '!', '!', '!', '!']
 ```

--- a/docs/core_lib/map.md
+++ b/docs/core_lib/map.md
@@ -105,7 +105,7 @@ check! 123
 
 x = {}
 print! x.extend 'abc'.each |c| c, '$c!'
-check! {a: "a!", b: "b!", c: "c!"}
+check! {a: 'a!', b: 'b!', c: 'c!'}
 print! x.c
 check! c!
 ```
@@ -132,16 +132,16 @@ If no default value is provided then Null is returned.
 
 ```koto
 x = {hello: -1}
-print! x.get "hello"
+print! x.get 'hello'
 check! -1
 
-print! x.get "goodbye"
+print! x.get 'goodbye'
 check! null
 
-print! x.get "goodbye", "byeeee"
+print! x.get 'goodbye', 'byeeee'
 check! byeeee
 
-x.insert 99, "xyz"
+x.insert 99, 'xyz'
 print! x.get 99
 check! xyz
 ```
@@ -169,12 +169,12 @@ If no default value is provided then Null is returned.
 ```koto
 x = {foo: -1, bar: -2}
 print! x.get_index 1
-check! ("bar", -2)
+check! ('bar', -2)
 
 print! x.get_index -99
 check! null
 
-print! x.get_index 99, "xyz"
+print! x.get_index 99, 'xyz'
 check! xyz
 ```
 
@@ -234,13 +234,13 @@ If the key didn't already exist, then Null is returned.
 
 ```koto
 x = {hello: -1}
-print! x.insert "hello", 99 # -1 already exists at `hello`, so it's returned here
+print! x.insert 'hello', 99 # -1 already exists at `hello`, so it's returned here
 check! -1
 
 print! x.hello # hello is now 99
 check! 99
 
-print! x.insert "goodbye", 123 # No existing value at `goodbye`, so null is returned
+print! x.insert 'goodbye', 123 # No existing value at `goodbye`, so null is returned
 check! null
 
 print! x.goodbye
@@ -322,13 +322,13 @@ x =
   hello: -1
   goodbye: 99
 
-print! x.remove "hello"
+print! x.remove 'hello'
 check! -1
 
-print! x.remove "xyz"
+print! x.remove 'xyz'
 check! null
 
-print! x.remove "goodbye"
+print! x.remove 'goodbye'
 check! 99
 
 print! x.is_empty()
@@ -353,7 +353,7 @@ Returns the number of entries contained in the map.
 print! {}.size()
 check! 0
 
-print! {"a": 0, "b": 1}.size()
+print! {a: 0, b: 1}.size()
 check! 2
 ```
 
@@ -432,12 +432,12 @@ x =
   hello: -1
   goodbye: 99
 
-print! x.update "hello", |n| n * 2
+print! x.update 'hello', |n| n * 2
 check! -2
 print! x.hello
 check! -2
 
-print! x.update "tschüss", 10, |n| n * 10
+print! x.update 'tschüss', 10, |n| n * 10
 check! 100
 print! x.tschüss
 check! 100

--- a/docs/core_lib/map.md
+++ b/docs/core_lib/map.md
@@ -86,6 +86,34 @@ check! 99
 
 - [`map.copy`](#copy)
 
+## extend
+
+```kototype
+|Map, Iterable| -> Map
+```
+
+Extends the map with the output of the iterator, and returns the map.
+
+### Example
+
+```koto
+x = {foo: 42, bar: 99}
+print! x.extend {baz: 123}
+check! {foo: 42, bar: 99, baz: 123}
+print! x.baz 
+check! 123
+
+x = {}
+print! x.extend 'abc'.each |c| c, '$c!'
+check! {a: "a!", b: "b!", c: "c!"}
+print! x.c
+check! c!
+```
+
+### See also
+
+- [`map.insert`](#insert)
+
 ## get
 
 ```kototype

--- a/docs/core_lib/string.md
+++ b/docs/core_lib/string.md
@@ -12,7 +12,7 @@ contained in the string data.
 ### Example
 
 ```koto
-print! "Hëy!".bytes().to_tuple()
+print! 'Hëy!'.bytes().to_tuple()
 check! (72, 195, 171, 121, 33)
 ```
 
@@ -41,8 +41,8 @@ Note that this is the default iteration behaviour for a string, so calling
 ### Example
 
 ```koto
-print! "Héllø! 👋".chars().to_tuple()
-check! ("H", "é", "l", "l", "ø", "!", " ", "👋")
+print! 'Héllø! 👋'.chars().to_tuple()
+check! ('H', 'é', 'l', 'l', 'ø', '!', ' ', '👋')
 ```
 
 ## contains
@@ -56,16 +56,16 @@ Returns `true` if the second provided string is a sub-string of the first.
 ### Example
 
 ```koto
-print! "xyz".contains "abc"
+print! 'xyz'.contains 'abc'
 check! false
 
-print! "xyz".contains "yz"
+print! 'xyz'.contains 'yz'
 check! true
 
-print! "xyz".contains "xyz"
+print! 'xyz'.contains 'xyz'
 check! true
 
-print! "xyz".contains ""
+print! 'xyz'.contains ''
 check! true
 ```
 
@@ -80,10 +80,10 @@ Returns `true` if the first string ends with the second string.
 ### Example
 
 ```koto
-print! "abcdef".ends_with "def"
+print! 'abcdef'.ends_with 'def'
 check! true
 
-print! "xyz".ends_with "abc"
+print! 'xyz'.ends_with 'abc'
 check! false
 ```
 
@@ -100,7 +100,7 @@ For example, newlines get replaced with `\n`, tabs get replaced with `\t`.
 ### Example
 
 ```koto
-print! "👋".escape()
+print! '👋'.escape()
 check! \u{1f44b}
 ```
 
@@ -130,7 +130,7 @@ The syntax for format strings in Koto is similar to
     - The Map is expected to be the first argument after the format string.
 
 `{` characters can be included in the output string by escaping them with
-another `{`, e.g. `"{{}}".format()` will output `"{}"`.
+another `{`, e.g. `'{{}}'.format()` will output `'{}'`.
 
 #### Formatting modifiers
 
@@ -139,7 +139,7 @@ Modifiers can be provided after a `:` separator in the format string.
 ##### Minimum width, fill, and alignment
 
 A minimum width can be specified, ensuring that the formatted value takes up at
-least that many characters, e.g. `"x{:4}x".format "ab"` will output `xab  x`.
+least that many characters, e.g. `'x{:4}x'.format 'ab'` will output `xab  x`.
 
 The minimum width can be prefixed with an alignment modifier:
 
@@ -147,46 +147,46 @@ The minimum width can be prefixed with an alignment modifier:
 - `^` - centered
 - `>` - right-aligned
 
-e.g. `"x{:>4}x".format "ab"` will output `x  abx`.
+e.g. `'x{:>4}x'.format 'ab'` will output `x  abx`.
 
 Values are left-aligned by default, except for numbers which are right-aligned
-by default, e.g. `"x{:4}x".format 1.2` will output `x 1.2x`.
+by default, e.g. `'x{:4}x'.format 1.2` will output `x 1.2x`.
 
 The alignment modifier can be prefixed with a character which will be used to
 fill any empty space in the formatted string (the default character being ` `).
-e.g. `"{:x^8}".format 1234` will output `xx1234xx`.
+e.g. `'{:x^8}'.format 1234` will output `xx1234xx`.
 
 ##### Maximum width / Precision
 
 A maximum width can be specified following a `.` character,
-e.g. `"{:.2}".format abcd"` will output `ab`.
+e.g. `'{:.2}'.format abcd'` will output `ab`.
 
 For numbers this will define the number of decimal places that should be
 displayed.
 
 Combining a maximum width with a minimum width is allowed, with the minimum
 coming before the maximum in the format string,
-e.g. `"x{:4.2}x".format "abcd"` will output `xab  x`.
+e.g. `'x{:4.2}x'.format 'abcd'` will output `xab  x`.
 
 ### Example
 
 ```koto
-print! "{}, {}!".format "Hello", "World"
+print! '{}, {}!'.format 'Hello', 'World'
 check! Hello, World!
 
-print! "{0}-{1}-{0}".format 99, "xxx"
+print! '{0}-{1}-{0}'.format 99, 'xxx'
 check! 99-xxx-99
 
-print! "{foo} {bar}".format {foo: 42, bar: true}
+print! '{foo} {bar}'.format {foo: 42, bar: true}
 check! 42 true
 
-print! "{:.2}".format 1/3
+print! '{:.2}'.format 1/3
 check! 0.33
 
-print! "{:-^8.2}".format 2/3
+print! '{:-^8.2}'.format 2/3
 check! --0.67--
 
-print! "foo = {foo:8.3}".format {foo: 42}
+print! 'foo = {foo:8.3}'.format {foo: 42}
 check! foo =   42.000
 ```
 
@@ -201,10 +201,10 @@ Returns `true` if the string contains no characters.
 ### Example
 
 ```koto
-print! "abcdef".is_empty()
+print! 'abcdef'.is_empty()
 check! false
 
-print! "".is_empty()
+print! ''.is_empty()
 check! true
 ```
 
@@ -244,11 +244,11 @@ Lines end with either `\r\n` or `\n`.
 ### Example
 
 ```koto
-print! "foo\nbar\nbaz".lines().to_tuple()
-check! ("foo", "bar", "baz")
+print! 'foo\nbar\nbaz'.lines().to_tuple()
+check! ('foo', 'bar', 'baz')
 
-print! "\n\n\n".lines().to_tuple()
-check! ("", "", "")
+print! '\n\n\n'.lines().to_tuple()
+check! ('', '', '')
 ```
 
 ## size
@@ -266,13 +266,13 @@ Equivalent to calling `.chars().count()`.
 ### Example
 
 ```koto
-print! "".size()
+print! ''.size()
 check! 0
 
-print! "abcdef".size()
+print! 'abcdef'.size()
 check! 6
 
-print! "🥳👋😁".size()
+print! '🥳👋😁'.size()
 check! 3
 ```
 
@@ -299,13 +299,13 @@ Invalid start indices return Null.
 ### Example
 
 ```koto
-print! "abcdef".slice 3
+print! 'abcdef'.slice 3
 check! def
 
-print! "abcdef".slice 2, 4
+print! 'abcdef'.slice 2, 4
 check! cd
 
-print! "abcdef".slice 100, 110
+print! 'abcdef'.slice 100, 110
 check! null
 ```
 
@@ -330,14 +330,14 @@ returns true.
 ### Example
 
 ```koto
-print! "a,b,c".split(",").to_tuple()
-check! ("a", "b", "c")
+print! 'a,b,c'.split(',').to_tuple()
+check! ('a', 'b', 'c')
 
-print! "O_O".split("O").to_tuple()
-check! ("", "_", "")
+print! 'O_O'.split('O').to_tuple()
+check! ('', '_', '')
 
-print! "x!y?z".split(|c| c == "!" or c == "?").to_tuple()
-check! ("x", "y", "z")
+print! 'x!y?z'.split(|c| c == '!' or c == '?').to_tuple()
+check! ('x', 'y', 'z')
 ```
 
 ## starts_with
@@ -351,10 +351,10 @@ Returns `true` if the first string starts with the second string.
 ### Example
 
 ```koto
-print! "abcdef".starts_with "abc"
+print! 'abcdef'.starts_with 'abc'
 check! true
 
-print! "xyz".starts_with "abc"
+print! 'xyz'.starts_with 'abc'
 check! false
 ```
 
@@ -369,10 +369,10 @@ Returns a lowercase version of the input string.
 ### Example
 
 ```koto
-print! "HÉLLÖ".to_lowercase()
+print! 'HÉLLÖ'.to_lowercase()
 check! héllö
 
-print! "O_o".to_lowercase()
+print! 'O_o'.to_lowercase()
 check! o_o
 ```
 
@@ -387,10 +387,10 @@ Returns the string parsed as a number.
 ### Example
 
 ```koto
-print! "123".to_number()
+print! '123'.to_number()
 check! 123
 
-print! "-8.9".to_number()
+print! '-8.9'.to_number()
 check! -8.9
 ```
 
@@ -405,10 +405,10 @@ Returns an uppercase version of the input string.
 ### Example
 
 ```koto
-print! "héllö".to_uppercase()
+print! 'héllö'.to_uppercase()
 check! HÉLLÖ
 
-print! "O_o".to_uppercase()
+print! 'O_o'.to_uppercase()
 check! O_O
 ```
 
@@ -423,9 +423,9 @@ Returns the string with whitespace at the start and end of the string trimmed.
 ### Example
 
 ```koto
-print! "   x    ".trim()
+print! '   x    '.trim()
 check! x
 
-print! "     >".trim()
+print! '     >'.trim()
 check! >
 ```

--- a/docs/language/conditional_expressions.md
+++ b/docs/language/conditional_expressions.md
@@ -98,7 +98,7 @@ List and Tuple entries can be matched against, with `...` available for capturin
 rest of the list.
 
 ```koto
-print! match ['a', 'b', 'c'] + [1, 2, 3]
+print! match ['a', 'b', 'c'].extend [1, 2, 3]
   [1, ...] then "Starts with '1'"
   [..., 'y', last] then "Ends with 'y' followed by '$last'"
   ['a', x, others...] then

--- a/docs/language/conditional_expressions.md
+++ b/docs/language/conditional_expressions.md
@@ -91,7 +91,7 @@ fizz_buzz = |n|
 print! (10, 11, 12, 13, 14, 15)
   .each |n| fizz_buzz n
   .to_tuple()
-check! ("Buzz", 11, "Fizz", 13, 14, "Fizz Buzz")
+check! ('Buzz', 11, 'Fizz', 13, 14, 'Fizz Buzz')
 ```
 
 List and Tuple entries can be matched against, with `...` available for capturing the 

--- a/docs/language/lists.md
+++ b/docs/language/lists.md
@@ -32,12 +32,3 @@ y[1] = 99
 print! x # x and y share the same data
 check! [10, 99, 30]
 ```
-
-The `+` operator can be used to join two Lists together into a new List.
-
-```koto
-x = [1, 2, 3]
-y = ['a', 'b', 'c']
-print! x + y
-check! [1, 2, 3, "a", "b", "c"]
-```

--- a/docs/language/maps.md
+++ b/docs/language/maps.md
@@ -76,12 +76,3 @@ m.name = 'Friend'
 print! m.hello()
 check! Hello, Friend!
 ```
-
-Maps can be merged together using the `+` operator.
-
-```koto
-x = {hello: 123}
-y = {goodbye: 99}
-print! x + y
-check! {hello: 123, goodbye: 99}
-```

--- a/docs/language/strings.md
+++ b/docs/language/strings.md
@@ -1,6 +1,6 @@
 # Strings
 
-Strings can be declared using `"` or `'` quotes. 
+Strings can be declared using `'` or `"` quotes. 
 
 ```koto
 print! 'Hello, World!'

--- a/docs/language/tuples.md
+++ b/docs/language/tuples.md
@@ -31,7 +31,7 @@ check! (1, 2, 3)
 x = "a", 10
 y = "b", 20
 print! x, y
-check! (("a", 10), ("b", 20))
+check! (('a', 10), ('b', 20))
 ```
 
 Tuples behave like Lists with a fixed size and with entries that can't be replaced, 

--- a/examples/poetry/scripts/readme.koto
+++ b/examples/poetry/scripts/readme.koto
@@ -1,12 +1,12 @@
 @main = ||
-  input_file = io.extend_path koto.script_dir, "..", "..", "..", "README.md"
+  input_file = io.extend_path koto.script_dir, '..', '..', '..', 'README.md'
   generator = poetry
     .new io.read_to_string input_file
     .iter()
 
-  separator = "==================================================="
+  separator = '==================================================='
   print separator
-  print ""
+  print ''
 
   stanzas = 5
   word_counts = 1, 3, 5, 3, 1
@@ -15,9 +15,9 @@
     for count in word_counts
       line = generator
         .take count
-        .intersperse " "
+        .intersperse ' '
         .to_string()
       print line
-    print ""
+    print ''
 
   print separator

--- a/examples/poetry/scripts/string_docs.koto
+++ b/examples/poetry/scripts/string_docs.koto
@@ -1,6 +1,6 @@
 @main = ||
   input_file = io.extend_path 
-    koto.script_dir, "..", "..", "..", "docs", "reference", "core_lib", "string.md"
+    koto.script_dir, "..", "..", "..", "docs", "core_lib", "string.md"
   generator = poetry.new io.read_to_string input_file
 
   separator = "==================================================="

--- a/examples/poetry/scripts/string_docs.koto
+++ b/examples/poetry/scripts/string_docs.koto
@@ -1,11 +1,11 @@
 @main = ||
   input_file = io.extend_path 
-    koto.script_dir, "..", "..", "..", "docs", "core_lib", "string.md"
+    koto.script_dir, '..', '..', '..', 'docs', 'core_lib', 'string.md'
   generator = poetry.new io.read_to_string input_file
 
-  separator = "==================================================="
+  separator = '==================================================='
   print separator
-  print ""
+  print ''
 
   stanzas = 3
   lines = 5
@@ -15,7 +15,7 @@
       words = [word, word, word]
       match random.pick 0..4
         n if n < 3 then words[n] = words[n].to_uppercase()
-      print "${words[0]}, ${words[1]}. ${words[2]}!"
-    print ""
+      print '${words[0]}, ${words[1]}. ${words[2]}!'
+    print ''
 
   print separator

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -66,9 +66,9 @@ fannkuch = |n|
 
   sum, flips = fannkuch n
 
-  if (koto.args.get 1) != "quiet"
+  if (koto.args.get 1) != 'quiet'
     print sum
-    print "Pfannkuchen($n) = $flips"
+    print 'Pfannkuchen($n) = $flips'
 
 @tests =
   @test fannkuch_5: ||

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -123,11 +123,11 @@ run_nbody = |n|
 
   initial_energy, end_energy = run_nbody n
 
-  quiet = (koto.args.get 1) == "quiet"
+  quiet = (koto.args.get 1) == 'quiet'
 
   if not quiet
-    print "{:.9}", initial_energy
-    print "{:.9}", end_energy
+    print '{:.9}', initial_energy
+    print '{:.9}', end_energy
 
 @tests =
   @test nbody_100: ||

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -51,7 +51,7 @@ spectral_norm = |n|
 
   result = spectral_norm n
 
-  if (koto.args.get 1) != "quiet"
+  if (koto.args.get 1) != 'quiet'
     io.print result
 
 @tests =

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -1,14 +1,13 @@
-digits = "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
-  "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
-  "eighteen", "nineteen"
+digits =
+  'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven',
+  'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen'
 
-tens = "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty",
-  "ninety"
+tens = '', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 'eighty', 'ninety'
 
 number_to_english = |n|
   n = n.floor()
   switch
-    n < 0 then "minus ${number_to_english n.abs()}"
+    n < 0 then 'minus ${number_to_english n.abs()}'
     n < 20 then digits[n]
     n < 100 then
       x = (n / 10).floor()
@@ -16,16 +15,16 @@ number_to_english = |n|
       if y == 0
         tens[x]
       else
-        "${tens[x]}-${digits[y]}"
+        '${tens[x]}-${digits[y]}'
     n < 1000 then
       x = (n / 100).floor()
       x_string = number_to_english x
       y = n % 100
       if y == 0
-        "$x_string hundred"
+        '$x_string hundred'
       else
-        "$x_string hundred and ${number_to_english y}"
-    else "???"
+        '$x_string hundred and ${number_to_english y}'
+    else '???'
 
 @main = ||
   n = match koto.args.get 0
@@ -36,13 +35,13 @@ number_to_english = |n|
     .each |x| number_to_english x
     .to_tuple()
 
-  if not (koto.args.get 1) == "quiet"
+  if not (koto.args.get 1) == 'quiet'
     io.print result
 
 @tests =
   @test number_to_english: ||
-    assert_eq (number_to_english 0), "zero"
-    assert_eq (number_to_english -42), "minus forty-two"
-    assert_eq (number_to_english 217), "two hundred and seventeen"
-    assert_eq (number_to_english 999), "nine hundred and ninety-nine"
-    assert_eq (number_to_english 123456), "???"
+    assert_eq (number_to_english 0), 'zero'
+    assert_eq (number_to_english -42), 'minus forty-two'
+    assert_eq (number_to_english 217), 'two hundred and seventeen'
+    assert_eq (number_to_english 999), 'nine hundred and ninety-nine'
+    assert_eq (number_to_english 123456), '???'

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -257,7 +257,7 @@ make_foo = |x|
   @test sum: ||
     assert_eq (1..=5).sum(), 15
     # An initial value can be provided to override the default initial value of 0
-    assert_eq ([1], [2], [3]).sum([]), [1, 2, 3]
+    assert_eq (1, 2, 3).sum(100), 106
 
   @test sum_with_overloaded_add_operator: ||
     foo = |x|

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -39,6 +39,13 @@ make_foo = |x|
         .to_map(),
       {"entry 1": 1, "entry 2": 2, "entry 3": 3}
 
+    try
+      # Only immutable values can be used as keys
+      x = [[1, 2, 3], [4, 5, 6]].to_map()
+    catch _
+      error_caught = true
+    assert error_caught
+
   @test to_num2: ||
     assert_eq (1, 2).to_num2(), (make_num2 1, 2)
     assert_eq [1].to_num2(), (make_num2 1, 0)

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -36,6 +36,15 @@ make_foo = |x|
     x[1][0] = 99
     assert_eq x2[1][0], 2
 
+  @test extend: ||
+    x = [1, 2, 3]
+    x.extend [10, 20, 30]
+    assert_eq x[5], 30
+    x.extend 'abc'
+    assert_eq x[8], 'c'
+    x.extend (-1, -2, -3)
+    assert_eq x[11], -3
+
   @test push_pop: ||
     z = [1]
     z.push 2

--- a/koto/tests/lists.koto
+++ b/koto/tests/lists.koto
@@ -9,16 +9,6 @@
     assert_eq z, z
     assert_ne z, []
 
-  @test list_addition: ||
-    x = [0]
-    x = x + [1]
-    assert_eq x, [0, 1]
-    x += [2, 3]
-    assert_eq x, [0, 1, 2, 3]
-    # Tuples can also be added to lists
-    x += (4, 5)
-    assert_eq x, [0, 1, 2, 3, 4, 5]
-
   @test list_unpacking: ||
     a, b, c = [10, 20, 30, 40]
     assert_eq a, 10

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -22,6 +22,12 @@ make_foo = |x|
     m.bar.baz = 123
     assert_eq m2.bar.baz, 99
 
+  @test extend: ||
+    m = {foo: 42, bar: 99}
+    m.extend ['baz', ('foo', 123)]
+    assert_eq m.baz, null
+    assert_eq m.foo, 123
+
   @test insert: ||
     m = {foo: 42}
     old_value = m.insert "foo", 99

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -80,13 +80,6 @@
     assert_eq (m.square 9), 81
     assert_eq m.baz.child_foo, 99
 
-  @test addition: ||
-    m = {foo: 42}
-    m2 = m + {bar: -1}
-    assert_eq m2.bar, -1
-    m2 += {extra: 99}
-    assert_eq m2.extra, 99
-
   @test value_mutation: ||
     m = {}
     m.foo = 42
@@ -105,11 +98,12 @@
     assert_eq 42, m.get_foo() # m is implicitly passed to get_foo as an argument
 
     make_map_2 = ||
-      make_map() +
-        foo_2: 57
-        get_foo_2: |self| self.foo_2
-        set_foo_2: |self, x| self.foo_2 = x
-        sum_foo: |self| self.foo + self.foo_2
+      make_map()
+        .extend
+          foo_2: 57
+          get_foo_2: |self| self.foo_2
+          set_foo_2: |self, x| self.foo_2 = x
+          sum_foo: |self| self.foo + self.foo_2
 
     m2 = make_map_2()
     assert_eq m2.foo, 42 # .foo takes no arguments

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -98,12 +98,11 @@
     assert_eq 42, m.get_foo() # m is implicitly passed to get_foo as an argument
 
     make_map_2 = ||
-      make_map()
-        .extend
-          foo_2: 57
-          get_foo_2: |self| self.foo_2
-          set_foo_2: |self, x| self.foo_2 = x
-          sum_foo: |self| self.foo + self.foo_2
+      make_map().extend
+        foo_2: 57
+        get_foo_2: |self| self.foo_2
+        set_foo_2: |self, x| self.foo_2 = x
+        sum_foo: |self| self.foo + self.foo_2
 
     m2 = make_map_2()
     assert_eq m2.foo, 42 # .foo takes no arguments

--- a/src/cli/src/help.rs
+++ b/src/cli/src/help.rs
@@ -164,7 +164,7 @@ impl Help {
                         help.push_str(", ");
                     }
 
-                    help.push_str(&topic);
+                    help.push_str(topic);
                 }
 
                 help.push_str(
@@ -179,7 +179,7 @@ impl Help {
                         help.push_str(", ");
                     }
 
-                    help.push_str(&module_name);
+                    help.push_str(module_name);
                 }
 
                 help
@@ -194,7 +194,7 @@ impl Help {
         let (file_name, help) = consume_help_section(&mut parser, None);
         if !help.trim().is_empty() {
             self.help_map.insert(
-                file_name.to_lowercase().replace(" ", "_"),
+                file_name.to_lowercase().replace(' ', "_"),
                 HelpEntry {
                     name: file_name,
                     help,
@@ -206,7 +206,7 @@ impl Help {
         while parser.peek().is_some() {
             let (entry_name, help) = consume_help_section(&mut parser, None);
             self.help_map.insert(
-                entry_name.to_lowercase().replace(" ", "_"),
+                entry_name.to_lowercase().replace(' ', "_"),
                 HelpEntry {
                     name: entry_name,
                     help,
@@ -290,7 +290,7 @@ fn consume_help_section<'a, 'b>(
                     let heading_length = result.len() - heading_start;
                     result.push('\n');
                     for _ in 0..heading_length {
-                        result.push_str("-")
+                        result.push('-');
                     }
                 }
                 in_section_heading = false;

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -3691,6 +3691,43 @@ x.foo
         }
 
         #[test]
+        fn lookup_indentation_separated_with_map_arg() {
+            let source = "
+x.takes_a_map
+  foo: 42
+";
+            check_ast(
+                source,
+                &[
+                    Id(constant(0)),  // x
+                    Int(constant(3)), // 42
+                    Map(vec![
+                        (MapKey::Id(constant(2)), Some(1)), // foo: 42
+                    ]),
+                    Lookup((
+                        LookupNode::Call {
+                            args: vec![2],
+                            with_parens: false,
+                        },
+                        None,
+                    )),
+                    Lookup((LookupNode::Id(constant(1)), Some(3))), // takes_a_map
+                    Lookup((LookupNode::Root(0), Some(4))),         // @5
+                    MainBlock {
+                        body: vec![5],
+                        local_count: 0,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("x"),
+                    Constant::Str("takes_a_map"),
+                    Constant::Str("foo"),
+                    Constant::I64(42),
+                ]),
+            )
+        }
+
+        #[test]
         fn map_lookup_in_list() {
             let sources = [
                 "[my_map.foo, my_map.bar]",

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -68,10 +68,6 @@ impl DataMap {
         self.insert(id.into(), value)
     }
 
-    pub fn extend(&mut self, other: &DataMap) {
-        self.0.extend(other.0.clone().into_iter());
-    }
-
     /// Allows access to map entries without having to create a ValueString
     pub fn get_with_string(&self, key: &str) -> Option<&Value> {
         self.0.get(&key as &dyn ValueKeyRef)

--- a/src/runtime/src/value_string.rs
+++ b/src/runtime/src/value_string.rs
@@ -141,7 +141,7 @@ impl fmt::Debug for ValueString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "ValueString(bounds: {:?}, string: \"{}\")",
+            "ValueString(bounds: {:?}, string: '{}')",
             self.bounds,
             self.as_str()
         )
@@ -151,7 +151,7 @@ impl fmt::Debug for ValueString {
 impl fmt::Display for ValueString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            write!(f, "\"{}\"", self.as_str())
+            write!(f, "'{}'", self.as_str())
         } else {
             write!(f, "{}", self.as_str())
         }

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1469,7 +1469,12 @@ impl Vm {
                 call_binary_op_or_else!(self, result, lhs, rhs_value, map, Add, {
                     if let Map(rhs_map) = rhs_value {
                         let mut data = map.data().clone();
-                        data.extend(&rhs_map.data());
+                        data.extend(
+                            rhs_map
+                                .data()
+                                .iter()
+                                .map(|(key, value)| (key.clone(), value.clone())),
+                        );
 
                         let meta = match (map.meta_map(), rhs_map.meta_map()) {
                             (Some(lhs), Some(rhs)) => {

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1451,45 +1451,13 @@ impl Vm {
             (Number(a), Num4(b)) => Num4(a + b),
             (Num4(a), Num4(b)) => Num4(a + b),
             (Num4(a), Number(b)) => Num4(a + b),
-            (List(a), List(b)) => {
-                let mut result = ValueVec::new();
-                result.extend(a.data().iter().chain(b.data().iter()).cloned());
-                List(ValueList::with_data(result))
-            }
-            (List(a), Tuple(b)) => {
-                let mut result = ValueVec::new();
-                result.extend(a.data().iter().chain(b.data().iter()).cloned());
-                List(ValueList::with_data(result))
-            }
             (Str(a), Str(b)) => {
                 let result = a.to_string() + b.as_ref();
                 Str(result.into())
             }
             (Map(map), _) => {
                 call_binary_op_or_else!(self, result, lhs, rhs_value, map, Add, {
-                    if let Map(rhs_map) = rhs_value {
-                        let mut data = map.data().clone();
-                        data.extend(
-                            rhs_map
-                                .data()
-                                .iter()
-                                .map(|(key, value)| (key.clone(), value.clone())),
-                        );
-
-                        let meta = match (map.meta_map(), rhs_map.meta_map()) {
-                            (Some(lhs), Some(rhs)) => {
-                                let mut lhs = lhs.borrow().clone();
-                                lhs.extend(&rhs.borrow());
-                                Some(lhs)
-                            }
-                            (Some(lhs), None) => Some(lhs.borrow().clone()),
-                            (None, Some(rhs)) => Some(rhs.borrow().clone()),
-                            (None, None) => None,
-                        };
-                        Map(ValueMap::with_contents(data, meta))
-                    } else {
-                        return self.binary_op_error(lhs_value, rhs_value, "+");
-                    }
+                    return self.binary_op_error(lhs_value, rhs_value, "+");
                 })
             }
             (ExternalValue(ev), _) => {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -347,11 +347,6 @@ a";
         }
 
         #[test]
-        fn addition() {
-            test_script("[1, 2, 3] + [4, 5]", number_list(&[1, 2, 3, 4, 5]));
-        }
-
-        #[test]
         fn shared_data_by_default() {
             let script = "
 l = [1, 2, 3]
@@ -1730,14 +1725,6 @@ o.foo";
         }
 
         #[test]
-        fn addition() {
-            let script = "
-m = {foo: -1, bar: 42} + {foo: 99}
-[m.foo, m.bar]";
-            test_script(script, number_list(&[99, 42]));
-        }
-
-        #[test]
         fn equality() {
             let script = "
 m = {foo: 42, bar: 'abc'}
@@ -2630,7 +2617,7 @@ catch _
         fn arithmetic() {
             let script = "
 locals = {}
-foo = |x| {x} + locals.foo_meta
+foo = |x| {x}.with_meta_map locals.foo_meta
 locals.foo_meta =
   @+: |self, other| foo self.x + other.x
   @-: |self, other| foo self.x - other.x
@@ -2855,7 +2842,7 @@ foos[0] == foos[1]
         fn basic_access() {
             let script = "
 locals = {}
-foo = |x| {x} + locals.foo_meta
+foo = |x| {x}.with_meta_map locals.foo_meta
 locals.foo_meta =
   @meta get_x: |self| self.x
 a = foo 10
@@ -2868,7 +2855,7 @@ a.x + a.get_x()
         fn lookup_order() {
             let script = "
 locals = {}
-foo = |x| {x, y: 100} + locals.foo_meta
+foo = |x| {x, y: 100}.with_meta_map locals.foo_meta
 locals.foo_meta =
   @meta y: 0
 a = foo 10


### PR DESCRIPTION
This PR contains followups from working on the language guide.

The main user-facing change is that it removes the use of `+` with Lists and Maps (that don't implement `@+`), and adds `list.extend` and `map.extend` as an alternative.
