### PR TITLE
Fix execution error when capturing values

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,38 +1,40 @@
+checks: fmt clippy test doc wasm
+
 clippy:
-  cargo watch -x "clippy --all-targets --all-features"
+  cargo clippy --all-targets --all-features
 
 doc:
-  cargo watch -x "doc --workspace --exclude koto_cli"
+  cargo doc --workspace --exclude koto_cli
 
 fmt:
   cargo fmt --all -- --check
 
 temp:
-  cargo watch -x "run -- --tests -i temp.koto"
+  cargo run -- --tests -i temp.koto
 
 test:
-  cargo watch -x "test --tests"
-
-test_all:
-  cargo watch -x "test --all-targets"
+  cargo test --all-targets
 
 test_benches:
-  cargo watch -x "test --benches"
+  cargo test --benches
 
 test_docs:
-  cargo watch -x "test --test docs_examples"
+  cargo test --test docs_examples
 
 test_koto:
-  cargo watch -x "test --test koto_tests"
+  cargo test --test koto_tests
 
 test_libs:
-  cargo watch -x "test --test lib_tests"
+  cargo test --test lib_tests
 
 test_parser:
-  cargo watch -x "test --package koto_lexer --package koto_parser"
+  cargo test --package koto_lexer --package koto_parser
 
 test_runtime:
-  cargo watch -x "test --package koto_runtime"
+  cargo test --package koto_runtime
 
 wasm:
   cd examples/wasm && wasm-pack test --node
+
+watch command:
+  cargo watch -s "just {{command}}"

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -15,7 +15,10 @@
 
   @test sum_variadic: ||
     sum = |x, y, z...|
-      x + y + z.fold(0, |a, b| a + b)
+      if z
+        x + y + z.fold 0, |a, b| a + b
+      else
+        x + y
     assert_eq (sum 1, 2), 3
     assert_eq (sum 3, 4, 5), 12
     assert_eq (sum 6, 7, 8, 9), 30

--- a/src/bytecode/src/instruction_reader.rs
+++ b/src/bytecode/src/instruction_reader.rs
@@ -539,7 +539,7 @@ impl fmt::Debug for Instruction {
             } => write!(
                 f,
                 "Function\tresult: {register}\targs: {arg_count}\
-                 \tcaptures: {capture_count}
+                 \t\tcaptures: {capture_count}
                  \t\t\tsize: {size} \tgenerator: {generator}
                  \t\t\tvariadic: {variadic}\targ_is_unpacked_tuple: {arg_is_unpacked_tuple}",
             ),

--- a/src/runtime/src/vm.rs
+++ b/src/runtime/src/vm.rs
@@ -1371,7 +1371,7 @@ impl Vm {
             let capture_list = match function {
                 Value::Function(f) => &f.captures,
                 Value::Generator(g) => &g.captures,
-                unexpected => return type_error("Function", unexpected),
+                unexpected => return type_error("Function while capturing value", unexpected),
             };
 
             match capture_list {
@@ -1386,7 +1386,7 @@ impl Vm {
             // The function was temporary and has been removed from the value stack,
             // but the capture of `x` is still attempted. It would be cleaner for the compiler to
             // detect this case but for now a runtime error will have to do.
-            runtime_error!("Attempting to capture a reserved value in a temporary function")
+            runtime_error!("Function not found while attempting to capture a value")
         }
     }
 
@@ -2606,7 +2606,6 @@ impl Vm {
             ExternalValue(ev) => match ev.get_meta_value(&MetaKey::Named(key_string.clone())) {
                 Some(value) => self.set_register(result_register, value),
                 None => {
-                    dbg!("iterator fallback");
                     // Iterator fallback?
                     if ev.contains_meta_key(&UnaryOp::Iterator.into()) {
                         let iterator_op = self.get_core_op(

--- a/src/runtime/tests/external_value_tests.rs
+++ b/src/runtime/tests/external_value_tests.rs
@@ -156,7 +156,9 @@ mod external_values {
             _ => runtime_error!("make_external: Expected a Number"),
         });
 
-        test_script_with_vm(vm, script, expected_output.into());
+        if let Err(e) = run_script_with_vm(vm, script, expected_output.into()) {
+            panic!("{e}");
+        }
     }
 
     mod named_functions {

--- a/src/runtime/tests/runtime_test_utils.rs
+++ b/src/runtime/tests/runtime_test_utils.rs
@@ -3,51 +3,69 @@
 use {
     koto_bytecode::{Chunk, Loader},
     koto_runtime::{prelude::*, Value::*},
-    std::rc::Rc,
+    std::{cell::RefCell, rc::Rc},
 };
 
 pub fn test_script(script: &str, expected_output: impl Into<Value>) {
-    test_script_with_vm(Vm::default(), script, expected_output.into());
+    let output = Rc::new(RefCell::new(String::new()));
+
+    let vm = Vm::with_settings(VmSettings {
+        stdout: Rc::new(TestStdout {
+            output: output.clone(),
+        }),
+        stderr: Rc::new(TestStdout {
+            output: output.clone(),
+        }),
+        ..Default::default()
+    });
+
+    if let Err(e) = run_script_with_vm(vm, script, expected_output.into()) {
+        let output = output.borrow();
+        if !output.is_empty() {
+            println!("Stdout:\n-------\n\n{output}\n-------\n");
+        }
+        panic!("{e}");
+    }
 }
 
-pub fn test_script_with_vm(mut vm: Vm, script: &str, expected_output: Value) {
+pub fn run_script_with_vm(mut vm: Vm, script: &str, expected_output: Value) -> Result<(), String> {
     let mut loader = Loader::default();
     let chunk = match loader.compile_script(script, &None) {
         Ok(chunk) => chunk,
         Err(error) => {
             print_chunk(script, vm.chunk());
-            panic!("Error while compiling script: {error}");
+            return Err(format!("Error while compiling script: {error}"));
         }
     };
 
     match vm.run(chunk) {
         Ok(result) => {
             match vm.run_binary_op(BinaryOp::Equal, result.clone(), expected_output.clone()) {
-                Ok(Value::Bool(true)) => {}
+                Ok(Value::Bool(true)) => Ok(()),
                 Ok(Value::Bool(false)) => {
                     print_chunk(script, vm.chunk());
-                    panic!(
+                    Err(format!(
                         "Unexpected result - expected: {}, result: {}",
                         vm.value_to_string(&expected_output).unwrap(),
                         vm.value_to_string(&result).unwrap(),
-                    );
+                    ))
                 }
                 Ok(other) => {
                     print_chunk(script, vm.chunk());
-                    panic!(
+                    Err(format!(
                         "Expected bool from equality comparison, found '{}'",
                         vm.value_to_string(&other).unwrap()
-                    );
+                    ))
                 }
                 Err(e) => {
                     print_chunk(script, vm.chunk());
-                    panic!("Error while comparing output value: {e}");
+                    Err(format!("Error while comparing output value: {e}"))
                 }
             }
         }
         Err(e) => {
             print_chunk(script, vm.chunk());
-            panic!("Error while running script: {e}");
+            Err(format!("Error while running script: {e}"))
         }
     }
 }
@@ -105,4 +123,35 @@ pub fn value_tuple(values: &[Value]) -> Value {
 
 pub fn string(s: &str) -> Value {
     Str(s.into())
+}
+
+#[derive(Debug)]
+pub struct TestStdout {
+    pub output: Rc<RefCell<String>>,
+}
+
+impl KotoFile for TestStdout {
+    fn id(&self) -> ValueString {
+        "_teststdout_".into()
+    }
+}
+
+impl KotoRead for TestStdout {}
+impl KotoWrite for TestStdout {
+    fn write(&self, bytes: &[u8]) -> Result<(), RuntimeError> {
+        self.output
+            .borrow_mut()
+            .push_str(std::str::from_utf8(bytes).unwrap());
+        Ok(())
+    }
+
+    fn write_line(&self, s: &str) -> Result<(), RuntimeError> {
+        self.output.borrow_mut().push_str(s);
+        self.output.borrow_mut().push('\n');
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), RuntimeError> {
+        Ok(())
+    }
 }

--- a/src/runtime/tests/stdout.rs
+++ b/src/runtime/tests/stdout.rs
@@ -1,39 +1,11 @@
+mod runtime_test_utils;
+
 use {
+    crate::runtime_test_utils::TestStdout,
     koto_bytecode::{Chunk, Loader},
     koto_runtime::prelude::*,
     std::{cell::RefCell, rc::Rc},
 };
-
-#[derive(Debug)]
-struct TestStdout {
-    output: Rc<RefCell<String>>,
-}
-
-impl KotoFile for TestStdout {
-    fn id(&self) -> ValueString {
-        "_teststdout_".into()
-    }
-}
-
-impl KotoRead for TestStdout {}
-impl KotoWrite for TestStdout {
-    fn write(&self, bytes: &[u8]) -> Result<(), RuntimeError> {
-        self.output
-            .borrow_mut()
-            .push_str(std::str::from_utf8(bytes).unwrap());
-        Ok(())
-    }
-
-    fn write_line(&self, s: &str) -> Result<(), RuntimeError> {
-        self.output.borrow_mut().push_str(s);
-        self.output.borrow_mut().push('\n');
-        Ok(())
-    }
-
-    fn flush(&self) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-}
 
 mod vm {
     use super::*;

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -1263,6 +1263,35 @@ else
         }
 
         #[test]
+        fn missing_argument_in_function_with_capture() {
+            let script = "
+z =
+  foo: || 42
+x = 100
+f = |a|
+  if a then return -a
+  x
+g = |b|
+  b = f z.foo()
+  f()
+g 42
+";
+            test_script(script, 100);
+        }
+
+        #[test]
+        fn returning_captured_value_after_if() {
+            let script = "
+x = 100
+f = ||
+  if false then return -1
+  x
+f()
+";
+            test_script(script, 100);
+        }
+
+        #[test]
         fn mutation_of_captured_map() {
             let script = "
 f = |x|

--- a/src/runtime/tests/vm_tests.rs
+++ b/src/runtime/tests/vm_tests.rs
@@ -3,7 +3,7 @@ mod runtime_test_utils;
 mod vm {
     use {
         crate::runtime_test_utils::{
-            number, number_list, number_tuple, string, test_script, test_script_with_vm,
+            number, number_list, number_tuple, string, test_script, run_script_with_vm,
             value_tuple,
         },
         koto_runtime::{prelude::*, Value::*},
@@ -870,7 +870,9 @@ x
                 Ok(Null)
             });
 
-            test_script_with_vm(vm, script, expected_output);
+            if let Err(e) = run_script_with_vm(vm, script, expected_output) {
+                panic!("{e}");
+            }
         }
 
         #[test]


### PR DESCRIPTION
- Capture stdout of runtime tests so debug expressions can be used
- Fix implicit return after previous conditional return
- Ensure temporary registers are truncated correctly when calling a function
