### PR TITLE
Iterator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ The Koto project adheres to
     a, b, c = (1..10).each |n| n * 10
     # 10, 20, 30
     ```
+  - Iteration is also used when unpacking for loop arguments.
+    - e.g. 
+    ```koto
+    for a, b, c in (1..10).windows 3
+      debug a, b, c
+      # 1, 2, 3
+      # 2, 3, 4
+      # ...
+    ```
 - Ranges now preserve whether or not they're inclusive.
 - `File`s now implement `@display`, showing their paths.
 - `Tuple`s now share data when sub-tuples are made via indexing or unpacking, 

--- a/core/bytecode/src/compiler.rs
+++ b/core/bytecode/src/compiler.rs
@@ -1207,7 +1207,7 @@ impl Compiler {
                                     &[*target_register, iter_register, i as u8],
                                 );
                             } else {
-                                self.push_op(IterNext, &[*target_register, iter_register, 0, 0]);
+                                self.push_op(IterUnpack, &[*target_register, iter_register]);
                             }
                             // The register was reserved before the RHS was compiled, and now it
                             // needs to be committed.
@@ -1223,7 +1223,7 @@ impl Compiler {
                             if rhs_is_temp_tuple {
                                 self.push_op(TempIndex, &[value_register, iter_register, i as u8]);
                             } else {
-                                self.push_op(IterNext, &[value_register, iter_register, 0, 0]);
+                                self.push_op(IterUnpack, &[value_register, iter_register]);
                             }
 
                             self.compile_value_export(*id_index, value_register)?;
@@ -1248,7 +1248,7 @@ impl Compiler {
                     if rhs_is_temp_tuple {
                         self.push_op(TempIndex, &[value_register, iter_register, i as u8]);
                     } else {
-                        self.push_op(IterNext, &[value_register, iter_register, 0, 0]);
+                        self.push_op(IterUnpack, &[value_register, iter_register]);
                     }
 
                     self.compile_lookup(
@@ -1273,7 +1273,7 @@ impl Compiler {
                         if rhs_is_temp_tuple {
                             self.push_op(TempIndex, &[value_register, iter_register, i as u8]);
                         } else {
-                            self.push_op(IterNext, &[value_register, iter_register, 0, 0]);
+                            self.push_op(IterUnpack, &[value_register, iter_register]);
                         }
 
                         self.push_op(SequencePush, &[result.register, value_register]);
@@ -3747,7 +3747,7 @@ impl Compiler {
                     match &ast.node(*arg).node {
                         Node::Id(id) => {
                             let arg_register = self.assign_local_register(*id)?;
-                            self.push_op_without_span(IterNext, &[arg_register, temp_register, 0, 0]);
+                            self.push_op_without_span(IterUnpack, &[arg_register, temp_register]);
                         }
                         Node::Wildcard(_) => {
                             self.push_op_without_span(IterNextQuiet, &[temp_register, 0, 0]);

--- a/core/bytecode/src/op.rs
+++ b/core/bytecode/src/op.rs
@@ -418,6 +418,13 @@ pub enum Op {
     /// `[*iterator, offset[2]]`
     IterNextQuiet,
 
+    /// Gets the next value from an Iterator, used during value unpacking
+    ///
+    /// If the iterator is finished then null is assigned to the target register.
+    ///
+    /// `[*output, *iterator]`
+    IterUnpack,
+
     /// Accesses a contained value from a temporary value using a u8 index
     ///
     /// This is used for internal indexing operations.
@@ -568,7 +575,6 @@ pub enum Op {
     CheckSizeMin,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused99,
     Unused100,
     Unused101,
     Unused102,

--- a/core/runtime/src/value_string.rs
+++ b/core/runtime/src/value_string.rs
@@ -106,6 +106,22 @@ impl ValueString {
         self.with_bounds(result_bounds).unwrap_or_else(Self::empty)
     }
 
+    /// Removes and returns the first grapheme from the string
+    pub fn pop_front(&mut self) -> Option<Self> {
+        match self.graphemes(true).next() {
+            Some(grapheme) => {
+                let start = self.bounds.start;
+                let end = start + grapheme.len();
+                self.bounds.start = end;
+                Some(Self {
+                    string: self.string.clone(),
+                    bounds: start..end,
+                })
+            }
+            None => None,
+        }
+    }
+
     /// Returns the number of graphemes contained within the ValueString's bounds
     pub fn grapheme_count(&self) -> usize {
         self.graphemes(true).count()

--- a/core/runtime/src/value_string.rs
+++ b/core/runtime/src/value_string.rs
@@ -122,6 +122,22 @@ impl ValueString {
         }
     }
 
+    /// Removes and returns the last grapheme from the string
+    pub fn pop_back(&mut self) -> Option<Self> {
+        match self.grapheme_indices(true).next_back() {
+            Some((mut start, grapheme)) => {
+                start += self.bounds.start;
+                let end = self.bounds.end;
+                self.bounds.end -= grapheme.len();
+                Some(Self {
+                    string: self.string.clone(),
+                    bounds: start..end,
+                })
+            }
+            None => None,
+        }
+    }
+
     /// Returns the number of graphemes contained within the ValueString's bounds
     pub fn grapheme_count(&self) -> usize {
         self.graphemes(true).count()

--- a/core/runtime/src/value_tuple.rs
+++ b/core/runtime/src/value_tuple.rs
@@ -34,6 +34,19 @@ impl ValueTuple {
     pub fn is_hashable(&self) -> bool {
         self.iter().all(Value::is_hashable)
     }
+
+    /// Removes and returns the first value in the tuple
+    ///
+    /// The internal bounds of the tuple are adjusted to 'remove' the first element;
+    /// no copy of the underlying tuple data is made.
+    pub fn pop_front(&mut self) -> Option<Value> {
+        if let Some(value) = self.first().cloned() {
+            self.bounds.start += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
 }
 
 impl Deref for ValueTuple {

--- a/core/runtime/src/value_tuple.rs
+++ b/core/runtime/src/value_tuple.rs
@@ -38,10 +38,23 @@ impl ValueTuple {
     /// Removes and returns the first value in the tuple
     ///
     /// The internal bounds of the tuple are adjusted to 'remove' the first element;
-    /// no copy of the underlying tuple data is made.
+    /// no change is made to the underlying tuple data.
     pub fn pop_front(&mut self) -> Option<Value> {
         if let Some(value) = self.first().cloned() {
             self.bounds.start += 1;
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    /// Removes and returns the last value in the tuple
+    ///
+    /// The internal bounds of the tuple are adjusted to 'remove' the first element;
+    /// no change is made to the underlying tuple data.
+    pub fn pop_back(&mut self) -> Option<Value> {
+        if let Some(value) = self.last().cloned() {
+            self.bounds.end -= 1;
             Some(value)
         } else {
             None

--- a/core/runtime/src/vm.rs
+++ b/core/runtime/src/vm.rs
@@ -927,19 +927,11 @@ impl Vm {
                 Ok(())
             }
             Instruction::IterNext {
-                register,
+                result,
                 iterator,
                 jump_offset,
-            } => self.run_iterator_next(Some(register), iterator, jump_offset, false),
-            Instruction::IterNextTemp {
-                register,
-                iterator,
-                jump_offset,
-            } => self.run_iterator_next(Some(register), iterator, jump_offset, true),
-            Instruction::IterNextQuiet {
-                iterator,
-                jump_offset,
-            } => self.run_iterator_next(None, iterator, jump_offset, false),
+                temporary_output,
+            } => self.run_iterator_next(result, iterator, jump_offset, temporary_output),
             Instruction::TempIndex {
                 register,
                 value,

--- a/core/runtime/src/vm.rs
+++ b/core/runtime/src/vm.rs
@@ -1174,7 +1174,13 @@ impl Vm {
                 (Some(_), None) => {
                     // No result register, so the output can be discarded
                 }
-                (None, _) => self.jump_ip(jump_offset),
+                (None, Some(register)) => {
+                    self.set_register(register, Null);
+                    self.jump_ip(jump_offset);
+                }
+                (None, None) => {
+                    self.jump_ip(jump_offset);
+                }
             }
         } else {
             // Not an iterator, but maybe a temporary iterable used in value unpacking
@@ -1216,8 +1222,12 @@ impl Vm {
                 (Some(_), None) => {
                     // No result register, so the output can be discarded
                 }
-                (None, _) => {
+                (None, Some(register)) => {
                     // The iterator is finished, so jump to the provided offset
+                    self.set_register(register, Null);
+                    self.jump_ip(jump_offset);
+                }
+                (None, None) => {
                     self.jump_ip(jump_offset);
                 }
             }

--- a/core/runtime/src/vm.rs
+++ b/core/runtime/src/vm.rs
@@ -420,7 +420,7 @@ impl Vm {
 
         match op {
             UnaryOp::Display => self.run_display(result_register, value_register)?,
-            UnaryOp::Iterator => self.run_make_iterator(result_register, value_register)?,
+            UnaryOp::Iterator => self.run_make_iterator(result_register, value_register, false)?,
             UnaryOp::Negate => self.run_negate(result_register, value_register)?,
             UnaryOp::Not => self.run_not(result_register, value_register)?,
         }
@@ -797,7 +797,7 @@ impl Vm {
             }
             Instruction::RangeFull { register } => self.run_make_range(register, None, None, false),
             Instruction::MakeIterator { register, iterable } => {
-                self.run_make_iterator(register, iterable)
+                self.run_make_iterator(register, iterable, true)
             }
             Instruction::SimpleFunction {
                 register,
@@ -1095,82 +1095,133 @@ impl Vm {
 
     // Runs the MakeIterator instruction
     //
-    // Distinct from the public `make_iterator` function, which will defer to this function when
-    // the input value implements @iterator.
-    fn run_make_iterator(&mut self, result: u8, iterable_register: u8) -> InstructionResult {
+    // This function is distinct from the public `make_iterator`, which will defer to this function
+    // when the input value implements @iterator.
+    //
+    // temp_iterator is used for temporary unpacking operations.
+    fn run_make_iterator(
+        &mut self,
+        result: u8,
+        iterable_register: u8,
+        temp_iterator: bool,
+    ) -> InstructionResult {
         use Value::*;
 
         let iterable = self.clone_register(iterable_register);
 
-        if matches!(iterable, Iterator(_)) {
-            self.set_register(result, iterable);
-        } else {
-            let iterator = match iterable {
-                Range(int_range) => ValueIterator::with_range(int_range)?,
-                List(list) => ValueIterator::with_list(list),
-                Tuple(tuple) => ValueIterator::with_tuple(tuple),
-                Str(s) => ValueIterator::with_string(s),
-                Map(map) if map.contains_meta_key(&UnaryOp::Iterator.into()) => {
-                    let op = map.get_meta_value(&UnaryOp::Iterator.into()).unwrap();
-                    return self.call_overloaded_unary_op(result, iterable_register, op);
-                }
-                Map(map) => ValueIterator::with_map(map),
-                External(v) if v.contains_meta_key(&UnaryOp::Iterator.into()) => {
-                    let op = v.get_meta_value(&UnaryOp::Iterator.into()).unwrap();
-                    return self.call_overloaded_unary_op(result, iterable_register, op);
-                }
-                unexpected => {
-                    return type_error("Iterable while making iterator", &unexpected);
-                }
-            };
+        let iterator = match iterable {
+            Iterator(_) => iterable,
+            Range(r) if temp_iterator && r.is_bounded() => iterable,
+            Tuple(_) | Str(_) | TemporaryTuple(_) if temp_iterator => {
+                // Immutable sequences can be iterated over directly when used in temporary
+                // situations like argument unpacking.
+                iterable
+            }
+            Range(range) => ValueIterator::with_range(range)?.into(),
+            List(list) => ValueIterator::with_list(list).into(),
+            Tuple(tuple) => ValueIterator::with_tuple(tuple).into(),
+            Str(s) => ValueIterator::with_string(s).into(),
+            Map(map) if map.contains_meta_key(&UnaryOp::Iterator.into()) => {
+                let op = map.get_meta_value(&UnaryOp::Iterator.into()).unwrap();
+                return self.call_overloaded_unary_op(result, iterable_register, op);
+            }
+            Map(map) => ValueIterator::with_map(map).into(),
+            External(v) if v.contains_meta_key(&UnaryOp::Iterator.into()) => {
+                let op = v.get_meta_value(&UnaryOp::Iterator.into()).unwrap();
+                return self.call_overloaded_unary_op(result, iterable_register, op);
+            }
+            unexpected => {
+                return type_error("Iterable while making iterator", &unexpected);
+            }
+        };
 
-            self.set_register(result, iterator.into());
-        }
-
+        self.set_register(result, iterator);
         Ok(())
     }
 
     fn run_iterator_next(
         &mut self,
         result_register: Option<u8>,
-        iterator: u8,
+        iterable_register: u8,
         jump_offset: usize,
         output_is_temporary: bool,
     ) -> InstructionResult {
-        use Value::{Iterator, TemporaryTuple, Tuple};
+        use Value::*;
 
-        let result = match self.get_register_mut(iterator) {
-            Iterator(iterator) => iterator.next(),
-            unexpected => return type_error("Iterator", unexpected),
-        };
-
-        match (result, result_register) {
-            (Some(ValueIteratorOutput::Value(value)), Some(register)) => {
-                self.set_register(register, value)
+        if let Iterator(iterator) = self.get_register_mut(iterable_register) {
+            match (iterator.next(), result_register) {
+                (Some(ValueIteratorOutput::Value(value)), Some(register)) => {
+                    self.set_register(register, value)
+                }
+                (Some(ValueIteratorOutput::ValuePair(first, second)), Some(register)) => {
+                    if output_is_temporary {
+                        self.set_register(
+                            register,
+                            TemporaryTuple(RegisterSlice {
+                                start: register + 1,
+                                count: 2,
+                            }),
+                        );
+                        self.set_register(register + 1, first);
+                        self.set_register(register + 2, second);
+                    } else {
+                        self.set_register(register, Tuple(vec![first, second].into()));
+                    }
+                }
+                (Some(ValueIteratorOutput::Error(error)), _) => {
+                    return runtime_error!(error.to_string());
+                }
+                (Some(_), None) => {
+                    // No result register, so the output can be discarded
+                }
+                (None, _) => self.jump_ip(jump_offset),
             }
-            (Some(ValueIteratorOutput::ValuePair(first, second)), Some(register)) => {
-                if output_is_temporary {
-                    self.set_register(
-                        register,
-                        TemporaryTuple(RegisterSlice {
-                            start: register + 1,
-                            count: 2,
-                        }),
-                    );
-                    self.set_register(register + 1, first);
-                    self.set_register(register + 2, second);
-                } else {
-                    self.set_register(register, Tuple(vec![first, second].into()));
+        } else {
+            // Not an iterator, but maybe a temporary iterable used in value unpacking
+            let (output, new_iterable) = match self.clone_register(iterable_register) {
+                Range(mut r) => {
+                    let output = r.pop_front()?;
+                    (output.map(Value::from), Range(r))
+                }
+                Tuple(mut t) => {
+                    let output = t.pop_front();
+                    (output, Tuple(t))
+                }
+                Str(mut s) => {
+                    let output = s.pop_front();
+                    (output.map(Value::from), Str(s))
+                }
+                TemporaryTuple(RegisterSlice { start, count }) => {
+                    if count > 0 {
+                        (
+                            Some(self.clone_register(start)),
+                            TemporaryTuple(RegisterSlice {
+                                start: start + 1,
+                                count: count - 1,
+                            }),
+                        )
+                    } else {
+                        (None, TemporaryTuple(RegisterSlice { start, count }))
+                    }
+                }
+                unexpected => return type_error("Iterator", &unexpected),
+            };
+
+            self.set_register(iterable_register, new_iterable);
+
+            match (output, result_register) {
+                (Some(output), Some(register)) => {
+                    self.set_register(register, output);
+                }
+                (Some(_), None) => {
+                    // No result register, so the output can be discarded
+                }
+                (None, _) => {
+                    // The iterator is finished, so jump to the provided offset
+                    self.jump_ip(jump_offset);
                 }
             }
-            (Some(ValueIteratorOutput::Error(error)), _) => {
-                return runtime_error!(error.to_string())
-            }
-            (Some(_), None) => {
-                // No result register, so the output can be discarded
-            }
-            (None, _) => self.jump_ip(jump_offset),
-        };
+        }
 
         Ok(())
     }

--- a/core/runtime/tests/iterator_tests.rs
+++ b/core/runtime/tests/iterator_tests.rs
@@ -1,6 +1,6 @@
 mod runtime_test_utils;
 
-use crate::runtime_test_utils::{number_tuple, test_script, value_tuple};
+use crate::runtime_test_utils::*;
 
 mod iterator {
     use super::*;
@@ -162,6 +162,22 @@ x.next() # 'c'
 y.next()
 ";
             test_script(script, "c");
+        }
+    }
+
+    mod windows {
+        use super::*;
+
+        #[test]
+        fn windows_in_for_loop() {
+            let script = "
+result = []
+for a, b in (1..=5).windows(2)
+  result.push a
+  result.push b
+result
+";
+            test_script(script, number_list(&[1, 2, 2, 3, 3, 4, 4, 5]));
         }
     }
 

--- a/core/runtime/tests/vm_tests.rs
+++ b/core/runtime/tests/vm_tests.rs
@@ -483,6 +483,16 @@ type xy
 ";
             test_script(script, string("Tuple"));
         }
+
+        #[test]
+        fn exhausted_iterator_in_unpacking_produces_null() {
+            let script = "
+a, b, c = 1..=3
+a, b, c = 1..=2
+c
+";
+            test_script(script, Null);
+        }
     }
 
     mod if_expressions {
@@ -2053,7 +2063,6 @@ m =
   foo: |first, xs...|
     for x in xs
       yield self.offset + first + x
-    self.offset + xs.fold x, |a, b| a + b
   offset: 100
 m.foo(10, 1, 2, 3).to_tuple()
 ";


### PR DESCRIPTION
- Unpack for loop arguments via iteration instead of indexing
- Iterators should set the result register to null when exhausted
