### PR TITLE
Object Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The Koto project adheres to
 
 #### Language
 
+- `self` is now provided implicitly in functions and doesn't need to be declared
+    as an argument.
 - `File`s now implement `@display`, showing their paths.
 - `Tuple`s now share data when sub-tuples are made via indexing or unpacking, 
     avoiding unnecessary copies. 

--- a/docs/core_lib/map.md
+++ b/docs/core_lib/map.md
@@ -198,11 +198,11 @@ my_map =
   data: 42
   @type: 'My Map'
 
-meta = my_map.get_meta_map()
+meta = map.get_meta_map my_map
 
-print! my_map.keys().count()
+print! map.keys(my_map).count()
 check! 1
-print! meta.keys().count()
+print! map.keys(meta).count()
 check! 0
 
 print! koto.type meta

--- a/docs/core_lib/test.md
+++ b/docs/core_lib/test.md
@@ -113,11 +113,11 @@ Runs the tests contained in the map.
 
 ```koto,skip_check
 my_tests =
-  @pre_test: |self| self.test_data = 1, 2, 3
-  @post_test: |self| self.test_data = null
+  @pre_test: || self.test_data = 1, 2, 3
+  @post_test: || self.test_data = null
 
-  @test data_size: |self| assert_eq self.test_data.size(), 3
-  @test failure: |self| assert_eq self.test_data.size(), 0
+  @test data_size: || assert_eq self.test_data.size(), 3
+  @test failure: || assert_eq self.test_data.size(), 0
 
 try
   test.run_tests my_tests

--- a/docs/language/generators.md
+++ b/docs/language/generators.md
@@ -41,10 +41,10 @@ Inserting an adaptor into the `iterator` module makes it available in any iterat
 ```koto
 # Make an iterator adaptor that yields 
 # every other value from the adapted iterator
-iterator.every_other = |iter|
+iterator.every_other = ||
   n = 0
   loop
-    match iter.next()
+    match self.next()
       # Exit when there are no more values 
       # produced by the iterator
       null then 

--- a/docs/language/maps.md
+++ b/docs/language/maps.md
@@ -80,12 +80,12 @@ print! m.bye 'Friend'
 check! Bye, Friend!
 ```
 
-When the first argument in a Map's function is `self`, then the runtime will assign the map to `self` when the function is called.
+`self` is a special identifier that refers to the instance of the map that the function is contained in. 
 
 ```koto
 m = 
   name: 'World'
-  hello: |self| 'Hello, ${self.name}!'
+  hello: || 'Hello, ${self.name}!'
 
 print! m.hello()
 check! Hello, World!

--- a/docs/language/meta_maps.md
+++ b/docs/language/meta_maps.md
@@ -1,12 +1,16 @@
-# Meta Maps
+# Objects and Meta Maps
 
-The behaviour of maps in Koto can be customized.
+The behaviour of values in Koto can be customized by making an _Object_.
 
-Keys with `@` prefixes go into the map's 'meta map',
-and when the map is used by the runtime for a particular operation, its meta map 
-will be checked for an entry corresponding to the operation.
+An Object is created by making a map that contains at least one key with a `@` 
+prefix, known as a _metakey_.
 
-In the following example, addition and subtraction are overridden for a custom `Foo` value type.
+Metakeys go in to the object's _metamap_. When the runtime encounters the object
+while performing operations, the object's metamap will be checked for an entry 
+corresponding to the operation.
+
+In the following example, addition and subtraction are overridden for a custom 
+`Foo` object.
 
 ```koto
 # foo is a function that makes Foo values
@@ -185,7 +189,7 @@ check! ('data')
 
 ## Sharing Meta Maps
 
-If you're creating lots of values, then it will likely be more efficient to create a single map with the meta logic, and then share it between values using [`Map.with_meta_map`](../../core/map/#with-meta-map).
+If you're creating lots of values, then it will likely be more efficient to create a single value with the meta logic, and then share it between values using [`Map.with_meta_map`](../../core/map/#with-meta-map).
 
 ```koto
 # Create an empty map for global values 
@@ -194,7 +198,7 @@ globals = {}
 # Define a function that makes a Foo
 foo = |data|
   # Make a map that contains `data`, 
-  # and the meta map from foo_meta
+  # along with the meta map from foo_meta
   {data}.with_meta_map globals.foo_meta
 
 # Define some meta behaviour in foo_meta

--- a/docs/language/meta_maps.md
+++ b/docs/language/meta_maps.md
@@ -160,6 +160,34 @@ print! koto.type (foo 42)
 check! Foo
 ```
 
+### `@base`
+
+Objects can inherit the entries of another value by declaring it as the object's
+_base value_ using the `@base` metakey.
+
+In the following example, two kinds of animals are created that share the
+`speak` function from their base value.
+
+```koto
+animal = |name|
+  name: name
+  speak: |self| '${self.noise}! My name is ${self.name}!'
+
+dog = |name|
+  @base: animal name
+  noise: 'Woof'
+
+cat = |name|
+  @base: animal name
+  noise: 'Meow'
+
+print! dog('Fido').speak()
+check! Woof! My name is Fido!
+
+print! cat('Smudge').speak()
+check! Meow! My name is Smudge!
+```
+
 ### `@meta`
 
 Named meta entries can be inserted into the map, which will be accessible via
@@ -183,7 +211,7 @@ check! Hello!
 print x.get_info()
 check! -1 is negative
 
-print x.keys().to_tuple()
+print map.keys(x).to_tuple()
 check! ('data')
 ```
 

--- a/docs/language/meta_maps.md
+++ b/docs/language/meta_maps.md
@@ -18,17 +18,17 @@ foo = |n|
   data: n
 
   # Overloading the addition operator
-  @+: |self, other|
+  @+: |other|
     # A new Foo is made using the result 
     # of adding the two data values together
     foo self.data + other.data
 
   # Overloading the subtraction operator
-  @-: |self, other|
+  @-: |other|
     foo self.data - other.data
 
   # Overloading the multiply-assignment operator
-  @*=: |self, other|
+  @*=: |other|
     self.data *= other.data
     self
 
@@ -57,7 +57,7 @@ The `@negate` meta key overloads the unary negation operator.
 ```koto
 foo = |n|
   data: n
-  @negate: |self| foo -self.data
+  @negate: || foo -self.data
 
 x = -foo(100)
 print! x.data
@@ -71,7 +71,7 @@ The `@not` meta key overloads the unary `not` operator.
 ```koto
 foo = |n|
   data: n
-  @not: |self| self.data == 0
+  @not: || self.data == 0
 
 print! not (foo 10)
 check! false
@@ -84,7 +84,7 @@ The `@[]` meta key defines how indexing the value with `[]` should behave.
 ```koto
 foo = |n|
   data: n
-  @[]: |self, index| self.data + index
+  @[]: |index| self.data + index
 
 print! (foo 10)[7]
 check! 17
@@ -98,7 +98,7 @@ function.
 ```koto
 foo = |n|
   data: n
-  @||: |self| 
+  @||: || 
     self.data *= 2
     self.data
 
@@ -118,7 +118,7 @@ instead of the default behaviour of iterating over the map's entries.
 ```koto
 foo = |n|
   data: n
-  @iterator: |self| 0..=self.data
+  @iterator: || 0..=self.data
 
 print! (foo 5).to_tuple()
 check! (0, 1, 2, 3, 4, 5)
@@ -136,7 +136,7 @@ or [`string.format`](../../core/string/#format).
 ```koto
 foo = |n|
   data: n
-  @display: |self| 'Foo: {}'.format self.data
+  @display: || 'Foo: {}'.format self.data
 
 print! foo 42
 check! Foo: 42
@@ -171,7 +171,7 @@ In the following example, two kinds of animals are created that share the
 ```koto
 animal = |name|
   name: name
-  speak: |self| '${self.noise}! My name is ${self.name}!'
+  speak: || '${self.noise}! My name is ${self.name}!'
 
 dog = |name|
   @base: animal name
@@ -197,7 +197,7 @@ Named meta entries can be inserted into the map, which will be accessible via
 foo = |n|
   data: n
   @meta hello: "Hello!"
-  @meta get_info: |self| 
+  @meta get_info: || 
     info = match self.data 
       0 then "zero"
       n if n < 0 then "negative"
@@ -232,10 +232,10 @@ foo = |data|
 # Define some meta behaviour in foo_meta
 globals.foo_meta =
   # Override the + operator
-  @+: |self, other| foo self.data + other.data
+  @+: |other| foo self.data + other.data
 
   # Define how the value should be displayed 
-  @display: |self| "Foo (${self.data})"
+  @display: || "Foo (${self.data})"
 
 print! (foo 10) + (foo 20)
 check! Foo (30)

--- a/docs/language/testing.md
+++ b/docs/language/testing.md
@@ -32,25 +32,24 @@ basic_tests =
 test.run_tests basic_tests
 ```
 
-If a test function takes `self` as its first argument, then the test map will be passed in as `self`. 
 `@pre_test` and `@post_test` functions can be used to define shared setup and cleanup steps.
 
 ```koto
 make_x = |n|
   data: n
-  @+: |self, other| make_x self.data + other.data
-  @-: |self, other| make_x self.data - other.data
+  @+: |other| make_x self.data + other.data
+  @-: |other| make_x self.data - other.data
 
 x_tests =
-  @pre_test: |self| 
+  @pre_test: || 
     self.x1 = make_x 100
     self.x2 = make_x 200
 
-  @test addition: |self|
+  @test addition: ||
     print 'Testing addition'
     assert_eq self.x1 + self.x2, make_x 300
 
-  @test subtraction: |self|
+  @test subtraction: ||
     print 'Testing subtraction'
     assert_eq self.x1 - self.x2, make_x -100
 

--- a/examples/poetry/src/main.rs
+++ b/examples/poetry/src/main.rs
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     if args.watch {
         if let Err(e) = compile_and_run(&mut koto, &script_path) {
-            eprintln!("{}", e);
+            eprintln!("{e}");
         }
 
         let mut hotwatch = Hotwatch::new_with_custom_delay(Duration::from_secs_f64(0.25))

--- a/koto/tests/functions_in_lookups.koto
+++ b/koto/tests/functions_in_lookups.koto
@@ -1,8 +1,8 @@
 test_map = ||
   child_map:
     foo: 42
-    set_foo: |self, x| self.foo = x
-  get_child_map: |self| self.child_map
+    set_foo: |x| self.foo = x
+  get_child_map: || self.child_map
 
 # Make a list of two test maps
 maps = [test_map(), test_map()]

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -22,7 +22,7 @@ import test_module
   @test import_module: ||
     # The test_module module being imported here is defined in the neighbouring
     # test_module directory, with test_module/main.koto as its entry point.
-    assert_eq (type test_module), "Map"
+    assert_eq (type test_module), "test_module"
     assert_eq test_module.foo, 42
     assert_eq (test_module.square 9), 81
 
@@ -69,5 +69,5 @@ import test_module
 
   @test dynamic_exported_value: ||
     x = "value_x"
-    koto.exports().insert x, 99
+    map.insert koto.exports(), x, 99
     assert_eq value_x, 99

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -1,8 +1,8 @@
 make_foo = |x|
   x: x
-  @<: |self, other| self.x < other.x
-  @>: |self, other| self.x > other.x
-  @==: |self, other| self.x == other.x
+  @<: |other| self.x < other.x
+  @>: |other| self.x > other.x
+  @==: |other| self.x == other.x
 
 @tests =
   @test next: ||
@@ -221,7 +221,7 @@ make_foo = |x|
   @test product_with_overloaded_multiply_operator: ||
     foo = |x|
       x: x
-      @*: |self, other| foo self.x * other.x
+      @*: |other| foo self.x * other.x
     foos = (foo 2), (foo 3), (foo 4)
     assert_eq foos.product(foo 1), (foo 24)
 
@@ -250,7 +250,7 @@ make_foo = |x|
   @test sum_with_overloaded_add_operator: ||
     foo = |x|
       x: x
-      @+: |self, other| foo self.x + other.x
+      @+: |other| foo self.x + other.x
     foos = (foo 10), (foo 20), (foo 30)
     assert_eq foos.sum(foo 0), (foo 60)
 
@@ -267,9 +267,12 @@ make_foo = |x|
       (1, 1, 1)
 
   @test windows: ||
+    import iterator.to_tuple
+
     assert_eq
-      (1..=5).windows(3).each(iterator.to_tuple).to_tuple(),
+      (1..=5).windows(3).each(to_tuple).to_tuple(),
       ((1, 2, 3), (2, 3, 4), (3, 4, 5))
+
     # If there aren't enough values in the input, then no windows are produced.
     assert_eq (1, 2).windows(3).count(), 0
 
@@ -288,22 +291,21 @@ make_foo = |x|
 
   @test custom_iterator_adaptor: ||
     # Inserting a function into the iterator map makes it available as an iterator adaptor
-    iterator.every_other = |iter|
+    iterator.every_other = ||
       n = 0
+      iter = self.iter()
       loop
         match iter.next()
           null then return
           value if n % 2 == 0 then yield value
         n += 1
 
-    make_iter = ||
-      (10..15).each |x| "$x"
-
+    # As an adaptor for an iterable
     assert_eq
-      make_iter().every_other().to_tuple(),
-      ("10", "12", "14")
+      (1..=5).every_other().to_tuple(),
+      (1, 3, 5)
 
-    # The every_other adaptor can also be called via iterator.every_other
+    # As an adaptor in an adaptor chain
     assert_eq
-      iterator.every_other(make_iter()).to_tuple(),
-      ("10", "12", "14")
+      (10..15).each(|x| '$x').every_other().to_tuple(),
+      ('10', '12', '14')

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -1,8 +1,8 @@
 make_foo = |x|
   x: x
-  @<: |self, other| self.x < other.x
-  @>: |self, other| self.x > other.x
-  @==: |self, other| self.x == other.x
+  @<: |other| self.x < other.x
+  @>: |other| self.x > other.x
+  @==: |other| self.x == other.x
 
 @tests =
   @test clear: ||
@@ -18,7 +18,7 @@ make_foo = |x|
   @test contains_with_overloaded_equality_op: ||
     bar = |x|
       x: x
-      @==: |self, other| self.x != other.x # This inverts the usual behaviour of ==
+      @==: |other| self.x != other.x # This inverts the usual behaviour of ==
 
     assert not [(bar 1)].contains (bar 1)
 
@@ -129,7 +129,7 @@ make_foo = |x|
   @test retain_with_overloaded_equality_op: ||
     bar = |x|
       x: x
-      @==: |self, other| self.x != other.x # This inverts the usual behaviour of ==
+      @==: |other| self.x != other.x # This inverts the usual behaviour of ==
 
     z = [bar(0), bar(1), bar(1), bar(1), bar(2)]
     z.retain bar(1) # The inverted == operator causes the 'bar 1's to be dropped

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -1,8 +1,8 @@
 make_foo = |x|
   x: x
-  @<: |self, other| self.x < other.x
-  @>: |self, other| self.x > other.x
-  @==: |self, other| self.x == other.x
+  @<: |other| self.x < other.x
+  @>: |other| self.x > other.x
+  @==: |other| self.x == other.x
 
 @tests =
   @test clear: ||

--- a/koto/tests/maps.koto
+++ b/koto/tests/maps.koto
@@ -89,10 +89,7 @@
   @test instance_functions: ||
     make_map = ||
       foo: 42
-      get_foo: |self|
-        # self as first argument creates an instance function,
-        # where self refers to the container value that its contained in
-        self.foo
+      get_foo: || self.foo
 
     m = make_map()
     assert_eq 42, m.get_foo() # m is implicitly passed to get_foo as an argument
@@ -100,9 +97,9 @@
     make_map_2 = ||
       make_map().extend
         foo_2: 57
-        get_foo_2: |self| self.foo_2
-        set_foo_2: |self, x| self.foo_2 = x
-        sum_foo: |self| self.foo + self.foo_2
+        get_foo_2: || self.foo_2
+        set_foo_2: |x| self.foo_2 = x
+        sum_foo: || self.foo + self.foo_2
 
     m2 = make_map_2()
     assert_eq m2.foo, 42 # .foo takes no arguments
@@ -138,7 +135,7 @@
           c:
             d:
               foo: -1
-              set_foo: |self, x| self.foo = x
+              set_foo: |x| self.foo = x
     assert_eq deep.a.b.c.d.foo, -1
     deep.a.b.c.d.set_foo(42)
     assert_eq deep.a.b.c.d.foo, 42

--- a/koto/tests/maps_and_lists.koto
+++ b/koto/tests/maps_and_lists.koto
@@ -18,7 +18,7 @@
   @test maps_in_lists: ||
     make_foo = |x|
       foo: x
-      set_foo: |self, x| self.foo = x
+      set_foo: |x| self.foo = x
 
     # Getting a value
     foos = [(make_foo 42), (make_foo 99)]

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -125,9 +125,8 @@ globals.foo_meta =
     assert_eq bar(100, -1), bar(100, -2)
 
   @test not_equal: ||
-    assert foo(7) != foo(8)
+    assert_ne foo(7), foo(8)
     assert not (foo(7) != foo(7))
-    # TODO Add an assert_ne test
 
   @test negate: ||
     assert_eq -foo(1), foo(-1)
@@ -155,18 +154,18 @@ globals.foo_meta =
 
   @test named_meta_entries: ||
     f = foo 99
-    assert_eq f.keys().to_list(), ["x"]
-    assert_eq f.size(), 1
+    assert_eq map.keys(f).to_list(), ["x"]
+    assert_eq map.size(f), 1
 
     assert_eq f.hello, "Hello"
     assert_eq f.say_hello("you"), "Hello, you!"
 
   @test get_meta_map: ||
     f = foo 42
-    meta = f.get_meta_map()
+    meta = map.get_meta_map f
 
     # get_meta_map returns a map with the argument's meta map, but no data
-    assert_eq meta.keys().count(), 0
+    assert_eq map.keys(meta).count(), 0
     assert_eq meta.hello, "Hello"
 
     # Add an "x" entry, allowing it to be treated as a Foo

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -9,61 +9,61 @@ foo = |x|
 # instance is more efficient than declaring them each time foo is called.
 globals.foo_meta =
   # Arithmetic operators
-  @+: |self, other| foo self.x + other.x
-  @-: |self, other| foo self.x - other.x
-  @*: |self, other| foo self.x * other.x
-  @/: |self, other| foo self.x / other.x
-  @%: |self, other| foo self.x % other.x
+  @+: |other| foo self.x + other.x
+  @-: |other| foo self.x - other.x
+  @*: |other| foo self.x * other.x
+  @/: |other| foo self.x / other.x
+  @%: |other| foo self.x % other.x
 
   # Modify-Assignment operators
-  @+=: |self, other|
+  @+=: |other|
     self.x += other
     self
-  @-=: |self, other|
+  @-=: |other|
     self.x -= other
     self
-  @*=: |self, other|
+  @*=: |other|
     self.x *= other
     self
-  @/=: |self, other|
+  @/=: |other|
     self.x /= other
     self
-  @%=: |self, other|
+  @%=: |other|
     self.x %= other
     self
 
   # Comparison operators
-  @<: |self, other| self.x < other.x
-  @<=: |self, other| self.x <= other.x
-  @>: |self, other| self.x > other.x
-  @>=: |self, other| self.x >= other.x
-  @==: |self, other| self.x == other.x
-  @!=: |self, other| not self == other
+  @<: |other| self.x < other.x
+  @<=: |other| self.x <= other.x
+  @>: |other| self.x > other.x
+  @>=: |other| self.x >= other.x
+  @==: |other| self.x == other.x
+  @!=: |other| not self == other
 
   # Negation (e.g. -foo)
-  @negate: |self| foo -self.x
+  @negate: || foo -self.x
 
   # Not (e.g. !foo)
-  @not: |self| if self.x == 0 then true else false
+  @not: || if self.x == 0 then true else false
 
   # Function call
-  @||: |self| self.x
+  @||: || self.x
 
   # Indexing
-  @[]: |self, index| self.x + index
+  @[]: |index| self.x + index
 
   # Overloaded iteration behaviour
-  @iterator: |self| 0..self.x
+  @iterator: || 0..self.x
 
   # Formatting
-  @display: |self| "Foo (${self.x})"
+  @display: || "Foo (${self.x})"
 
   # Type
   @type: "Foo"
 
   # Named meta entries are accessible on the value but don't appear as map entries
   @meta hello: "Hello"
-  @meta say_hello: |self, name| "${self.hello}, $name!"
+  @meta say_hello: |name| "${self.hello}, $name!"
 
 @tests =
   @test add: ||
@@ -116,7 +116,7 @@ globals.foo_meta =
     bar = |x, y|
       x: x
       y: y
-      @==: |self, other|
+      @==: |other|
         # Maps already have equality comparison that compare each member,
         # so to show the effect of overloading, ignore y
         self.x == other.x

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -22,3 +22,6 @@ export tests_were_run = false
 
   @test local_value_unmodified_by_import: ||
     assert_eq local_value, 123
+
+@type =
+  'test_module'

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -2,15 +2,15 @@
 # the script is loaded.
 @tests =
   # '@pre_test' will be run before each test
-  @pre_test: |self|
+  @pre_test: ||
     self.test_data = 1, 2, 3
 
   # '@post_test' will be run after each test
-  @post_test: |self|
+  @post_test: ||
     self.test_data = null
 
   # Functions with that are tagged with @test will be automatically run as tests
-  @test size: |self|
+  @test size: ||
     # assert_eq checks that its two arguments are equal
     assert_eq self.test_data.size(), 3
 
@@ -25,15 +25,15 @@
     # assert_near checks that its arguments are equal, within a specied margin
     allowed_error = 0.1
     assert_near 1.3, 1.301, allowed_error
-  
+
     # The allowed margin of error for assert_near is optional
-    assert_near 1 % 0.2, 0.2 
+    assert_near 1 % 0.2, 0.2
 
   @test run_tests: ||
     tests_were_run = {}
     my_tests =
-      @pre_test: |self| tests_were_run.pre_test = true
-      @post_test: |self| tests_were_run.post_test = true
+      @pre_test: || tests_were_run.pre_test = true
+      @post_test: || tests_were_run.post_test = true
       @test foo: || tests_were_run.foo = true
       @test bar: || tests_were_run.bar = true
       # Functions that aren't tagged with @test shouldn't be run

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -1,8 +1,8 @@
 make_foo = |x|
   x: x
-  @<: |self, other| self.x < other.x
-  @>: |self, other| self.x > other.x
-  @==: |self, other| self.x == other.x
+  @<: |other| self.x < other.x
+  @>: |other| self.x > other.x
+  @==: |other| self.x == other.x
 
 @tests =
   @test for_loop: ||
@@ -20,7 +20,7 @@ make_foo = |x|
   @test contains_with_overloaded_equality_op: ||
     bar = |x|
       x: x
-      @==: |self, other| self.x != other.x # This inverts the usual behaviour of ==
+      @==: |other| self.x != other.x # This inverts the usual behaviour of ==
 
     x = (bar 1), (bar 1)
     assert not x.contains (bar 1)

--- a/libs/lib_tests/tests/lib_tests.rs
+++ b/libs/lib_tests/tests/lib_tests.rs
@@ -44,7 +44,7 @@ fn load_and_run_script(script_path: &str) {
     path.push("../../koto/tests/libs");
     path.push(script_path);
     if !path.exists() {
-        panic!("Path doesn't exist: {:?}", path);
+        panic!("Path doesn't exist: {path:?}");
     }
     let script =
         read_to_string(&path).unwrap_or_else(|_| panic!("Unable to load path '{:?}'", &path));

--- a/src/bytecode/src/compiler.rs
+++ b/src/bytecode/src/compiler.rs
@@ -717,6 +717,10 @@ impl Compiler {
                 result
             }
             Node::Throw(expression) => {
+                // A throw will prevent the result from being used, but the caller should be
+                // provided with a result register regardless.
+                let result = self.get_result_register(result_register)?;
+
                 let expression_register = self
                     .compile_node(ResultRegister::Any, ast.node(*expression), ast)?
                     .unwrap();
@@ -727,7 +731,7 @@ impl Compiler {
                     self.pop_register()?;
                 }
 
-                None
+                result
             }
             Node::Try(try_expression) => {
                 self.compile_try_expression(result_register, try_expression, ast)?

--- a/src/bytecode/src/lib.rs
+++ b/src/bytecode/src/lib.rs
@@ -1,4 +1,3 @@
-//! # koto_bytecode
 //!
 //! Contains Koto's compiler and its bytecode operations
 

--- a/src/koto/tests/docs_examples.rs
+++ b/src/koto/tests/docs_examples.rs
@@ -108,7 +108,7 @@ impl KotoWrite for OutputCapture {
 
 fn load_markdown_and_run_examples(path: &Path) {
     if !path.exists() {
-        panic!("Path doesn't exist: {:?}", path);
+        panic!("Path doesn't exist: {path:?}");
     }
 
     let markdown = std::fs::read_to_string(path)

--- a/src/koto/tests/koto_tests.rs
+++ b/src/koto/tests/koto_tests.rs
@@ -66,10 +66,10 @@ fn load_and_run_script(script_file_name: &str, imported_modules: &[&str]) {
     let mut script_path = test_folder.clone();
     script_path.push(script_file_name);
     if !script_path.exists() {
-        panic!("Path doesn't exist: {:?}", script_path);
+        panic!("Path doesn't exist: {script_path:?}");
     }
     let script = read_to_string(&script_path)
-        .unwrap_or_else(|_| panic!("Unable to load path '{:?}'", &script_path));
+        .unwrap_or_else(|_| panic!("Unable to load path '{script_path:?}'"));
 
     let expected_module_paths = imported_modules
         .iter()

--- a/src/lexer/src/lexer.rs
+++ b/src/lexer/src/lexer.rs
@@ -85,6 +85,7 @@ pub enum Token {
     Null,
     Or,
     Return,
+    Self_,
     Switch,
     Then,
     Throw,
@@ -482,6 +483,7 @@ impl<'a> TokenLexer<'a> {
             check_keyword!("null", Null);
             check_keyword!("or", Or);
             check_keyword!("return", Return);
+            check_keyword!("self", Self_);
             check_keyword!("switch", Switch);
             check_keyword!("then", Then);
             check_keyword!("throw", Throw);

--- a/src/parser/src/error.rs
+++ b/src/parser/src/error.rs
@@ -107,7 +107,7 @@ pub enum SyntaxError {
     LexerError,
     MatchEllipsisOutsideOfNestedPatterns,
     MatchElseNotInLastArm,
-    SelfArgNotInFirstPosition,
+    SelfArg,
     SwitchElseNotInLastArm,
     UnexpectedCharInNumericEscapeCode,
     UnexpectedElseIndentation,
@@ -330,7 +330,7 @@ impl fmt::Display for SyntaxError {
             SwitchElseNotInLastArm => {
                 f.write_str("else can only be used in the last arm in a switch expression")
             }
-            SelfArgNotInFirstPosition => f.write_str("self is only allowed as the first argument"),
+            SelfArg => f.write_str("self doesn't need to be declared as an argument"),
             UnexpectedCharInNumericEscapeCode => {
                 f.write_str("Unexpected character in numeric escape code")
             }

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -6,9 +6,10 @@ use {
 /// A parsed node that can be included in the [AST](crate::Ast).
 ///
 /// Nodes refer to each other via [AstIndex]s, see [AstNode](crate::AstNode).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum Node {
     /// The `null` keyword
+    #[default]
     Null,
 
     /// A single expression wrapped in parentheses
@@ -260,12 +261,6 @@ pub enum Node {
         /// The expression that should be debugged
         expression: AstIndex,
     },
-}
-
-impl Default for Node {
-    fn default() -> Self {
-        Node::Null
-    }
 }
 
 impl fmt::Display for Node {

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -107,6 +107,9 @@ pub enum Node {
     /// Values are optional for inline maps.
     Map(Vec<(MapKey, Option<AstIndex>)>),
 
+    /// The `self` keyword
+    Self_,
+
     /// The main block node
     ///
     /// Typically all ASTs will have this node at the root.
@@ -299,6 +302,7 @@ impl fmt::Display for Node {
             BinaryOp { .. } => write!(f, "BinaryOp"),
             If(_) => write!(f, "If"),
             Match { .. } => write!(f, "Match"),
+            Self_ { .. } => write!(f, "Self"),
             Switch { .. } => write!(f, "Switch"),
             Wildcard(_) => write!(f, "Wildcard"),
             Ellipsis(_) => write!(f, "Ellipsis"),
@@ -334,8 +338,6 @@ pub struct Function {
     pub accessed_non_locals: Vec<ConstantIndex>,
     /// The function's body
     pub body: AstIndex,
-    /// A flag that indicates if the function has used `self` as its first argument
-    pub is_instance_function: bool,
     /// A flag that indicates if the function arguments end with a variadic `...` argument
     pub is_variadic: bool,
     /// A flag that indicates if the function is a generator or not

--- a/src/parser/src/node.rs
+++ b/src/parser/src/node.rs
@@ -572,6 +572,8 @@ pub enum MetaKeyId {
     Not,
     /// @type
     Type,
+    /// @base
+    Base,
 
     /// @||
     Call,

--- a/src/parser/src/parser.rs
+++ b/src/parser/src/parser.rs
@@ -2027,6 +2027,9 @@ impl<'source> Parser<'source> {
                 "display" => MetaKeyId::Display,
                 "iterator" => MetaKeyId::Iterator,
                 "negate" => MetaKeyId::Negate,
+                "type" => MetaKeyId::Type,
+                "base" => MetaKeyId::Base,
+                "main" => MetaKeyId::Main,
                 "tests" => MetaKeyId::Tests,
                 "pre_test" => MetaKeyId::PreTest,
                 "post_test" => MetaKeyId::PostTest,
@@ -2046,8 +2049,6 @@ impl<'source> Parser<'source> {
                     }
                     _ => return self.error(SyntaxError::ExpectedMetaId),
                 },
-                "type" => MetaKeyId::Type,
-                "main" => MetaKeyId::Main,
                 _ => return self.error(SyntaxError::UnexpectedMetaKey),
             },
             Some(Token::SquareOpen) => match self.consume_token() {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -1709,7 +1709,8 @@ a = (1
 
         #[test]
         fn if_block() {
-            let source = "\
+            let sources = [
+                "
 a = if false
   0
 else if true
@@ -1718,9 +1719,31 @@ else if false
   0
 else
   1
-a";
-            check_ast(
-                source,
+a",
+                "
+a =
+  if false
+    0
+  else if true
+    1
+  else if false
+    0
+  else
+    1
+a",
+                "
+a = if false
+      0
+    else if true
+      1
+    else if false
+      0
+    else
+      1
+a",
+            ];
+            check_ast_for_equivalent_sources(
+                &sources,
                 &[
                     Id(constant(0)),
                     BoolFalse,

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -2,7 +2,7 @@ mod parser {
     use koto_parser::{Node::*, *};
 
     fn check_ast(source: &str, expected_ast: &[Node], expected_constants: Option<&[Constant]>) {
-        println!("{}", source);
+        println!("{source}");
 
         match Parser::parse(source) {
             Ok(ast) => {

--- a/src/parser/tests/parser_tests.rs
+++ b/src/parser/tests/parser_tests.rs
@@ -1823,7 +1823,6 @@ a";
                         local_count: 0,
                         accessed_non_locals: vec![constant(0)],
                         body: 4,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // 5
@@ -2032,7 +2031,6 @@ a()";
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 1,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -2091,7 +2089,6 @@ a()";
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 4,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // 5
@@ -2133,7 +2130,6 @@ a()";
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 7,
-                        is_instance_function: false,
                         is_variadic: true,
                         is_generator: false,
                     }),
@@ -2178,7 +2174,6 @@ f 42";
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 6,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -2224,7 +2219,6 @@ f 42";
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 4,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // 5
@@ -2246,7 +2240,6 @@ f 42";
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 9,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // 10
@@ -2412,7 +2405,6 @@ foo
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 2,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -2475,7 +2467,6 @@ f x";
                         local_count: 1,
                         accessed_non_locals: vec![constant(0)],
                         body: 3,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -2514,7 +2505,6 @@ f x";
                         local_count: 1,
                         accessed_non_locals: vec![constant(0)],
                         body: 4,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // 5
@@ -2530,7 +2520,6 @@ f x";
                         local_count: 1,
                         accessed_non_locals: vec![constant(1)],
                         body: 9,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // 10
@@ -2645,46 +2634,43 @@ foo.bar x
 
         #[test]
         fn instance_function() {
-            let source = "{foo: 42, bar: |self, x| self.foo = x}";
+            let source = "{foo: 42, bar: |x| self.foo = x}";
             check_ast(
                 source,
                 &[
                     SmallInt(42),
-                    Id(constant(2)), // self
-                    Id(constant(3)), // x
-                    Id(constant(2)),
+                    Id(constant(2)), // x
+                    Self_,           // self
                     Lookup((LookupNode::Id(constant(0)), None)),
-                    Lookup((LookupNode::Root(3), Some(4))), // 5
-                    Id(constant(3)),
+                    Lookup((LookupNode::Root(2), Some(3))),
+                    Id(constant(2)), // 5
                     Assign {
                         target: AssignTarget {
-                            target_index: 5,
+                            target_index: 4,
                             scope: Scope::Local,
                         },
-                        expression: 6,
+                        expression: 5,
                     },
                     Function(koto_parser::Function {
-                        args: vec![1, 2],
-                        local_count: 2,
+                        args: vec![1],
+                        local_count: 1,
                         accessed_non_locals: vec![],
-                        body: 7,
-                        is_instance_function: true,
+                        body: 6,
                         is_variadic: false,
                         is_generator: false,
                     }),
                     Map(vec![
                         (MapKey::Id(constant(0)), Some(0)),
-                        (MapKey::Id(constant(1)), Some(8)),
+                        (MapKey::Id(constant(1)), Some(7)),
                     ]),
                     MainBlock {
-                        body: vec![9],
+                        body: vec![8],
                         local_count: 0,
                     },
                 ],
                 Some(&[
                     Constant::Str("foo"),
                     Constant::Str("bar"),
-                    Constant::Str("self"),
                     Constant::Str("x"),
                 ]),
             )
@@ -2712,7 +2698,6 @@ f = ||
                         local_count: 0,
                         accessed_non_locals: vec![constant(2)],
                         body: 3,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -2763,7 +2748,6 @@ f = ||
                         local_count: 0,
                         accessed_non_locals: vec![constant(3)],
                         body: 4,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // 5
@@ -2794,45 +2778,42 @@ f = ||
             let source = "
 f = ||
   foo: 42
-  bar: |self, x| self.foo = x
+  bar: |x| self.foo = x
 f()";
             check_ast(
                 source,
                 &[
                     Id(constant(0)),
                     SmallInt(42),
-                    Id(constant(3)), // self
-                    Id(constant(4)), // x
+                    Id(constant(3)), // x
+                    Self_,
+                    Lookup((LookupNode::Id(constant(1)), None)),
+                    Lookup((LookupNode::Root(3), Some(4))), // 5
                     Id(constant(3)),
-                    Lookup((LookupNode::Id(constant(1)), None)), // 5
-                    Lookup((LookupNode::Root(4), Some(5))),
-                    Id(constant(4)),
                     Assign {
                         target: AssignTarget {
-                            target_index: 6,
+                            target_index: 5,
                             scope: Scope::Local,
                         },
-                        expression: 7,
+                        expression: 6,
                     },
                     Function(koto_parser::Function {
-                        args: vec![2, 3],
-                        local_count: 2,
+                        args: vec![2],
+                        local_count: 1,
                         accessed_non_locals: vec![],
-                        body: 8,
-                        is_instance_function: true,
+                        body: 7,
                         is_variadic: false,
                         is_generator: false,
-                    }),
+                    }), // 10
                     Map(vec![
                         (MapKey::Id(constant(1)), Some(1)),
-                        (MapKey::Id(constant(2)), Some(9)),
-                    ]), // 10
+                        (MapKey::Id(constant(2)), Some(8)),
+                    ]),
                     Function(koto_parser::Function {
                         args: vec![],
                         local_count: 0,
                         accessed_non_locals: vec![],
-                        body: 10,
-                        is_instance_function: false,
+                        body: 9,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -2841,7 +2822,7 @@ f()";
                             target_index: 0,
                             scope: Scope::Local,
                         },
-                        expression: 11,
+                        expression: 10,
                     },
                     Id(constant(0)),
                     Lookup((
@@ -2850,10 +2831,10 @@ f()";
                             with_parens: true,
                         },
                         None,
-                    )),
-                    Lookup((LookupNode::Root(13), Some(14))), // 15
+                    )), // 15
+                    Lookup((LookupNode::Root(12), Some(13))),
                     MainBlock {
-                        body: vec![12, 15],
+                        body: vec![11, 14],
                         local_count: 1,
                     },
                 ],
@@ -2861,7 +2842,6 @@ f()";
                     Constant::Str("f"),
                     Constant::Str("foo"),
                     Constant::Str("bar"),
-                    Constant::Str("self"),
                     Constant::Str("x"),
                 ]),
             )
@@ -2917,7 +2897,6 @@ f = |n|
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 14,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }), // ast 15
@@ -2935,7 +2914,6 @@ f = |n|
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 18,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -2992,7 +2970,6 @@ f = |n|
                         local_count: 1,
                         accessed_non_locals: vec![constant(0)], // initial read of x via capture
                         body: 6,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -3039,7 +3016,6 @@ f = |n|
                         local_count: 2,
                         accessed_non_locals: vec![], // b is locally assigned when accessed
                         body: 7,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -3072,7 +3048,6 @@ f = |n|
                         local_count: 0,
                         accessed_non_locals: vec![constant(0)], // initial read of x via capture
                         body: 2,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -3115,7 +3090,6 @@ y z";
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 8,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -3157,7 +3131,6 @@ y z";
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 1,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: true,
                     }),
@@ -3185,7 +3158,6 @@ y z";
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 3,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: true,
                     }),
@@ -3216,7 +3188,6 @@ y z";
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 2,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: true,
                     }),
@@ -3263,7 +3234,6 @@ y z";
                         local_count: 3,
                         accessed_non_locals: vec![],
                         body: 8,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),
@@ -3316,7 +3286,6 @@ y z";
                         local_count: 3,
                         accessed_non_locals: vec![],
                         body: 8,
-                        is_instance_function: false,
                         is_variadic: false,
                         is_generator: false,
                     }),

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -68,23 +68,14 @@ x =
             }
 
             #[test]
-            fn else_at_same_indentation_as_if_body() {
+            fn else_at_greater_indentation_than_else_if() {
                 let source = "
-if f x
-  0
-  else
-    1
-";
-                check_parsing_fails(source);
-            }
-
-            #[test]
-            fn else_if_at_same_indentation_as_if_body() {
-                let source = "
-if f x
-  0
-  else if g x
-    1
+z = if f x
+        0
+    else if g x
+        1
+      else
+        2
 ";
                 check_parsing_fails(source);
             }

--- a/src/parser/tests/parsing_failures.rs
+++ b/src/parser/tests/parsing_failures.rs
@@ -107,7 +107,12 @@ for x in y if f x
             use super::*;
 
             #[test]
-            fn self_not_in_first_position() {
+            fn self_as_first_arg() {
+                check_parsing_fails("f = |self, x| x");
+            }
+
+            #[test]
+            fn self_as_last_arg() {
                 check_parsing_fails("f = |x, self| x");
             }
 

--- a/src/runtime/src/core/string/format.rs
+++ b/src/runtime/src/core/string/format.rs
@@ -552,7 +552,7 @@ mod tests {
             let mut vm = Vm::default();
             match format_string(&mut vm, format, args) {
                 Ok(result) => assert_eq!(result, expected),
-                Err(error) => panic!("format_string failed: '{}'", error),
+                Err(error) => panic!("format_string failed: '{error}'"),
             }
         }
 

--- a/src/runtime/src/frame.rs
+++ b/src/runtime/src/frame.rs
@@ -4,8 +4,9 @@ use {koto_bytecode::Chunk, std::rc::Rc};
 pub(crate) struct Frame {
     // The chunk being interpreted in this frame
     pub chunk: Rc<Chunk>,
-    // The index in the VM value stack of the first argument register,
-    // or the first local register if there are no arguments.
+    // The index in the VM's value stack of the first frame register.
+    // The frame's instance is always in register 0 (Null if not set).
+    // Call arguments followed by local values are in registers starting from index 1.
     pub register_base: usize,
     // When returning to this frame, the ip that produced the most recently read instruction
     pub return_instruction_ip: usize,

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -133,6 +133,10 @@ pub enum MetaKey {
     ///
     /// Used to define a [ValueString](crate::ValueString) that declare the value's type.
     Type,
+    /// `@base`
+    ///
+    /// Defines a base map to be used as fallback for accesses when a key isn't found.
+    Base,
 }
 
 impl MetaKey {
@@ -148,6 +152,7 @@ impl MetaKey {
             MetaKey::PostTest => MetaKeyRef::PostTest,
             MetaKey::Main => MetaKeyRef::Main,
             MetaKey::Type => MetaKeyRef::Type,
+            MetaKey::Base => MetaKeyRef::Base,
         }
     }
 }
@@ -298,6 +303,7 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKe
         MetaKeyId::PostTest => MetaKey::PostTest,
         MetaKeyId::Main => MetaKey::Main,
         MetaKeyId::Type => MetaKey::Type,
+        MetaKeyId::Base => MetaKey::Base,
         MetaKeyId::Invalid => return Err("Invalid MetaKeyId".to_string()),
     };
 
@@ -317,6 +323,7 @@ enum MetaKeyRef<'a> {
     PostTest,
     Main,
     Type,
+    Base,
 }
 
 // A trait that allows for allocation-free map accesses with &str

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -3,13 +3,12 @@ use {
         external::{ArgRegisters, ExternalFunction},
         prelude::*,
     },
-    indexmap::IndexMap,
+    indexmap::{Equivalent, IndexMap},
     koto_parser::MetaKeyId,
     std::{
-        borrow::Borrow,
         cell::RefCell,
         fmt,
-        hash::{BuildHasherDefault, Hash, Hasher},
+        hash::{BuildHasherDefault, Hash},
         marker::PhantomData,
         ops::{Deref, DerefMut},
         rc::Rc,
@@ -26,16 +25,6 @@ type MetaMapType = IndexMap<MetaKey, Value, BuildHasherDefault<KotoHasher>>;
 pub struct MetaMap(MetaMapType);
 
 impl MetaMap {
-    /// Allows access to named entries without having to create a ValueString
-    pub fn get_with_string(&self, key: &str) -> Option<&Value> {
-        self.0.get(&key as &dyn AsMetaKeyRef)
-    }
-
-    /// Allows access to named entries without having to create a ValueString
-    pub fn get_with_string_mut(&mut self, key: &str) -> Option<&mut Value> {
-        self.0.get_mut(&key as &dyn AsMetaKeyRef)
-    }
-
     /// Extends the MetaMap with clones of another MetaMap's entries
     pub fn extend(&mut self, other: &MetaMap) {
         self.0.extend(other.0.clone().into_iter());
@@ -137,24 +126,6 @@ pub enum MetaKey {
     ///
     /// Defines a base map to be used as fallback for accesses when a key isn't found.
     Base,
-}
-
-impl MetaKey {
-    fn as_ref(&self) -> MetaKeyRef {
-        match self {
-            MetaKey::BinaryOp(op) => MetaKeyRef::BinaryOp(*op),
-            MetaKey::UnaryOp(op) => MetaKeyRef::UnaryOp(*op),
-            MetaKey::Call => MetaKeyRef::Call,
-            MetaKey::Named(name) => MetaKeyRef::Named(name),
-            MetaKey::Test(name) => MetaKeyRef::Test(name),
-            MetaKey::Tests => MetaKeyRef::Tests,
-            MetaKey::PreTest => MetaKeyRef::PreTest,
-            MetaKey::PostTest => MetaKeyRef::PostTest,
-            MetaKey::Main => MetaKeyRef::Main,
-            MetaKey::Type => MetaKeyRef::Type,
-            MetaKey::Base => MetaKeyRef::Base,
-        }
-    }
 }
 
 impl From<&str> for MetaKey {
@@ -310,64 +281,22 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKe
     Ok(result)
 }
 
-// Currently only used to support MetaMap::get_with_string()
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-enum MetaKeyRef<'a> {
-    BinaryOp(BinaryOp),
-    UnaryOp(UnaryOp),
-    Call,
-    Named(&'a str),
-    Test(&'a str),
-    Tests,
-    PreTest,
-    PostTest,
-    Main,
-    Type,
-    Base,
-}
-
-// A trait that allows for allocation-free map accesses with &str
-trait AsMetaKeyRef {
-    fn as_meta_key_ref(&self) -> MetaKeyRef;
-}
-
-impl<'a> Hash for dyn AsMetaKeyRef + 'a {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_meta_key_ref().hash(state);
+// Support efficient map lookups with &str
+impl Equivalent<MetaKey> for str {
+    fn equivalent(&self, other: &MetaKey) -> bool {
+        match &other {
+            MetaKey::Named(s) => self == s.as_str(),
+            _ => false,
+        }
     }
 }
 
-impl<'a> PartialEq for dyn AsMetaKeyRef + 'a {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_meta_key_ref() == other.as_meta_key_ref()
-    }
-}
-
-impl<'a> Eq for dyn AsMetaKeyRef + 'a {}
-
-impl AsMetaKeyRef for MetaKey {
-    fn as_meta_key_ref(&self) -> MetaKeyRef {
-        self.as_ref()
-    }
-}
-
-// The key part of this whole mechanism; wrap a &str as MetaKeyRef::Named,
-// allowing a map search to be performed directly against &str
-impl<'a> AsMetaKeyRef for &'a str {
-    fn as_meta_key_ref(&self) -> MetaKeyRef {
-        MetaKeyRef::Named(self)
-    }
-}
-
-impl<'a> Borrow<dyn AsMetaKeyRef + 'a> for MetaKey {
-    fn borrow(&self) -> &(dyn AsMetaKeyRef + 'a) {
-        self
-    }
-}
-
-impl<'a> Borrow<dyn AsMetaKeyRef + 'a> for &'a str {
-    fn borrow(&self) -> &(dyn AsMetaKeyRef + 'a) {
-        self
+impl Equivalent<MetaKey> for ValueString {
+    fn equivalent(&self, other: &MetaKey) -> bool {
+        match &other {
+            MetaKey::Named(s) => self == s,
+            _ => false,
+        }
     }
 }
 

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -178,11 +178,12 @@ impl Value {
             List(_) => TYPE_LIST.with(|x| x.clone()),
             Range { .. } => TYPE_RANGE.with(|x| x.clone()),
             IndexRange { .. } => TYPE_INDEX_RANGE.with(|x| x.clone()),
-            Map(m) => match m.get_meta_value(&MetaKey::Type) {
+            Map(m) if m.meta_map().is_some() => match m.get_meta_value(&MetaKey::Type) {
                 Some(Str(s)) => s,
                 Some(_) => "Error: expected string for overloaded type".into(),
-                None => TYPE_MAP.with(|x| x.clone()),
+                None => TYPE_OBJECT.with(|x| x.clone()),
             },
+            Map(_) => TYPE_MAP.with(|x| x.clone()),
             Str(_) => TYPE_STRING.with(|x| x.clone()),
             Tuple(_) => TYPE_TUPLE.with(|x| x.clone()),
             SimpleFunction(_) | Function(_) => TYPE_FUNCTION.with(|x| x.clone()),
@@ -238,6 +239,7 @@ thread_local! {
     static TYPE_RANGE: ValueString = "Range".into();
     static TYPE_INDEX_RANGE: ValueString = "IndexRange".into();
     static TYPE_MAP: ValueString = "Map".into();
+    static TYPE_OBJECT: ValueString = "Object".into();
     static TYPE_STRING: ValueString = "String".into();
     static TYPE_TUPLE: ValueString = "Tuple".into();
     static TYPE_FUNCTION: ValueString = "Function".into();

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -10,9 +10,10 @@ use {
 };
 
 /// The core Value type for Koto
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum Value {
     /// The default type representing the absence of a value
+    #[default]
     Null,
 
     /// A boolean, can be either true or false
@@ -249,12 +250,6 @@ thread_local! {
     static TYPE_TEMPORARY_TUPLE: ValueString = "TemporaryTuple".into();
     static TYPE_SEQUENCE_BUILDER: ValueString = "SequenceBuilder".into();
     static TYPE_STRING_BUILDER: ValueString = "StringBuilder".into();
-}
-
-impl Default for Value {
-    fn default() -> Self {
-        Value::Null
-    }
 }
 
 impl From<()> for Value {

--- a/src/runtime/src/value.rs
+++ b/src/runtime/src/value.rs
@@ -39,7 +39,7 @@ pub enum Value {
     /// A callable function with simple properties
     SimpleFunction(SimpleFunctionInfo),
 
-    /// A callable function with less simple properties, e.g. captures, instance function, etc.
+    /// A callable function with less simple properties, e.g. captures, variadic arguments, etc.
     Function(FunctionInfo),
 
     /// A function that produces an Iterator when called
@@ -339,8 +339,6 @@ pub struct FunctionInfo {
     pub ip: usize,
     /// The expected number of arguments for the function.
     pub arg_count: u8,
-    /// If the function is an instance function, then the first argument will be `self`.
-    pub instance_function: bool,
     /// If the function is variadic, then extra args will be captured in a tuple.
     pub variadic: bool,
     /// If the function has a single arg, and that arg is an unpacked tuple

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -2551,9 +2551,15 @@ impl Vm {
                 Some(value) => {
                     self.set_register(result_register, value.clone());
                 }
-                None => match map.get_meta_value(&MetaKey::Named(key_string)) {
+                None if map.meta_map().is_none() => core_op!(map, true),
+                _ => match map.get_meta_value(&MetaKey::Named(key_string)) {
                     Some(value) => self.set_register(result_register, value),
-                    None => core_op!(map, true),
+                    None => {
+                        return runtime_error!(
+                            "'{key}' not found in '{}'",
+                            accessed_value.type_as_string()
+                        )
+                    }
                 },
             },
             List(_) => core_op!(list, true),

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -344,16 +344,17 @@ impl Vm {
                         //
                         // At runtime the unpacking instructions will still be executed, resulting
                         // in the tuple values being unpacked into the same registers that they're
-                        // already in. This is redundant work, but still more efficient than
-                        // allocating a non-temporary Tuple for the values.
+                        // already in. This is redundant work, but more efficient than allocating a
+                        // non-temporary Tuple for the values.
 
                         let capture_count =
                             captures.as_ref().map_or(0, |captures| captures.len() as u8);
 
                         let temp_tuple = Value::TemporaryTuple(RegisterSlice {
                             // The unpacked tuple contents go into the registers after the
-                            // captures, which are placed after the temp tuple register
-                            start: capture_count + 1,
+                            // captures, which are placed after the temp tuple and instance
+                            // registers.
+                            start: capture_count + 2,
                             count: args.len() as u8,
                         });
 
@@ -541,7 +542,7 @@ impl Vm {
     ///
     /// Any test failure will be returned as an error.
     pub fn run_tests(&mut self, tests: ValueMap) -> RuntimeResult {
-        use Value::{Function, Map, Null};
+        use Value::{Map, Null};
 
         // It's important throughout this function to make sure we don't hang on to any references
         // to the internal test map data while calling the test functions, otherwise we'll end up in
@@ -560,14 +561,8 @@ impl Vm {
         };
 
         let self_arg = Map(tests.clone());
-        let pass_self_to_pre_test = match &pre_test {
-            Some(Function(f)) => f.instance_function,
-            _ => false,
-        };
-        let pass_self_to_post_test = match &post_test {
-            Some(Function(f)) => f.instance_function,
-            _ => false,
-        };
+        let pass_self_to_pre_test = true; // TODO
+        let pass_self_to_post_test = true;
 
         for i in 0..meta_entry_count {
             let meta_entry = tests.meta_map().and_then(|meta| {
@@ -600,10 +595,12 @@ impl Vm {
                         }
                     }
 
-                    let pass_self_to_test = match &test {
-                        Function(f) => f.arg_count == 1,
-                        _ => false,
-                    };
+                    // let pass_self_to_test = match &test {
+                    //     Function(f) => f.arg_count == 1,
+                    //     _ => false,
+                    // };
+
+                    let pass_self_to_test = true; // TODO
 
                     let test_result = if pass_self_to_test {
                         self.run_instance_function(self_arg.clone(), test, CallArgs::None)
@@ -1320,7 +1317,6 @@ impl Vm {
                 register,
                 arg_count,
                 capture_count,
-                instance_function,
                 variadic,
                 generator,
                 arg_is_unpacked_tuple,
@@ -1339,7 +1335,6 @@ impl Vm {
                     chunk: self.chunk(),
                     ip: self.ip(),
                     arg_count,
-                    instance_function,
                     variadic,
                     captures,
                     arg_is_unpacked_tuple,
@@ -2629,6 +2624,12 @@ impl Vm {
             maybe_op => maybe_op,
         };
 
+        // if let Some(op) = maybe_op {
+        //     Ok(op)
+        // } else {
+        //     runtime_error!("'{key}' not found in '{module_name}'")
+        // }
+        //
         let result = match maybe_op {
             Some(op) => match op {
                 // Core module functions accessed in a lookup need to be invoked as
@@ -2648,32 +2649,31 @@ impl Vm {
                     };
                     ExternalFunction(f_as_instance_function)
                 }
-                SimpleFunction(f) => {
-                    let f_as_instance_function = FunctionInfo {
-                        chunk: f.chunk,
-                        ip: f.ip,
-                        arg_count: f.arg_count,
-                        instance_function: true,
-                        variadic: false,
-                        captures: None,
-                        arg_is_unpacked_tuple: false,
-                    };
-                    Function(f_as_instance_function)
-                }
-                Function(f) => {
-                    let f_as_instance_function = FunctionInfo {
-                        instance_function: true,
-                        ..f
-                    };
-                    Function(f_as_instance_function)
-                }
-                Generator(f) => {
-                    let f_as_instance_function = FunctionInfo {
-                        instance_function: true,
-                        ..f
-                    };
-                    Generator(f_as_instance_function)
-                }
+                // SimpleFunction(f) => {
+                //     let f_as_instance_function = FunctionInfo {
+                //         chunk: f.chunk,
+                //         ip: f.ip,
+                //         arg_count: f.arg_count,
+                //         variadic: false,
+                //         captures: None,
+                //         arg_is_unpacked_tuple: false,
+                //     };
+                //     Function(f_as_instance_function)
+                // }
+                // Function(f) => {
+                //     let f_as_instance_function = FunctionInfo {
+                //         instance_function: true,
+                //         ..f
+                //     };
+                //     Function(f_as_instance_function)
+                // }
+                // Generator(f) => {
+                //     let f_as_instance_function = FunctionInfo {
+                //         instance_function: true,
+                //         ..f
+                //     };
+                //     Generator(f_as_instance_function)
+                // }
                 other => other,
             },
             None => {
@@ -2745,7 +2745,6 @@ impl Vm {
             chunk,
             ip: function_ip,
             arg_count: function_arg_count,
-            instance_function,
             variadic,
             captures,
             arg_is_unpacked_tuple: _unused,
@@ -2761,27 +2760,21 @@ impl Vm {
             0,
         );
 
-        let expected_arg_count = match (instance_function, variadic) {
-            (true, true) => function_arg_count - 2,
-            (true, false) | (false, true) => function_arg_count - 1,
-            (false, false) => function_arg_count,
-        };
-
-        // Copy the instance value into the generator vm
-        let arg_offset = if instance_function {
-            if let Some(instance_register) = instance_register {
-                let instance = self.clone_register(instance_register);
-                // Place the instance in the first register of the generator vm
-                generator_vm.set_register(0, instance);
-                1
-            } else {
-                return runtime_error!("Missing instance for call to instance function");
-            }
+        let expected_arg_count = if variadic {
+            function_arg_count - 1
         } else {
-            0
+            function_arg_count
         };
 
-        // Copy any regular (non-instance, non-variadic) arguments into the generator vm
+        // Place the instance in the first register of the generator vm
+        let instance = instance_register
+            .map(|register| self.clone_register(register))
+            .unwrap_or_default();
+        generator_vm.set_register(0, instance);
+
+        let arg_offset = 1;
+
+        // Copy any regular (non-variadic) arguments into the generator vm
         for (arg_index, arg) in self
             .register_slice(frame_base + 1, expected_arg_count.min(call_arg_count))
             .iter()
@@ -2849,34 +2842,22 @@ impl Vm {
             chunk,
             ip: function_ip,
             arg_count: function_arg_count,
-            instance_function,
             variadic,
             captures,
             arg_is_unpacked_tuple: _unused,
         } = function;
 
-        let expected_arg_count = match (instance_function, variadic) {
-            (true, true) => function_arg_count - 2,
-            (true, false) | (false, true) => function_arg_count - 1,
-            (false, false) => function_arg_count,
+        let expected_arg_count = if variadic {
+            function_arg_count - 1
+        } else {
+            function_arg_count
         };
 
         // Clone the instance register into the first register of the frame
-        let adjusted_frame_base = if instance_function {
-            if let Some(instance_register) = instance_register {
-                if instance_register != frame_base {
-                    let instance = self.clone_register(instance_register);
-                    self.set_register(frame_base, instance);
-                }
-                frame_base
-            } else {
-                return runtime_error!("Missing instance for call to instance function");
-            }
-        } else {
-            // If there's no self arg, then the frame's instance register is unused,
-            // so the new function's frame base is offset by 1
-            frame_base + 1
-        };
+        let instance = instance_register
+            .map(|register| self.clone_register(register))
+            .unwrap_or_default();
+        self.set_register(frame_base, instance);
 
         if variadic && call_arg_count >= expected_arg_count {
             // The last defined arg is the start of the var_args,
@@ -2890,19 +2871,18 @@ impl Vm {
             self.truncate_registers(varargs_start + 1);
         }
 
-        let frame_base_index = self.register_index(adjusted_frame_base);
+        let arg_index = self.register_index(frame_base + 1);
         if expected_arg_count > call_arg_count {
             // Ensure that temporary registers used to prepare the call args have been removed from
             // the value stack.
             let missing_args = expected_arg_count - call_arg_count;
-            self.value_stack
-                .truncate(frame_base_index + missing_args as usize);
+            self.value_stack.truncate(arg_index + missing_args as usize);
         }
         // Ensure that registers have been filled with Null for any missing args.
         // If there are extra args, truncating is necessary at this point. Extra args have either
         // been bundled into a variadic Tuple or they can be ignored.
         self.value_stack
-            .resize(frame_base_index + function_arg_count as usize, Value::Null);
+            .resize(arg_index + function_arg_count as usize, Value::Null);
 
         if let Some(captures) = captures {
             // Copy the captures list into the registers following the args
@@ -2915,7 +2895,7 @@ impl Vm {
         }
 
         // Set up a new frame for the called function
-        self.push_frame(chunk, function_ip, adjusted_frame_base, result_register);
+        self.push_frame(chunk, function_ip, frame_base, result_register);
 
         Ok(())
     }
@@ -2937,18 +2917,20 @@ impl Vm {
                 ip: function_ip,
                 arg_count: function_arg_count,
             }) => {
-                // The frame base is offset by one since the frame's instance register is unused.
-                let frame_base = frame_base + 1;
+                let instance = instance_register
+                    .map(|register| self.clone_register(register))
+                    .unwrap_or_default();
+                self.set_register(frame_base, instance);
 
-                let frame_base_index = self.register_index(frame_base);
+                let arg_base_index = self.register_index(frame_base) + 1;
                 // Remove any temporary registers used to prepare the call args
                 self.value_stack
-                    .truncate(frame_base_index + call_arg_count as usize);
+                    .truncate(arg_base_index + call_arg_count as usize);
                 // Ensure that registers have been filled with Null for any missing args.
                 // If there are extra args, truncating is OK at this point (variadic calls aren't
                 // available for SimpleFunction).
                 self.value_stack
-                    .resize(frame_base_index + function_arg_count as usize, Value::Null);
+                    .resize(arg_base_index + function_arg_count as usize, Value::Null);
 
                 // Set up a new frame for the called function
                 self.push_frame(chunk, function_ip, frame_base, result_register);

--- a/src/runtime/tests/runtime_failures.rs
+++ b/src/runtime/tests/runtime_failures.rs
@@ -8,7 +8,7 @@ mod runtime {
         let mut vm = Vm::default();
 
         let print_chunk = |script: &str, chunk| {
-            println!("{}\n", script);
+            println!("{script}\n");
             let script_lines = script.lines().collect::<Vec<_>>();
 
             println!("{}", Chunk::instructions_as_string(chunk, &script_lines));
@@ -19,7 +19,7 @@ mod runtime {
             Ok(chunk) => chunk,
             Err(error) => {
                 print_chunk(script, vm.chunk());
-                panic!("Error while compiling script: {}", error);
+                panic!("Error while compiling script: {error}");
             }
         };
 

--- a/src/runtime/tests/runtime_test_utils.rs
+++ b/src/runtime/tests/runtime_test_utils.rs
@@ -16,7 +16,7 @@ pub fn test_script_with_vm(mut vm: Vm, script: &str, expected_output: Value) {
         Ok(chunk) => chunk,
         Err(error) => {
             print_chunk(script, vm.chunk());
-            panic!("Error while compiling script: {}", error);
+            panic!("Error while compiling script: {error}");
         }
     };
 
@@ -41,19 +41,19 @@ pub fn test_script_with_vm(mut vm: Vm, script: &str, expected_output: Value) {
                 }
                 Err(e) => {
                     print_chunk(script, vm.chunk());
-                    panic!("Error while comparing output value: {}", e);
+                    panic!("Error while comparing output value: {e}");
                 }
             }
         }
         Err(e) => {
             print_chunk(script, vm.chunk());
-            panic!("Error while running script: {}", e);
+            panic!("Error while running script: {e}");
         }
     }
 }
 
 pub fn print_chunk(script: &str, chunk: Rc<Chunk>) {
-    println!("{}\n", script);
+    println!("{script}\n");
     let script_lines = script.lines().collect::<Vec<_>>();
 
     println!("Constants\n---------\n{}\n", chunk.constants);

--- a/src/runtime/tests/stdout.rs
+++ b/src/runtime/tests/stdout.rs
@@ -52,7 +52,7 @@ mod vm {
         });
 
         let print_chunk = |script: &str, chunk: Rc<Chunk>| {
-            println!("{}\n", script);
+            println!("{script}\n");
             let script_lines = script.lines().collect::<Vec<_>>();
 
             println!("Constants\n---------\n{}\n", chunk.constants);
@@ -67,7 +67,7 @@ mod vm {
             Ok(chunk) => chunk,
             Err(error) => {
                 print_chunk(script, vm.chunk());
-                panic!("Error while compiling script: {}", error);
+                panic!("Error while compiling script: {error}");
             }
         };
 
@@ -77,7 +77,7 @@ mod vm {
             }
             Err(e) => {
                 print_chunk(script, vm.chunk());
-                panic!("Error while running script: {}", e);
+                panic!("Error while running script: {e}");
             }
         }
     }

--- a/src/runtime/tests/stdout.rs
+++ b/src/runtime/tests/stdout.rs
@@ -104,7 +104,7 @@ foo 4
     fn print_value_with_overridden_display() {
         let script = "
 foo =
-  @display: |self| 'Hello from @display'
+  @display: || 'Hello from @display'
   @type: 'Foo'
 print foo
 ";

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2123,6 +2123,19 @@ foo([42]).next()
 ";
             test_script(script, 123);
         }
+
+        #[test]
+        fn if_else_used_in_map_block() {
+            let script = "
+foo = 
+  x: if 1 == 2
+       99
+     else 
+       42
+foo.x
+";
+            test_script(script, 42);
+        }
     }
 
     mod placeholders {

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2782,7 +2782,7 @@ foo = |x|
   @>=: |self, other| self.x >= other.x
 
 a = foo 42
-b = a.deep_copy()
+b = map.deep_copy a
 b >= a
 ";
             test_script(script, true);
@@ -2891,6 +2891,26 @@ a = foo 10
 a.x + a.y # The meta map's y entry is hidden by the data entry
 ";
             test_script(script, 110);
+        }
+    }
+
+    mod base_lookup {
+        use super::*;
+
+        #[test]
+        fn base_entry() {
+            let script = "
+animal = |name|
+  name: name
+  speak: |self| throw 'unimplemented'
+
+dog = |name|
+  @base: animal name
+  speak: |self| 'Woof! My name is ${self.name}'
+
+dog('Fido').speak()
+";
+            test_script(script, "Woof! My name is Fido");
         }
     }
 

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -2541,6 +2541,21 @@ catch _
 ";
             test_script(script, 4);
         }
+
+
+        #[test]
+        fn catch_throw_from_map_creation() {
+            // This would be a strange thing to do, but the compiler previously melted down while
+            // trying to compile the throw expression as map value, which it shouldn't do.
+            let script = "
+try
+  x = 
+    foo: throw 'foo'
+catch _
+  99
+";
+            test_script(script, 99);
+        }
     }
 
     mod operator_overloading {


### PR DESCRIPTION
This PR introduces some substantial changes to the way Maps with Metamaps behave in Koto.

- Disable map module fallback for maps containing metamaps
- Introduce `@base` metakey
- Make `self` an implicit argument rather than explicit
