### PR TITLE
Fix assignment from switch/match expressions without else branches

### DIFF
--- a/core/bytecode/src/compiler.rs
+++ b/core/bytecode/src/compiler.rs
@@ -3203,6 +3203,10 @@ impl Compiler {
     ) -> CompileNodeResult {
         let result = self.get_result_register(result_register)?;
 
+        if let Some(result) = result {
+            self.push_op(Op::SetNull, &[result.register]);
+        }
+
         let stack_count = self.frame().register_stack.len();
 
         let match_node = ast.node(match_expression);

--- a/core/bytecode/src/compiler.rs
+++ b/core/bytecode/src/compiler.rs
@@ -1170,10 +1170,15 @@ impl Compiler {
             .map(|target| self.local_register_for_assign_target(target, ast))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let rhs_is_temp_tuple = matches!(ast.node(expression).node, Node::TempTuple(_));
+        let rhs_node = ast.node(expression);
+        let rhs_is_temp_tuple = matches!(rhs_node.node, Node::TempTuple(_));
         let rhs = self
-            .compile_node(ResultRegister::Any, ast.node(expression), ast)?
+            .compile_node(ResultRegister::Any, rhs_node, ast)?
             .unwrap();
+
+        // Use the rhs node's span for assignment operations
+        let span_stack_count = self.span_stack.len();
+        self.span_stack.push(*ast.span(rhs_node.span));
 
         // If the result is needed then prepare a tuple in the result register
         if let Some(result) = result {
@@ -1297,6 +1302,7 @@ impl Compiler {
             self.push_op(SequenceToTuple, &[result.register]);
         }
 
+        self.span_stack.truncate(span_stack_count);
         self.truncate_register_stack(stack_count)?;
 
         Ok(result)
@@ -3140,6 +3146,14 @@ impl Compiler {
 
         let mut result_jump_placeholders = Vec::new();
 
+        let body_result_register = if let Some(result) = result {
+            // Set the result register to null, in case no switch arm is executed
+            self.push_op(Op::SetNull, &[result.register]);
+            ResultRegister::Fixed(result.register)
+        } else {
+            ResultRegister::None
+        };
+
         for (arm_index, arm) in arms.iter().enumerate() {
             let is_last_arm = arm_index == arms.len() - 1;
 
@@ -3157,12 +3171,6 @@ impl Compiler {
                 Some(self.push_offset_placeholder())
             } else {
                 None
-            };
-
-            let body_result_register = if let Some(result) = result {
-                ResultRegister::Fixed(result.register)
-            } else {
-                ResultRegister::None
             };
 
             self.compile_node(body_result_register, ast.node(arm.expression), ast)?;

--- a/core/parser/src/parser.rs
+++ b/core/parser/src/parser.rs
@@ -2370,7 +2370,7 @@ impl<'source> Parser<'source> {
         self.consume_token_with_context(match_context); // Token::Match
 
         let current_indent = self.current_indent();
-        let start_span = self.current_span();
+        let match_span = self.current_span();
 
         let match_expression =
             match self.parse_expressions(&ExpressionContext::inline(), TempResult::Yes)? {
@@ -2491,16 +2491,16 @@ impl<'source> Parser<'source> {
             let last_arm = arm_index == arms.len() - 1;
 
             if arm.patterns.is_empty() && arm.condition.is_none() && !last_arm {
-                return Err(ParserError::new(MatchElseNotInLastArm.into(), start_span));
+                return Err(ParserError::new(MatchElseNotInLastArm.into(), match_span));
             }
         }
 
-        self.push_node_with_start_span(
+        self.push_node_with_span(
             Node::Match {
                 expression: match_expression,
                 arms,
             },
-            start_span,
+            match_span,
         )
     }
 

--- a/core/parser/src/parser.rs
+++ b/core/parser/src/parser.rs
@@ -2291,7 +2291,7 @@ impl<'source> Parser<'source> {
         self.consume_token_with_context(switch_context); // Token::Switch
 
         let current_indent = self.current_indent();
-        let start_span = self.current_span();
+        let switch_span = self.current_span();
 
         let arm_context = match self.consume_until_token_with_context(switch_context) {
             Some(arm_context) if self.current_indent() > current_indent => arm_context,
@@ -2354,11 +2354,11 @@ impl<'source> Parser<'source> {
             let last_arm = arm_index == arms.len() - 1;
 
             if arm.condition.is_none() && !last_arm {
-                return Err(ParserError::new(SwitchElseNotInLastArm.into(), start_span));
+                return Err(ParserError::new(SwitchElseNotInLastArm.into(), switch_span));
             }
         }
 
-        self.push_node_with_start_span(Node::Switch(arms), start_span)
+        self.push_node_with_span(Node::Switch(arms), switch_span)
     }
 
     fn parse_match_expression(

--- a/core/runtime/tests/vm_tests.rs
+++ b/core/runtime/tests/vm_tests.rs
@@ -850,6 +850,19 @@ x
 "#;
             test_script(script, number_tuple(&[3, 4]));
         }
+
+        #[test]
+        fn missing_else_branch() {
+            // A bug meant that a missing else branch would leak previously assigned values
+            let script = r#"
+a, b = 42, 43
+x = switch
+  1 == 2 then 1, 2
+  3 == 4 then 3, 4
+x
+"#;
+            test_script(script, Null);
+        }
     }
 
     mod prelude {

--- a/core/runtime/tests/vm_tests.rs
+++ b/core/runtime/tests/vm_tests.rs
@@ -822,6 +822,19 @@ m
 "#;
             test_script(script, number_tuple(&[3, 4]));
         }
+
+        #[test]
+        fn missing_else_branch() {
+            // A bug meant that a missing else branch would leak previously assigned values
+            let script = r#"
+a, b = 42, 43
+x = match a, b
+  1, 2 then 1, 2
+  3, 4 then 3, 4
+x
+"#;
+            test_script(script, Null);
+        }
     }
 
     mod switch_expressions {


### PR DESCRIPTION
- Use Null as the default value in switch expressions
- Use Null as the default value in match expressions
