### PR TITLE
Add more types of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,5 @@ jobs:
         with:
           version: v0.10.3
 
-      - name: Build wasm example
-        run: cd examples/wasm && wasm-pack build
+      - name: Run wasm example tests
+        run: cd examples/wasm && wasm-pack test --node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "criterion"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -618,6 +628,7 @@ version = "0.11.0"
 dependencies = [
  "koto",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -831,6 +842,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"
@@ -1099,6 +1116,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,9 +1387,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1374,13 +1397,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1388,10 +1411,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.80"
+name = "wasm-bindgen-futures"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1399,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1412,9 +1447,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "koto_parser",
  "koto_runtime",
  "pulldown-cmark",
+ "test_bin",
 ]
 
 [[package]]
@@ -1232,6 +1233,12 @@ dependencies = [
  "remove_dir_all",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "test_bin"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7a7de15468c6e65dd7db81cf3822c1ec94c71b2a3c1a976ea8e4696c91115c"
 
 [[package]]
 name = "textwrap"

--- a/README.md
+++ b/README.md
@@ -38,50 +38,56 @@ a try, your early feedback will be invaluable.
 
 ### A Quick Tour
 
-```coffee
+```coffee,skip_check
 # Numbers
 x = 1 + 2.5 + 100.sqrt()
 assert_eq x, 13.5
 
 # Strings
-name = "Koto"
-print "Hello, $name!"
+name = 'Koto'
+print 'Hello, $name!'
+# -> Hello, Koto!
 
 # Functions
 square = |n| n * n
-print "8 squared is ${square 8}"
+print '8 squared is ${square 8}'
+# -> 8 squared is 64
 
 add_squares = |a, b| (square a) + (square b)
 assert_eq (add_squares 2, 4), 20
 
-# Iterators, ranges, and lists
+# Iterators, Ranges, and Lists
 fizz_buzz = (1..100)
   .keep |n| (10..=15).contains n
   .each |n|
     match n % 3, n % 5
-      0, 0 then "Fizz Buzz"
-      0, _ then "Fizz"
-      _, 0 then "Buzz"
+      0, 0 then 'Fizz Buzz'
+      0, _ then 'Fizz'
+      _, 0 then 'Buzz'
       else n
   .to_list()
 assert_eq
   fizz_buzz,
-  ["Buzz", 11, "Fizz", 13, 14, "Fizz Buzz"]
+  ['Buzz', 11, 'Fizz', 13, 14, 'Fizz Buzz']
 
 # Maps and tuples
-x = {peaches: 42, pears: 99}
-assert_eq
-  x.keys().to_tuple(),
-  ("peaches", "pears")
 
-y = # Maps can also be defined using indented `key: value` pairs
+## Maps can be defined with curly braces
+fruits = {peaches: 42, pears: 99}
+
+## Maps can also be defined using indented `key: value` pairs
+more_fruits = 
   apples: 123
   plums: 99
 
-fruits = x + y # Maps can be combined using the `+` operator
+fruits.extend more_fruits
+assert_eq
+  fruits.keys().to_tuple(),
+  ('peaches', 'pears', 'apples', 'plums')
 
 fruit, amount = fruits.max |(_, amount)| amount
-print "The highest amount of fruit is: $amount $fruit"
+'The highest amount of fruit is: $amount $fruit'
+# -> The highest amount of fruit is: 123 apples
 ```
 
 ### Learning the Language
@@ -121,7 +127,7 @@ Launching the `koto` CLI without providing a script enters the REPL.
 Welcome to Koto 
 » 1 + 1
 ➝ 2
-» print "{}, {}!", "Hello", "World"
+» print '{}, {}!', 'Hello', 'World'
 Hello, World!
 ➝ null
 ```

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -13,3 +13,6 @@ crate-type = ["cdylib"]
 [dependencies]
 koto = { path = "../../src/koto" }
 wasm-bindgen = "0.2.71"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.33" # Internal testing crate for wasm-bindgen

--- a/examples/wasm/package.json
+++ b/examples/wasm/package.json
@@ -3,18 +3,19 @@
   "version": "0.0.1",
   "scripts": {
     "build": "webpack",
-    "start": "webpack serve --open"
+    "start": "webpack serve --open",
+    "test": "wasmpack test --node"
   },
   "dependencies": {
     "brace": "^0.11.1",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.11.1"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "^1.5.0",
-    "css-loader": "^6.2.0",
-    "html-webpack-plugin": "^5.3.2",
-    "style-loader": "^3.2.1",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2"
+    "@wasm-tool/wasm-pack-plugin": "^1.6.0",
+    "css-loader": "^6.7.3",
+    "html-webpack-plugin": "^5.5.0",
+    "style-loader": "^3.3.1",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
   }
 }

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -82,3 +82,18 @@ pub fn compile_and_run(input: &str) -> String {
         Err(error) => format!("Compilation error: {error}"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {super::*, wasm_bindgen_test::wasm_bindgen_test};
+
+    #[wasm_bindgen_test]
+    fn one_plus_one() {
+        assert_eq!(compile_and_run("print 1 + 1"), "2\n");
+    }
+
+    #[wasm_bindgen_test]
+    fn tuple_to_list() {
+        assert_eq!(compile_and_run("print (1, 2, 3).to_list()"), "[1, 2, 3]\n");
+    }
+}

--- a/examples/wasm/webpack.config.js
+++ b/examples/wasm/webpack.config.js
@@ -35,6 +35,6 @@ module.exports = {
     clean: true,
   },
   devServer: {
-    contentBase: dist,
+    static: dist,
   },
 };

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -52,7 +52,7 @@ spectral_norm = |n|
   result = spectral_norm n
 
   if (koto.args.get 1) != 'quiet'
-    io.print result
+    print result
 
 @tests =
   @test spectral_norm_5: ||

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -31,12 +31,12 @@ number_to_english = |n|
     null then 50
     arg then arg.to_number()
 
-  result = -n..n
+  result = -n..=n
     .each |x| number_to_english x
     .to_tuple()
 
   if not (koto.args.get 1) == 'quiet'
-    io.print result
+    print result
 
 @tests =
   @test number_to_english: ||

--- a/src/koto/Cargo.toml
+++ b/src/koto/Cargo.toml
@@ -23,6 +23,7 @@ dunce = "1.0.2" # Normalize Windows paths to the most compatible format, avoidin
 
 [dev-dependencies]
 criterion = "0.3.1"
+test_bin = "0.4.0" # A crate for getting the crate binary in an integration test.
 
 [dev-dependencies.pulldown-cmark]
 # Markdown parsing

--- a/src/koto/tests/cli_tests.rs
+++ b/src/koto/tests/cli_tests.rs
@@ -1,0 +1,104 @@
+use std::{
+    io::Write,
+    iter,
+    path::PathBuf,
+    process::{Output, Stdio},
+    str,
+};
+
+fn check_output(output: Output, expected_stdout: &str, expected_stderr: &str) {
+    let stdout = str::from_utf8(&output.stdout).expect("Failed to read stdout");
+    let stderr = str::from_utf8(&output.stderr).expect("Failed to read stderr");
+
+    if !output.status.success() {
+        panic!("CLI test failed:\n\n>> stdout:\n{stdout}\n\n>> stderr:\n{stderr}",)
+    }
+
+    assert_eq!(stdout, expected_stdout);
+    assert_eq!(stderr, expected_stderr);
+}
+
+fn check_cli_run_file(
+    script_path: &[&str],
+    args: &[&str],
+    expected_stdout: &str,
+    expected_stderr: &str,
+) {
+    let script_path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "..", ".."]
+        .iter()
+        .chain(script_path.iter())
+        .collect();
+
+    check_output(
+        test_bin::get_test_bin("koto")
+            .args(iter::once(&script_path.to_string_lossy().as_ref()).chain(args))
+            .output()
+            .expect("Failed to run CLI"),
+        expected_stdout,
+        expected_stderr,
+    )
+}
+
+fn check_cli_piped_input(input: &'static str, expected_stdout: &str, expected_stderr: &str) {
+    let mut cli = test_bin::get_test_bin("koto")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to run CLI");
+
+    let mut stdin = cli.stdin.take().expect("Failed to open stdin");
+
+    std::thread::spawn(move || {
+        stdin
+            .write_all(input.as_bytes())
+            .expect("Failed to write to stdin");
+    });
+
+    check_output(
+        cli.wait_with_output().expect("Failed to run CLI"),
+        expected_stdout,
+        expected_stderr,
+    )
+}
+
+mod cli {
+    use super::*;
+
+    mod run_file {
+        use super::*;
+
+        #[test]
+        fn spectral_norm() {
+            check_cli_run_file(
+                &["koto", "benches", "spectral_norm.koto"],
+                &["2"],
+                "1.1833501765516568\n",
+                "",
+            );
+        }
+
+        #[test]
+        fn string_formatting() {
+            check_cli_run_file(
+                &["koto", "benches", "string_formatting.koto"],
+                &["1"],
+                "('minus one', 'zero', 'one')\n",
+                "",
+            );
+        }
+    }
+
+    mod piped_input {
+        use super::*;
+
+        #[test]
+        fn square() {
+            let input = "
+square = |x| x * x
+print square 9
+";
+            check_cli_piped_input(input, "81\n", "");
+        }
+    }
+}

--- a/src/koto/tests/docs_examples.rs
+++ b/src/koto/tests/docs_examples.rs
@@ -129,7 +129,8 @@ fn load_markdown_and_run_examples(path: &Path) {
         match event {
             Start(CodeBlock(CodeBlockKind::Fenced(lang))) => {
                 let mut lang_info = lang.deref().split(',');
-                if matches!(lang_info.next(), Some("koto")) {
+                // Coffeescript highlighting is used for the code example in the readme
+                if matches!(lang_info.next(), Some("koto" | "coffee")) {
                     in_koto_code = true;
                     code_block.clear();
                     let modifier = lang_info.next();
@@ -232,4 +233,11 @@ mod guide {
     test_lang_guide_examples!(testing);
     test_lang_guide_examples!(tuples);
     test_lang_guide_examples!(value_unpacking);
+}
+
+mod readme {
+    #[test]
+    fn check_readme() {
+        super::run_doc_examples(&[".."], "README")
+    }
 }


### PR DESCRIPTION
- Add tests that check running scripts via the CLI
- Ensure that the code example in the readme can be run
- Refresh the wasm example dependencies, and run wasm tests on CI
  - This fixes #132.
