### PR TITLE
Rename external_value_fn to value_fn

### DIFF
--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -36,7 +36,7 @@ fn make_poetry_meta_map() -> Rc<RefCell<MetaMap>> {
             }
             unexpected => type_error_with_slice("a String", unexpected),
         })
-        .external_value_fn("iter", |poetry_value, _args| {
+        .value_fn("iter", |poetry_value, _args| {
             let iter = PoetryIter {
                 poetry: poetry_value.clone(),
             };

--- a/koto/tests/libs/color.koto
+++ b/koto/tests/libs/color.koto
@@ -24,14 +24,14 @@ import color
 
   @test set_components: ||
     allowed_error = 1.0e-7
-    c = color 'yellow'
-    c.set_r 0.4
+    c = color('yellow')
+      .set_r 0.4
+      .set_g 0.9
+      .set_b 0.7
+      .set_a 0.2
     assert_near c.r(), 0.4, allowed_error
-    c.set_g 0.9
     assert_near c.g(), 0.9, allowed_error
-    c.set_b 0.7
     assert_near c.b(), 0.7, allowed_error
-    c.set_a 0.2
     assert_near c.a(), 0.2, allowed_error
 
   @test arithmetic: ||

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -179,13 +179,13 @@ macro_rules! color_arithmetic_assign_op {
     ($op:tt) => {
         |a, b| match b {
             [Value::ExternalValue(b)] if b.has_data::<Color>() =>{
-                let b = b.data::<Color>().unwrap();
-                *a $op *b;
-                Ok(Value::Null)
+                let b: Color = *b.data::<Color>().unwrap();
+                *a.data_mut::<Color>().unwrap() $op b;
+                Ok(a.clone().into())
             }
             [Value::Number(n)] => {
-                *a $op f32::from(n);
-                Ok(Value::Null)
+                *a.data_mut::<Color>().unwrap() $op f32::from(n);
+                Ok(a.clone().into())
             }
             unexpected => {
                 type_error_with_slice("a Color or Number", unexpected)
@@ -215,31 +215,31 @@ fn make_color_meta_map() -> Rc<RefCell<MetaMap>> {
         .data_fn("g", |c| Ok(c.g().into()))
         .data_fn("b", |c| Ok(c.b().into()))
         .data_fn("a", |c| Ok(c.a().into()))
-        .data_fn_with_args_mut("set_r", |c, args| match args {
+        .value_fn("set_r", |c, args| match args {
             [Number(n)] => {
-                c.color.red = n.into();
-                Ok(Null)
+                c.data_mut::<Color>().unwrap().color.red = n.into();
+                Ok(c.clone().into())
             }
             unexpected => type_error_with_slice("a Number", unexpected),
         })
-        .data_fn_with_args_mut("set_g", |c, args| match args {
+        .value_fn("set_g", |c, args| match args {
             [Number(n)] => {
-                c.color.green = n.into();
-                Ok(Null)
+                c.data_mut::<Color>().unwrap().color.green = n.into();
+                Ok(c.clone().into())
             }
             unexpected => type_error_with_slice("a Number", unexpected),
         })
-        .data_fn_with_args_mut("set_b", |c, args| match args {
+        .value_fn("set_b", |c, args| match args {
             [Number(n)] => {
-                c.color.blue = n.into();
-                Ok(Null)
+                c.data_mut::<Color>().unwrap().color.blue = n.into();
+                Ok(c.clone().into())
             }
             unexpected => type_error_with_slice("a Number", unexpected),
         })
-        .data_fn_with_args_mut("set_a", |c, args| match args {
+        .value_fn("set_a", |c, args| match args {
             [Number(n)] => {
-                c.alpha = n.into();
-                Ok(Null)
+                c.data_mut::<Color>().unwrap().alpha = n.into();
+                Ok(c.clone().into())
             }
             unexpected => type_error_with_slice("a Number", unexpected),
         })
@@ -248,10 +248,10 @@ fn make_color_meta_map() -> Rc<RefCell<MetaMap>> {
         .data_fn_with_args(Subtract, color_arithmetic_op!(-))
         .data_fn_with_args(Multiply, color_arithmetic_op!(*))
         .data_fn_with_args(Divide, color_arithmetic_op!(/))
-        .data_fn_with_args_mut(AddAssign, color_arithmetic_assign_op!(+=))
-        .data_fn_with_args_mut(SubtractAssign, color_arithmetic_assign_op!(-=))
-        .data_fn_with_args_mut(MultiplyAssign, color_arithmetic_assign_op!(*=))
-        .data_fn_with_args_mut(DivideAssign, color_arithmetic_assign_op!(/=))
+        .value_fn(AddAssign, color_arithmetic_assign_op!(+=))
+        .value_fn(SubtractAssign, color_arithmetic_assign_op!(-=))
+        .value_fn(MultiplyAssign, color_arithmetic_assign_op!(*=))
+        .value_fn(DivideAssign, color_arithmetic_assign_op!(/=))
         .data_fn_with_args(Equal, color_comparison_op!(==))
         .data_fn_with_args(NotEqual, color_comparison_op!(!=))
         .data_fn_with_args(Index, |a, b| match b {

--- a/libs/geometry/src/macros.rs
+++ b/libs/geometry/src/macros.rs
@@ -78,15 +78,15 @@ macro_rules! koto_arithmetic_op {
 #[macro_export]
 macro_rules! koto_arithmetic_assign_op {
     ($type:ident, $op:tt) => {
-        |a, b| match b {
+        |value, args| match args {
             [Value::ExternalValue(b)] if b.has_data::<$type>() =>{
-                let b = b.data::<$type>().unwrap();
-                *a $op *b;
-                Ok(Value::Null)
+                let b: $type = *b.data::<$type>().unwrap().deref();
+                *value.data_mut::<$type>().unwrap() $op b;
+                Ok(value.clone().into())
             }
             [Value::Number(n)] => {
-                *a $op f64::from(n);
-                Ok(Value::Null)
+                *value.data_mut::<$type>().unwrap() $op f64::from(n);
+                Ok(value.clone().into())
             }
             unexpected => {
                 type_error_with_slice(&format!("a {} or Number", stringify!($type)), unexpected)
@@ -120,10 +120,10 @@ macro_rules! add_ops {
             .data_fn_with_args(Subtract, koto_arithmetic_op!($type, -))
             .data_fn_with_args(Multiply, koto_arithmetic_op!($type, *))
             .data_fn_with_args(Divide, koto_arithmetic_op!($type, /))
-            .data_fn_with_args_mut(AddAssign, koto_arithmetic_assign_op!($type, +=))
-            .data_fn_with_args_mut(SubtractAssign, koto_arithmetic_assign_op!($type, -=))
-            .data_fn_with_args_mut(MultiplyAssign, koto_arithmetic_assign_op!($type, *=))
-            .data_fn_with_args_mut(DivideAssign, koto_arithmetic_assign_op!($type, /=))
+            .value_fn(AddAssign, koto_arithmetic_assign_op!($type, +=))
+            .value_fn(SubtractAssign, koto_arithmetic_assign_op!($type, -=))
+            .value_fn(MultiplyAssign, koto_arithmetic_assign_op!($type, *=))
+            .value_fn(DivideAssign, koto_arithmetic_assign_op!($type, /=))
             .data_fn_with_args(Equal, koto_comparison_op!($type, ==))
             .data_fn_with_args(NotEqual, koto_comparison_op!($type, !=))
     }}

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -27,7 +27,8 @@ fn make_rect_meta_map() -> Rc<RefCell<MetaMap>> {
             }
             unexpected => type_error_with_slice("Vec2", unexpected),
         })
-        .data_fn_with_args_mut("set_center", |r, args| {
+        .value_fn("set_center", |value, args| {
+            let mut r = value.data_mut::<Rect>().unwrap();
             let (x, y) = match args {
                 [Number(x), Number(y)] => (x.into(), y.into()),
                 [ExternalValue(p)] if p.has_data::<Vec2>() => {
@@ -37,7 +38,7 @@ fn make_rect_meta_map() -> Rc<RefCell<MetaMap>> {
                 unexpected => return type_error_with_slice("two Numbers or a Vec2", unexpected),
             };
             r.0 = Inner::from_x_y_w_h(x, y, r.w(), r.h());
-            Ok(Null)
+            Ok(value.clone().into())
         })
         .data_fn(Display, |r| Ok(r.to_string().into()))
         .data_fn_with_args(Equal, koto_comparison_op!(Rect, ==))

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -386,7 +386,7 @@ impl<T: ExternalData> MetaMapBuilder<T> {
     ///
     /// This is useful when the value itself is needed rather than its internal data.
     /// When the internal data is needed, see the various `data_` functions.
-    pub fn external_value_fn<Key, F>(mut self, key: Key, f: F) -> Self
+    pub fn value_fn<Key, F>(mut self, key: Key, f: F) -> Self
     where
         Key: Into<MetaKey>,
         F: Fn(&ExternalValue, &[Value]) -> RuntimeResult + 'static,

--- a/src/runtime/src/meta_map.rs
+++ b/src/runtime/src/meta_map.rs
@@ -380,12 +380,13 @@ impl<T: ExternalData> MetaMapBuilder<T> {
         self
     }
 
-    /// Adds a function that provides the ExternalValue instance
+    /// Adds a function that takes the ExternalValue instance as the first argument
     ///
-    /// A helper for a function that expects an instance of ExternalValue as the only argument.
+    /// This is useful when the value itself is needed rather than its internal data,
+    /// which is useful for self-modifying functions that return self as the result,
+    /// like when implementing a builder pattern.
     ///
-    /// This is useful when the value itself is needed rather than its internal data.
-    /// When the internal data is needed, see the various `data_` functions.
+    /// When only the internal data is needed, see the various `data_` functions.
     pub fn value_fn<Key, F>(mut self, key: Key, f: F) -> Self
     where
         Key: Into<MetaKey>,
@@ -396,7 +397,7 @@ impl<T: ExternalData> MetaMapBuilder<T> {
         self.map
             .add_instance_fn(key.into(), move |vm, args| match vm.get_args(args) {
                 [Value::ExternalValue(value), extra_args @ ..]
-                    if value.value_type() == type_name =>
+                    if value.value_type() == type_name && value.has_data::<T>() =>
                 {
                     f(value, extra_args)
                 }
@@ -489,10 +490,14 @@ impl<T: ExternalData> MetaMapBuilder<T> {
     /// Adds a function that takes an ExternalValue instance, followed by other arguments
     ///
     /// A helper for a function that expects an instance of ExternalValue as the first argument,
-    /// followed by other arguments.
+    /// followed by any other arguments.
     ///
     /// This is useful when you want mutable access to the internal data of an ExternalValue,
     /// along with following arguments.
+    ///
+    /// The mutable reference take of the first argument will prevent additional references from
+    /// being taken, so if one of the other arguments could be another instance of the first
+    /// argument, then value_fn should be used instead.
     pub fn data_fn_with_args_mut<Key, F>(mut self, key: Key, f: F) -> Self
     where
         Key: Into<MetaKey>,
@@ -515,10 +520,14 @@ impl<T: ExternalData> MetaMapBuilder<T> {
     /// Adds a function that takes an ExternalValue instance, along with a shared VM and args
     ///
     /// A helper for a function that expects an instance of ExternalValue as the first argument,
-    /// followed by other arguments.
+    /// followed by any other arguments, along with a VM that shares the calling context.
     ///
     /// This is useful when you want mutable access to the internal data of an ExternalValue,
     /// along with following arguments.
+    ///
+    /// The mutable reference take of the first argument will prevent additional references from
+    /// being taken, so if one of the other arguments could be another instance of the first
+    /// argument, then value_fn should be used instead.
     pub fn data_fn_with_vm_mut<Key, F>(mut self, key: Key, f: F) -> Self
     where
         Key: Into<MetaKey>,


### PR DESCRIPTION
- Rename external_value_fn to value_fn
- Use value_fn where appropriate in external value ops
