### PR TITLE
Miscellaneous Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,17 @@ The Koto project adheres to
     # 1006
     ```
 - Meta map improvements
-  - Arithmetic-assignment operators (`@+=`, `@*=`, etc.) can now be implemented in meta maps and external values.
-  - The function call operator (`@||`) can be implemented to values that behave like functions.
+  - Arithmetic-assignment operators (`@+=`, `@*=`, etc.) can now be implemented 
+    in meta maps and external values.
+  - The function call operator (`@||`) can be implemented to values that behave 
+    like functions.
+  - Values that implement `@[]` can now be used in unpacking assignment
+    expressions.
 
 #### Libs
 
-- New `color` and `geometry` libs have been added, and are available by default in the CLI.
+- New `color` and `geometry` libs have been added, and are available by default 
+  in the CLI.
 - `koto.hash` has been added to allow value hashes to be accessed.
 
 #### Internals

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -760,10 +760,6 @@ check! {a: 1, bbb: 3, cc: 2}
 - [`iterator.to_string`](#to-string)
 - [`iterator.to_tuple`](#to-tuple)
 
-### See also
-
-- [`iterator.to_num4`](#to-num4)
-
 ## to_string
 
 ```kototype

--- a/docs/language/getting_started.md
+++ b/docs/language/getting_started.md
@@ -16,7 +16,7 @@ Running `koto` without arguments will start the Koto
 expressions can be entered and evaluated interactively. 
 
 
-```
+```lua
 > koto
 Welcome to Koto v0.11.0
 » 1 + 1
@@ -29,7 +29,7 @@ Welcome to Koto v0.11.0
 This guide, along with the [core library reference](../../core), 
 can be read in the REPL using the `help` command. 
 
-```
+```lua
 > koto
 Welcome to Koto v0.11.0
 » help bool

--- a/koto/tests/libs/color.koto
+++ b/koto/tests/libs/color.koto
@@ -39,3 +39,9 @@ import color
     c = color 'black'
     c += 0.5
     assert_eq c, (color 0.5, 0.5, 0.5)
+
+  @test index: ||
+    assert_eq (color 'blue')[1], 0
+    assert_eq (color 'blue')[2], 1
+    r, g, b, a = color 'red'
+    assert_eq (r, g, b, a), (1, 0, 0, 1)

--- a/koto/tests/libs/geometry/vec2.koto
+++ b/koto/tests/libs/geometry/vec2.koto
@@ -1,9 +1,15 @@
-import geometry.vec2
+import geometry.vec2, number.pi
 
 @tests =
   @test vec2: ||
     assert_eq vec2(), (vec2 0)
     assert_eq (vec2 1), (vec2 1, 0)
+
+  @test angle: ||
+    assert_eq (vec2 0, 0).angle(), pi
+    assert_eq (vec2 1, 0).angle(), 0
+    assert_eq (vec2 0, 1).angle(), pi / 2
+    assert_eq (vec2 0, -1).angle(), -pi / 2
 
   @test length: ||
     assert_eq (vec2 0, 0).length(), 0

--- a/koto/tests/libs/geometry/vec2.koto
+++ b/koto/tests/libs/geometry/vec2.koto
@@ -35,3 +35,9 @@ import geometry.vec2, number.pi
   @test equality: ||
     assert_eq (vec2 2, 3), (vec2 2, 3)
     assert_ne (vec2 2, 3), (vec2 2, 1)
+
+  @test index: ||
+    assert_eq (vec2 1, 2)[0], 1
+    assert_eq (vec2 5, 6)[1], 6
+    x, y = vec2 10, 11
+    assert_eq (x, y), (10, 11)

--- a/koto/tests/libs/geometry/vec2.koto
+++ b/koto/tests/libs/geometry/vec2.koto
@@ -4,6 +4,7 @@ import geometry.vec2, number.pi
   @test vec2: ||
     assert_eq vec2(), (vec2 0)
     assert_eq (vec2 1), (vec2 1, 0)
+    assert_eq (vec2 vec2 1, 2), (vec2 1, 2)
 
   @test angle: ||
     assert_eq (vec2 0, 0).angle(), pi

--- a/koto/tests/libs/geometry/vec3.koto
+++ b/koto/tests/libs/geometry/vec3.koto
@@ -31,3 +31,10 @@ import geometry.vec3
   @test equality: ||
     assert_eq (vec3 1, 2, 3), (vec3 1, 2, 3)
     assert_ne (vec3 1, 2, 3), (vec3 3, 2, 1)
+
+  @test index: ||
+    assert_eq (vec3 1, 2, 3)[0], 1
+    assert_eq (vec3 4, 5, 6)[1], 5
+    assert_eq (vec3 7, 8, 9)[2], 9
+    x, y, z = vec3 10, 11, 12
+    assert_eq (x, y, z), (10, 11, 12)

--- a/koto/tests/libs/geometry/vec3.koto
+++ b/koto/tests/libs/geometry/vec3.koto
@@ -1,4 +1,4 @@
-import geometry.vec3
+from geometry import vec2, vec3
 
 @tests =
   @test vec3: ||
@@ -6,6 +6,8 @@ import geometry.vec3
     assert_eq (vec3 1), (vec3 1, 0)
     assert_eq (vec3 1, 2), (vec3 1, 2, 0)
     assert_eq (vec3 1, 2, 3), (vec3 1, 2, 3)
+    assert_eq (vec3 (vec2 1, 2), 3), (vec3 1, 2, 3)
+    assert_eq (vec3 vec3 1, 2, 3), (vec3 1, 2, 3)
 
   @test add: ||
     assert_eq (vec3 1, 2, 3) + (vec3 4, 5, 6), vec3 5, 7, 9

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -15,11 +15,11 @@ pub struct Color(Inner);
 
 impl Color {
     pub fn from_r_g_b(r: f32, g: f32, b: f32) -> Self {
-        Self(Inner::new(r, b, g, 1.0))
+        Self(Inner::new(r, g, b, 1.0))
     }
 
     pub fn from_r_g_b_a(r: f32, g: f32, b: f32, a: f32) -> Self {
-        Self(Inner::new(r, b, g, a))
+        Self(Inner::new(r, g, b, a))
     }
 
     pub fn named(name: &str) -> Option<Self> {

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -75,6 +75,12 @@ impl DerefMut for Color {
     }
 }
 
+impl From<(f32, f32, f32, f32)> for Color {
+    fn from((r, g, b, a): (f32, f32, f32, f32)) -> Self {
+        Self::from_r_g_b_a(r, g, b, a)
+    }
+}
+
 impl From<Inner> for Color {
     fn from(c: Inner) -> Self {
         Self(c)

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -254,6 +254,16 @@ fn make_color_meta_map() -> Rc<RefCell<MetaMap>> {
         .data_fn_with_args_mut(DivideAssign, color_arithmetic_assign_op!(/=))
         .data_fn_with_args(Equal, color_comparison_op!(==))
         .data_fn_with_args(NotEqual, color_comparison_op!(!=))
+        .data_fn_with_args(Index, |a, b| match b {
+            [Number(n)] => match usize::from(n) {
+                0 => Ok(a.r().into()),
+                1 => Ok(a.g().into()),
+                2 => Ok(a.b().into()),
+                3 => Ok(a.a().into()),
+                other => runtime_error!("index out of range (got {other}, should be <= 3)"),
+            },
+            unexpected => type_error_with_slice("expected a Number", unexpected),
+        })
         .build()
 }
 

--- a/libs/color/src/lib.rs
+++ b/libs/color/src/lib.rs
@@ -2,7 +2,9 @@
 
 mod color;
 
-use {color::Color, koto_runtime::prelude::*};
+pub use color::Color;
+
+use koto_runtime::prelude::*;
 
 pub fn make_module() -> ValueMap {
     use Value::*;

--- a/libs/geometry/src/lib.rs
+++ b/libs/geometry/src/lib.rs
@@ -6,7 +6,9 @@ mod rect;
 mod vec2;
 mod vec3;
 
-use {koto_runtime::prelude::*, rect::Rect, vec2::Vec2, vec3::Vec3};
+pub use {rect::Rect, vec2::Vec2, vec3::Vec3};
+
+use koto_runtime::prelude::*;
 
 pub fn make_module() -> ValueMap {
     use Value::*;

--- a/libs/geometry/src/lib.rs
+++ b/libs/geometry/src/lib.rs
@@ -32,6 +32,9 @@ pub fn make_module() -> ValueMap {
             [] => (0.0, 0.0),
             [Number(x)] => (x.into(), 0.0),
             [Number(x), Number(y)] => (x.into(), y.into()),
+            [ExternalValue(vec2)] if vec2.has_data::<Vec2>() => {
+                return Ok((*vec2.data::<Vec2>().unwrap()).into())
+            }
             unexpected => return type_error_with_slice("up to 2 Numbers", unexpected),
         };
 
@@ -44,7 +47,20 @@ pub fn make_module() -> ValueMap {
             [Number(x)] => (x.into(), 0.0, 0.0),
             [Number(x), Number(y)] => (x.into(), y.into(), 0.0),
             [Number(x), Number(y), Number(z)] => (x.into(), y.into(), z.into()),
-            unexpected => return type_error_with_slice("up to 3 Numbers", unexpected),
+            [ExternalValue(v)] if v.has_data::<Vec2>() => {
+                let xy = v.data::<Vec2>().unwrap();
+                (xy.x, xy.y, 0.0)
+            }
+            [ExternalValue(v), Number(z)] if v.has_data::<Vec2>() => {
+                let xy = v.data::<Vec2>().unwrap();
+                (xy.x, xy.y, z.into())
+            }
+            [ExternalValue(v)] if v.has_data::<Vec3>() => {
+                return Ok((*v.data::<Vec3>().unwrap()).into())
+            }
+            unexpected => {
+                return type_error_with_slice("up to 3 Numbers, a Vec2, or a Vec3", unexpected)
+            }
         };
 
         Ok(Vec3::new(x, y, z).into())

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -79,6 +79,12 @@ impl From<Inner> for Rect {
     }
 }
 
+impl From<(f64, f64, f64, f64)> for Rect {
+    fn from((x, y, w, h): (f64, f64, f64, f64)) -> Self {
+        Self::from_x_y_w_h(x, y, w, h)
+    }
+}
+
 impl From<Rect> for Value {
     fn from(point: Rect) -> Self {
         let meta = RECT_META.with(|meta| meta.clone());

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -12,6 +12,7 @@ use {
 fn make_vec2_meta_map() -> Rc<RefCell<MetaMap>> {
     let builder = MetaMapBuilder::<Vec2>::new("Vec2");
     add_ops!(Vec2, builder)
+        .data_fn("angle", |v| Ok(DVec2::X.angle_between(*v.deref()).into()))
         .data_fn("length", |v| Ok(v.length().into()))
         .data_fn("x", |v| Ok(v.x.into()))
         .data_fn("y", |v| Ok(v.y.into()))

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -10,12 +10,22 @@ use {
 };
 
 fn make_vec2_meta_map() -> Rc<RefCell<MetaMap>> {
+    use {BinaryOp::*, Value::*};
+
     let builder = MetaMapBuilder::<Vec2>::new("Vec2");
     add_ops!(Vec2, builder)
         .data_fn("angle", |v| Ok(DVec2::X.angle_between(*v.deref()).into()))
         .data_fn("length", |v| Ok(v.length().into()))
         .data_fn("x", |v| Ok(v.x.into()))
         .data_fn("y", |v| Ok(v.y.into()))
+        .data_fn_with_args(Index, |a, b| match b {
+            [Number(n)] => match usize::from(n) {
+                0 => Ok(a.x.into()),
+                1 => Ok(a.y.into()),
+                other => runtime_error!("index out of range (got {other}, should be <= 1)"),
+            },
+            unexpected => type_error_with_slice("expected a Number", unexpected),
+        })
         .build()
 }
 

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -63,6 +63,12 @@ impl From<Vec2> for Value {
     }
 }
 
+impl From<(f64, f64)> for Vec2 {
+    fn from((x, y): (f64, f64)) -> Self {
+        Self::new(x, y)
+    }
+}
+
 impl fmt::Display for Vec2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Vec2{{x: {}, y: {}}}", self.x, self.y)

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -10,12 +10,23 @@ use {
 };
 
 fn make_vec3_meta_map() -> Rc<RefCell<MetaMap>> {
+    use {BinaryOp::*, Value::*};
+
     let builder = MetaMapBuilder::<Vec3>::new("Vec3");
     add_ops!(Vec3, builder)
         .data_fn("x", |v| Ok(v.x.into()))
         .data_fn("y", |v| Ok(v.y.into()))
         .data_fn("z", |v| Ok(v.z.into()))
         .data_fn("sum", |v| Ok((v.x + v.y + v.z).into()))
+        .data_fn_with_args(Index, |a, b| match b {
+            [Number(n)] => match usize::from(n) {
+                0 => Ok(a.x.into()),
+                1 => Ok(a.y.into()),
+                2 => Ok(a.z.into()),
+                other => runtime_error!("index out of range (got {other}, should be <= 2)"),
+            },
+            unexpected => type_error_with_slice("expected a Number", unexpected),
+        })
         .build()
 }
 

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -53,6 +53,12 @@ impl From<DVec3> for Vec3 {
     }
 }
 
+impl From<(f64, f64, f64)> for Vec3 {
+    fn from((x, y, z): (f64, f64, f64)) -> Self {
+        Self::new(x, y, z)
+    }
+}
+
 impl From<Vec3> for Value {
     fn from(vec3: Vec3) -> Self {
         let meta = VEC3_META.with(|meta| meta.clone());

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -152,23 +152,6 @@ impl MetaKey {
     }
 }
 
-impl fmt::Display for MetaKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MetaKey::BinaryOp(op) => write!(f, "@{op}"),
-            MetaKey::UnaryOp(op) => write!(f, "@{op}"),
-            MetaKey::Call => f.write_str("@||"),
-            MetaKey::Named(name) => f.write_str(name.as_str()),
-            MetaKey::Test(test) => write!(f, "test({})", test.as_str()),
-            MetaKey::Tests => f.write_str("@tests"),
-            MetaKey::PreTest => f.write_str("@pre_test"),
-            MetaKey::PostTest => f.write_str("@post_test"),
-            MetaKey::Main => f.write_str("@main"),
-            MetaKey::Type => f.write_str("@type"),
-        }
-    }
-}
-
 impl From<&str> for MetaKey {
     fn from(name: &str) -> Self {
         Self::Named(name.into())
@@ -277,23 +260,6 @@ pub enum UnaryOp {
     Negate,
     /// `@not`
     Not,
-}
-
-impl fmt::Display for UnaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use UnaryOp::*;
-
-        write!(
-            f,
-            "{}",
-            match self {
-                Display => "display",
-                Iterator => "iterator",
-                Negate => "negate",
-                Not => "not",
-            }
-        )
-    }
 }
 
 /// Converts a [MetaKeyId](koto_parser::MetaKeyId) into a [MetaKey]

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -2,7 +2,7 @@ mod runtime_test_utils;
 
 mod external_values {
     use {
-        crate::runtime_test_utils::{string, test_script_with_vm},
+        crate::runtime_test_utils::*,
         koto_runtime::prelude::*,
         std::{cell::RefCell, rc::Rc},
     };
@@ -351,6 +351,16 @@ x = make_external 100
 x[23]
 ";
             test_script_with_external_value(script, 123);
+        }
+
+        #[test]
+        fn unpacking_via_index() {
+            let script = "
+x = make_external 10
+a, b, c = x
+a, b, c
+";
+            test_script_with_external_value(script, number_tuple(&[10, 11, 12]));
         }
 
         #[test]

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2824,6 +2824,31 @@ x 10
         }
     }
 
+    mod overloaded_index {
+        use super::*;
+
+        #[test]
+        fn index() {
+            let script = "
+x =
+  @[]: |self, i| i + 10
+x[1]
+";
+            test_script(script, 11);
+        }
+
+        #[test]
+        fn unpacking() {
+            let script = "
+x =
+  @[]: |self, i| i + 10
+a, b = x
+a + b
+";
+            test_script(script, 21);
+        }
+    }
+
     mod named_meta_entries {
         use super::*;
 


### PR DESCRIPTION
- Make color/geometry types public
- Add tuple converters for lib types
- Remove old to_num4 reference in the docs
- Add highlighting to the repl examples in getting_started.md
- Fix the argument ordering in the Color initializers
- Support unpacking values that implement @[]
- Add Vec2.angle
- Add indexing support to Vec2, Vec3, and Color
- Add extra Vec2/Vec3 initializers
- Remove unused MetaKey Display impl
