### PR TITLE
Switch to using the `crate` import granularity style

### DIFF
--- a/core/bytecode/src/chunk.rs
+++ b/core/bytecode/src/chunk.rs
@@ -1,11 +1,9 @@
-use {
-    crate::InstructionReader,
-    koto_memory::Ptr,
-    koto_parser::{ConstantPool, Span},
-    std::{
-        fmt::{self, Write},
-        path::PathBuf,
-    },
+use crate::InstructionReader;
+use koto_memory::Ptr;
+use koto_parser::{ConstantPool, Span};
+use std::{
+    fmt::{self, Write},
+    path::PathBuf,
 };
 
 /// Debug information for a Koto program

--- a/core/bytecode/src/compiler.rs
+++ b/core/bytecode/src/compiler.rs
@@ -1,13 +1,11 @@
-use {
-    crate::{DebugInfo, FunctionFlags, Op, TypeId},
-    koto_parser::{
-        AssignTarget, Ast, AstBinaryOp, AstFor, AstIf, AstIndex, AstNode, AstTry, AstUnaryOp,
-        ConstantIndex, Function, ImportItemNode, LookupNode, MapKey, MatchArm, MetaKeyId, Node,
-        Scope, Span, StringNode, SwitchArm,
-    },
-    smallvec::SmallVec,
-    std::{collections::HashSet, error, fmt},
+use crate::{DebugInfo, FunctionFlags, Op, TypeId};
+use koto_parser::{
+    AssignTarget, Ast, AstBinaryOp, AstFor, AstIf, AstIndex, AstNode, AstTry, AstUnaryOp,
+    ConstantIndex, Function, ImportItemNode, LookupNode, MapKey, MatchArm, MetaKeyId, Node, Scope,
+    Span, StringNode, SwitchArm,
 };
+use smallvec::SmallVec;
+use std::{collections::HashSet, error, fmt};
 
 /// The error type used to report errors during compilation
 #[derive(Clone, Debug)]

--- a/core/bytecode/src/instruction_reader.rs
+++ b/core/bytecode/src/instruction_reader.rs
@@ -1,9 +1,7 @@
-use {
-    crate::{Chunk, Op},
-    koto_memory::Ptr,
-    koto_parser::{ConstantIndex, MetaKeyId},
-    std::fmt,
-};
+use crate::{Chunk, Op};
+use koto_memory::Ptr;
+use koto_parser::{ConstantIndex, MetaKeyId};
+use std::fmt;
 
 #[derive(Debug)]
 #[repr(u8)]

--- a/core/bytecode/src/lib.rs
+++ b/core/bytecode/src/lib.rs
@@ -9,7 +9,7 @@ mod instruction_reader;
 mod loader;
 mod op;
 
-pub use {
+pub use crate::{
     chunk::{Chunk, DebugInfo},
     compiler::{Compiler, CompilerError, CompilerSettings},
     instruction_reader::{FunctionFlags, Instruction, InstructionReader, TypeId},

--- a/core/bytecode/src/loader.rs
+++ b/core/bytecode/src/loader.rs
@@ -1,11 +1,9 @@
-use {
-    crate::{Chunk, Compiler, CompilerError, CompilerSettings},
-    dunce::canonicalize,
-    koto_memory::Ptr,
-    koto_parser::{format_error_with_excerpt, Parser, ParserError},
-    rustc_hash::FxHasher,
-    std::{collections::HashMap, error, fmt, hash::BuildHasherDefault, path::PathBuf},
-};
+use crate::{Chunk, Compiler, CompilerError, CompilerSettings};
+use dunce::canonicalize;
+use koto_memory::Ptr;
+use koto_parser::{format_error_with_excerpt, Parser, ParserError};
+use rustc_hash::FxHasher;
+use std::{collections::HashMap, error, fmt, hash::BuildHasherDefault, path::PathBuf};
 
 /// Errors that can be returned from [Loader] operations
 #[derive(Clone, Debug)]

--- a/core/bytecode/tests/compile_failures.rs
+++ b/core/bytecode/tests/compile_failures.rs
@@ -1,8 +1,6 @@
 mod bytecode {
-    use {
-        koto_bytecode::{Compiler, CompilerSettings},
-        koto_parser::Parser,
-    };
+    use koto_bytecode::{Compiler, CompilerSettings};
+    use koto_parser::Parser;
 
     fn check_compilation_fails(source: &str) {
         match Parser::parse(source) {

--- a/core/cli/src/help.rs
+++ b/core/cli/src/help.rs
@@ -1,4 +1,5 @@
-use {indexmap::IndexMap, std::iter::Peekable};
+use indexmap::IndexMap;
+use std::iter::Peekable;
 
 const HELP_RESULT_STR: &str = "# ➝ ";
 const HELP_INDENT: usize = 2;

--- a/core/cli/src/main.rs
+++ b/core/cli/src/main.rs
@@ -1,12 +1,10 @@
 mod help;
 mod repl;
 
-use {
-    crossterm::tty::IsTty,
-    koto::{bytecode::Chunk, Koto, KotoSettings},
-    repl::{Repl, ReplSettings},
-    std::{fs, io},
-};
+use crossterm::tty::IsTty;
+use koto::{bytecode::Chunk, Koto, KotoSettings};
+use repl::{Repl, ReplSettings};
+use std::{fs, io};
 
 #[cfg(all(jemalloc, not(debug_assertions), not(target_env = "msvc")))]
 #[global_allocator]

--- a/core/cli/src/repl.rs
+++ b/core/cli/src/repl.rs
@@ -1,21 +1,19 @@
-use {
-    crate::help::Help,
-    crossterm::{
-        cursor,
-        event::{read, Event, KeyCode, KeyEvent, KeyModifiers},
-        execute, queue, style,
-        terminal::{self, ClearType},
-        tty::IsTty,
-        Result,
-    },
-    koto::{bytecode::Chunk, Koto, KotoSettings},
-    std::{
-        cmp::Ordering,
-        fmt,
-        io::{self, Stdout, Write},
-    },
-    unicode_width::UnicodeWidthChar,
+use crate::help::Help;
+use crossterm::{
+    cursor,
+    event::{read, Event, KeyCode, KeyEvent, KeyModifiers},
+    execute, queue, style,
+    terminal::{self, ClearType},
+    tty::IsTty,
+    Result,
 };
+use koto::{bytecode::Chunk, Koto, KotoSettings};
+use std::{
+    cmp::Ordering,
+    fmt,
+    io::{self, Stdout, Write},
+};
+use unicode_width::UnicodeWidthChar;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/core/koto/benches/koto_benchmark.rs
+++ b/core/koto/benches/koto_benchmark.rs
@@ -1,8 +1,6 @@
-use {
-    criterion::{criterion_group, criterion_main, Criterion},
-    koto::Koto,
-    std::{fs::read_to_string, path::PathBuf},
-};
+use criterion::{criterion_group, criterion_main, Criterion};
+use koto::Koto;
+use std::{fs::read_to_string, path::PathBuf};
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/core/koto/src/koto.rs
+++ b/core/koto/src/koto.rs
@@ -1,10 +1,8 @@
-use {
-    crate::prelude::*,
-    dunce::canonicalize,
-    koto_bytecode::CompilerSettings,
-    koto_runtime::ModuleImportedCallback,
-    std::{error::Error, fmt, path::PathBuf, rc::Rc},
-};
+use crate::prelude::*;
+use dunce::canonicalize;
+use koto_bytecode::CompilerSettings;
+use koto_runtime::ModuleImportedCallback;
+use std::{error::Error, fmt, path::PathBuf, rc::Rc};
 
 /// The error type returned by [Koto] operations
 #[allow(missing_docs)]

--- a/core/koto/src/lib.rs
+++ b/core/koto/src/lib.rs
@@ -31,7 +31,7 @@
 mod koto;
 pub mod prelude;
 
-pub use {
-    crate::koto::{Koto, KotoError, KotoSettings},
-    koto_bytecode as bytecode, koto_parser as parser, koto_runtime as runtime,
-};
+pub use crate::koto::{Koto, KotoError, KotoSettings};
+pub use koto_bytecode as bytecode;
+pub use koto_parser as parser;
+pub use koto_runtime as runtime;

--- a/core/koto/src/prelude.rs
+++ b/core/koto/src/prelude.rs
@@ -1,7 +1,5 @@
 //! A collection of useful items to make it easier to work with `koto`
 
-pub use {
-    crate::{Koto, KotoError, KotoSettings},
-    koto_bytecode::{Chunk, Loader, LoaderError},
-    koto_runtime::prelude::*,
-};
+pub use crate::{Koto, KotoError, KotoSettings};
+pub use koto_bytecode::{Chunk, Loader, LoaderError};
+pub use koto_runtime::prelude::*;

--- a/core/koto/tests/docs_examples.rs
+++ b/core/koto/tests/docs_examples.rs
@@ -1,10 +1,8 @@
-use {
-    koto::prelude::*,
-    std::{
-        ops::Deref,
-        path::{Path, PathBuf},
-        rc::Rc,
-    },
+use koto::prelude::*;
+use std::{
+    ops::Deref,
+    path::{Path, PathBuf},
+    rc::Rc,
 };
 
 struct ExampleTestRunner {

--- a/core/koto/tests/koto_tests.rs
+++ b/core/koto/tests/koto_tests.rs
@@ -1,11 +1,9 @@
-use {
-    koto::prelude::*,
-    std::{
-        cell::RefCell,
-        fs::read_to_string,
-        path::{Path, PathBuf},
-        rc::Rc,
-    },
+use koto::prelude::*;
+use std::{
+    cell::RefCell,
+    fs::read_to_string,
+    path::{Path, PathBuf},
+    rc::Rc,
 };
 
 fn run_script(script: &str, script_path: Option<PathBuf>, expected_module_paths: &[PathBuf]) {

--- a/core/koto/tests/repl_mode_tests.rs
+++ b/core/koto/tests/repl_mode_tests.rs
@@ -5,7 +5,8 @@
 //! The exports map gets populated with any top-level assigned IDs, and is then made available to
 //! each subsequent chunk.
 
-use {koto::prelude::*, std::rc::Rc};
+use koto::prelude::*;
+use std::rc::Rc;
 
 fn run_repl_mode_test(inputs_and_expected_outputs: &[(&str, &str)]) {
     let output = PtrMut::from(String::new());

--- a/core/lexer/src/lexer.rs
+++ b/core/lexer/src/lexer.rs
@@ -1,9 +1,7 @@
-use {
-    crate::{Position, Span},
-    std::{iter::Peekable, str::Chars},
-    unicode_width::UnicodeWidthChar,
-    unicode_xid::UnicodeXID,
-};
+use crate::{Position, Span};
+use std::{iter::Peekable, str::Chars};
+use unicode_width::UnicodeWidthChar;
+use unicode_xid::UnicodeXID;
 
 /// The tokens that can emerge from the lexer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/core/lexer/src/lib.rs
+++ b/core/lexer/src/lib.rs
@@ -5,7 +5,7 @@
 mod lexer;
 mod span;
 
-pub use {
+pub use crate::{
     lexer::{is_id_continue, is_id_start, KotoLexer as Lexer, Token},
     span::{Position, Span},
 };

--- a/core/memory/src/lib.rs
+++ b/core/memory/src/lib.rs
@@ -14,4 +14,4 @@
 
 mod rc;
 
-pub use rc::*;
+pub use crate::rc::*;

--- a/core/memory/src/rc/mod.rs
+++ b/core/memory/src/rc/mod.rs
@@ -3,4 +3,5 @@
 mod ptr;
 mod ptr_mut;
 
-pub use {ptr::*, ptr_mut::*};
+pub use ptr::*;
+pub use ptr_mut::*;

--- a/core/parser/src/ast.rs
+++ b/core/parser/src/ast.rs
@@ -1,7 +1,5 @@
-use {
-    crate::{error::*, ConstantPool, Node},
-    koto_lexer::Span,
-};
+use crate::{error::*, ConstantPool, Node};
+use koto_lexer::Span;
 
 /// The index type used by nodes in the [Ast]
 pub type AstIndex = u32;

--- a/core/parser/src/constant_pool.rs
+++ b/core/parser/src/constant_pool.rs
@@ -1,12 +1,10 @@
-use {
-    crate::{ConstantIndex, ConstantIndexTryFromOutOfRange},
-    koto_memory::Ptr,
-    std::{
-        collections::{hash_map::DefaultHasher, HashMap},
-        fmt,
-        hash::{Hash, Hasher},
-        ops::Range,
-    },
+use crate::{ConstantIndex, ConstantIndexTryFromOutOfRange};
+use koto_memory::Ptr;
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Range,
 };
 
 // An entry in the list of constants contained in a [ConstantPool]

--- a/core/parser/src/error.rs
+++ b/core/parser/src/error.rs
@@ -1,10 +1,8 @@
-use {
-    koto_lexer::{Position, Span},
-    std::{
-        error,
-        fmt::{self, Write},
-        path::PathBuf,
-    },
+use koto_lexer::{Position, Span};
+use std::{
+    error,
+    fmt::{self, Write},
+    path::PathBuf,
 };
 
 /// An error that represents a problem with the Parser's internal logic, rather than a user error

--- a/core/parser/src/lib.rs
+++ b/core/parser/src/lib.rs
@@ -9,12 +9,12 @@ mod error;
 mod node;
 mod parser;
 
-pub use {
+pub use crate::{
     ast::*,
     constant_index::{ConstantIndex, ConstantIndexTryFromOutOfRange},
     constant_pool::{Constant, ConstantPool},
     error::{format_error_with_excerpt, ParserError},
-    koto_lexer::{Position, Span},
     node::*,
     parser::Parser,
 };
+pub use koto_lexer::{Position, Span};

--- a/core/parser/src/node.rs
+++ b/core/parser/src/node.rs
@@ -1,7 +1,5 @@
-use {
-    crate::{ast::AstIndex, ConstantIndex},
-    std::fmt,
-};
+use crate::{ast::AstIndex, ConstantIndex};
+use std::fmt;
 
 /// A parsed node that can be included in the [AST](crate::Ast).
 ///

--- a/core/parser/src/parser.rs
+++ b/core/parser/src/parser.rs
@@ -1,17 +1,14 @@
 #![cfg_attr(feature = "panic_on_parser_error", allow(unreachable_code))]
 
-use {
-    crate::{
-        constant_pool::ConstantPoolBuilder,
-        error::{
-            ErrorType as ParserErrorType, ExpectedIndentation, InternalError, ParserError,
-            SyntaxError,
-        },
-        *,
+use crate::{
+    constant_pool::ConstantPoolBuilder,
+    error::{
+        ErrorType as ParserErrorType, ExpectedIndentation, InternalError, ParserError, SyntaxError,
     },
-    koto_lexer::{Lexer, Span, Token},
-    std::{collections::HashSet, str::FromStr},
+    *,
 };
+use koto_lexer::{Lexer, Span, Token};
+use std::{collections::HashSet, str::FromStr};
 
 // Contains info about the current frame, representing either the module's top level or a function
 #[derive(Debug, Default)]
@@ -2793,7 +2790,8 @@ impl<'source> Parser<'source> {
         &mut self,
         context: &ExpressionContext,
     ) -> Result<Option<(AstString, Span, ExpressionContext)>, ParserError> {
-        use {SyntaxError::*, Token::*};
+        use SyntaxError::*;
+        use Token::*;
 
         match self.peek_token_with_context(context) {
             Some(PeekInfo {

--- a/core/runtime/src/core/io.rs
+++ b/core/runtime/src/core/io.rs
@@ -4,17 +4,15 @@ mod buffered_file;
 
 pub use buffered_file::BufferedFile;
 
-use {
-    super::string::format,
-    crate::{prelude::*, Result},
-    std::{
-        cell::RefCell,
-        fmt, fs,
-        io::{self, BufRead, Read, Seek, SeekFrom, Write},
-        ops::Deref,
-        path::{Path, PathBuf},
-        rc::Rc,
-    },
+use super::string::format;
+use crate::{prelude::*, Result};
+use std::{
+    cell::RefCell,
+    fmt, fs,
+    io::{self, BufRead, Read, Seek, SeekFrom, Write},
+    ops::Deref,
+    path::{Path, PathBuf},
+    rc::Rc,
 };
 
 /// The initializer for the io module

--- a/core/runtime/src/core/iterator.rs
+++ b/core/runtime/src/core/iterator.rs
@@ -844,7 +844,8 @@ fn run_iterator_comparison_by_key(
 //
 // Returns the lesser of the two values, unless `invert_result` is set to Yes
 fn compare_values(vm: &mut Vm, a: Value, b: Value, invert_result: InvertResult) -> RuntimeResult {
-    use {InvertResult::*, Value::Bool};
+    use InvertResult::*;
+    use Value::Bool;
 
     let comparison_result = vm.run_binary_op(BinaryOp::Less, a.clone(), b.clone())?;
 
@@ -869,7 +870,8 @@ fn compare_values_with_key(
     b_and_key: (Value, Value),
     invert_result: InvertResult,
 ) -> Result<(Value, Value), RuntimeError> {
-    use {InvertResult::*, Value::Bool};
+    use InvertResult::*;
+    use Value::Bool;
 
     let comparison_result =
         vm.run_binary_op(BinaryOp::Less, a_and_key.1.clone(), b_and_key.1.clone())?;

--- a/core/runtime/src/core/iterator/adaptors.rs
+++ b/core/runtime/src/core/iterator/adaptors.rs
@@ -1,11 +1,9 @@
 //! Adapators used by the `iterator` core library module
 
-use {
-    super::collect_pair,
-    crate::{prelude::*, Result, ValueIteratorOutput as Output},
-    std::{collections::VecDeque, error, fmt, result::Result as StdResult},
-    thiserror::Error,
-};
+use super::collect_pair;
+use crate::{prelude::*, Result, ValueIteratorOutput as Output};
+use std::{collections::VecDeque, error, fmt, result::Result as StdResult};
+use thiserror::Error;
 
 /// An iterator that links the output of two iterators together in a chained sequence
 pub struct Chain {

--- a/core/runtime/src/core/iterator/peekable.rs
+++ b/core/runtime/src/core/iterator/peekable.rs
@@ -1,9 +1,7 @@
 //! A double-ended peekable iterator for Koto
 
-use {
-    super::iter_output_to_result,
-    crate::{prelude::*, Result, ValueIteratorOutput as Output},
-};
+use super::iter_output_to_result;
+use crate::{prelude::*, Result, ValueIteratorOutput as Output};
 
 /// A double-ended peekable iterator for Koto
 #[derive(Clone, Debug)]

--- a/core/runtime/src/core/koto.rs
+++ b/core/runtime/src/core/koto.rs
@@ -1,9 +1,7 @@
 //! The `koto` core library module
 
-use {
-    crate::prelude::*,
-    std::hash::{Hash, Hasher},
-};
+use crate::prelude::*;
+use std::hash::{Hash, Hasher};
 
 /// Initializes the `koto` core library module
 pub fn make_module() -> ValueMap {

--- a/core/runtime/src/core/list.rs
+++ b/core/runtime/src/core/list.rs
@@ -1,13 +1,11 @@
 //! The `list` core library module
 
-use {
-    super::iterator::collect_pair,
-    crate::{
-        prelude::*,
-        value_sort::{compare_values, sort_values},
-    },
-    std::{cmp::Ordering, ops::DerefMut},
+use super::iterator::collect_pair;
+use crate::{
+    prelude::*,
+    value_sort::{compare_values, sort_values},
 };
+use std::{cmp::Ordering, ops::DerefMut};
 
 /// Initializes the `list` core library module
 pub fn make_module() -> ValueMap {

--- a/core/runtime/src/core/map.rs
+++ b/core/runtime/src/core/map.rs
@@ -1,10 +1,8 @@
 //! The `map` core library module
 
-use {
-    super::iterator::adaptors,
-    crate::{prelude::*, value_sort::compare_values},
-    std::cmp::Ordering,
-};
+use super::iterator::adaptors;
+use crate::{prelude::*, value_sort::compare_values};
+use std::cmp::Ordering;
 
 /// Initializes the `map` core library module
 pub fn make_module() -> ValueMap {

--- a/core/runtime/src/core/os.rs
+++ b/core/runtime/src/core/os.rs
@@ -1,11 +1,9 @@
 //! The `os` core library module
 
-use {
-    crate::{prelude::*, Result},
-    chrono::prelude::*,
-    instant::Instant,
-    std::ops::Deref,
-};
+use crate::{prelude::*, Result};
+use chrono::prelude::*;
+use instant::Instant;
+use std::ops::Deref;
 
 /// Initializes the `os` core library module
 pub fn make_module() -> ValueMap {

--- a/core/runtime/src/core/string.rs
+++ b/core/runtime/src/core/string.rs
@@ -3,10 +3,10 @@
 pub mod format;
 pub mod iterators;
 
-use {
-    super::iterator::collect_pair, crate::prelude::*, std::convert::TryFrom,
-    unicode_segmentation::UnicodeSegmentation,
-};
+use super::iterator::collect_pair;
+use crate::prelude::*;
+use std::convert::TryFrom;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Initializes the `string` core library module
 pub fn make_module() -> ValueMap {

--- a/core/runtime/src/core/string/format.rs
+++ b/core/runtime/src/core/string/format.rs
@@ -2,11 +2,9 @@
 
 use unicode_segmentation::UnicodeSegmentation;
 
-use {
-    crate::{runtime_error, RuntimeError, UnaryOp, Value, Vm},
-    koto_lexer::{is_id_continue, is_id_start},
-    std::{iter::Peekable, str::Chars},
-};
+use crate::{runtime_error, RuntimeError, UnaryOp, Value, Vm};
+use koto_lexer::{is_id_continue, is_id_start};
+use std::{iter::Peekable, str::Chars};
 
 #[derive(Debug, PartialEq, Eq)]
 enum FormatToken<'a> {
@@ -416,10 +414,8 @@ fn value_to_string(
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::{DataMap, ValueMap},
-    };
+    use super::*;
+    use crate::{DataMap, ValueMap};
 
     fn spec_with_precision(precision: u32) -> FormatSpec {
         FormatSpec {

--- a/core/runtime/src/core/string/iterators.rs
+++ b/core/runtime/src/core/string/iterators.rs
@@ -1,13 +1,11 @@
 //! A collection of string iterators
 
-use {
-    crate::{
-        make_runtime_error,
-        value_iterator::{KotoIterator, ValueIterator, ValueIteratorOutput as Output},
-        CallArgs, Result, Value, ValueString, Vm,
-    },
-    unicode_segmentation::UnicodeSegmentation,
+use crate::{
+    make_runtime_error,
+    value_iterator::{KotoIterator, ValueIterator, ValueIteratorOutput as Output},
+    CallArgs, Result, Value, ValueString, Vm,
 };
+use unicode_segmentation::UnicodeSegmentation;
 
 /// An iterator that outputs the individual bytes contained in a string
 #[derive(Clone)]

--- a/core/runtime/src/error.rs
+++ b/core/runtime/src/error.rs
@@ -1,9 +1,7 @@
-use {
-    crate::prelude::*,
-    koto_bytecode::Chunk,
-    koto_parser::format_error_with_excerpt,
-    std::{cell::RefCell, error, fmt, ops::DerefMut},
-};
+use crate::prelude::*;
+use koto_bytecode::Chunk;
+use koto_parser::format_error_with_excerpt;
+use std::{cell::RefCell, error, fmt, ops::DerefMut};
 
 /// A chunk and ip in a call stack where an error was thrown
 #[derive(Clone, Debug)]

--- a/core/runtime/src/external_function.rs
+++ b/core/runtime/src/external_function.rs
@@ -1,10 +1,8 @@
-use {
-    crate::prelude::*,
-    std::{
-        fmt,
-        hash::{Hash, Hasher},
-        rc::Rc,
-    },
+use crate::prelude::*;
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    rc::Rc,
 };
 
 /// An function that's defined outside of the Koto runtime

--- a/core/runtime/src/frame.rs
+++ b/core/runtime/src/frame.rs
@@ -1,4 +1,5 @@
-use {crate::Ptr, koto_bytecode::Chunk};
+use crate::Ptr;
+use koto_bytecode::Chunk;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Frame {

--- a/core/runtime/src/int_range.rs
+++ b/core/runtime/src/int_range.rs
@@ -1,7 +1,5 @@
-use {
-    crate::prelude::*,
-    std::{cmp::Ordering, fmt, hash::Hash, ops::Range},
-};
+use crate::prelude::*;
+use std::{cmp::Ordering, fmt, hash::Hash, ops::Range};
 
 /// The integer range type used by the Koto runtime
 ///

--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -26,13 +26,12 @@ pub mod core;
 pub mod prelude;
 pub mod value;
 
-pub use {
+pub use crate::{
     display::{KotoDisplay, KotoDisplayOptions},
     error::{type_error, type_error_with_slice, Result, RuntimeError, RuntimeResult},
     external_function::{ArgRegisters, ExternalFunction},
     file::{KotoFile, KotoRead, KotoWrite},
     int_range::IntRange,
-    koto_memory::{Borrow, BorrowMut, Ptr, PtrMut},
     meta_map::{BinaryOp, MetaKey, MetaMap, UnaryOp},
     object::{IsIterable, KotoObject, KotoType, MethodContext, Object, ObjectEntryBuilder},
     stdio::{DefaultStderr, DefaultStdin, DefaultStdout},
@@ -47,3 +46,4 @@ pub use {
     value_tuple::ValueTuple,
     vm::{CallArgs, ModuleImportedCallback, Vm, VmSettings},
 };
+pub use koto_memory::{Borrow, BorrowMut, Ptr, PtrMut};

--- a/core/runtime/src/meta_map.rs
+++ b/core/runtime/src/meta_map.rs
@@ -1,15 +1,13 @@
-use {
-    crate::{
-        external_function::{ArgRegisters, ExternalFunction},
-        prelude::*,
-    },
-    indexmap::{Equivalent, IndexMap},
-    koto_parser::MetaKeyId,
-    std::{
-        fmt,
-        hash::{BuildHasherDefault, Hash},
-        ops::{Deref, DerefMut},
-    },
+use crate::{
+    external_function::{ArgRegisters, ExternalFunction},
+    prelude::*,
+};
+use indexmap::{Equivalent, IndexMap};
+use koto_parser::MetaKeyId;
+use std::{
+    fmt,
+    hash::{BuildHasherDefault, Hash},
+    ops::{Deref, DerefMut},
 };
 
 type MetaMapType = IndexMap<MetaKey, Value, BuildHasherDefault<KotoHasher>>;
@@ -232,7 +230,8 @@ pub enum UnaryOp {
 
 /// Converts a [MetaKeyId](koto_parser::MetaKeyId) into a [MetaKey]
 pub fn meta_id_to_key(id: MetaKeyId, name: Option<ValueString>) -> Result<MetaKey, String> {
-    use {BinaryOp::*, UnaryOp::*};
+    use BinaryOp::*;
+    use UnaryOp::*;
 
     let result = match id {
         MetaKeyId::Add => MetaKey::BinaryOp(Add),

--- a/core/runtime/src/object.rs
+++ b/core/runtime/src/object.rs
@@ -1,8 +1,6 @@
-use {
-    crate::{prelude::*, ExternalFunction, Result},
-    downcast_rs::{impl_downcast, Downcast},
-    std::{cell::RefCell, fmt, marker::PhantomData, rc::Rc},
-};
+use crate::{prelude::*, ExternalFunction, Result};
+use downcast_rs::{impl_downcast, Downcast};
+use std::{cell::RefCell, fmt, marker::PhantomData, rc::Rc};
 
 /// A trait for implementing objects that can be added to the Koto runtime
 ///

--- a/core/runtime/src/stdio.rs
+++ b/core/runtime/src/stdio.rs
@@ -1,7 +1,5 @@
-use {
-    crate::{core::io::map_io_err, KotoFile, KotoRead, KotoWrite, RuntimeError, ValueString},
-    std::io::{self, Read, Write},
-};
+use crate::{core::io::map_io_err, KotoFile, KotoRead, KotoWrite, RuntimeError, ValueString};
+use std::io::{self, Read, Write};
 
 /// The default stdin used in Koto
 #[derive(Default)]

--- a/core/runtime/src/value.rs
+++ b/core/runtime/src/value.rs
@@ -1,10 +1,8 @@
 //! The core value type used in the Koto runtime
 
-use {
-    crate::{prelude::*, ExternalFunction, Result},
-    koto_bytecode::Chunk,
-    std::fmt::Write,
-};
+use crate::{prelude::*, ExternalFunction, Result};
+use koto_bytecode::Chunk;
+use std::fmt::Write;
 
 /// The core Value type for Koto
 #[derive(Clone, Debug, Default)]

--- a/core/runtime/src/value_iterator.rs
+++ b/core/runtime/src/value_iterator.rs
@@ -1,7 +1,5 @@
-use {
-    crate::{prelude::*, Result},
-    std::{cell::RefCell, cmp::Ordering, fmt, ops::DerefMut, rc::Rc, result::Result as StdResult},
-};
+use crate::{prelude::*, Result};
+use std::{cell::RefCell, cmp::Ordering, fmt, ops::DerefMut, rc::Rc, result::Result as StdResult};
 
 /// The trait used to implement iterators in Koto
 ///

--- a/core/runtime/src/value_key.rs
+++ b/core/runtime/src/value_key.rs
@@ -1,11 +1,9 @@
-use {
-    crate::prelude::*,
-    indexmap::Equivalent,
-    std::{
-        cmp::Ordering,
-        fmt,
-        hash::{Hash, Hasher},
-    },
+use crate::prelude::*;
+use indexmap::Equivalent;
+use std::{
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
 };
 
 /// The key type used by [DataMap](crate::DataMap)

--- a/core/runtime/src/value_map.rs
+++ b/core/runtime/src/value_map.rs
@@ -1,16 +1,14 @@
-use {
-    crate::{
-        external_function::{ArgRegisters, ExternalFunction},
-        prelude::*,
-        Result,
-    },
-    indexmap::IndexMap,
-    rustc_hash::FxHasher,
-    std::{
-        hash::BuildHasherDefault,
-        iter::IntoIterator,
-        ops::{Deref, DerefMut},
-    },
+use crate::{
+    external_function::{ArgRegisters, ExternalFunction},
+    prelude::*,
+    Result,
+};
+use indexmap::IndexMap;
+use rustc_hash::FxHasher;
+use std::{
+    hash::BuildHasherDefault,
+    iter::IntoIterator,
+    ops::{Deref, DerefMut},
 };
 
 /// The hasher used throughout the Koto runtime

--- a/core/runtime/src/value_number.rs
+++ b/core/runtime/src/value_number.rs
@@ -1,11 +1,9 @@
-use {
-    crate::Value,
-    std::{
-        cmp::Ordering,
-        fmt,
-        hash::{Hash, Hasher},
-        ops,
-    },
+use crate::Value;
+use std::{
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    ops,
 };
 
 /// The Number type used by the Koto runtime

--- a/core/runtime/src/value_string.rs
+++ b/core/runtime/src/value_string.rs
@@ -1,12 +1,10 @@
-use {
-    crate::{prelude::*, Result},
-    std::{
-        fmt,
-        hash::{Hash, Hasher},
-        ops::{Deref, Range},
-    },
-    unicode_segmentation::UnicodeSegmentation,
+use crate::{prelude::*, Result};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    ops::{Deref, Range},
 };
+use unicode_segmentation::UnicodeSegmentation;
 
 /// The String type used by the Koto runtime
 ///

--- a/core/runtime/src/value_tuple.rs
+++ b/core/runtime/src/value_tuple.rs
@@ -1,7 +1,5 @@
-use {
-    crate::{prelude::*, Result},
-    std::ops::{Deref, Range},
-};
+use crate::{prelude::*, Result};
+use std::ops::{Deref, Range};
 
 /// The Tuple type used by the Koto runtime
 #[derive(Clone, Debug)]

--- a/core/runtime/src/vm.rs
+++ b/core/runtime/src/vm.rs
@@ -1,25 +1,23 @@
-use {
-    crate::{
-        core::CoreLib,
-        error::RuntimeErrorType,
-        external_function::{self, ArgRegisters, ExternalFunction},
-        frame::Frame,
-        meta_map::meta_id_to_key,
-        prelude::*,
-        value::{FunctionInfo, RegisterSlice, SimpleFunctionInfo},
-        DefaultStderr, DefaultStdin, DefaultStdout, Result,
-    },
-    koto_bytecode::{Chunk, Instruction, InstructionReader, Loader, TypeId},
-    koto_parser::{ConstantIndex, MetaKeyId},
-    rustc_hash::FxHasher,
-    std::{
-        cell::RefCell,
-        collections::HashMap,
-        fmt,
-        hash::BuildHasherDefault,
-        path::{Path, PathBuf},
-        rc::Rc,
-    },
+use crate::{
+    core::CoreLib,
+    error::RuntimeErrorType,
+    external_function::{self, ArgRegisters, ExternalFunction},
+    frame::Frame,
+    meta_map::meta_id_to_key,
+    prelude::*,
+    value::{FunctionInfo, RegisterSlice, SimpleFunctionInfo},
+    DefaultStderr, DefaultStdin, DefaultStdout, Result,
+};
+use koto_bytecode::{Chunk, Instruction, InstructionReader, Loader, TypeId};
+use koto_parser::{ConstantIndex, MetaKeyId};
+use rustc_hash::FxHasher;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    fmt,
+    hash::BuildHasherDefault,
+    path::{Path, PathBuf},
+    rc::Rc,
 };
 
 macro_rules! call_binary_op_or_else {
@@ -1381,7 +1379,8 @@ impl Vm {
     }
 
     fn run_negate(&mut self, result: u8, value: u8) -> InstructionResult {
-        use {UnaryOp::Negate, Value::*};
+        use UnaryOp::Negate;
+        use Value::*;
 
         let result_value = match self.clone_register(value) {
             Number(n) => Number(-n),
@@ -1398,7 +1397,8 @@ impl Vm {
     }
 
     fn run_not(&mut self, result: u8, value: u8) -> InstructionResult {
-        use {UnaryOp::Not, Value::*};
+        use UnaryOp::Not;
+        use Value::*;
 
         let result_value = match &self.get_register(value) {
             Null => Bool(true),
@@ -1436,7 +1436,8 @@ impl Vm {
     }
 
     fn run_add(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Add, Value::*};
+        use BinaryOp::Add;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1460,7 +1461,8 @@ impl Vm {
     }
 
     fn run_subtract(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Subtract, Value::*};
+        use BinaryOp::Subtract;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1480,7 +1482,8 @@ impl Vm {
     }
 
     fn run_multiply(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Multiply, Value::*};
+        use BinaryOp::Multiply;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1501,7 +1504,8 @@ impl Vm {
     }
 
     fn run_divide(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Divide, Value::*};
+        use BinaryOp::Divide;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1521,7 +1525,8 @@ impl Vm {
     }
 
     fn run_remainder(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Remainder, Value::*};
+        use BinaryOp::Remainder;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1546,7 +1551,8 @@ impl Vm {
     }
 
     fn run_add_assign(&mut self, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::AddAssign, Value::*};
+        use BinaryOp::AddAssign;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1572,7 +1578,8 @@ impl Vm {
     }
 
     fn run_subtract_assign(&mut self, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::SubtractAssign, Value::*};
+        use BinaryOp::SubtractAssign;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1598,7 +1605,8 @@ impl Vm {
     }
 
     fn run_multiply_assign(&mut self, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::MultiplyAssign, Value::*};
+        use BinaryOp::MultiplyAssign;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1624,7 +1632,8 @@ impl Vm {
     }
 
     fn run_divide_assign(&mut self, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::DivideAssign, Value::*};
+        use BinaryOp::DivideAssign;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1650,7 +1659,8 @@ impl Vm {
     }
 
     fn run_remainder_assign(&mut self, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::RemainderAssign, Value::*};
+        use BinaryOp::RemainderAssign;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1676,7 +1686,8 @@ impl Vm {
     }
 
     fn run_less(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Less, Value::*};
+        use BinaryOp::Less;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1697,7 +1708,8 @@ impl Vm {
     }
 
     fn run_less_or_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::LessOrEqual, Value::*};
+        use BinaryOp::LessOrEqual;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1718,7 +1730,8 @@ impl Vm {
     }
 
     fn run_greater(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Greater, Value::*};
+        use BinaryOp::Greater;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1739,7 +1752,8 @@ impl Vm {
     }
 
     fn run_greater_or_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::GreaterOrEqual, Value::*};
+        use BinaryOp::GreaterOrEqual;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1760,7 +1774,8 @@ impl Vm {
     }
 
     fn run_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::Equal, Value::*};
+        use BinaryOp::Equal;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1826,7 +1841,8 @@ impl Vm {
     }
 
     fn run_not_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> InstructionResult {
-        use {BinaryOp::NotEqual, Value::*};
+        use BinaryOp::NotEqual;
+        use Value::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -2203,7 +2219,8 @@ impl Vm {
         value_register: u8,
         index_register: u8,
     ) -> InstructionResult {
-        use {BinaryOp::Index, Value::*};
+        use BinaryOp::Index;
+        use Value::*;
 
         let value = self.clone_register(value_register);
         let index = self.clone_register(index_register);

--- a/core/runtime/tests/iterator_tests.rs
+++ b/core/runtime/tests/iterator_tests.rs
@@ -1,6 +1,7 @@
 mod runtime_test_utils;
 
-use {crate::runtime_test_utils::*, koto_runtime::Value};
+use crate::runtime_test_utils::*;
+use koto_runtime::Value;
 
 mod iterator {
     use super::*;

--- a/core/runtime/tests/object_tests.rs
+++ b/core/runtime/tests/object_tests.rs
@@ -1,10 +1,8 @@
 mod runtime_test_utils;
 
 mod objects {
-    use {
-        crate::runtime_test_utils::*,
-        koto_runtime::{prelude::*, Result},
-    };
+    use crate::runtime_test_utils::*;
+    use koto_runtime::{prelude::*, Result};
 
     #[derive(Clone, Copy, Debug)]
     struct TestObject {
@@ -374,7 +372,8 @@ make_object(10)
     }
 
     mod binary_op {
-        use {super::*, Value::Bool};
+        use super::*;
+        use Value::Bool;
 
         #[test]
         fn add() {

--- a/core/runtime/tests/runtime_failures.rs
+++ b/core/runtime/tests/runtime_failures.rs
@@ -1,8 +1,6 @@
 mod runtime {
-    use {
-        koto_bytecode::{Chunk, CompilerSettings, Loader},
-        koto_runtime::Vm,
-    };
+    use koto_bytecode::{Chunk, CompilerSettings, Loader};
+    use koto_runtime::Vm;
 
     fn check_script_fails(script: &str) {
         let mut vm = Vm::default();

--- a/core/runtime/tests/runtime_test_utils.rs
+++ b/core/runtime/tests/runtime_test_utils.rs
@@ -1,10 +1,8 @@
 #![allow(unused)]
 
-use {
-    koto_bytecode::{Chunk, CompilerSettings, Loader},
-    koto_runtime::{prelude::*, Value::*},
-    std::{cell::RefCell, rc::Rc},
-};
+use koto_bytecode::{Chunk, CompilerSettings, Loader};
+use koto_runtime::{prelude::*, Value::*};
+use std::{cell::RefCell, rc::Rc};
 
 pub fn test_script(script: &str, expected_output: impl Into<Value>) {
     let output = PtrMut::from(String::new());

--- a/core/runtime/tests/stdout.rs
+++ b/core/runtime/tests/stdout.rs
@@ -1,11 +1,9 @@
 mod runtime_test_utils;
 
-use {
-    crate::runtime_test_utils::TestStdout,
-    koto_bytecode::{Chunk, CompilerSettings, Loader},
-    koto_runtime::prelude::*,
-    std::rc::Rc,
-};
+use crate::runtime_test_utils::TestStdout;
+use koto_bytecode::{Chunk, CompilerSettings, Loader};
+use koto_runtime::prelude::*;
+use std::rc::Rc;
 
 mod vm {
     use super::*;

--- a/core/runtime/tests/vm_tests.rs
+++ b/core/runtime/tests/vm_tests.rs
@@ -1,12 +1,10 @@
 mod runtime_test_utils;
 
 mod vm {
-    use {
-        crate::runtime_test_utils::{
-            number, number_list, number_tuple, run_script_with_vm, string, test_script, value_tuple,
-        },
-        koto_runtime::{prelude::*, Value::*},
+    use crate::runtime_test_utils::{
+        number, number_list, number_tuple, run_script_with_vm, string, test_script, value_tuple,
     };
+    use koto_runtime::{prelude::*, Value::*};
 
     mod literals {
         use super::*;

--- a/core/serialize/src/lib.rs
+++ b/core/serialize/src/lib.rs
@@ -1,9 +1,7 @@
 //! Serde serialization support for Koto value types
 
-use {
-    koto_runtime::Value,
-    serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer},
-};
+use koto_runtime::Value;
+use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 /// A newtype that allows us to implement support for Serde serialization
 pub struct SerializableValue<'a>(pub &'a Value);

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -1,4 +1,5 @@
-use {crate::Poetry, koto::prelude::*};
+use crate::Poetry;
+use koto::prelude::*;
 
 pub fn make_module() -> ValueMap {
     let result = ValueMap::new();

--- a/examples/poetry/src/main.rs
+++ b/examples/poetry/src/main.rs
@@ -1,20 +1,18 @@
 mod koto_bindings;
 mod poetry;
 
-use {
-    hotwatch::{
-        blocking::{Flow, Hotwatch},
-        Event,
-    },
-    koto::{Koto, KotoSettings},
-    poetry::*,
-    std::{
-        error::Error,
-        fmt, fs,
-        path::{Path, PathBuf},
-        str::FromStr,
-        time::Duration,
-    },
+use hotwatch::{
+    blocking::{Flow, Hotwatch},
+    Event,
+};
+use koto::{Koto, KotoSettings};
+use poetry::*;
+use std::{
+    error::Error,
+    fmt, fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+    time::Duration,
 };
 
 #[derive(Debug)]

--- a/examples/poetry/src/poetry.rs
+++ b/examples/poetry/src/poetry.rs
@@ -1,8 +1,6 @@
-use {
-    indexmap::IndexMap,
-    rand::{seq::SliceRandom, thread_rng, Rng},
-    std::rc::Rc,
-};
+use indexmap::IndexMap;
+use rand::{seq::SliceRandom, thread_rng, Rng};
+use std::rc::Rc;
 
 /// A basic Markov chain,
 #[derive(Clone, Debug, Default)]

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -1,4 +1,5 @@
-use {koto::prelude::*, wasm_bindgen::prelude::*};
+use koto::prelude::*;
+use wasm_bindgen::prelude::*;
 
 // Captures output from Koto in a String
 #[derive(Debug)]
@@ -81,7 +82,8 @@ pub fn compile_and_run(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, wasm_bindgen_test::wasm_bindgen_test};
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test]
     fn one_plus_one() {

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -1,9 +1,7 @@
-use {
-    koto_runtime::{prelude::*, Result},
-    std::{
-        fmt,
-        ops::{self, Deref, DerefMut},
-    },
+use koto_runtime::{prelude::*, Result};
+use std::{
+    fmt,
+    ops::{self, Deref, DerefMut},
 };
 
 type Inner = palette::rgb::LinSrgba;

--- a/libs/geometry/src/lib.rs
+++ b/libs/geometry/src/lib.rs
@@ -6,7 +6,9 @@ mod rect;
 mod vec2;
 mod vec3;
 
-pub use {rect::Rect, vec2::Vec2, vec3::Vec3};
+pub use rect::Rect;
+pub use vec2::Vec2;
+pub use vec3::Vec3;
 
 use koto_runtime::prelude::*;
 

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -1,8 +1,6 @@
-use {
-    crate::Vec2,
-    koto_runtime::{prelude::*, Result},
-    std::{fmt, ops::Deref},
-};
+use crate::Vec2;
+use koto_runtime::{prelude::*, Result};
+use std::{fmt, ops::Deref};
 
 type Inner = nannou_core::geom::Rect<f64>;
 

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -1,9 +1,7 @@
-use {
-    koto_runtime::{prelude::*, Result},
-    std::{
-        fmt,
-        ops::{self, Deref},
-    },
+use koto_runtime::{prelude::*, Result};
+use std::{
+    fmt,
+    ops::{self, Deref},
 };
 
 type Inner = nannou_core::geom::DVec2;

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -1,10 +1,8 @@
-use {
-    koto_runtime::{prelude::*, Result},
-    nannou_core::geom::DVec3,
-    std::{
-        fmt,
-        ops::{self, Deref},
-    },
+use koto_runtime::{prelude::*, Result};
+use nannou_core::geom::DVec3;
+use std::{
+    fmt,
+    ops::{self, Deref},
 };
 
 #[derive(Copy, Clone, PartialEq)]

--- a/libs/json/src/lib.rs
+++ b/libs/json/src/lib.rs
@@ -1,6 +1,8 @@
 //! A Koto language module for working with JSON data
 
-use {koto_runtime::prelude::*, koto_serialize::SerializableValue, serde_json::Value as JsonValue};
+use koto_runtime::prelude::*;
+use koto_serialize::SerializableValue;
+use serde_json::Value as JsonValue;
 
 pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<Value, String> {
     let result = match value {

--- a/libs/lib_tests/tests/lib_tests.rs
+++ b/libs/lib_tests/tests/lib_tests.rs
@@ -1,7 +1,5 @@
-use {
-    koto::prelude::*,
-    std::{fs::read_to_string, path::PathBuf},
-};
+use koto::prelude::*;
+use std::{fs::read_to_string, path::PathBuf};
 
 fn run_script(script: &str, path: Option<PathBuf>, should_fail_at_runtime: bool) {
     let mut koto = Koto::with_settings(KotoSettings {

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -1,11 +1,9 @@
 //! A random number module for the Koto language
 
-use {
-    koto_runtime::prelude::*,
-    rand::{Rng, SeedableRng},
-    rand_chacha::ChaCha8Rng,
-    std::cell::RefCell,
-};
+use koto_runtime::prelude::*;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::cell::RefCell;
 
 pub fn make_module() -> ValueMap {
     let result = ValueMap::new();

--- a/libs/tempfile/src/lib.rs
+++ b/libs/tempfile/src/lib.rs
@@ -1,12 +1,10 @@
 //! A Koto language module for working with temporary files
 
-use {
-    koto_runtime::{
-        core::io::{map_io_err, File},
-        ValueMap,
-    },
-    tempfile::NamedTempFile,
+use koto_runtime::{
+    core::io::{map_io_err, File},
+    ValueMap,
 };
+use tempfile::NamedTempFile;
 
 pub fn make_module() -> ValueMap {
     let result = ValueMap::new();

--- a/libs/toml/src/lib.rs
+++ b/libs/toml/src/lib.rs
@@ -1,6 +1,8 @@
 //! A Koto language module for working with TOML data
 
-use {koto_runtime::prelude::*, koto_serialize::SerializableValue, toml::Value as Toml};
+use koto_runtime::prelude::*;
+use koto_serialize::SerializableValue;
+use toml::Value as Toml;
 
 pub fn toml_to_koto_value(value: &Toml) -> Result<Value, String> {
     let result = match value {

--- a/libs/yaml/src/lib.rs
+++ b/libs/yaml/src/lib.rs
@@ -1,6 +1,8 @@
 //! A Koto language module for working with YAML data
 
-use {koto_runtime::prelude::*, koto_serialize::SerializableValue, serde_yaml::Value as YamlValue};
+use koto_runtime::prelude::*;
+use koto_serialize::SerializableValue;
+use serde_yaml::Value as YamlValue;
 
 pub fn yaml_value_to_koto_value(value: &serde_yaml::Value) -> Result<Value, RuntimeError> {
     let result = match value {


### PR DESCRIPTION
Koto's been using the `one` import granularity style [1], but this doesn't play well with Rust Analyzer [2] which has made wish for a change, and the `crate` style seems like a decent alternative.

[1] https://rust-lang.github.io/rustfmt/?search=#imports_granularity
[2] https://github.com/rust-lang/rust-analyzer/issues/11361
