### PR TITLE
Allow tuples to be used as map keys, introduce koto.hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ The Koto project adheres to
 
 #### Libs
 
-- New `color` and `geometry` libs have been added, and are available by default
-  in the CLI.
+- New `color` and `geometry` libs have been added, and are available by default in the CLI.
+- `koto.hash` has been added to allow value hashes to be accessed.
 
 #### Internals
 
@@ -44,7 +44,7 @@ The Koto project adheres to
 
 - `File`s now implement `@display`, showing their paths.
 - `Tuple`s now share data when sub-tuples are made via indexing or unpacking, 
-  avoiding unnecessary copies. 
+    avoiding unnecessary copies. 
 
 #### Internals
 
@@ -58,6 +58,9 @@ The Koto project adheres to
   expected to be `ValueString`s.
 - `unexpected_type_error_with_slice` has been renamed to
   `type_error_with_slice`, and has had the prefix argument removed.
+- `DataMap::get_with_string` has been replaced with a simplified `ValueKey`
+  implementation that allows for efficient `&str` accesses without the
+  intermediate steps.
 
 ### Removed
 

--- a/docs/core_lib/koto.md
+++ b/docs/core_lib/koto.md
@@ -37,6 +37,29 @@ Although typically module items are exported with `export` expressions,
 it can be useful to export items programatically.
 
 
+## hash
+
+```kototype
+|Value| -> Value
+```
+
+Returns the value's hash as an integer, or Null if the value is not hashable.
+
+```koto
+import koto.hash
+
+print! (hash 'hi') == (hash 'bye')
+check! false
+
+# Lists aren't hashable
+print! hash [1, 2] 
+check! null
+
+# Tuples are hashable if they only contain hashable values 
+print! (hash (1, 2)) == null
+check! false
+```
+
 ## script_dir
 
 ```kototype

--- a/docs/core_lib/map.md
+++ b/docs/core_lib/map.md
@@ -216,24 +216,39 @@ check! My Map
 ## insert
 
 ```kototype
-|Map, Key| -> Value
-```
-
-Inserts Null into the map with the given key.
-
-```kototype
 |Map, Key, Value| -> Value
 ```
 
-Inserts a value into the map with the given key.
+Inserts an entry into the map with the given key and value. 
+
+```kototype
+|Map, Key| -> Value
+```
+
+Inserts an entry into the map with the given key, and Null as its value.
 
 If the key already existed in the map, then the old value is returned.
 If the key didn't already exist, then Null is returned.
+
+### Map Keys
+
+Map keys are typically strings, but any _immutable_ value can be used.
+
+Values that can be used as keys are:
+- `Bool`
+- `Number`
+- `Null`
+- `Range`
+- `String`
+- `Tuple` 
+  - A Tuple can only be used as a key when its contained values are immutable, 
+    any mutable value (like a `List` or `Map`) will throw an error.
 
 ### Example
 
 ```koto
 x = {hello: -1}
+
 print! x.insert 'hello', 99 # -1 already exists at `hello`, so it's returned here
 check! -1
 
@@ -245,10 +260,23 @@ check! null
 
 print! x.goodbye
 check! 123
+
+print! x.insert 123, 'hi!' # Numbers can be used as map keys 
+check! null
+
+print! x.get 123
+check! hi!
+
+print! x.insert ('a', 'b'), -1 # Tuples can be used as map keys 
+check! null
+
+print! x.get ('a', 'b')
+check! -1
 ```
 
 ### See also
 
+- [`map.get`](#get)
 - [`map.remove`](#remove)
 - [`map.update`](#update)
 

--- a/libs/yaml/src/lib.rs
+++ b/libs/yaml/src/lib.rs
@@ -2,7 +2,7 @@
 
 use {koto_runtime::prelude::*, koto_serialize::SerializableValue, serde_yaml::Value as YamlValue};
 
-pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, String> {
+pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, RuntimeError> {
     let result = match value {
         YamlValue::Null => Value::Null,
         YamlValue::Bool(b) => Value::Bool(*b),
@@ -10,7 +10,7 @@ pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, Stri
             Some(n64) => Value::Number(n64.into()),
             None => match n.as_f64() {
                 Some(n64) => Value::Number(n64.into()),
-                None => return Err(format!("Number is out of range: {n}")),
+                None => return runtime_error!("Number is out of range: {n}"),
             },
         },
         YamlValue::String(s) => Value::Str(s.as_str().into()),
@@ -18,7 +18,7 @@ pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, Stri
             match sequence
                 .iter()
                 .map(yaml_value_to_koto_value)
-                .collect::<Result<ValueVec, String>>()
+                .collect::<Result<ValueVec, RuntimeError>>()
             {
                 Ok(result) => Value::List(ValueList::with_data(result)),
                 Err(e) => return Err(e),
@@ -28,13 +28,10 @@ pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, Stri
             let map = ValueMap::with_capacity(mapping.len());
             for (key, value) in mapping.iter() {
                 let key_as_koto_value = yaml_value_to_koto_value(key)?;
-                if !key_as_koto_value.is_hashable() {
-                    return Err(format!(
-                        "Invalid value type for map key: {}",
-                        key_as_koto_value.type_as_string()
-                    ));
-                }
-                map.insert(key_as_koto_value.into(), yaml_value_to_koto_value(value)?);
+                map.insert(
+                    ValueKey::try_from(key_as_koto_value)?,
+                    yaml_value_to_koto_value(value)?,
+                );
             }
             Value::Map(map)
         }

--- a/libs/yaml/src/lib.rs
+++ b/libs/yaml/src/lib.rs
@@ -28,7 +28,7 @@ pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, Stri
             let map = ValueMap::with_capacity(mapping.len());
             for (key, value) in mapping.iter() {
                 let key_as_koto_value = yaml_value_to_koto_value(key)?;
-                if !key_as_koto_value.is_immutable() {
+                if !key_as_koto_value.is_hashable() {
                     return Err(format!(
                         "Invalid value type for map key: {}",
                         key_as_koto_value.type_as_string()

--- a/src/koto/src/koto.rs
+++ b/src/koto/src/koto.rs
@@ -309,12 +309,7 @@ impl Koto {
             .map(|arg| Str(arg.as_str().into()))
             .collect::<Vec<_>>();
 
-        match self
-            .runtime
-            .prelude()
-            .data_mut()
-            .get_with_string_mut("koto")
-        {
+        match self.runtime.prelude().data_mut().get("koto") {
             Some(Map(map)) => {
                 map.add_value("args", Tuple(koto_args.into()));
                 Ok(())
@@ -348,12 +343,7 @@ impl Koto {
 
         self.script_path = path;
 
-        match self
-            .runtime
-            .prelude()
-            .data_mut()
-            .get_with_string_mut("koto")
-        {
+        match self.runtime.prelude().data_mut().get("koto") {
             Some(Map(map)) => {
                 map.add_value("script_dir", script_dir);
                 map.add_value("script_path", script_path);

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -646,13 +646,7 @@ pub fn make_module() -> ValueMap {
                     Output::Error(error) => return Err(error),
                 };
 
-                if !key.is_hashable() {
-                    return runtime_error!(
-                        "Only immutable Values can be used as keys (found '{}')",
-                        key.type_as_string()
-                    );
-                }
-                result.insert(key.into(), value);
+                result.insert(ValueKey::try_from(key)?, value);
             }
 
             Ok(Map(ValueMap::with_data(result)))

--- a/src/runtime/src/core/iterator.rs
+++ b/src/runtime/src/core/iterator.rs
@@ -646,7 +646,7 @@ pub fn make_module() -> ValueMap {
                     Output::Error(error) => return Err(error),
                 };
 
-                if !key.is_immutable() {
+                if !key.is_hashable() {
                     return runtime_error!(
                         "Only immutable Values can be used as keys (found '{}')",
                         key.type_as_string()

--- a/src/runtime/src/core/koto.rs
+++ b/src/runtime/src/core/koto.rs
@@ -1,6 +1,9 @@
 //! The `koto` core library module
 
-use crate::prelude::*;
+use {
+    crate::prelude::*,
+    std::hash::{Hash, Hasher},
+};
 
 /// Initializes the `koto` core library module
 pub fn make_module() -> ValueMap {
@@ -11,6 +14,18 @@ pub fn make_module() -> ValueMap {
     result.add_value("args", Tuple(ValueTuple::default()));
 
     result.add_fn("exports", |vm, _| Ok(Map(vm.exports().clone())));
+
+    result.add_fn("hash", |vm, args| match vm.get_args(args) {
+        [value] => match ValueKey::try_from(value.clone()) {
+            Ok(key) => {
+                let mut hasher = KotoHasher::default();
+                key.hash(&mut hasher);
+                Ok(hasher.finish().into())
+            }
+            Err(_) => Ok(Null),
+        },
+        unexpected => type_error_with_slice("a single argument", unexpected),
+    });
 
     result.add_value("script_dir", Null);
     result.add_value("script_path", Null);

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -317,7 +317,7 @@ pub fn format_string(
                 None => return runtime_error!("Missing argument for index {n}"),
             },
             FormatToken::Identifier(id, format_spec) => match format_args.first() {
-                Some(Value::Map(map)) => match map.data().get_with_string(id) {
+                Some(Value::Map(map)) => match map.data().get(id) {
                     Some(value) => result.push_str(&value_to_string(vm, value, format_spec)?),
                     None => return runtime_error!("Key '{id}' not found in map"),
                 },

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -34,7 +34,7 @@ pub use {
     value_iterator::{KotoIterator, ValueIterator, ValueIteratorOutput},
     value_key::ValueKey,
     value_list::{ValueList, ValueVec},
-    value_map::{DataMap, ValueMap},
+    value_map::{DataMap, KotoHasher, ValueMap},
     value_number::ValueNumber,
     value_string::ValueString,
     value_tuple::ValueTuple,

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -1,12 +1,10 @@
 use {
     crate::{
         external::{ArgRegisters, ExternalFunction},
-        runtime_error, type_error_with_slice, ExternalData, ExternalValue, RuntimeError,
-        RuntimeResult, Value, ValueString, Vm,
+        prelude::*,
     },
     indexmap::IndexMap,
     koto_parser::MetaKeyId,
-    rustc_hash::FxHasher,
     std::{
         borrow::Borrow,
         cell::RefCell,
@@ -18,7 +16,7 @@ use {
     },
 };
 
-type MetaMapType = IndexMap<MetaKey, Value, BuildHasherDefault<FxHasher>>;
+type MetaMapType = IndexMap<MetaKey, Value, BuildHasherDefault<KotoHasher>>;
 
 /// The meta map used by [ValueMap](crate::ValueMap) and [ExternalValue](crate::ExternalValue)
 ///

--- a/src/runtime/src/prelude.rs
+++ b/src/runtime/src/prelude.rs
@@ -4,7 +4,7 @@
 pub use crate::{
     make_runtime_error, runtime_error, type_error, type_error_with_slice, BinaryOp, CallArgs,
     DataMap, ExternalData, ExternalValue, IntRange, KotoDisplay, KotoDisplayOptions, KotoFile,
-    KotoIterator, KotoRead, KotoWrite, MetaKey, MetaMap, MetaMapBuilder, RuntimeError,
+    KotoHasher, KotoIterator, KotoRead, KotoWrite, MetaKey, MetaMap, MetaMapBuilder, RuntimeError,
     RuntimeResult, UnaryOp, Value, ValueIterator, ValueIteratorOutput, ValueKey, ValueList,
     ValueMap, ValueNumber, ValueString, ValueTuple, ValueVec, Vm, VmSettings,
 };

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -135,10 +135,10 @@ impl Value {
         }
     }
 
-    /// Returns true if the value doesn't have internal mutability
+    /// Returns true if the value is hashable
     ///
-    /// Only immutable values are acceptable as map keys.
-    pub fn is_immutable(&self) -> bool {
+    /// Only hashable values are acceptable as map keys.
+    pub fn is_hashable(&self) -> bool {
         use Value::*;
         matches!(self, Null | Bool(_) | Number(_) | Range(_) | Str(_))
     }

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -1,7 +1,7 @@
 //! The core value type used in the Koto runtime
 
 use {
-    crate::{prelude::*, value_key::ValueRef, ExternalFunction},
+    crate::{prelude::*, ExternalFunction},
     koto_bytecode::Chunk,
     std::{
         fmt::{self, Write},
@@ -82,18 +82,6 @@ pub enum Value {
 }
 
 impl Value {
-    #[inline]
-    pub(crate) fn as_ref(&self) -> ValueRef {
-        match &self {
-            Value::Null => ValueRef::Null,
-            Value::Bool(b) => ValueRef::Bool(b),
-            Value::Number(n) => ValueRef::Number(n),
-            Value::Str(s) => ValueRef::Str(s),
-            Value::Range(r) => ValueRef::Range(r),
-            _ => unreachable!(), // Only immutable values can be used in ValueKey
-        }
-    }
-
     /// Returns a recursive 'deep copy' of a Value
     ///
     /// This is used by the various `.deep_copy()` core library functions.
@@ -140,7 +128,11 @@ impl Value {
     /// Only hashable values are acceptable as map keys.
     pub fn is_hashable(&self) -> bool {
         use Value::*;
-        matches!(self, Null | Bool(_) | Number(_) | Range(_) | Str(_))
+        match self {
+            Null | Bool(_) | Number(_) | Range(_) | Str(_) => true,
+            Tuple(t) => t.is_hashable(),
+            _ => false,
+        }
     }
 
     /// Returns true if a `ValueIterator` can be made from the value

--- a/src/runtime/src/value_key.rs
+++ b/src/runtime/src/value_key.rs
@@ -54,13 +54,15 @@ impl PartialEq for ValueKey {
     }
 }
 
-impl From<Value> for ValueKey {
-    fn from(value: Value) -> Self {
-        assert!(
-            value.is_hashable(),
-            "Only immutable Value types can be used as a ValueKey"
-        );
-        Self(value)
+impl TryFrom<Value> for ValueKey {
+    type Error = RuntimeError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        if value.is_hashable() {
+            Ok(Self(value))
+        } else {
+            runtime_error!("Only hashable values can be used as value keys")
+        }
     }
 }
 

--- a/src/runtime/src/value_key.rs
+++ b/src/runtime/src/value_key.rs
@@ -10,7 +10,7 @@ use {
 
 /// The key type used by [ValueMap](crate::ValueMap)
 ///
-/// Only immutable values can be used as keys, see [Value::is_immutable]
+/// Only immutable values can be used as keys, see [Value::is_hashable]
 #[derive(Clone, Debug)]
 pub struct ValueKey(Value);
 
@@ -57,7 +57,7 @@ impl PartialEq for ValueKey {
 impl From<Value> for ValueKey {
     fn from(value: Value) -> Self {
         assert!(
-            value.is_immutable(),
+            value.is_hashable(),
             "Only immutable Value types can be used as a ValueKey"
         );
         Self(value)

--- a/src/runtime/src/value_key.rs
+++ b/src/runtime/src/value_key.rs
@@ -1,16 +1,16 @@
 use {
     crate::prelude::*,
+    indexmap::Equivalent,
     std::{
-        borrow::Borrow,
         cmp::Ordering,
+        fmt,
         hash::{Hash, Hasher},
-        ops::Deref,
     },
 };
 
 /// The key type used by [ValueMap](crate::ValueMap)
 ///
-/// Only immutable values can be used as keys, see [Value::is_hashable]
+/// Only hashable values can be used as keys, see [Value::is_hashable]
 #[derive(Clone, Debug)]
 pub struct ValueKey(Value);
 
@@ -19,23 +19,17 @@ impl ValueKey {
     pub fn value(&self) -> &Value {
         &self.0
     }
+}
 
-    /// Returns a display string for the key
-    pub fn key_to_string(&self) -> Result<String, RuntimeError> {
-        use Value::*;
+impl TryFrom<Value> for ValueKey {
+    type Error = RuntimeError;
 
-        let result = match &self.0 {
-            Null => "null".to_string(),
-            Bool(b) => b.to_string(),
-            Number(n) => n.to_string(),
-            Range(r) => r.to_string(),
-            Str(s) => s.to_string(),
-            unexpected => {
-                return runtime_error!("Invalid ValueKeyType: {}", unexpected.type_as_string())
-            }
-        };
-
-        Ok(result)
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        if value.is_hashable() {
+            Ok(Self(value))
+        } else {
+            runtime_error!("Only hashable values can be used as value keys")
+        }
     }
 }
 
@@ -49,19 +43,91 @@ impl PartialEq for ValueKey {
             (Str(a), Str(b)) => a == b,
             (Range(a), Range(b)) => a == b,
             (Null, Null) => true,
+            (Tuple(a), Tuple(b)) => {
+                a.len() == b.len()
+                    && a.iter()
+                        .zip(b.iter())
+                        .all(|(value_a, value_b)| Self(value_a.clone()) == Self(value_b.clone()))
+            }
             _ => false,
         }
     }
 }
+impl Eq for ValueKey {}
 
-impl TryFrom<Value> for ValueKey {
-    type Error = RuntimeError;
+impl Hash for ValueKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        use Value::*;
 
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
-        if value.is_hashable() {
-            Ok(Self(value))
-        } else {
-            runtime_error!("Only hashable values can be used as value keys")
+        match &self.0 {
+            Null => {}
+            Bool(b) => b.hash(state),
+            Number(n) => n.hash(state),
+            Str(s) => s.hash(state),
+            Range(IntRange { start, end }) => {
+                state.write_isize(*start);
+                state.write_isize(*end);
+            }
+            Tuple(t) => {
+                for value in t.iter() {
+                    Self(value.clone()).hash(state)
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl PartialOrd for ValueKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        use Value::*;
+
+        match (&self.0, &other.0) {
+            (Null, Null) => Some(Ordering::Equal),
+            (Null, _) => Some(Ordering::Less),
+            (_, Null) => Some(Ordering::Greater),
+            (Number(a), Number(b)) => a.partial_cmp(b),
+            (Str(a), Str(b)) => a.partial_cmp(b),
+            (Tuple(a), Tuple(b)) => match a.len().cmp(&b.len()) {
+                Ordering::Equal => {
+                    for (value_a, value_b) in a.iter().zip(b.iter()) {
+                        // Only ValueRef-able values will be contained in a tuple that's made it
+                        // into a ValueKey
+                        match Self(value_a.clone()).partial_cmp(&Self(value_b.clone())) {
+                            Some(Ordering::Equal) => {}
+                            other => return other,
+                        }
+                    }
+                    Some(Ordering::Equal)
+                }
+                other => Some(other),
+            },
+            _ => Some(Ordering::Equal),
+        }
+    }
+}
+
+impl fmt::Display for ValueKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        use Value::*;
+
+        match &self.0 {
+            Null => f.write_str("null"),
+            Bool(b) => write!(f, "{b}"),
+            Number(n) => write!(f, "{n}"),
+            Range(r) => write!(f, "{r}"),
+            Str(s) => f.write_str(s),
+            Tuple(t) => {
+                f.write_str("(")?;
+                for (i, value) in t.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{}", Self(value.clone()))?;
+                }
+                f.write_str(")")
+            }
+            _ => Ok(()),
         }
     }
 }
@@ -78,164 +144,21 @@ impl From<&str> for ValueKey {
     }
 }
 
-impl Borrow<Value> for ValueKey {
-    fn borrow(&self) -> &Value {
-        &self.0
-    }
-}
-
-impl Deref for ValueKey {
-    type Target = Value;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Hash for ValueKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state)
-    }
-}
-
-impl PartialOrd for ValueKey {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        use Value::*;
-
-        match (&self.0, &other.0) {
-            (Null, Null) => Some(Ordering::Equal),
-            (Null, _) => Some(Ordering::Less),
-            (_, Null) => Some(Ordering::Greater),
-            (Number(a), Number(b)) => a.partial_cmp(b),
-            (Str(a), Str(b)) => a.partial_cmp(b),
-            _ => Some(Ordering::Less),
-        }
-    }
-}
-
-impl Ord for ValueKey {
-    fn cmp(&self, other: &Self) -> Ordering {
-        use Value::*;
-
-        match (&self.0, &other.0) {
-            (Null, Null) => Ordering::Equal,
-            (Null, _) => Ordering::Less,
-            (_, Null) => Ordering::Greater,
-            (Number(a), Number(b)) => a.cmp(b),
-            (Str(a), Str(b)) => a.cmp(b),
-            _ => Ordering::Less,
-        }
-    }
-}
-
-impl Eq for ValueKey {}
-
-// Currently only used to support DataMap::get_with_string()
-#[derive(Clone, Debug)]
-pub(crate) enum ValueRef<'a> {
-    Null,
-    Bool(&'a bool),
-    Number(&'a ValueNumber),
-    Str(&'a str),
-    Range(&'a IntRange),
-}
-
-impl<'a> From<&'a Value> for ValueRef<'a> {
-    fn from(value: &'a Value) -> Self {
-        match value {
-            Value::Null => ValueRef::Null,
-            Value::Bool(b) => ValueRef::Bool(b),
-            Value::Number(n) => ValueRef::Number(n),
-            Value::Str(s) => ValueRef::Str(s),
-            Value::Range(r) => ValueRef::Range(r),
-            _ => unreachable!(), // Only immutable values can be used in ValueKey
-        }
-    }
-}
-
-impl<'a> PartialEq for ValueRef<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        use ValueRef::*;
-
-        match (self, other) {
-            (Number(a), Number(b)) => a == b,
-            (Bool(a), Bool(b)) => a == b,
-            (Str(a), Str(b)) => a == b,
-            (Range(a), Range(b)) => a == b,
-            (Null, Null) => true,
+// Support efficient map lookups with &str
+impl Equivalent<ValueKey> for str {
+    fn equivalent(&self, other: &ValueKey) -> bool {
+        match &other.0 {
+            Value::Str(s) => self == s.as_str(),
             _ => false,
         }
     }
 }
 
-impl<'a> Eq for ValueRef<'a> {}
-
-impl<'a> Hash for ValueRef<'a> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        use ValueRef::*;
-
-        std::mem::discriminant(self).hash(state);
-
-        match self {
-            Null => {}
-            Bool(b) => b.hash(state),
-            Number(n) => n.hash(state),
-            Str(s) => s.hash(state),
-            Range(IntRange { start, end }) => {
-                state.write_isize(*start);
-                state.write_isize(*end);
-            }
+impl Equivalent<ValueKey> for ValueString {
+    fn equivalent(&self, other: &ValueKey) -> bool {
+        match &other.0 {
+            Value::Str(s) => self == s,
+            _ => false,
         }
-    }
-}
-
-// A trait that allows for allocation-free map accesses with &str
-pub(crate) trait ValueKeyRef {
-    fn to_value_ref(&self) -> ValueRef;
-}
-
-impl<'a> Hash for dyn ValueKeyRef + 'a {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.to_value_ref().hash(state);
-    }
-}
-
-impl<'a> PartialEq for dyn ValueKeyRef + 'a {
-    fn eq(&self, other: &Self) -> bool {
-        self.to_value_ref() == other.to_value_ref()
-    }
-}
-
-impl<'a> Eq for dyn ValueKeyRef + 'a {}
-
-impl ValueKeyRef for Value {
-    fn to_value_ref(&self) -> ValueRef {
-        self.as_ref()
-    }
-}
-
-impl ValueKeyRef for ValueKey {
-    fn to_value_ref(&self) -> ValueRef {
-        self.0.as_ref()
-    }
-}
-
-// The key part of this whole mechanism; wrap a &str as ValueRef::Str,
-// allowing a map search to be performed directly against &str
-impl<'a> ValueKeyRef for &'a str {
-    fn to_value_ref(&self) -> ValueRef {
-        ValueRef::Str(self)
-    }
-}
-
-impl<'a> Borrow<dyn ValueKeyRef + 'a> for ValueKey {
-    fn borrow(&self) -> &(dyn ValueKeyRef + 'a) {
-        self
-    }
-}
-
-impl<'a> Borrow<dyn ValueKeyRef + 'a> for &'a str {
-    fn borrow(&self) -> &(dyn ValueKeyRef + 'a) {
-        self
     }
 }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -2,8 +2,6 @@ use {
     crate::{
         external::{ArgRegisters, ExternalFunction},
         prelude::*,
-        value_key::ValueKeyRef,
-        // MetaKey, MetaMap, RuntimeResult, Value, ValueKey, Vm,
     },
     indexmap::IndexMap,
     rustc_hash::FxHasher,
@@ -31,21 +29,6 @@ impl DataMap {
             capacity,
             Default::default(),
         ))
-    }
-
-    /// Allows access to map entries without having to create a ValueString
-    pub fn get_with_string(&self, key: &str) -> Option<&Value> {
-        self.0.get(&key as &dyn ValueKeyRef)
-    }
-
-    /// Allows access to map entries without having to create a ValueString
-    pub fn get_with_string_mut(&mut self, key: &str) -> Option<&mut Value> {
-        self.0.get_mut(&key as &dyn ValueKeyRef)
-    }
-
-    /// Removes any entry with a matching name and returns the removed value
-    pub fn remove_with_string(&mut self, key: &str) -> Option<Value> {
-        self.0.remove(&key as &dyn ValueKeyRef)
     }
 }
 
@@ -209,7 +192,7 @@ impl KotoDisplay for ValueMap {
                 if i > 0 {
                     s.push_str(", ");
                 }
-                key.display(s, vm, KotoDisplayOptions::default())?;
+                key.value().display(s, vm, KotoDisplayOptions::default())?;
                 s.push_str(": ");
                 value.display(
                     s,
@@ -234,13 +217,10 @@ mod tests {
     fn get_and_remove_with_string() {
         let m = ValueMap::default();
 
-        assert!(m.data().get_with_string("test").is_none());
+        assert!(m.data().get("test").is_none());
         m.add_value("test", Value::Null);
-        assert!(m.data().get_with_string("test").is_some());
-        assert!(matches!(
-            m.data_mut().remove_with_string("test"),
-            Some(Value::Null)
-        ));
-        assert!(m.data().get_with_string("test").is_none());
+        assert!(m.data().get("test").is_some());
+        assert!(matches!(m.data_mut().remove("test"), Some(Value::Null)));
+        assert!(m.data().get("test").is_none());
     }
 }

--- a/src/runtime/src/value_map.rs
+++ b/src/runtime/src/value_map.rs
@@ -14,7 +14,10 @@ use {
     },
 };
 
-type DataMapType = IndexMap<ValueKey, Value, BuildHasherDefault<FxHasher>>;
+/// The hasher used throughout the Koto runtime
+pub type KotoHasher = FxHasher;
+
+type DataMapType = IndexMap<ValueKey, Value, BuildHasherDefault<KotoHasher>>;
 
 /// The underlying ValueKey -> Value 'data' hash map used in Koto
 ///

--- a/src/runtime/src/value_tuple.rs
+++ b/src/runtime/src/value_tuple.rs
@@ -32,6 +32,11 @@ impl ValueTuple {
             None
         }
     }
+
+    /// Returns true if the tuple contains only immutable values
+    pub fn is_hashable(&self) -> bool {
+        self.iter().all(Value::is_hashable)
+    }
 }
 
 impl Deref for ValueTuple {

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -68,15 +68,7 @@ fn setup_core_lib_and_prelude() -> (CoreLib, ValueMap) {
 
     macro_rules! default_import {
         ($name:expr, $module:ident) => {{
-            prelude.add_value(
-                $name,
-                core_lib
-                    .$module
-                    .data()
-                    .get_with_string($name)
-                    .unwrap()
-                    .clone(),
-            );
+            prelude.add_value($name, core_lib.$module.data().get($name).unwrap().clone());
         }};
     }
 
@@ -243,7 +235,7 @@ impl Vm {
 
     /// Returns the named value from the exports map, or None if no matching value is found
     pub fn get_exported_value(&self, id: &str) -> Option<Value> {
-        self.exports.data().get_with_string(id).cloned()
+        self.exports.data().get(id).cloned()
     }
 
     /// Returns the named function from the exports map
@@ -1058,9 +1050,9 @@ impl Vm {
         let non_local = self
             .exports
             .data()
-            .get_with_string(name)
+            .get(name)
             .cloned()
-            .or_else(|| self.context.prelude.data().get_with_string(name).cloned());
+            .or_else(|| self.context.prelude.data().get(name).cloned());
 
         if let Some(non_local) = non_local {
             self.set_register(register, non_local);
@@ -2084,19 +2076,14 @@ impl Vm {
         };
 
         // Is the import in the exports?
-        let maybe_in_exports = self.exports.data().get_with_string(&import_name).cloned();
+        let maybe_in_exports = self.exports.data().get(&import_name).cloned();
         if let Some(value) = maybe_in_exports {
             self.set_register(import_register, value);
             return Ok(());
         }
 
         // Is the import in the prelude?
-        let maybe_in_prelude = self
-            .context
-            .prelude
-            .data()
-            .get_with_string(&import_name)
-            .cloned();
+        let maybe_in_prelude = self.context.prelude.data().get(&import_name).cloned();
         if let Some(value) = maybe_in_prelude {
             self.set_register(import_register, value);
             return Ok(());
@@ -2642,7 +2629,7 @@ impl Vm {
                 other => other,
             },
             None => {
-                return runtime_error!("'{}' not found in '{module_name}'", key.key_to_string()?);
+                return runtime_error!("'{key}' not found in '{module_name}'");
             }
         };
 

--- a/src/runtime/tests/runtime_failures.rs
+++ b/src/runtime/tests/runtime_failures.rs
@@ -157,5 +157,36 @@ x[3] = 3
                 check_script_fails(script);
             }
         }
+
+        mod maps {
+            use super::*;
+
+            #[test]
+            fn list_as_key() {
+                let script = "
+x = {}
+x.insert [1, 2], 'hello'
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn map_as_key() {
+                let script = "
+x = {}
+x.insert {foo: 42}, 'hello'
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn tuple_as_key_with_contained_list() {
+                let script = "
+x = {}
+x.insert (1, [2, 3]), 'hello'
+";
+                check_script_fails(script);
+            }
+        }
     }
 }

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1782,6 +1782,15 @@ m.baz"#;
         }
 
         #[test]
+        fn tuple_keys() {
+            let script = r#"
+m = {}
+m.insert (1, 2), 'hello'
+m.get (1, 2)"#;
+            test_script(script, "hello");
+        }
+
+        #[test]
         fn instance_function_no_args() {
             let script = "
 make_o = ||

--- a/src/serialize/src/lib.rs
+++ b/src/serialize/src/lib.rs
@@ -2,7 +2,7 @@
 
 use {
     koto_runtime::Value,
-    serde::ser::{self, Serialize, SerializeMap, SerializeSeq, Serializer},
+    serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer},
 };
 
 /// A newtype that allows us to implement support for Serde serialization
@@ -40,11 +40,7 @@ impl<'a> Serialize for SerializableValue<'a> {
             Value::Map(m) => {
                 let mut seq = s.serialize_map(Some(m.len()))?;
                 for (key, value) in m.data().iter() {
-                    seq.serialize_entry(
-                        &key.key_to_string()
-                            .map_err(|e| ser::Error::custom(e.to_string()))?,
-                        &SerializableValue(value),
-                    )?;
+                    seq.serialize_entry(&key.to_string(), &SerializableValue(value))?;
                 }
                 seq.end()
             }


### PR DESCRIPTION
- Rename Value::is_immutable -> is_hashable
- Implement TryFrom instead of From for Value -> ValueKey conversions
- Simplify ValueKey and allow Tuples to used as map keys
- Add koto.hash
