### PR TITLE
Introduce SmallInt AST node and SetNumberNegU8 bytecode op

### DIFF
--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -434,17 +434,19 @@ impl Compiler {
                 }
                 result
             }
-            Node::Number0 => {
+            Node::SmallInt(n) => {
+                dbg!(n);
                 let result = self.get_result_register(result_register)?;
                 if let Some(result) = result {
-                    self.push_op(Set0, &[result.register]);
-                }
-                result
-            }
-            Node::Number1 => {
-                let result = self.get_result_register(result_register)?;
-                if let Some(result) = result {
-                    self.push_op(Set1, &[result.register]);
+                    match *n {
+                        0 => {
+                            println!("Set0!");
+                            self.push_op(Set0, &[result.register])
+                        }
+                        1 => self.push_op(Set1, &[result.register]),
+                        n if n >= 0 => self.push_op(SetNumberU8, &[result.register, n as u8]),
+                        n => self.push_op(SetNumberNegU8, &[result.register, n.abs() as u8]),
+                    }
                 }
                 result
             }
@@ -3336,10 +3338,9 @@ impl Compiler {
                 Node::Null
                 | Node::BoolTrue
                 | Node::BoolFalse
-                | Node::Number0
-                | Node::Number1
-                | Node::Float(_)
+                | Node::SmallInt(_)
                 | Node::Int(_)
+                | Node::Float(_)
                 | Node::Str(_)
                 | Node::Lookup(_) => {
                     let pattern = self.push_register()?;

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -999,6 +999,10 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 value: get_u8!() as i64,
             }),
+            Op::SetNumberNegU8 => Some(SetNumber {
+                register: get_u8!(),
+                value: -(get_u8!() as i64),
+            }),
             Op::LoadFloat => Some(LoadFloat {
                 register: get_u8!(),
                 constant: ConstantIndex::from(get_u8!()),

--- a/src/bytecode/src/op.rs
+++ b/src/bytecode/src/op.rs
@@ -45,6 +45,11 @@ pub enum Op {
     /// `[*target, n]`
     SetNumberU8,
 
+    /// Sets a register to contain Int(-n)
+    ///
+    /// `[*target, n]`
+    SetNumberNegU8,
+
     /// Loads an f64 constant into a register
     ///
     /// `[*target, constant]`
@@ -563,7 +568,6 @@ pub enum Op {
     CheckSizeMin,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused98,
     Unused99,
     Unused100,
     Unused101,

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -39,13 +39,10 @@ pub enum Node {
     /// The `false` keyword
     BoolFalse,
 
-    /// The integer `0`
-    Number0,
+    /// An integer in the range -255..=255
+    SmallInt(i16),
 
-    /// The integer `1`
-    Number1,
-
-    /// An integer literal
+    /// An integer outside of the range -255..=255
     Int(ConstantIndex),
 
     /// An float literal
@@ -280,9 +277,8 @@ impl fmt::Display for Node {
             BoolTrue => write!(f, "BoolTrue"),
             BoolFalse => write!(f, "BoolFalse"),
             Float(_) => write!(f, "Float"),
+            SmallInt(_) => write!(f, "SmallInt"),
             Int(_) => write!(f, "Int"),
-            Number0 => write!(f, "Number0"),
-            Number1 => write!(f, "Number1"),
             Str(_) => write!(f, "Str"),
             List(_) => write!(f, "List"),
             Tuple(_) => write!(f, "Tuple"),

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -1678,10 +1678,10 @@ impl<'source> Parser<'source> {
         };
 
         let number_node = if let Ok(n) = maybe_integer {
-            if n == 0 {
-                self.push_node(Number0)?
-            } else if n == 1 && !negate {
-                self.push_node(Number1)?
+            // Should we store the number as a SmallInt or as a stored constant?
+            if u8::try_from(n).is_ok() {
+                let n = if negate { -n } else { n };
+                self.push_node(SmallInt(n as i16))?
             } else {
                 let n = if negate { -n } else { n };
                 match self.constants.add_i64(n) {


### PR DESCRIPTION
`SetNumberU8` already exists for arg unpacking, it can be used for all positive u8 values, and with `SetNumberNegU8` now all integers in the `-255..=255` range can be compiled without stored constants.
