### PR TITLE
Support for custom iterators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-20.04, windows-2019]
+        os: [macos-12, ubuntu-22.04, windows-2022]
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The Koto project adheres to
     like functions.
   - Values that implement `@[]` can now be used in unpacking assignment
     expressions.
+  - `@next` and `@next_back` meta keys have been added to enable custom iterators.
 
 #### Libs
 
@@ -42,6 +43,7 @@ The Koto project adheres to
       # true
       ```
   - `is_inclusive` and `intersection` have been added.
+- `iterator.next_back` has been added.
 
 #### Internals
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["core/*", "examples/*", "libs/*"]
+resolver = "2"
 
 [workspace.dependencies]
 # Statistics-driven micro-benchmarking library

--- a/core/bytecode/src/compiler.rs
+++ b/core/bytecode/src/compiler.rs
@@ -3729,7 +3729,7 @@ impl Compiler {
                     }
                 }
             }
-            [args @ ..] => {
+            args => {
                 // e.g. for a, b, c in list_of_lists()
                 // e.g. for key, value in map
 

--- a/core/parser/src/node.rs
+++ b/core/parser/src/node.rs
@@ -579,6 +579,10 @@ pub enum MetaKeyId {
     Display,
     /// @iterator
     Iterator,
+    /// @next
+    Next,
+    /// @next_back
+    NextBack,
     /// @negate
     Negate,
     /// @not

--- a/core/parser/src/parser.rs
+++ b/core/parser/src/parser.rs
@@ -2050,6 +2050,8 @@ impl<'source> Parser<'source> {
             Some(Token::Id) => match self.lexer.slice() {
                 "display" => MetaKeyId::Display,
                 "iterator" => MetaKeyId::Iterator,
+                "next" => MetaKeyId::Next,
+                "next_back" => MetaKeyId::NextBack,
                 "negate" => MetaKeyId::Negate,
                 "type" => MetaKeyId::Type,
                 "base" => MetaKeyId::Base,

--- a/core/runtime/src/core/iterator.rs
+++ b/core/runtime/src/core/iterator.rs
@@ -476,6 +476,23 @@ pub fn make_module() -> ValueMap {
         }
     });
 
+    result.add_fn("next_back", |vm, args| {
+        let mut iter = match vm.get_args(args) {
+            [Iterator(i)] => i.clone(),
+            [iterable] if iterable.is_iterable() => vm.make_iterator(iterable.clone())?,
+            unexpected => {
+                return type_error_with_slice("an iterable value as argument", unexpected)
+            }
+        };
+
+        match iter.next_back().map(collect_pair) {
+            Some(Output::Value(value)) => Ok(value),
+            Some(Output::Error(error)) => Err(error),
+            None => Ok(Value::Null),
+            _ => unreachable!(),
+        }
+    });
+
     result.add_fn("position", |vm, args| match vm.get_args(args) {
         [iterable, predicate] if iterable.is_iterable() && predicate.is_callable() => {
             let iterable = iterable.clone();

--- a/core/runtime/src/core/iterator.rs
+++ b/core/runtime/src/core/iterator.rs
@@ -459,14 +459,21 @@ pub fn make_module() -> ValueMap {
         ),
     });
 
-    result.add_fn("next", |vm, args| match vm.get_args(args) {
-        [Iterator(i)] => match i.clone().next().map(collect_pair) {
+    result.add_fn("next", |vm, args| {
+        let mut iter = match vm.get_args(args) {
+            [Iterator(i)] => i.clone(),
+            [iterable] if iterable.is_iterable() => vm.make_iterator(iterable.clone())?,
+            unexpected => {
+                return type_error_with_slice("an iterable value as argument", unexpected)
+            }
+        };
+
+        match iter.next().map(collect_pair) {
             Some(Output::Value(value)) => Ok(value),
             Some(Output::Error(error)) => Err(error),
             None => Ok(Value::Null),
             _ => unreachable!(),
-        },
-        unexpected => type_error_with_slice("an Iterator as argument", unexpected),
+        }
     });
 
     result.add_fn("position", |vm, args| match vm.get_args(args) {

--- a/core/runtime/src/core/iterator/adaptors.rs
+++ b/core/runtime/src/core/iterator/adaptors.rs
@@ -30,15 +30,6 @@ impl KotoIterator for Chain {
         };
         ValueIterator::new(result)
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        if let Some(iter_a) = &self.iter_a {
-            if iter_a.might_have_side_effects() {
-                return true;
-            }
-        }
-        self.iter_b.might_have_side_effects()
-    }
 }
 
 impl Iterator for Chain {
@@ -87,8 +78,6 @@ impl Chunks {
     pub fn new(iter: ValueIterator, chunk_size: usize) -> Result<Self, ChunksError> {
         if chunk_size < 1 {
             Err(ChunksError::ChunkSizeMustBeAtLeastOne)
-        } else if iter.might_have_side_effects() {
-            Err(ChunksError::IteratorMightHaveSideEffects)
         } else {
             Ok(Self { iter, chunk_size })
         }
@@ -102,10 +91,6 @@ impl KotoIterator for Chunks {
             chunk_size: self.chunk_size,
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
     }
 }
 
@@ -157,16 +142,12 @@ impl Iterator for Chunks {
 /// An error that can be returned by [Chunks::new]
 #[allow(missing_docs)]
 pub enum ChunksError {
-    IteratorMightHaveSideEffects,
     ChunkSizeMustBeAtLeastOne,
 }
 
 impl fmt::Display for ChunksError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ChunksError::IteratorMightHaveSideEffects => {
-                write!(f, "the iterator to be chunked should not run any functions")
-            }
             ChunksError::ChunkSizeMustBeAtLeastOne => {
                 write!(f, "the chunk size must be at least 1")
             }
@@ -205,10 +186,6 @@ impl KotoIterator for Cycle {
             current_cycle: self.current_cycle.make_copy(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
     }
 }
 
@@ -277,10 +254,6 @@ impl KotoIterator for Each {
         ValueIterator::new(result)
     }
 
-    fn might_have_side_effects(&self) -> bool {
-        true
-    }
-
     fn is_bidirectional(&self) -> bool {
         self.iter.is_bidirectional()
     }
@@ -322,10 +295,6 @@ impl KotoIterator for Enumerate {
             index: self.index,
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
     }
 }
 
@@ -377,10 +346,6 @@ impl KotoIterator for Flatten {
             nested: self.nested.as_ref().map(|nested| nested.make_copy()),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        true
     }
 }
 
@@ -440,10 +405,6 @@ impl KotoIterator for Intersperse {
             separator: self.separator.clone(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
     }
 }
 
@@ -507,10 +468,6 @@ impl KotoIterator for IntersperseWith {
             vm: self.vm.spawn_shared_vm(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        true
     }
 }
 
@@ -585,10 +542,6 @@ impl KotoIterator for Keep {
         };
         ValueIterator::new(result)
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        true
-    }
 }
 
 impl Iterator for Keep {
@@ -648,10 +601,6 @@ impl KotoIterator for PairFirst {
         };
         ValueIterator::new(result)
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
-    }
 }
 
 impl Iterator for PairFirst {
@@ -687,10 +636,6 @@ impl KotoIterator for PairSecond {
             iter: self.iter.make_copy(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
     }
 }
 
@@ -733,10 +678,6 @@ impl KotoIterator for Reversed {
             iter: self.iter.make_copy(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
     }
 }
 
@@ -800,10 +741,6 @@ impl KotoIterator for Take {
         };
         ValueIterator::new(result)
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
-    }
 }
 
 impl Iterator for Take {
@@ -839,8 +776,6 @@ impl Windows {
     pub fn new(iter: ValueIterator, window_size: usize) -> Result<Self, WindowsError> {
         if window_size < 1 {
             Err(WindowsError::WindowSizeMustBeAtLeastOne)
-        } else if iter.might_have_side_effects() {
-            Err(WindowsError::IteratorMightHaveSideEffects)
         } else {
             let mut end_iter = iter.make_copy();
             // Skip the end iterator to 'one before the last' of the first window
@@ -865,10 +800,6 @@ impl KotoIterator for Windows {
             window_size: self.window_size,
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter.might_have_side_effects()
     }
 }
 
@@ -902,16 +833,12 @@ impl Iterator for Windows {
 /// An error that can be returned by [Windows::new]
 #[allow(missing_docs)]
 pub enum WindowsError {
-    IteratorMightHaveSideEffects,
     WindowSizeMustBeAtLeastOne,
 }
 
 impl fmt::Display for WindowsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            WindowsError::IteratorMightHaveSideEffects => {
-                write!(f, "the iterator to be chunked should not run any functions")
-            }
             WindowsError::WindowSizeMustBeAtLeastOne => {
                 write!(f, "the window size must be at least 1")
             }
@@ -947,10 +874,6 @@ impl KotoIterator for Zip {
             iter_b: self.iter_b.make_copy(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        self.iter_a.might_have_side_effects() || self.iter_b.might_have_side_effects()
     }
 }
 

--- a/core/runtime/src/core/iterator/adaptors.rs
+++ b/core/runtime/src/core/iterator/adaptors.rs
@@ -679,6 +679,14 @@ impl KotoIterator for Reversed {
         };
         ValueIterator::new(result)
     }
+
+    fn is_bidirectional(&self) -> bool {
+        true
+    }
+
+    fn next_back(&mut self) -> Option<Output> {
+        self.iter.next()
+    }
 }
 
 impl Iterator for Reversed {

--- a/core/runtime/src/core/iterator/generators.rs
+++ b/core/runtime/src/core/iterator/generators.rs
@@ -24,10 +24,6 @@ impl KotoIterator for Repeat {
         };
         ValueIterator::new(result)
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
 }
 
 impl Iterator for Repeat {
@@ -61,10 +57,6 @@ impl KotoIterator for RepeatN {
             value: self.value.clone(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
     }
 }
 
@@ -105,10 +97,6 @@ impl KotoIterator for Generate {
             vm: self.vm.spawn_shared_vm(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        true
     }
 }
 
@@ -151,10 +139,6 @@ impl KotoIterator for GenerateN {
             vm: self.vm.spawn_shared_vm(),
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        true
     }
 }
 

--- a/core/runtime/src/core/string/iterators.rs
+++ b/core/runtime/src/core/string/iterators.rs
@@ -27,10 +27,6 @@ impl KotoIterator for Bytes {
     fn make_copy(&self) -> ValueIterator {
         ValueIterator::new(self.clone())
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
 }
 
 impl Iterator for Bytes {
@@ -73,10 +69,6 @@ impl Lines {
 impl KotoIterator for Lines {
     fn make_copy(&self) -> ValueIterator {
         ValueIterator::new(self.clone())
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
     }
 }
 
@@ -138,10 +130,6 @@ impl KotoIterator for Split {
     fn make_copy(&self) -> ValueIterator {
         ValueIterator::new(self.clone())
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
 }
 
 impl Iterator for Split {
@@ -198,10 +186,6 @@ impl KotoIterator for SplitWith {
             start: self.start,
         };
         ValueIterator::new(result)
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        true
     }
 }
 

--- a/core/runtime/src/meta_map.rs
+++ b/core/runtime/src/meta_map.rs
@@ -24,7 +24,7 @@ pub struct MetaMap(MetaMapType);
 impl MetaMap {
     /// Extends the MetaMap with clones of another MetaMap's entries
     pub fn extend(&mut self, other: &MetaMap) {
-        self.0.extend(other.0.clone().into_iter());
+        self.0.extend(other.0.clone());
     }
 
     /// Adds a function to the meta map

--- a/core/runtime/src/meta_map.rs
+++ b/core/runtime/src/meta_map.rs
@@ -223,6 +223,10 @@ pub enum UnaryOp {
     Display,
     /// `@iterator`
     Iterator,
+    /// `@next`
+    Next,
+    /// `@next_back`
+    NextBack,
     /// `@negate`
     Negate,
     /// `@not`
@@ -252,6 +256,8 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKe
         MetaKeyId::NotEqual => MetaKey::BinaryOp(NotEqual),
         MetaKeyId::Index => MetaKey::BinaryOp(Index),
         MetaKeyId::Iterator => MetaKey::UnaryOp(Iterator),
+        MetaKeyId::Next => MetaKey::UnaryOp(Next),
+        MetaKeyId::NextBack => MetaKey::UnaryOp(NextBack),
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
         MetaKeyId::Not => MetaKey::UnaryOp(Not),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),

--- a/core/runtime/src/value.rs
+++ b/core/runtime/src/value.rs
@@ -189,6 +189,26 @@ impl Value {
             StringBuilder(_) => TYPE_STRING_BUILDER.with(|x| x.clone()),
         }
     }
+
+    /// Returns true if the value is a Map or an External that contains the given meta key
+    pub fn contains_meta_key(&self, key: &MetaKey) -> bool {
+        use Value::*;
+        match &self {
+            Map(m) => m.contains_meta_key(key),
+            External(e) => e.contains_meta_key(key),
+            _ => false,
+        }
+    }
+
+    /// If the value is a Map or an External, returns a clone of the corresponding meta value
+    pub fn get_meta_value(&self, key: &MetaKey) -> Option<Value> {
+        use Value::*;
+        match &self {
+            Map(m) => m.get_meta_value(key),
+            External(e) => e.get_meta_value(key),
+            _ => None,
+        }
+    }
 }
 
 impl KotoDisplay for Value {

--- a/core/runtime/src/value_iterator.rs
+++ b/core/runtime/src/value_iterator.rs
@@ -10,12 +10,6 @@ pub trait KotoIterator: Iterator<Item = ValueIteratorOutput> {
     /// Returns a copy of the iterator that (when possible), will produce the same output
     fn make_copy(&self) -> ValueIterator;
 
-    /// Returns true when the iterator executes functions that may cause side effects
-    ///
-    /// This is used to determine whether or not the iterator is repeatable, which is used in
-    /// iterator adaptors like chunks() or windows().
-    fn might_have_side_effects(&self) -> bool;
-
     /// Returns true if the iterator supports reversed iteration via `next_back`
     fn is_bidirectional(&self) -> bool {
         false
@@ -124,13 +118,6 @@ impl ValueIterator {
         self.0.borrow().make_copy()
     }
 
-    /// Returns true if the iterator might have side-effects
-    ///
-    /// See [KotoIterator::might_have_side_effects]
-    pub fn might_have_side_effects(&self) -> bool {
-        self.0.borrow().might_have_side_effects()
-    }
-
     /// Returns true if the iterator supports reversed iteration via `next_back`
     ///
     /// See [KotoIterator::is_bidirectional]
@@ -216,10 +203,6 @@ impl KotoIterator for RangeIterator {
         ValueIterator::new(self.clone())
     }
 
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
-
     fn is_bidirectional(&self) -> bool {
         true
     }
@@ -292,10 +275,6 @@ impl KotoIterator for ListIterator {
         ValueIterator::new(self.clone())
     }
 
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
-
     fn is_bidirectional(&self) -> bool {
         true
     }
@@ -341,10 +320,6 @@ impl TupleIterator {
 impl KotoIterator for TupleIterator {
     fn make_copy(&self) -> ValueIterator {
         ValueIterator::new(self.clone())
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
     }
 
     fn is_bidirectional(&self) -> bool {
@@ -399,10 +374,6 @@ impl KotoIterator for MapIterator {
         ValueIterator::new(self.clone())
     }
 
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
-
     fn is_bidirectional(&self) -> bool {
         true
     }
@@ -451,10 +422,6 @@ impl KotoIterator for StringIterator {
         ValueIterator::new(self.clone())
     }
 
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
-
     fn is_bidirectional(&self) -> bool {
         true
     }
@@ -498,10 +465,6 @@ impl KotoIterator for GeneratorIterator {
         let new_vm = crate::vm::clone_generator_vm(&self.vm);
         ValueIterator::with_vm(new_vm)
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        true
-    }
 }
 
 impl Iterator for GeneratorIterator {
@@ -534,10 +497,6 @@ where
     fn make_copy(&self) -> ValueIterator {
         ValueIterator::new(self.clone())
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
 }
 
 impl<T> Iterator for StdForwardIterator<T>
@@ -565,10 +524,6 @@ where
 {
     fn make_copy(&self) -> ValueIterator {
         ValueIterator::new(self.clone())
-    }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
     }
 
     fn is_bidirectional(&self) -> bool {

--- a/core/runtime/tests/iterator_tests.rs
+++ b/core/runtime/tests/iterator_tests.rs
@@ -37,6 +37,25 @@ y.next()
         }
     }
 
+    mod chunks {
+        use super::*;
+
+        #[test]
+        fn chunks_with_generator() {
+            let script = "
+generator = || 
+  for i in 1..=4
+    yield i
+generator()
+  .chunks 2
+  .skip 1
+  .flatten()
+  .to_tuple()
+";
+            test_script(script, number_tuple(&[3, 4]));
+        }
+    }
+
     mod cycle {
         use super::*;
 
@@ -178,6 +197,20 @@ y.next()
 
     mod windows {
         use super::*;
+
+        #[test]
+        fn windows_with_a_generator() {
+            let script = "
+generator = ||
+  for i in 1..=4
+    yield i
+generator()
+  .windows 2
+  .flatten()
+  .to_tuple()
+";
+            test_script(script, number_tuple(&[1, 2, 2, 3, 3, 4]));
+        }
 
         #[test]
         fn windows_in_for_loop() {

--- a/core/runtime/tests/runtime_failures.rs
+++ b/core/runtime/tests/runtime_failures.rs
@@ -205,5 +205,39 @@ x.insert (1, [2, 3]), 'hello'
                 check_script_fails(script);
             }
         }
+
+        mod meta_maps {
+            use super::*;
+
+            #[test]
+            fn next_with_generator() {
+                let script = "
+x =
+  @next: || yield 42
+a, b = x
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn next_with_non_function() {
+                let script = "
+x =
+  @next: 42
+a, b = x
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn next_back_without_next() {
+                let script = "
+x =
+  @next_back: || 42
+x.reversed().next()
+";
+                check_script_fails(script);
+            }
+        }
     }
 }

--- a/core/runtime/tests/vm_tests.rs
+++ b/core/runtime/tests/vm_tests.rs
@@ -3020,19 +3020,6 @@ x[1]
         use super::*;
 
         #[test]
-        fn generator() {
-            let script = "
-x =
-  @iterator: ||
-    yield 1
-    yield 2
-    yield 3
-x.to_tuple()
-";
-            test_script(script, number_tuple(&[1, 2, 3]));
-        }
-
-        #[test]
         fn unpacking() {
             let script = "
 x =
@@ -3043,6 +3030,35 @@ a, b, c = x
 a, b, c
 ";
             test_script(script, value_tuple(&[10.into(), 20.into(), Null]));
+        }
+    }
+
+    mod overloaded_next {
+        use super::*;
+
+        #[test]
+        fn next() {
+            let script = "
+x =
+  foo: 0
+  @next: || self.foo += 1
+
+x.take(3).to_tuple()
+";
+            test_script(script, number_tuple(&[1, 2, 3]));
+        }
+
+        #[test]
+        fn next_back() {
+            let script = "
+x =
+  foo: 0
+  @next: || self.foo += 1
+  @next_back: || self.foo -= 1
+
+x.skip(3).reversed().take(3).to_tuple()
+";
+            test_script(script, number_tuple(&[2, 1, 0]));
         }
     }
 

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -517,7 +517,7 @@ check! (-3, 99)
 ## next
 
 ```kototype
-|Iterator| -> Value
+|Iterable| -> Value
 ```
 
 Returns the next value from the iterator.

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -534,6 +534,47 @@ print! x.next()
 check! null
 ```
 
+### See Also
+
+- [`iterator.next_back`](#next_back)
+
+## next_back
+
+```kototype
+|Iterable| -> Value
+```
+
+Returns the next value from the end of the iterator.
+
+This only works with iterators that have a defined end, so attempting to call
+`next_back` on endless iterators like [`iterator.generate`](#generate) will 
+result in an error.
+
+### Example
+
+```koto
+x = (1..=5).iter()
+print! x.next_back()
+check! 5
+print! x.next_back()
+check! 4
+# calls to next and next_back can be mixed together
+print! x.next()
+check! 1
+print! x.next_back()
+check! 3
+print! x.next_back()
+check! 2
+# 1 has already been produced by the iterator, so now it's finished
+print! x.next_back()
+check! null
+```
+
+### See Also
+
+- [`iterator.next`](#next)
+- [`iterator.reversed`](#reversed)
+
 ## position
 
 ```kototype
@@ -622,7 +663,7 @@ check! ('x', 'x', 'x')
 Reverses the order of the iterator's output.
 
 This only works with iterators that have a defined end, so attempting to reverse
-endless iterators like `generate` will result in an error.
+endless iterators like [`iterator.generate`](#generate) will result in an error.
 
 ### Example
 

--- a/docs/language/generators.md
+++ b/docs/language/generators.md
@@ -44,6 +44,7 @@ Inserting an adaptor into the `iterator` module makes it available in any iterat
 iterator.every_other = ||
   n = 0
   loop
+    # self is the iterator being adapted
     match self.next()
       # Exit when there are no more values 
       # produced by the iterator

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -57,10 +57,6 @@ impl KotoIterator for PoetryIter {
     fn make_copy(&self) -> ValueIterator {
         ValueIterator::new(self.clone())
     }
-
-    fn might_have_side_effects(&self) -> bool {
-        false
-    }
 }
 
 impl Iterator for PoetryIter {

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -12,6 +12,15 @@ make_foo = |x|
     assert_eq i.next(), 3
     assert_eq i.next(), null
 
+  @test next_back: ||
+    i = (1..=5).iter()
+    assert_eq i.next_back(), 5
+    assert_eq i.next_back(), 4
+    assert_eq i.next(), 1
+    assert_eq i.next_back(), 3
+    assert_eq i.next_back(), 2
+    assert_eq i.next_back(), null
+
   @test to_list: ||
     assert_eq (1..=3).to_list(), [1, 2, 3]
     assert_eq [2, 4, 6].to_list(), [2, 4, 6]
@@ -58,14 +67,14 @@ make_foo = |x|
       (("foo", 42), ("bar", 99))
 
   @test all: ||
-    assert (1..10).all(|n| n < 10)
-    assert not (1..10).all(|n| n < 5)
+    assert (1..10).all |n| n < 10
+    assert not (1..10).all |n| n < 5
     assert "xyz".all |c| "zyx".contains c
 
   @test any: ||
-    assert (1..10).any(|n| n == 5)
-    assert not (1..10).any(|n| n == 15)
-    assert "xyz".any(|c| c == "z")
+    assert (1..10).any |n| n == 5
+    assert not (1..10).any |n| n == 15
+    assert "xyz".any |c| c == "z"
 
   @test chain: ||
     assert_eq
@@ -236,6 +245,7 @@ make_foo = |x|
     assert_eq (1, 3, 5, 7).reversed().to_tuple(), (7, 5, 3, 1)
     assert_eq {foo: 42, bar: 99}.reversed().to_tuple(), (('bar', 99), ('foo', 42))
     assert_eq "Héllö".reversed().to_tuple(), ('ö', 'l', 'l', 'é', 'H')
+    assert_eq "Héllö".reversed().next_back(), 'H'
 
   @test skip: ||
     assert_eq

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -52,8 +52,30 @@ globals.foo_meta =
   # Indexing
   @[]: |index| self.x + index
 
-  # Overloaded iteration behaviour
-  @iterator: || 0..self.x
+  # Custom iteration
+  # @iterator must be a function that returns an iterable value,
+  # in this case a map with implementations of @next and @next_back
+  @iterator: ||
+    # Start iterating from 0
+    start: 0
+    # End at self.x
+    end: self.x
+
+    @next: ||
+      result = self.start
+      if result < self.end
+        self.start += 1
+        result
+      else
+        null
+
+    @next_back: ||
+      result = self.end
+      if result > self.start
+        self.end -= 1
+        result
+      else
+        null
 
   # Formatting
   @display: || "Foo (${self.x})"
@@ -144,7 +166,7 @@ globals.foo_meta =
 
   @test iterator: ||
     assert_eq foo(5).to_tuple(), (0, 1, 2, 3, 4)
-    assert_eq foo(-4).to_list(), [0, -1, -2, -3]
+    assert_eq foo(4).to_list(), [0, 1, 2, 3]
 
   @test display: ||
     assert_eq "${foo -1}", "Foo (-1)"


### PR DESCRIPTION
This PR adds support for custom iterators via `@next`/`@next_back` meta keys.

- Remove the repeatability requirement for iterator.windows()/chunks()
- Guard against recursive operations overflowing the register stack
- Introduce @next/@next_back meta keys
- Add external value support for @next/@next_back
- Introduce iterator.next_back
