### PR TITLE
Update to Rust 1.62

### DIFF
--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -32,14 +32,10 @@ use {
     dunce::canonicalize,
     koto_bytecode::{Chunk, LoaderError},
     koto_runtime::{
-        CallArgs, KotoFile, MetaKey, RuntimeError, UnaryOp, Value, ValueMap, Vm, VmSettings,
+        CallArgs, KotoFile, MetaKey, ModuleImportedCallback, RuntimeError, UnaryOp, Value,
+        ValueMap, Vm, VmSettings,
     },
-    std::{
-        error::Error,
-        fmt,
-        path::{Path, PathBuf},
-        rc::Rc,
-    },
+    std::{error::Error, fmt, path::PathBuf, rc::Rc},
 };
 
 #[derive(Debug)]
@@ -122,7 +118,7 @@ pub struct KotoSettings {
     ///
     /// This allows you to track the runtime's dependencies, which might be useful if you want to
     /// reload the script when one of its dependencies has changed.
-    pub module_imported_callback: Option<Box<dyn Fn(&Path)>>,
+    pub module_imported_callback: Option<Box<dyn ModuleImportedCallback>>,
 }
 
 impl KotoSettings {
@@ -155,7 +151,10 @@ impl KotoSettings {
 
     /// Convenience function for declaring the 'module imported' callback
     #[must_use]
-    pub fn with_module_imported_callback(self, callback: impl Fn(&Path) + 'static) -> Self {
+    pub fn with_module_imported_callback(
+        self,
+        callback: impl ModuleImportedCallback + 'static,
+    ) -> Self {
         Self {
             module_imported_callback: Some(Box::new(callback)),
             ..self

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -2914,6 +2914,7 @@ impl<'source> Parser<'source> {
     where
         E: Into<ParserErrorType>,
     {
+        #[allow(clippy::let_and_return)]
         let error = ParserError::new(error_type.into(), self.current_span());
 
         #[cfg(feature = "panic_on_parser_error")]

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -29,9 +29,7 @@ pub fn make_module() -> ValueMap {
                 let path = Path::new(path.as_str()).to_path_buf();
                 match fs::File::create(&path) {
                     Ok(file) => Ok(File::system_file(file, path)),
-                    Err(error) => {
-                        return runtime_error!("io.create: Error while creating file: {error}");
-                    }
+                    Err(error) => runtime_error!("io.create: Error while creating file: {error}"),
                 }
             }
             unexpected => unexpected_type_error_with_slice(
@@ -80,9 +78,7 @@ pub fn make_module() -> ValueMap {
             [Str(path)] => match fs::canonicalize(path.as_str()) {
                 Ok(path) => match fs::File::open(&path) {
                     Ok(file) => Ok(File::system_file(file, path)),
-                    Err(error) => {
-                        return runtime_error!("io.open: Error while opening path: {error}");
-                    }
+                    Err(error) => runtime_error!("io.open: Error while opening path: {error}"),
                 },
                 Err(_) => runtime_error!("io.open: Failed to canonicalize path"),
             },

--- a/src/runtime/src/core/os.rs
+++ b/src/runtime/src/core/os.rs
@@ -61,7 +61,7 @@ impl DateTime {
             Some(utc) => Ok(Self::with_chrono_datetime(
                 chrono::DateTime::<Local>::from_utc(utc, offset),
             )),
-            None => return runtime_error!("timestamp in seconds is out of range: {seconds}"),
+            None => runtime_error!("timestamp in seconds is out of range: {seconds}"),
         }
     }
 

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -39,5 +39,5 @@ pub use {
     value_number::ValueNumber,
     value_string::ValueString,
     value_tuple::ValueTuple,
-    vm::{CallArgs, Vm, VmSettings},
+    vm::{CallArgs, ModuleImportedCallback, Vm, VmSettings},
 };

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -131,6 +131,12 @@ impl VmContext {
     }
 }
 
+/// The trait used by the 'module imported' callback mechanism
+pub trait ModuleImportedCallback: Fn(&Path) {}
+
+// Implement the trait for any matching function
+impl<T> ModuleImportedCallback for T where T: Fn(&Path) {}
+
 /// The configurable settings that should be used by the Koto runtime
 pub struct VmSettings {
     /// Whether or not tests should be run when importing modules
@@ -139,7 +145,7 @@ pub struct VmSettings {
     ///
     /// This allows you to track the runtime's dependencies, which might be useful if you want to
     /// reload the script when one of its dependencies has changed.
-    pub module_imported_callback: Option<Box<dyn Fn(&Path)>>,
+    pub module_imported_callback: Option<Box<dyn ModuleImportedCallback>>,
     /// The runtime's stdin
     pub stdin: Rc<dyn KotoFile>,
     /// The runtime's stdout


### PR DESCRIPTION
- Disable clippy warning in Parser::make_error
- Listen to clippy
