### PR TITLE
Docs and API tweaks

### DIFF
--- a/src/koto/src/koto.rs
+++ b/src/koto/src/koto.rs
@@ -318,7 +318,7 @@ impl Koto {
             .get_with_string_mut("koto")
         {
             Some(Map(map)) => {
-                map.data_mut().add_value("args", Tuple(koto_args.into()));
+                map.add_value("args", Tuple(koto_args.into()));
                 Ok(())
             }
             _ => Err(KotoError::MissingKotoModuleInPrelude),
@@ -357,7 +357,6 @@ impl Koto {
             .get_with_string_mut("koto")
         {
             Some(Map(map)) => {
-                let map = &mut map.data_mut();
                 map.add_value("script_dir", script_dir);
                 map.add_value("script_path", script_path);
                 Ok(())

--- a/src/koto/src/lib.rs
+++ b/src/koto/src/lib.rs
@@ -26,6 +26,8 @@
 //! }
 //! ```
 
+#![warn(missing_docs)]
+
 mod koto;
 pub mod prelude;
 

--- a/src/koto/src/prelude.rs
+++ b/src/koto/src/prelude.rs
@@ -1,3 +1,5 @@
+//! A collection of useful items to make it easier to work with `koto`
+
 pub use {
     crate::{Koto, KotoError, KotoSettings},
     koto_bytecode::{Chunk, Loader, LoaderError},

--- a/src/koto/tests/one_plus_two.rs
+++ b/src/koto/tests/one_plus_two.rs
@@ -1,22 +1,20 @@
-#![allow(clippy::float_cmp)]
-
 use koto::prelude::*;
 
 #[test]
 fn one_plus_two() {
     let mut koto = Koto::default();
-    match koto.compile("1 + 2") {
-        Ok(_) => match koto.run() {
-            Ok(result) => match result {
-                Value::Number(n) => assert_eq!(n, 3.0),
-                other => panic!("Unexpected result: {other}"),
-            },
-            Err(runtime_error) => {
-                panic!("Runtime error: {runtime_error}");
-            }
+
+    if let Err(compiler_error) = koto.compile("1 + 2") {
+        panic!("Compiler error: {compiler_error}");
+    }
+
+    match koto.run() {
+        Ok(result) => match result {
+            Value::Number(n) => assert_eq!(n, 3),
+            other => panic!("Unexpected result: {other}"),
         },
-        Err(compiler_error) => {
-            panic!("Compiler error: {compiler_error}");
+        Err(runtime_error) => {
+            panic!("Runtime error: {runtime_error}");
         }
     }
 }

--- a/src/runtime/src/core/io.rs
+++ b/src/runtime/src/core/io.rs
@@ -1,3 +1,5 @@
+//! The `io` core library module
+
 mod buffered_file;
 
 pub use buffered_file::BufferedFile;
@@ -19,6 +21,7 @@ use {
     },
 };
 
+/// The initializer for the io module
 pub fn make_module() -> ValueMap {
     use Value::{Bool, Null, Str};
 
@@ -154,6 +157,7 @@ pub fn make_module() -> ValueMap {
 }
 
 thread_local! {
+    /// The meta map used by Files
     pub static FILE_META: Rc<RefCell<MetaMap>> = make_file_meta_map();
 }
 
@@ -363,6 +367,7 @@ where
     }
 }
 
+/// Converts an io::Error into a RuntimeError
 pub fn map_io_err(e: io::Error) -> RuntimeError {
     e.to_string().into()
 }

--- a/src/runtime/src/core/io/buffered_file.rs
+++ b/src/runtime/src/core/io/buffered_file.rs
@@ -3,6 +3,7 @@ use std::io::{self, prelude::*, BufReader, BufWriter, Result, Seek, SeekFrom};
 /// A combination of BufReader and BufWriter
 #[derive(Debug)]
 pub struct BufferedFile<T: Write>(Reader<T>);
+
 type Reader<T> = BufReader<BufWriterWrapper<T>>;
 type Writer<T> = BufWriter<T>;
 
@@ -10,6 +11,7 @@ impl<T> BufferedFile<T>
 where
     T: Read + Write,
 {
+    /// Creates a BufferedFile that wraps the provided Read + Write value
     pub fn new(file: T) -> Self {
         Self(BufReader::new(BufWriterWrapper::new(file)))
     }

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -1,3 +1,5 @@
+//! The `iterator` core library module
+
 pub mod adaptors;
 pub mod generators;
 
@@ -6,6 +8,7 @@ use {
     crate::{prelude::*, ValueIteratorOutput as Output},
 };
 
+/// Initializes the `iterator` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/iterator/adaptors.rs
+++ b/src/runtime/src/core/iterator/adaptors.rs
@@ -1,3 +1,5 @@
+//! Adapators used by the `iterator` core library module
+
 use {
     super::collect_pair,
     crate::{prelude::*, ValueIteratorOutput as Output},
@@ -11,6 +13,7 @@ pub struct Chain {
 }
 
 impl Chain {
+    /// Creates a [Chain] adapator from two iterators
     pub fn new(iter_a: ValueIterator, iter_b: ValueIterator) -> Self {
         Self {
             iter_a: Some(iter_a),
@@ -80,6 +83,7 @@ pub struct Chunks {
 }
 
 impl Chunks {
+    /// Creates a [Chunks] adapator
     pub fn new(iter: ValueIterator, chunk_size: usize) -> Result<Self, ChunksError> {
         if chunk_size < 1 {
             Err(ChunksError::ChunkSizeMustBeAtLeastOne)
@@ -150,6 +154,8 @@ impl Iterator for Chunks {
     }
 }
 
+/// An error that can be returned by [Chunks::new]
+#[allow(missing_docs)]
 pub enum ChunksError {
     IteratorMightHaveSideEffects,
     ChunkSizeMustBeAtLeastOne,
@@ -183,6 +189,7 @@ pub struct Cycle {
 }
 
 impl Cycle {
+    /// Creates a new [Cycle] adaptor
     pub fn new(iterator: ValueIterator) -> Self {
         Self {
             iter: iterator.make_copy(),
@@ -241,6 +248,7 @@ pub struct Each {
 }
 
 impl Each {
+    /// Creates a new [Each] adaptor
     pub fn new(iter: ValueIterator, function: Value, vm: Vm) -> Self {
         Self { iter, function, vm }
     }
@@ -293,6 +301,7 @@ pub struct Enumerate {
 }
 
 impl Enumerate {
+    /// Creates a new [Enumerate] adaptor
     pub fn new(iter: ValueIterator) -> Self {
         Self { iter, index: 0 }
     }
@@ -342,6 +351,7 @@ pub struct Flatten {
 }
 
 impl Flatten {
+    /// Creates a new [Flatten] adaptor
     pub fn new(iter: ValueIterator, vm: Vm) -> Self {
         Self {
             vm,
@@ -402,6 +412,7 @@ pub struct Intersperse {
 }
 
 impl Intersperse {
+    /// Creates a new [Intersperse] adaptor
     pub fn new(iter: ValueIterator, separator: Value) -> Self {
         Self {
             iter,
@@ -466,6 +477,7 @@ pub struct IntersperseWith {
 }
 
 impl IntersperseWith {
+    /// Creates a new [IntersperseWith] adaptor
     pub fn new(iter: ValueIterator, separator_function: Value, vm: Vm) -> Self {
         Self {
             iter,
@@ -546,6 +558,7 @@ pub struct Keep {
 }
 
 impl Keep {
+    /// Creates a new [Keep] adaptor
     pub fn new(iter: ValueIterator, predicate: Value, vm: Vm) -> Self {
         Self {
             iter,
@@ -614,6 +627,7 @@ pub struct PairFirst {
 }
 
 impl PairFirst {
+    /// Creates a new [PairFirst] adaptor
     pub fn new(iter: ValueIterator) -> Self {
         Self { iter }
     }
@@ -653,6 +667,7 @@ pub struct PairSecond {
 }
 
 impl PairSecond {
+    /// Creates a new [PairSecond] adaptor
     pub fn new(iter: ValueIterator) -> Self {
         Self { iter }
     }
@@ -692,6 +707,7 @@ pub struct Reversed {
 }
 
 impl Reversed {
+    /// Creates a new [Reversed] adaptor
     pub fn new(iter: ValueIterator) -> Result<Self, ReversedError> {
         if iter.is_bidirectional() {
             Ok(Self {
@@ -728,6 +744,8 @@ impl Iterator for Reversed {
     }
 }
 
+/// An error that can be returned by [Reversed::new]
+#[allow(missing_docs)]
 pub enum ReversedError {
     IteratorIsntReversible,
 }
@@ -757,6 +775,7 @@ pub struct Take {
 }
 
 impl Take {
+    /// Creates a new [Take] adaptor
     pub fn new(iter: ValueIterator, count: usize) -> Self {
         Self {
             iter,
@@ -808,6 +827,7 @@ pub struct Windows {
 }
 
 impl Windows {
+    /// Creates a new [Windows] adaptor
     pub fn new(iter: ValueIterator, window_size: usize) -> Result<Self, WindowsError> {
         if window_size < 1 {
             Err(WindowsError::WindowSizeMustBeAtLeastOne)
@@ -871,6 +891,8 @@ impl Iterator for Windows {
     }
 }
 
+/// An error that can be returned by [Windows::new]
+#[allow(missing_docs)]
 pub enum WindowsError {
     IteratorMightHaveSideEffects,
     WindowSizeMustBeAtLeastOne,
@@ -904,6 +926,7 @@ pub struct Zip {
 }
 
 impl Zip {
+    /// Creates a new [Zip] adaptor
     pub fn new(iter_a: ValueIterator, iter_b: ValueIterator) -> Self {
         Self { iter_a, iter_b }
     }

--- a/src/runtime/src/core/iterator/generators.rs
+++ b/src/runtime/src/core/iterator/generators.rs
@@ -1,3 +1,5 @@
+//! Generators used by the `iterator` core library module
+
 use crate::{
     value_iterator::{KotoIterator, ValueIterator, ValueIteratorOutput as Output},
     CallArgs, Value, Vm,
@@ -9,6 +11,7 @@ pub struct Repeat {
 }
 
 impl Repeat {
+    /// Creates a new [Repeat] generator
     pub fn new(value: Value) -> Self {
         Self { value }
     }
@@ -42,6 +45,7 @@ pub struct RepeatN {
 }
 
 impl RepeatN {
+    /// Creates a new [RepeatN] generator
     pub fn new(value: Value, n: usize) -> Self {
         Self {
             remaining: n,
@@ -88,6 +92,7 @@ pub struct Generate {
 }
 
 impl Generate {
+    /// Creates a new [Generate] generator
     pub fn new(function: Value, vm: Vm) -> Self {
         Self { function, vm }
     }
@@ -128,6 +133,7 @@ pub struct GenerateN {
 }
 
 impl GenerateN {
+    /// Creates a new [GenerateN] generator
     pub fn new(n: usize, function: Value, vm: Vm) -> Self {
         Self {
             remaining: n,

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -1,5 +1,8 @@
+//! The `koto` core library module
+
 use crate::prelude::*;
 
+/// Initializes the `koto` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/list.rs
+++ b/src/runtime/src/core/list.rs
@@ -1,3 +1,5 @@
+//! The `list` core library module
+
 use {
     super::iterator::collect_pair,
     crate::{
@@ -7,6 +9,7 @@ use {
     std::{cmp::Ordering, ops::DerefMut},
 };
 
+/// Initializes the `list` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/map.rs
+++ b/src/runtime/src/core/map.rs
@@ -1,9 +1,12 @@
+//! The `map` core library module
+
 use {
     super::iterator::adaptors,
     crate::{prelude::*, value_sort::compare_values},
     std::{cmp::Ordering, ops::Deref},
 };
 
+/// Initializes the `map` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/mod.rs
+++ b/src/runtime/src/core/mod.rs
@@ -17,6 +17,7 @@ pub mod tuple;
 use crate::ValueMap;
 
 #[derive(Clone)]
+#[allow(missing_docs)]
 pub struct CoreLib {
     pub io: ValueMap,
     pub iterator: ValueMap,

--- a/src/runtime/src/core/num2.rs
+++ b/src/runtime/src/core/num2.rs
@@ -1,8 +1,11 @@
+//! The `num2` core library module
+
 use {
     super::iterator::collect_pair,
     crate::{num2, prelude::*, ValueIteratorOutput as Output},
 };
 
+/// Initializes the `num2` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/num4.rs
+++ b/src/runtime/src/core/num4.rs
@@ -1,8 +1,11 @@
+//! The `num4` core library module
+
 use {
     super::iterator::collect_pair,
     crate::{num4, prelude::*, ValueIteratorOutput as Output},
 };
 
+/// Initializes the `num4` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/number.rs
+++ b/src/runtime/src/core/number.rs
@@ -1,5 +1,8 @@
+//! The `number` core library module
+
 use crate::prelude::*;
 
+/// Initializes the `number` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/os.rs
+++ b/src/runtime/src/core/os.rs
@@ -1,3 +1,5 @@
+//! The `os` core library module
+
 use {
     crate::prelude::*,
     chrono::prelude::*,
@@ -5,12 +7,15 @@ use {
     std::{cell::RefCell, rc::Rc},
 };
 
+/// Initializes the `os` core library module
 pub fn make_module() -> ValueMap {
     use Value::Number;
 
     let result = ValueMap::new();
 
     result.add_fn("name", |_, _| Ok(std::env::consts::OS.into()));
+
+    result.add_fn("start_timer", |_, _| Ok(Timer::now()));
 
     result.add_fn("time", |vm, args| match vm.get_args(args) {
         [] => Ok(DateTime::now()),
@@ -24,11 +29,10 @@ pub fn make_module() -> ValueMap {
         ),
     });
 
-    result.add_fn("start_timer", |_, _| Ok(Timer::now()));
-
     result
 }
 
+/// The underlying data type returned by `os.time()`
 pub struct DateTime(chrono::DateTime<Local>);
 
 impl DateTime {
@@ -67,6 +71,7 @@ impl DateTime {
 impl ExternalData for DateTime {}
 
 thread_local! {
+    /// The meta map used by [DateTime]
     pub static SYSTEM_TIME_META: Rc<RefCell<MetaMap>> = make_system_time_meta_map();
 }
 
@@ -96,6 +101,7 @@ fn make_system_time_meta_map() -> Rc<RefCell<MetaMap>> {
         .build()
 }
 
+/// The underlying data type returned by `os.start_timer()`
 pub struct Timer(Instant);
 
 impl Timer {
@@ -109,6 +115,7 @@ impl Timer {
 impl ExternalData for Timer {}
 
 thread_local! {
+    /// The meta map used by [Timer]
     pub static TIMER_META: Rc<RefCell<MetaMap>> = make_timer_meta_map();
 }
 

--- a/src/runtime/src/core/range.rs
+++ b/src/runtime/src/core/range.rs
@@ -1,5 +1,8 @@
+//! The `range` core library module
+
 use crate::prelude::*;
 
+/// Initializes the `range` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/string.rs
+++ b/src/runtime/src/core/string.rs
@@ -1,3 +1,5 @@
+//! The `string` core library module
+
 pub mod format;
 pub mod iterators;
 
@@ -6,6 +8,7 @@ use {
     unicode_segmentation::UnicodeSegmentation,
 };
 
+/// Initializes the `string` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -577,7 +577,7 @@ mod tests {
 
         #[test]
         fn identifier_placeholders() {
-            let mut map_data = DataMap::new();
+            let mut map_data = DataMap::default();
             map_data.insert("x".into(), Value::Number(42.into()));
             map_data.insert("y".into(), Value::Number(i64::from(-1).into()));
             let map = Value::Map(ValueMap::with_data(map_data));

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -1,3 +1,5 @@
+//! String formatting support for `string.format` and `io.print`
+
 use unicode_segmentation::UnicodeSegmentation;
 
 use {
@@ -7,7 +9,7 @@ use {
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum FormatToken<'a> {
+enum FormatToken<'a> {
     String(&'a str),
     Placeholder(FormatSpec),
     Positional(u32, FormatSpec),
@@ -16,7 +18,7 @@ pub enum FormatToken<'a> {
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct FormatSpec {
+struct FormatSpec {
     fill: Option<char>,
     alignment: Option<FormatAlign>,
     min_width: Option<u32>,
@@ -24,13 +26,13 @@ pub struct FormatSpec {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum FormatAlign {
+enum FormatAlign {
     Left,
     Center,
     Right,
 }
 
-pub struct FormatLexer<'a> {
+struct FormatLexer<'a> {
     format_string: &'a str,
     position: usize,
 }
@@ -295,6 +297,7 @@ impl<'a> Iterator for FormatLexer<'a> {
     }
 }
 
+/// Formats a string, used by `string.format` and `io.print`
 pub fn format_string(
     vm: &mut Vm,
     format_string: &str,

--- a/src/runtime/src/core/string/iterators.rs
+++ b/src/runtime/src/core/string/iterators.rs
@@ -1,3 +1,5 @@
+//! A collection of string iterators
+
 use {
     crate::{
         make_runtime_error,
@@ -15,6 +17,7 @@ pub struct Bytes {
 }
 
 impl Bytes {
+    /// Creates a new [Bytes] iterator
     pub fn new(input: ValueString) -> Self {
         Self { input, index: 0 }
     }
@@ -61,6 +64,7 @@ pub struct Lines {
 }
 
 impl Lines {
+    /// Creates a new [Lines] iterator
     pub fn new(input: ValueString) -> Self {
         Self { input, start: 0 }
     }
@@ -120,6 +124,7 @@ pub struct Split {
 }
 
 impl Split {
+    /// Creates a new [Split] iterator
     pub fn new(input: ValueString, pattern: ValueString) -> Self {
         Self {
             input,
@@ -173,6 +178,7 @@ pub struct SplitWith {
 }
 
 impl SplitWith {
+    /// Creates a new [SplitWith] iterator
     pub fn new(input: ValueString, predicate: Value, vm: Vm) -> Self {
         Self {
             input,

--- a/src/runtime/src/core/test.rs
+++ b/src/runtime/src/core/test.rs
@@ -1,5 +1,8 @@
+//! The `test` core library module
+
 use crate::{num2, num4, prelude::*};
 
+/// Initializes the `test` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/core/tuple.rs
+++ b/src/runtime/src/core/tuple.rs
@@ -1,5 +1,8 @@
+//! The `tuple` core library module
+
 use crate::{prelude::*, value_sort::sort_values};
 
+/// Initializes the `tuple` core library module
 pub fn make_module() -> ValueMap {
     use Value::*;
 

--- a/src/runtime/src/error.rs
+++ b/src/runtime/src/error.rs
@@ -142,8 +142,13 @@ impl fmt::Display for RuntimeError {
 
 impl error::Error for RuntimeError {}
 
+/// The main return type used in the Koto runtime
 pub type RuntimeResult = Result<Value, RuntimeError>;
 
+/// Creates a [RuntimeError] from a provided message
+///
+/// If the `panic_on_runtime_error` feature is enabled then a panic will occur,
+/// which can be useful when debugging.
 #[macro_export]
 macro_rules! make_runtime_error {
     ($message:expr) => {{
@@ -155,6 +160,11 @@ macro_rules! make_runtime_error {
     }};
 }
 
+/// Creates a [RuntimeError] from a message (with format-like behaviour), wrapped in `Err`
+///
+/// Wrapping the result in `Err` is a convenience for functions that need to return immediately when
+/// an error has occured. See `make_runtime_error` for the internal function that creates the
+/// internal error itself.
 #[macro_export]
 macro_rules! runtime_error {
     ($error:literal) => {
@@ -168,6 +178,7 @@ macro_rules! runtime_error {
     };
 }
 
+/// Creates an error that describes a type mismatch
 pub fn type_error<T>(expected_str: &str, unexpected: &Value) -> Result<T, RuntimeError> {
     runtime_error!(
         "Expected {expected_str}, but found {}.",
@@ -175,6 +186,7 @@ pub fn type_error<T>(expected_str: &str, unexpected: &Value) -> Result<T, Runtim
     )
 }
 
+/// Creates an error that describes a type mismatch with a slice of [Value]s
 pub fn type_error_with_slice<T>(
     expected_str: &str,
     unexpected: &[Value],

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -12,11 +12,12 @@ use {
 pub use downcast_rs::Downcast;
 
 thread_local! {
-    static EXTERNAL_DATA_TYPE: ValueString  = "External Data".into();
+    static EXTERNAL_DATA_TYPE: ValueString = "External Data".into();
 }
 
 /// A trait for external data
 pub trait ExternalData: Downcast {
+    /// The type of the ExternalData as a [ValueString]
     fn data_type(&self) -> ValueString {
         EXTERNAL_DATA_TYPE.with(|x| x.clone())
     }
@@ -39,11 +40,17 @@ impl_downcast!(ExternalData);
 /// A value with data and behaviour defined externally to the Koto runtime
 #[derive(Clone, Debug)]
 pub struct ExternalValue {
+    /// The [ExternalData] held by the value
     pub data: Rc<RefCell<dyn ExternalData>>,
+    /// The [MetaMap] held by the value
     pub meta: Rc<RefCell<MetaMap>>,
 }
 
 impl ExternalValue {
+    /// Creates a new ExternalValue from [ExternalData] and a [MetaMap]
+    ///
+    /// Typically you'll want to share the meta map between value instances,
+    /// see [ExternalValue::with_shared_meta_map].
     pub fn new(data: impl ExternalData, meta: MetaMap) -> Self {
         Self {
             data: Rc::new(RefCell::new(data)),
@@ -51,6 +58,7 @@ impl ExternalValue {
         }
     }
 
+    /// Creates a new ExternalValue from [ExternalData] and a shared [MetaMap]
     pub fn with_shared_meta_map(data: impl ExternalData, meta: Rc<RefCell<MetaMap>>) -> Self {
         Self {
             data: Rc::new(RefCell::new(data)),
@@ -58,6 +66,7 @@ impl ExternalValue {
         }
     }
 
+    /// Creates a new [ExternalValue] with the provided data, cloning the existing [MetaMap]
     #[must_use]
     pub fn with_new_data(&self, data: impl ExternalData) -> Self {
         Self {
@@ -66,6 +75,7 @@ impl ExternalValue {
         }
     }
 
+    /// Returns true if the value's data matches the provided type
     pub fn has_data<T: ExternalData>(&self) -> bool {
         match self.data.try_borrow() {
             Ok(data) => data.downcast_ref::<T>().is_some(),
@@ -73,6 +83,7 @@ impl ExternalValue {
         }
     }
 
+    /// Returns a reference to the value's data if it matches the provided type
     pub fn data<T: ExternalData>(&self) -> Option<Ref<T>> {
         match self.data.try_borrow() {
             Ok(data_ref) => Ref::filter_map(data_ref, |data| data.downcast_ref::<T>()).ok(),
@@ -80,6 +91,7 @@ impl ExternalValue {
         }
     }
 
+    /// Returns a mutable reference to the value's data if it matches the provided type
     pub fn data_mut<T: ExternalData>(&self) -> Option<RefMut<T>> {
         match self.data.try_borrow_mut() {
             Ok(data_ref) => RefMut::filter_map(data_ref, |data| data.downcast_mut::<T>()).ok(),
@@ -87,6 +99,10 @@ impl ExternalValue {
         }
     }
 
+    /// Returns the value's type as a [ValueString]
+    ///
+    /// [MetaKey::Type] will be checked for the type string,
+    /// with "ExternalValue" being returned if it's not present.
     pub fn value_type(&self) -> ValueString {
         match self.get_meta_value(&MetaKey::Type) {
             Some(Value::Str(s)) => s,
@@ -95,11 +111,11 @@ impl ExternalValue {
         }
     }
 
+    /// Returns the type of the internal [ExternalData]
     pub fn data_type(&self) -> ValueString {
         self.data.borrow().data_type()
     }
 
-    ///
     /// Returns true if the value's meta map contains an entry with the given key
     pub fn contains_meta_key(&self, key: &MetaKey) -> bool {
         self.meta.borrow().contains_key(key)
@@ -115,15 +131,23 @@ thread_local! {
     static TYPE_EXTERNAL_VALUE: ValueString = "ExternalValue".into();
 }
 
-// Once Trait aliases are stabilized this can be simplified a bit,
-// see: https://github.com/rust-lang/rust/issues/55628
-#[allow(clippy::type_complexity)]
+/// An function that's defined outside of the Koto runtime
+///
+/// See [Value::ExternalFunction]
 pub struct ExternalFunction {
+    /// The function implementation that should be called when calling the external function
+    ///
+    ///
+    // Once Trait aliases are stabilized this can be simplified a bit,
+    // see: https://github.com/rust-lang/rust/issues/55628
+    #[allow(clippy::type_complexity)]
     pub function: Rc<dyn Fn(&mut Vm, &ArgRegisters) -> RuntimeResult + 'static>,
+    /// True if the function should behave as an instance function
     pub is_instance_function: bool,
 }
 
 impl ExternalFunction {
+    /// Creates a new external function
     pub fn new(
         function: impl Fn(&mut Vm, &ArgRegisters) -> RuntimeResult + 'static,
         is_instance_function: bool,
@@ -166,6 +190,9 @@ impl Hash for ExternalFunction {
 }
 
 /// The start register and argument count for arguments when an ExternalFunction is called
+///
+/// [Vm::args] should be called with this struct to retrieve the corresponding slice of [Value]s.
+#[allow(missing_docs)]
 pub struct ArgRegisters {
     pub register: u8,
     pub count: u8,

--- a/src/runtime/src/external.rs
+++ b/src/runtime/src/external.rs
@@ -66,6 +66,13 @@ impl ExternalValue {
         }
     }
 
+    pub fn has_data<T: ExternalData>(&self) -> bool {
+        match self.data.try_borrow() {
+            Ok(data) => data.downcast_ref::<T>().is_some(),
+            Err(_) => false,
+        }
+    }
+
     pub fn data<T: ExternalData>(&self) -> Option<Ref<T>> {
         match self.data.try_borrow() {
             Ok(data_ref) => Ref::filter_map(data_ref, |data| data.downcast_ref::<T>()).ok(),

--- a/src/runtime/src/file.rs
+++ b/src/runtime/src/file.rs
@@ -2,6 +2,8 @@ use crate::{runtime_error, RuntimeError};
 
 /// A trait used for file-like-things in Koto
 pub trait KotoFile: KotoRead + KotoWrite {
+    /// An identifier for the file, accessed when displaying the file in strings
+    // TODO(#191) - Return a ValueString
     fn id(&self) -> String;
 
     /// Returns the path of the file

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -1,5 +1,7 @@
 //! Contains the runtime and core library for the Koto language
 
+#![warn(missing_docs)]
+
 mod error;
 mod external;
 mod file;

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -26,7 +26,7 @@ pub use {
     error::{type_error, type_error_with_slice, RuntimeError, RuntimeResult},
     external::{ExternalData, ExternalFunction, ExternalValue},
     file::{KotoFile, KotoRead, KotoWrite},
-    meta_map::{BinaryOp, DataOrArgs, DataOrArgsMut, MetaKey, MetaMap, MetaMapBuilder, UnaryOp},
+    meta_map::{BinaryOp, MetaKey, MetaMap, MetaMapBuilder, UnaryOp},
     num2::Num2,
     num4::Num4,
     stdio::{DefaultStderr, DefaultStdin, DefaultStdout},

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -20,6 +20,10 @@ use {
 
 type MetaMapType = IndexMap<MetaKey, Value, BuildHasherDefault<FxHasher>>;
 
+/// The meta map used by [ValueMap](crate::ValueMap) and [ExternalValue](crate::ExternalValue)
+///
+/// Each ValueMap and ExternalValue contains a metamap,
+/// which allows for customized value behaviour by implementing [MetaKeys](crate::MetaKey).
 #[derive(Clone, Debug, Default)]
 pub struct MetaMap(MetaMapType);
 
@@ -60,16 +64,50 @@ impl From<MetaMap> for Rc<RefCell<MetaMap>> {
     }
 }
 
+/// The key type used by [MetaMaps](crate::MetaMap)
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum MetaKey {
+    /// A binary operation
+    ///
+    /// e.g. `@+`, `@==`
     BinaryOp(BinaryOp),
+    /// A unary operation
+    ///
+    /// e.g. `@not`
     UnaryOp(UnaryOp),
+    /// A named key
+    ///
+    /// e.g. `@meta my_named_key`
+    ///
+    /// This allows for named entries to be included in the meta map,
+    /// which is particularly useful in [ExternalValue](crate::ExternalValue) metamaps.
+    ///
+    /// Named entries also have use in [ValueMaps][crate::ValueMap] where shared named items can be
+    /// made available without them being inserted into the map's contents.
     Named(ValueString),
+    /// A test function
+    ///
+    /// e.g. `@test my_test`
     Test(ValueString),
+    /// `@tests`
+    ///
+    /// Tests are defined together in a [ValueMap](crate::ValueMap).
     Tests,
+    /// `@pre_test`
+    ///
+    /// Used to define a function that will be run before each `@test`.
     PreTest,
+    /// `@post_test`
+    ///
+    /// Used to define a function that will be run after each `@test`.
     PostTest,
+    /// `@main`
+    ///
+    /// Used to define a function that will be run when a module is first imported.
     Main,
+    /// `@type`
+    ///
+    /// Used to define a [ValueString](crate::ValueString) that declare the value's type.
     Type,
 }
 
@@ -129,19 +167,34 @@ impl From<BinaryOp> for MetaKey {
     }
 }
 
+/// The binary operations that can be implemented in a [MetaMap](crate::MetaMap)
+///
+/// See [MetaKey::BinaryOp]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum BinaryOp {
+    /// `@+`
     Add,
+    /// `@-`
     Subtract,
+    /// `@*`
     Multiply,
+    /// `@/`
     Divide,
+    /// `@%`
     Remainder,
+    /// `@<`
     Less,
+    /// `@<=`
     LessOrEqual,
+    /// `@>`
     Greater,
+    /// `@>=`
     GreaterOrEqual,
+    /// `@==`
     Equal,
+    /// `@!=`
     NotEqual,
+    /// `@[]`
     Index,
 }
 
@@ -170,11 +223,18 @@ impl fmt::Display for BinaryOp {
     }
 }
 
+/// The unary operations that can be implemented in a [MetaMap](crate::MetaMap)
+///
+/// See [MetaKey::UnaryOp]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum UnaryOp {
+    /// `@display`
     Display,
+    /// `@iterator`
     Iterator,
+    /// `@negate`
     Negate,
+    /// `@not`
     Not,
 }
 
@@ -195,6 +255,7 @@ impl fmt::Display for UnaryOp {
     }
 }
 
+/// Converts a [MetaKeyId](koto_parser::MetaKeyId) into a [MetaKey]
 pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKey, String> {
     use {BinaryOp::*, UnaryOp::*};
 

--- a/src/runtime/src/num2.rs
+++ b/src/runtime/src/num2.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use {
     crate::ValueNumber,
     std::{

--- a/src/runtime/src/num4.rs
+++ b/src/runtime/src/num4.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use {
     crate::ValueNumber,
     std::{

--- a/src/runtime/src/prelude.rs
+++ b/src/runtime/src/prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::{
     make_runtime_error, runtime_error, type_error, type_error_with_slice, BinaryOp, CallArgs,
-    DataMap, DataOrArgs, DataOrArgsMut, ExternalData, ExternalValue, IntRange, KotoFile,
-    KotoIterator, KotoRead, KotoWrite, MetaKey, MetaMap, MetaMapBuilder, Num2, Num4, RuntimeError,
-    RuntimeResult, UnaryOp, Value, ValueIterator, ValueIteratorOutput, ValueKey, ValueList,
-    ValueMap, ValueNumber, ValueString, ValueTuple, ValueVec, Vm, VmSettings,
+    DataMap, ExternalData, ExternalValue, IntRange, KotoFile, KotoIterator, KotoRead, KotoWrite,
+    MetaKey, MetaMap, MetaMapBuilder, Num2, Num4, RuntimeError, RuntimeResult, UnaryOp, Value,
+    ValueIterator, ValueIteratorOutput, ValueKey, ValueList, ValueMap, ValueNumber, ValueString,
+    ValueTuple, ValueVec, Vm, VmSettings,
 };

--- a/src/runtime/src/prelude.rs
+++ b/src/runtime/src/prelude.rs
@@ -1,3 +1,6 @@
+//! A collection of useful items to make it easier to work with `koto_runtime`
+
+#[doc(inline)]
 pub use crate::{
     make_runtime_error, runtime_error, type_error, type_error_with_slice, BinaryOp, CallArgs,
     DataMap, ExternalData, ExternalValue, IntRange, KotoFile, KotoIterator, KotoRead, KotoWrite,

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -1,3 +1,5 @@
+//! The core value type used in the Koto runtime
+
 use {
     crate::{
         num2, num4, value_key::ValueRef, value_map::ValueMap, ExternalFunction, ExternalValue,
@@ -100,6 +102,9 @@ impl Value {
         }
     }
 
+    /// Returns a recursive 'deep copy' of a Value
+    ///
+    /// This is used by the various `.deep_copy()` core library functions.
     #[must_use]
     pub fn deep_copy(&self) -> Value {
         use Value::*;
@@ -127,11 +132,15 @@ impl Value {
         }
     }
 
+    /// Returns true if the value has function-like callable behaviour
     pub fn is_callable(&self) -> bool {
         use Value::*;
         matches!(self, SimpleFunction(_) | Function(_) | ExternalFunction(_))
     }
 
+    /// Returns true if the value doesn't have internal mutability
+    ///
+    /// Only immutable values are acceptable as map keys.
     pub fn is_immutable(&self) -> bool {
         use Value::*;
         matches!(
@@ -174,6 +183,7 @@ impl Value {
         }
     }
 
+    /// Returns the value's type as a ValueString
     pub fn type_as_string(&self) -> ValueString {
         use Value::*;
         match &self {
@@ -316,6 +326,11 @@ impl From<ValueIterator> for Value {
     }
 }
 
+/// A plain and simple function
+///
+/// See also:
+/// * [Value::SimpleFunction]
+/// * [FunctionInfo]
 #[derive(Clone, Debug)]
 pub struct SimpleFunctionInfo {
     /// The [Chunk] in which the function can be found.
@@ -326,6 +341,11 @@ pub struct SimpleFunctionInfo {
     pub arg_count: u8,
 }
 
+/// A fully-featured function with all the bells and whistles
+///
+/// See also:
+/// * [Value::Function]
+/// * [SimpleFunctionInfo]
 #[derive(Clone, Debug)]
 pub struct FunctionInfo {
     /// The [Chunk] in which the function can be found.
@@ -362,6 +382,10 @@ pub struct FunctionInfo {
     pub captures: Option<ValueList>,
 }
 
+/// The integer range type that's exposed to users in the runtime
+///
+/// See [Value::Range]
+#[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IntRange {
     pub start: isize,
@@ -369,10 +393,14 @@ pub struct IntRange {
 }
 
 impl IntRange {
+    /// Returns true if the range's start is less than or equal to its end
     pub fn is_ascending(&self) -> bool {
         self.start <= self.end
     }
 
+    /// Returns the size of the range
+    ///
+    /// Descending ranges have a non-negative size, i.e. the size is equal to `start - end`.
     pub fn len(&self) -> usize {
         if self.is_ascending() {
             (self.end - self.start) as usize
@@ -381,17 +409,28 @@ impl IntRange {
         }
     }
 
+    /// Returns true if the range's size is zero
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }
 
+/// A range type that's used in indexing expressions
+///
+/// Index ranges have an optional end to support indexing expressions like `foo[10..]`.
+///
+/// See [Value::IndexRange]
+#[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IndexRange {
     pub start: usize,
     pub end: Option<usize>,
 }
 
+/// A slice of a VM's registers
+///
+/// See [Value::TemporaryTuple]
+#[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RegisterSlice {
     pub start: u8,

--- a/src/runtime/src/value_iterator.rs
+++ b/src/runtime/src/value_iterator.rs
@@ -53,60 +53,81 @@ pub enum ValueIteratorOutput {
 pub struct ValueIterator(Rc<RefCell<dyn KotoIterator>>);
 
 impl ValueIterator {
+    /// Creates a new ValueIterator from any value that implements [KotoIterator]
     pub fn new(external: impl KotoIterator + 'static) -> Self {
         Self(Rc::new(RefCell::new(external)))
     }
 
+    /// Creates a new ValueIterator from a Range
     pub fn with_range(range: IntRange) -> Self {
         Self::new(RangeIterator::new(range))
     }
 
+    /// Creates a new ValueIterator from a Num2
     pub fn with_num2(n: Num2) -> Self {
         Self::new(Num2Iterator::new(n))
     }
 
+    /// Creates a new ValueIterator from a Num4
     pub fn with_num4(n: Num4) -> Self {
         Self::new(Num4Iterator::new(n))
     }
 
+    /// Creates a new ValueIterator from a List
     pub fn with_list(list: ValueList) -> Self {
         Self::new(ListIterator::new(list))
     }
 
+    /// Creates a new ValueIterator from a Tuple
     pub fn with_tuple(tuple: ValueTuple) -> Self {
         Self::new(TupleIterator::new(tuple))
     }
 
+    /// Creates a new ValueIterator from a Map
     pub fn with_map(map: ValueMap) -> Self {
         Self::new(MapIterator::new(map))
     }
 
+    /// Creates a new ValueIterator from a String
     pub fn with_string(s: ValueString) -> Self {
         Self::new(StringIterator::new(s))
     }
 
+    /// Creates a new ValueIterator from a Vm, used to implement generators
     pub fn with_vm(vm: Vm) -> Self {
         Self::new(GeneratorIterator::new(vm))
     }
 
+    /// Makes a copy of the iterator
+    ///
+    /// See [KotoIterator::make_copy]
     #[must_use]
     pub fn make_copy(&self) -> Self {
         self.0.borrow().make_copy()
     }
 
+    /// Returns true if the iterator might have side-effects
+    ///
+    /// See [KotoIterator::might_have_side_effects]
     pub fn might_have_side_effects(&self) -> bool {
         self.0.borrow().might_have_side_effects()
     }
 
+    /// Returns true if the iterator supports reversed iteration via `next_back`
+    ///
+    /// See [KotoIterator::is_bidirectional]
     pub fn is_bidirectional(&self) -> bool {
         self.0.borrow().is_bidirectional()
     }
 
+    /// Returns the next item produced by iterating backwards
+    ///
+    /// See [KotoIterator::next_back]
     pub fn next_back(&mut self) -> Option<ValueIteratorOutput> {
         self.0.borrow_mut().next_back()
     }
 
-    // For internal functions that want to perform repeated iterations with a single borrow
+    /// Mutably borrows the underlying iterator, allowing repeated iterations with a single borrow
     pub fn borrow_internals(
         &mut self,
         mut f: impl FnMut(&mut dyn KotoIterator) -> Option<ValueIteratorOutput>,

--- a/src/runtime/src/value_key.rs
+++ b/src/runtime/src/value_key.rs
@@ -15,6 +15,7 @@ use {
 pub struct ValueKey(Value);
 
 impl ValueKey {
+    /// Returns a reference to the key's value
     pub fn value(&self) -> &Value {
         &self.0
     }

--- a/src/runtime/src/value_list.rs
+++ b/src/runtime/src/value_list.rs
@@ -7,38 +7,47 @@ use {
     },
 };
 
+/// The underlying Vec type used by [ValueList]
 pub type ValueVec = smallvec::SmallVec<[Value; 4]>;
 
+/// The Koto runtime's List type
 #[derive(Clone, Debug, Default)]
 pub struct ValueList(Rc<RefCell<ValueVec>>);
 
 impl ValueList {
+    /// Creates an empty list with the given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self(Rc::new(RefCell::new(ValueVec::with_capacity(capacity))))
     }
 
+    /// Creates a list containing the provided data
     pub fn with_data(data: ValueVec) -> Self {
         Self(Rc::new(RefCell::new(data)))
     }
 
+    /// Creates a list containing the provided slice of [Values](crate::Value)
     pub fn from_slice(data: &[Value]) -> Self {
         Self(Rc::new(RefCell::new(
             data.iter().cloned().collect::<ValueVec>(),
         )))
     }
 
+    /// Returns the number of entries of the list
     pub fn len(&self) -> usize {
         self.data().len()
     }
 
+    /// Returns true if there are no entries in the list
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Returns a reference to the list's entries
     pub fn data(&self) -> Ref<ValueVec> {
         self.0.borrow()
     }
 
+    /// Returns a mutable reference to the list's entries
     pub fn data_mut(&self) -> RefMut<ValueVec> {
         self.0.borrow_mut()
     }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -25,10 +25,6 @@ type DataMapType = IndexMap<ValueKey, Value, BuildHasherDefault<FxHasher>>;
 pub struct DataMap(DataMapType);
 
 impl DataMap {
-    pub fn new() -> Self {
-        Self(DataMapType::default())
-    }
-
     pub fn with_capacity(capacity: usize) -> Self {
         Self(DataMapType::with_capacity_and_hasher(
             capacity,

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         external::{ArgRegisters, ExternalFunction},
         value_key::ValueKeyRef,
-        MetaKey, MetaMap, RuntimeResult, Value, ValueKey, ValueList, Vm,
+        MetaKey, MetaMap, RuntimeResult, Value, ValueKey, Vm,
     },
     indexmap::IndexMap,
     rustc_hash::FxHasher,
@@ -31,47 +31,6 @@ impl DataMap {
             capacity,
             Default::default(),
         ))
-    }
-
-    /// Adds a function with the given id to the map
-    pub fn add_fn(
-        &mut self,
-        id: &str,
-        f: impl Fn(&mut Vm, &ArgRegisters) -> RuntimeResult + 'static,
-    ) {
-        #[allow(clippy::useless_conversion)]
-        self.add_value(
-            id.into(),
-            Value::ExternalFunction(ExternalFunction::new(f, false)),
-        );
-    }
-
-    /// Adds an instance function with the given id to the map
-    pub fn add_instance_fn(
-        &mut self,
-        id: &str,
-        f: impl Fn(&mut Vm, &ArgRegisters) -> RuntimeResult + 'static,
-    ) {
-        #[allow(clippy::useless_conversion)]
-        self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, true)));
-    }
-
-    /// Adds a list with the given id to the map
-    pub fn add_list(&mut self, id: &str, list: ValueList) {
-        #[allow(clippy::useless_conversion)]
-        self.add_value(id.into(), Value::List(list));
-    }
-
-    /// Adds a map with the given id to the map
-    pub fn add_map(&mut self, id: &str, map: ValueMap) {
-        #[allow(clippy::useless_conversion)]
-        self.add_value(id.into(), Value::Map(map));
-    }
-
-    /// Adds a Value with the given id to the map
-    pub fn add_value(&mut self, id: &str, value: Value) -> Option<Value> {
-        #[allow(clippy::useless_conversion)]
-        self.insert(id.into(), value)
     }
 
     /// Allows access to map entries without having to create a ValueString
@@ -193,20 +152,6 @@ impl ValueMap {
             .insert(key, value);
     }
 
-    /// Returns the number of entries in the ValueMap's data map
-    ///
-    /// Note that this doesn't include entries in the meta map.
-    pub fn len(&self) -> usize {
-        self.data().len()
-    }
-
-    /// Returns true if the ValueMap's data map contains no entries
-    ///
-    /// Note that this doesn't take entries in the meta map into account.
-    pub fn is_empty(&self) -> bool {
-        self.data().is_empty()
-    }
-
     /// Adds a function to the ValueMap's data map
     pub fn add_fn(&self, id: &str, f: impl Fn(&mut Vm, &ArgRegisters) -> RuntimeResult + 'static) {
         self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, false)));
@@ -221,11 +166,6 @@ impl ValueMap {
         self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, true)));
     }
 
-    /// Adds a list to the ValueMap's data map
-    pub fn add_list(&self, id: &str, list: ValueList) {
-        self.add_value(id, Value::List(list));
-    }
-
     /// Adds a map to the ValueMap's data map
     pub fn add_map(&self, id: &str, map: ValueMap) {
         self.add_value(id, Value::Map(map));
@@ -234,6 +174,20 @@ impl ValueMap {
     /// Adds a [Value](crate::Value) to the ValueMap's data map
     pub fn add_value(&self, id: &str, value: Value) {
         self.insert(id.into(), value);
+    }
+
+    /// Returns the number of entries in the ValueMap's data map
+    ///
+    /// Note that this doesn't include entries in the meta map.
+    pub fn len(&self) -> usize {
+        self.data().len()
+    }
+
+    /// Returns true if the ValueMap's data map contains no entries
+    ///
+    /// Note that this doesn't take entries in the meta map into account.
+    pub fn is_empty(&self) -> bool {
+        self.data().is_empty()
     }
 }
 
@@ -259,12 +213,14 @@ mod tests {
     #[test]
     fn get_and_remove_with_string() {
         let m = ValueMap::default();
-        let mut data = m.data_mut();
 
-        assert!(data.get_with_string("test").is_none());
-        data.add_value("test", Value::Null);
-        assert!(data.get_with_string("test").is_some());
-        assert!(matches!(data.remove_with_string("test"), Some(Value::Null)));
-        assert!(data.get_with_string("test").is_none());
+        assert!(m.data().get_with_string("test").is_none());
+        m.add_value("test", Value::Null);
+        assert!(m.data().get_with_string("test").is_some());
+        assert!(matches!(
+            m.data_mut().remove_with_string("test"),
+            Some(Value::Null)
+        ));
+        assert!(m.data().get_with_string("test").is_none());
     }
 }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -25,6 +25,7 @@ type DataMapType = IndexMap<ValueKey, Value, BuildHasherDefault<FxHasher>>;
 pub struct DataMap(DataMapType);
 
 impl DataMap {
+    /// Creates a new DataMap with the given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self(DataMapType::with_capacity_and_hasher(
             capacity,
@@ -32,6 +33,7 @@ impl DataMap {
         ))
     }
 
+    /// Adds a function with the given id to the map
     pub fn add_fn(
         &mut self,
         id: &str,
@@ -44,6 +46,7 @@ impl DataMap {
         );
     }
 
+    /// Adds an instance function with the given id to the map
     pub fn add_instance_fn(
         &mut self,
         id: &str,
@@ -53,16 +56,19 @@ impl DataMap {
         self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, true)));
     }
 
+    /// Adds a list with the given id to the map
     pub fn add_list(&mut self, id: &str, list: ValueList) {
         #[allow(clippy::useless_conversion)]
         self.add_value(id.into(), Value::List(list));
     }
 
+    /// Adds a map with the given id to the map
     pub fn add_map(&mut self, id: &str, map: ValueMap) {
         #[allow(clippy::useless_conversion)]
         self.add_value(id.into(), Value::Map(map));
     }
 
+    /// Adds a Value with the given id to the map
     pub fn add_value(&mut self, id: &str, value: Value) -> Option<Value> {
         #[allow(clippy::useless_conversion)]
         self.insert(id.into(), value)
@@ -112,18 +118,22 @@ pub struct ValueMap {
 }
 
 impl ValueMap {
+    /// Creates an empty ValueMap
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Creates an empty ValueMap with the given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self::with_contents(DataMap::with_capacity(capacity), None)
     }
 
+    /// Creates a ValueMap initialized with the provided data
     pub fn with_data(data: DataMap) -> Self {
         Self::with_contents(data, None)
     }
 
+    /// Creates a ValueMap initialized with the provided data and meta map
     pub fn with_contents(data: DataMap, meta: Option<MetaMap>) -> Self {
         Self {
             data: Rc::new(RefCell::new(data)),
@@ -131,7 +141,7 @@ impl ValueMap {
         }
     }
 
-    // Makes a ValueMap taking the data map from the first arg, and the meta map from the second
+    /// Makes a ValueMap taking the data map from the first arg, and the meta map from the second
     pub fn from_data_and_meta_maps(data: &Self, meta: &Self) -> Self {
         Self {
             data: data.data.clone(),
@@ -139,14 +149,19 @@ impl ValueMap {
         }
     }
 
+    /// Provides a reference to the ValueMaps' data
     pub fn data(&self) -> Ref<DataMap> {
         self.data.borrow()
     }
 
+    /// Provides a mutable reference to the ValueMaps' data
     pub fn data_mut(&self) -> RefMut<DataMap> {
         self.data.borrow_mut()
     }
 
+    /// Provides a reference to the ValueMaps' meta map
+    ///
+    /// This is returned as a reference to the meta map's Rc to allow for cloning.
     pub fn meta_map(&self) -> Option<&Rc<RefCell<MetaMap>>> {
         self.meta.as_ref()
     }
@@ -165,6 +180,7 @@ impl ValueMap {
             .and_then(|meta| meta.borrow().get(key).cloned())
     }
 
+    /// Insert an entry into the ValueMap's data
     pub fn insert(&self, key: ValueKey, value: Value) {
         self.data_mut().insert(key, value);
     }
@@ -177,18 +193,26 @@ impl ValueMap {
             .insert(key, value);
     }
 
+    /// Returns the number of entries in the ValueMap's data map
+    ///
+    /// Note that this doesn't include entries in the meta map.
     pub fn len(&self) -> usize {
         self.data().len()
     }
 
+    /// Returns true if the ValueMap's data map contains no entries
+    ///
+    /// Note that this doesn't take entries in the meta map into account.
     pub fn is_empty(&self) -> bool {
         self.data().is_empty()
     }
 
+    /// Adds a function to the ValueMap's data map
     pub fn add_fn(&self, id: &str, f: impl Fn(&mut Vm, &ArgRegisters) -> RuntimeResult + 'static) {
         self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, false)));
     }
 
+    /// Adds an instance function to the ValueMap's data map
     pub fn add_instance_fn(
         &self,
         id: &str,
@@ -197,14 +221,17 @@ impl ValueMap {
         self.add_value(id, Value::ExternalFunction(ExternalFunction::new(f, true)));
     }
 
+    /// Adds a list to the ValueMap's data map
     pub fn add_list(&self, id: &str, list: ValueList) {
         self.add_value(id, Value::List(list));
     }
 
+    /// Adds a map to the ValueMap's data map
     pub fn add_map(&self, id: &str, map: ValueMap) {
         self.add_value(id, Value::Map(map));
     }
 
+    /// Adds a [Value](crate::Value) to the ValueMap's data map
     pub fn add_value(&self, id: &str, value: Value) {
         self.insert(id.into(), value);
     }

--- a/src/runtime/src/value_number.rs
+++ b/src/runtime/src/value_number.rs
@@ -8,6 +8,10 @@ use {
     },
 };
 
+/// The Number type used by the Koto runtime
+///
+/// The number can be either an `f64` or an `i64` depending on usage.
+#[allow(missing_docs)]
 #[derive(Clone, Copy)]
 pub enum ValueNumber {
     F64(f64),
@@ -15,6 +19,7 @@ pub enum ValueNumber {
 }
 
 impl ValueNumber {
+    /// Returns the absolute value of the number
     #[must_use]
     pub fn abs(self) -> Self {
         match self {
@@ -23,6 +28,7 @@ impl ValueNumber {
         }
     }
 
+    /// Returns the smallest integer greater than or equal to the number
     #[must_use]
     pub fn ceil(self) -> Self {
         match self {
@@ -31,11 +37,15 @@ impl ValueNumber {
         }
     }
 
+    /// Returns the largest integer less than or equal to the number
     #[must_use]
     pub fn floor(self) -> Self {
         Self::I64(self.as_i64())
     }
 
+    /// Returns the integer closest to the number
+    ///
+    /// Half-way values get rounded away from zero.
     #[must_use]
     pub fn round(self) -> Self {
         match self {
@@ -44,10 +54,12 @@ impl ValueNumber {
         }
     }
 
+    /// Returns true if the number is represented by an `f64`
     pub fn is_f64(self) -> bool {
         matches!(self, Self::F64(_))
     }
 
+    /// Returns true if the integer version of the number is representable by an `f64`
     pub fn is_i64_in_f64_range(&self) -> bool {
         if let Self::I64(n) = *self {
             (n as f64 as i64) == n
@@ -56,6 +68,7 @@ impl ValueNumber {
         }
     }
 
+    /// Returns true if the number is NaN
     pub fn is_nan(self) -> bool {
         match self {
             Self::F64(n) => n.is_nan(),
@@ -63,6 +76,10 @@ impl ValueNumber {
         }
     }
 
+    /// Returns the result of raising self to the power of `other`
+    ///
+    /// If both inputs are i64s then the result will also be an i64,
+    /// otherwise the result will be an f64.
     #[must_use]
     pub fn pow(self, other: Self) -> Self {
         use ValueNumber::*;
@@ -75,6 +92,7 @@ impl ValueNumber {
         }
     }
 
+    /// Returns the value transmuted to a `u64`
     pub fn to_bits(self) -> u64 {
         match self {
             Self::F64(n) => n.to_bits(),
@@ -82,6 +100,7 @@ impl ValueNumber {
         }
     }
 
+    /// Returns the number as an `i64`, calling `floor` if the number is an `f64`
     pub fn as_i64(self) -> i64 {
         match self {
             Self::F64(n) => n.floor() as i64,

--- a/src/runtime/src/value_tuple.rs
+++ b/src/runtime/src/value_tuple.rs
@@ -7,6 +7,7 @@ use {
     },
 };
 
+/// The Tuple type used by the Koto runtime
 #[derive(Clone, Debug)]
 pub struct ValueTuple {
     data: Rc<[Value]>,

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -166,6 +166,7 @@ impl Default for VmSettings {
     }
 }
 
+/// The Koto runtime's virtual machine
 #[derive(Clone)]
 pub struct Vm {
     exports: ValueMap,
@@ -413,6 +414,7 @@ impl Vm {
         result
     }
 
+    /// Provides the result of running a unary operation on a Value
     pub fn run_unary_op(&mut self, op: UnaryOp, value: Value) -> RuntimeResult {
         let old_frame_count = self.call_stack.len();
         let result_register = self.next_register();
@@ -445,6 +447,7 @@ impl Vm {
         result
     }
 
+    /// Provides the result of running a binary operation on a pair of Values
     pub fn run_binary_op(&mut self, op: BinaryOp, lhs: Value, rhs: Value) -> RuntimeResult {
         let old_frame_count = self.call_stack.len();
         let result_register = self.next_register();
@@ -524,6 +527,9 @@ impl Vm {
         Ok(result)
     }
 
+    /// Runs any tests that are contained in the map's @tests meta entry
+    ///
+    /// Any test failure will be returned as an error.
     pub fn run_tests(&mut self, tests: ValueMap) -> RuntimeResult {
         use Value::{Function, Map, Null};
 
@@ -2999,6 +3005,7 @@ impl Vm {
         }
     }
 
+    /// The bytecode chunk currently active in the VM
     pub fn chunk(&self) -> Rc<Chunk> {
         self.reader.chunk.clone()
     }
@@ -3134,7 +3141,7 @@ impl Vm {
         &mut self.value_stack[index]
     }
 
-    pub fn register_slice(&self, register: u8, count: u8) -> &[Value] {
+    fn register_slice(&self, register: u8, count: u8) -> &[Value] {
         if count > 0 {
             let start = self.register_index(register);
             &self.value_stack[start..start + count as usize]
@@ -3148,6 +3155,9 @@ impl Vm {
             .truncate(self.register_base() + len as usize);
     }
 
+    /// Returns the register slice corresponding to the given ArgRegisters
+    ///
+    /// This is called by external functions when they need access to the call's arguments.
     pub fn get_args(&self, args: &ArgRegisters) -> &[Value] {
         self.register_slice(args.register, args.count)
     }

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1695,14 +1695,11 @@ result";
 
         #[test]
         fn from_literals() {
-            let mut result_data = DataMap::default();
-            result_data.add_value("foo", 42.into());
-            result_data.add_value("bar", "baz".into());
+            let expected = ValueMap::default();
+            expected.add_value("foo", 42.into());
+            expected.add_value("bar", "baz".into());
 
-            test_script(
-                "{foo: 42, bar: 'baz'}",
-                Map(ValueMap::with_data(result_data)),
-            );
+            test_script("{foo: 42, bar: 'baz'}", Map(expected));
         }
 
         #[test]

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1695,7 +1695,7 @@ result";
 
         #[test]
         fn from_literals() {
-            let mut result_data = DataMap::new();
+            let mut result_data = DataMap::default();
             result_data.add_value("foo", 42.into());
             result_data.add_value("bar", "baz".into());
 

--- a/src/serialize/src/lib.rs
+++ b/src/serialize/src/lib.rs
@@ -5,6 +5,7 @@ use {
     serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer},
 };
 
+/// A newtype that allows us to implement support for Serde serialization
 pub struct SerializableValue<'a>(pub &'a Value);
 
 impl<'a> Serialize for SerializableValue<'a> {


### PR DESCRIPTION
- Remove data_fn_2 helpers from MetaMapBuilder
- Simplify the one_plus_two example
- Remove DataMap::new() in favour of DataMap::default()
- Add missing docs, enable #[warn(missing_docs)] in all remaining crates
- Remove some unnecessary functions from DataMap and ValueMap
