### PR TITLE
Simplify implementation of modify-assignment operations

### DIFF
--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -378,6 +378,8 @@ impl<'a> Borrow<dyn AsMetaKeyRef + 'a> for &'a str {
 /// # Example
 ///
 /// ```
+/// use koto_runtime::prelude::*;
+///
 /// #[derive(Debug)]
 /// struct MyData {
 ///     x: f64,

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1646,14 +1646,17 @@ impl Vm {
             (Num4(a), Num4(b)) => Num4(a + b),
             (Num4(a), Number(b)) => Num4(a + b),
             (Map(map), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, map, AddAssign, {
+                // The call result can be discarded, the result is always the modified LHS
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, map, AddAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "+=");
-                })
+                });
             }
             (ExternalValue(ev), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, ev, AddAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, ev, AddAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "+=");
-                })
+                });
             }
             _ => return self.binary_op_error(lhs_value, rhs_value, "+="),
         };
@@ -1676,12 +1679,14 @@ impl Vm {
             (Num4(a), Num4(b)) => Num4(a - b),
             (Num4(a), Number(b)) => Num4(a - b),
             (Map(map), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, map, SubtractAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, map, SubtractAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "-=");
                 })
             }
             (ExternalValue(ev), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, ev, SubtractAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, ev, SubtractAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "-=");
                 })
             }
@@ -1706,12 +1711,14 @@ impl Vm {
             (Num4(a), Num4(b)) => Num4(a * b),
             (Num4(a), Number(b)) => Num4(a * b),
             (Map(map), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, map, MultiplyAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, map, MultiplyAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "*=");
                 })
             }
             (ExternalValue(ev), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, ev, MultiplyAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, ev, MultiplyAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "*=");
                 })
             }
@@ -1736,12 +1743,14 @@ impl Vm {
             (Num4(a), Num4(b)) => Num4(a / b),
             (Num4(a), Number(b)) => Num4(a / b),
             (Map(map), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, map, DivideAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, map, DivideAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "/=");
                 })
             }
             (ExternalValue(ev), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, ev, DivideAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, ev, DivideAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "/=");
                 })
             }
@@ -1766,12 +1775,14 @@ impl Vm {
             (Num4(a), Num4(b)) => Num4(a % b),
             (Num4(a), Number(b)) => Num4(a % b),
             (Map(map), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, map, RemainderAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, map, RemainderAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "%=");
                 })
             }
             (ExternalValue(ev), _) => {
-                call_binary_op_or_else!(self, lhs, lhs, rhs_value, ev, RemainderAssign, {
+                let unused = self.next_register();
+                call_binary_op_or_else!(self, unused, lhs, rhs_value, ev, RemainderAssign, {
                     return self.binary_op_error(lhs_value, rhs_value, "%=");
                 })
             }

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -74,6 +74,29 @@ a = 99
         fn remainder_with_a_divisor_of_zero() {
             test_script("(1 % 0).is_nan()", true);
         }
+
+        #[test]
+        fn modify_assignment() {
+            let script = "
+a = 1
+a += 6  # 7
+a -= 4  # 3
+a *= 10 # 30
+a /= 3  # 10
+a %= 4  # 2
+";
+            test_script(script, 2);
+        }
+
+        #[test]
+        fn modify_assignment_chain() {
+            let script = "
+a = 1
+b = 2
+c = 3
+a += b *= c";
+            test_script(script, 7);
+        }
     }
 
     mod logic {
@@ -2720,21 +2743,11 @@ z.x
 locals = {}
 foo = |x| {x}.with_meta_map locals.foo_meta
 locals.foo_meta =
-  @+=: |self, y|
-    self.x += y
-    self
-  @-=: |self, y|
-    self.x -= y
-    self
-  @*=: |self, y|
-    self.x *= y
-    self
-  @/=: |self, y|
-    self.x /= y
-    self
-  @%=: |self, y|
-    self.x %= y
-    self
+  @+=: |self, y| self.x += y
+  @-=: |self, y| self.x -= y
+  @*=: |self, y| self.x *= y
+  @/=: |self, y| self.x /= y
+  @%=: |self, y| self.x %= y
 
 z = foo 2
 z += 10 # 12


### PR DESCRIPTION
Following on from #193, this PR simplifies the implementation of modify-assignment operations by making it so that the result of the operation is always the LHS. 
