### PR TITLE
Cached iterator adaptors

### DIFF
--- a/core/runtime/src/core/iterator.rs
+++ b/core/runtime/src/core/iterator.rs
@@ -757,7 +757,7 @@ pub(crate) fn collect_pair(iterator_output: Output) -> Output {
 }
 
 pub(crate) fn iter_output_to_result(iterator_output: Option<Output>) -> RuntimeResult {
-    match iterator_output.map(collect_pair) {
+    match iterator_output {
         Some(Output::Value(value)) => Ok(value),
         Some(Output::ValuePair(first, second)) => Ok(Value::Tuple(vec![first, second].into())),
         Some(Output::Error(error)) => Err(error),

--- a/core/runtime/src/core/iterator/peekable.rs
+++ b/core/runtime/src/core/iterator/peekable.rs
@@ -102,3 +102,5 @@ thread_local! {
     static PEEKABLE_META: PtrMut<MetaMap> = make_peekable_meta_map();
     static PEEKABLE_TYPE_STRING: ValueString = PEEKABLE_TYPE.into();
 }
+
+// For tests, see runtime/tests/iterator_tests.rs

--- a/core/runtime/src/value.rs
+++ b/core/runtime/src/value.rs
@@ -315,6 +315,12 @@ impl From<ValueList> for Value {
     }
 }
 
+impl From<ValueTuple> for Value {
+    fn from(value: ValueTuple) -> Self {
+        Self::Tuple(value)
+    }
+}
+
 impl From<ValueMap> for Value {
     fn from(value: ValueMap) -> Self {
         Self::Map(value)

--- a/core/runtime/src/value_iterator.rs
+++ b/core/runtime/src/value_iterator.rs
@@ -48,6 +48,20 @@ where
     }
 }
 
+impl TryFrom<ValueIteratorOutput> for Value {
+    type Error = RuntimeError;
+
+    fn try_from(iterator_output: ValueIteratorOutput) -> Result<Self, Self::Error> {
+        match iterator_output {
+            ValueIteratorOutput::Value(value) => Ok(value),
+            ValueIteratorOutput::ValuePair(first, second) => {
+                Ok(Value::Tuple(vec![first, second].into()))
+            }
+            ValueIteratorOutput::Error(error) => Err(error),
+        }
+    }
+}
+
 /// The iterator value type used in Koto
 #[derive(Clone)]
 pub struct ValueIterator(PtrMut<dyn KotoIterator>);

--- a/core/runtime/tests/iterator_tests.rs
+++ b/core/runtime/tests/iterator_tests.rs
@@ -41,7 +41,7 @@ y.next()
         use super::*;
 
         #[test]
-        fn chunks_with_generator() {
+        fn with_generator() {
             let script = "
 generator = || 
   for i in 1..=4
@@ -54,6 +54,26 @@ generator()
 ";
             test_script(script, number_tuple(&[3, 4]));
         }
+
+        #[test]
+        fn with_peekable() {
+            let script = "
+(1..=5)
+  .peekable()
+  .chunks 2
+  .each |w| w.to_tuple()
+  .to_tuple()
+";
+            test_script(
+                script,
+                value_tuple(&[
+                    number_tuple(&[1, 2]),
+                    number_tuple(&[3, 4]),
+                    number_tuple(&[5]),
+                ]),
+            );
+        }
+
     }
 
     mod cycle {

--- a/core/runtime/tests/iterator_tests.rs
+++ b/core/runtime/tests/iterator_tests.rs
@@ -79,6 +79,14 @@ generator()
         use super::*;
 
         #[test]
+        fn empty_input() {
+            let script = "
+[].cycle().next()
+";
+            test_script(script, Value::Null);
+        }
+
+        #[test]
         fn make_copy() {
             let script = "
 x = (1..=3).cycle()
@@ -89,6 +97,18 @@ x.next() # 3
 y.next()
 ";
             test_script(script, 2);
+        }
+
+        #[test]
+        fn with_peekable() {
+            let script = "
+(1..=3)
+  .peekable()
+  .cycle()
+  .take 7
+  .to_tuple()
+";
+            test_script(script, number_tuple(&[1, 2, 3, 1, 2, 3, 1]));
         }
     }
 
@@ -191,8 +211,6 @@ y.next()
 
         #[test]
         fn peek() {
-            use Value::Null;
-
             let script = "
 i = (1, 2, 3).peekable()
 result = []

--- a/core/runtime/tests/iterator_tests.rs
+++ b/core/runtime/tests/iterator_tests.rs
@@ -73,7 +73,6 @@ generator()
                 ]),
             );
         }
-
     }
 
     mod cycle {
@@ -314,7 +313,7 @@ y.next()
         use super::*;
 
         #[test]
-        fn windows_with_a_generator() {
+        fn with_a_generator() {
             let script = "
 generator = ||
   for i in 1..=4
@@ -328,7 +327,7 @@ generator()
         }
 
         #[test]
-        fn windows_in_for_loop() {
+        fn in_for_loop() {
             let script = "
 result = []
 for a, b in (1..=5).windows(2)
@@ -337,6 +336,25 @@ for a, b in (1..=5).windows(2)
 result
 ";
             test_script(script, number_list(&[1, 2, 2, 3, 3, 4, 4, 5]));
+        }
+
+        #[test]
+        fn with_peekable() {
+            let script = "
+(1..=5)
+  .peekable()
+  .windows 3
+  .each |w| w.to_tuple()
+  .to_tuple()
+";
+            test_script(
+                script,
+                value_tuple(&[
+                    number_tuple(&[1, 2, 3]),
+                    number_tuple(&[2, 3, 4]),
+                    number_tuple(&[3, 4, 5]),
+                ]),
+            );
         }
     }
 

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -156,8 +156,11 @@ check! 50
 |Iterable| -> Iterator
 ```
 
-Takes an Iterable and returns a new iterator that endlessly repeats the output
-of the iterable.
+Takes an Iterable and returns a new iterator that endlessly repeats the
+iterable's output.
+
+The iterable's output gets cached, which may result in a large amount of memory
+being used if the cycle has a long length.
 
 ### Example
 

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -894,22 +894,17 @@ check! ['a', 42, (-1, -2)]
 ```
 
 Returns an iterator that splits up the input data into overlapping windows of
-size `N`, where each window is provided as an iterator over the chunk's
-elements.
+size `N`, where each window is provided as a Tuple.
 
 If the input has fewer than `N` elements then no windows will be produced.
-
-Note that the input value should be an iterable value that has a defined range,
-e.g. a List or a String (i.e. not an adapted iterator or a generator).
 
 ### Example
 
 ```koto
 print! 1..=5
-  .windows(3)
-  .each iterator.to_list
+  .windows 3
   .to_list(),
-check! [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+check! [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
 ```
 
 ## zip

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -82,20 +82,16 @@ check! (1, 2, 3, 4, 5)
 ```
 
 Returns an iterator that splits up the input data into chunks of size `N`,
-where each chunk is provided as an iterator over the chunk's elements.
+where each chunk is provided as a Tuple.
 The final chunk may have fewer than `N` elements.
-
-Note that the input value should be an iterable value that has a defined range,
-e.g. a List or a String (i.e. not an adapted iterator or a generator).
 
 ### Example
 
 ```koto
 print! 1..=10
   .chunks 3
-  .each |chunk| chunk.to_list()
   .to_list()
-check! [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]
+check! [(1, 2, 3), (4, 5, 6), (7, 8, 9), (10)]
 ```
 
 ## consume

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 checks: fmt clippy test doc wasm
 
 clippy:
-  cargo clippy --workspace --all-features
+  cargo clippy --workspace --all-features -- -D warnings
 
 doc:
   cargo doc --workspace --exclude koto_cli


### PR DESCRIPTION
This PR makes the behaviour of `iterator.chunks`, `cycle`, and `windows` more predictable when adapting generators or stateful iterators like `peekable` by caching initial iterator output.
