### PR TITLE
Value size reduction - part one

### DIFF
--- a/core/memory/src/rc/ptr.rs
+++ b/core/memory/src/rc/ptr.rs
@@ -27,6 +27,19 @@ impl<T: ?Sized> Ptr<T> {
     }
 }
 
+impl<T: Clone> Ptr<T> {
+    /// Makes a mutable reference into the owned `T`
+    ///
+    /// If the pointer has the only reference to the value, then the reference will be returned.
+    /// Otherwise a clone of the value will be made to ensure uniqueness before returning the
+    /// reference.
+    ///
+    /// See also: [std::rc::Rc::make_mut]
+    pub fn make_mut(this: &mut Self) -> &mut T {
+        Rc::make_mut(&mut this.0)
+    }
+}
+
 impl<T> From<T> for Ptr<T> {
     fn from(value: T) -> Self {
         Self::new(value)

--- a/core/memory/src/rc/ptr.rs
+++ b/core/memory/src/rc/ptr.rs
@@ -1,4 +1,10 @@
-use std::{fmt, ops::Deref, rc::Rc};
+use std::{
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    rc::Rc,
+};
 
 use super::Address;
 
@@ -106,8 +112,29 @@ impl<T: ?Sized + PartialEq> PartialEq for Ptr<T> {
     }
 }
 
+impl<T: ?Sized + Eq> Eq for Ptr<T> {}
+
 impl<T: ?Sized + fmt::Display> fmt::Display for Ptr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl<T: ?Sized + Hash> Hash for Ptr<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+impl<T: ?Sized + Ord> Ord for Ptr<T> {
+    #[inline]
+    fn cmp(&self, other: &Ptr<T>) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<T: ?Sized + PartialOrd> PartialOrd for Ptr<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
     }
 }

--- a/core/memory/src/rc/ptr.rs
+++ b/core/memory/src/rc/ptr.rs
@@ -46,6 +46,12 @@ impl<T> From<T> for Ptr<T> {
     }
 }
 
+impl<T: ?Sized> From<Box<T>> for Ptr<T> {
+    fn from(boxed: Box<T>) -> Self {
+        Self(boxed.into())
+    }
+}
+
 impl<T: ?Sized> From<Rc<T>> for Ptr<T> {
     fn from(inner: Rc<T>) -> Self {
         Self(inner)

--- a/core/runtime/src/core_lib/range.rs
+++ b/core/runtime/src/core_lib/range.rs
@@ -22,18 +22,18 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("end", |vm, args| match vm.get_args(args) {
-        [Range(r)] => Ok(r.end.map_or(Null, |(end, _inclusive)| end.into())),
+        [Range(r)] => Ok(r.end().map_or(Null, |(end, _inclusive)| end.into())),
         unexpected => type_error_with_slice("a Range as argument", unexpected),
     });
 
     result.add_fn("expanded", |vm, args| match vm.get_args(args) {
-        [Range(r), Number(n)] => match (r.start, r.end) {
+        [Range(r), Number(n)] => match (r.start(), r.end()) {
             (Some(start), Some((end, inclusive))) => {
-                let n = isize::from(n);
+                let n = i64::from(n);
                 let result = if r.is_ascending() {
-                    IntRange::with_bounds(start - n, end + n, inclusive)
+                    IntRange::bounded(start - n, end + n, inclusive)
                 } else {
-                    IntRange::with_bounds(start + n, end - n, inclusive)
+                    IntRange::bounded(start + n, end - n, inclusive)
                 };
                 Ok(result.into())
             }
@@ -43,12 +43,12 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("intersection", |vm, args| match vm.get_args(args) {
-        [Range(a), Range(b)] => Ok(a.intersection(*b).map_or(Null, |result| result.into())),
+        [Range(a), Range(b)] => Ok(a.intersection(b).map_or(Null, |result| result.into())),
         unexpected => type_error_with_slice("two Ranges", unexpected),
     });
 
     result.add_fn("is_inclusive", |vm, args| match vm.get_args(args) {
-        [Range(r)] => Ok(r.end.map_or(false, |(_end, inclusive)| inclusive).into()),
+        [Range(r)] => Ok(r.end().map_or(false, |(_end, inclusive)| inclusive).into()),
         unexpected => type_error_with_slice("a Range as argument", unexpected),
     });
 
@@ -61,32 +61,32 @@ pub fn make_module() -> ValueMap {
     });
 
     result.add_fn("start", |vm, args| match vm.get_args(args) {
-        [Range(r)] => Ok(r.start.map_or(Null, |start| start.into())),
+        [Range(r)] => Ok(r.start().map_or(Null, Value::from)),
         unexpected => type_error_with_slice("a Range as argument", unexpected),
     });
 
     result.add_fn("union", |vm, args| match vm.get_args(args) {
         [Range(r), Number(n)] => {
-            let n = isize::from(n);
-            match (r.start, r.end) {
+            let n = i64::from(n);
+            match (r.start(), r.end()) {
                 (Some(start), Some((end, inclusive))) => {
                     let result = if start <= end {
-                        IntRange::with_bounds(start.min(n), end.max(n + 1), inclusive)
+                        IntRange::bounded(start.min(n), end.max(n + 1), inclusive)
                     } else {
-                        IntRange::with_bounds(start.max(n), end.min(n - 1), inclusive)
+                        IntRange::bounded(start.max(n), end.min(n - 1), inclusive)
                     };
                     Ok(result.into())
                 }
                 _ => runtime_error!("range.union can't be used with '{r}'"),
             }
         }
-        [Range(a), Range(b)] => match (a.start, a.end) {
+        [Range(a), Range(b)] => match (a.start(), a.end()) {
             (Some(start), Some((end, inclusive))) => {
                 let r_b = b.as_sorted_range();
                 let result = if start <= end {
-                    IntRange::with_bounds(start.min(r_b.start), end.max(r_b.end), inclusive)
+                    IntRange::bounded(start.min(r_b.start), end.max(r_b.end), inclusive)
                 } else {
-                    IntRange::with_bounds(start.max(r_b.end - 1), end.min(r_b.start), inclusive)
+                    IntRange::bounded(start.max(r_b.end - 1), end.min(r_b.start), inclusive)
                 };
                 Ok(result.into())
             }

--- a/core/runtime/src/types/meta_map.rs
+++ b/core/runtime/src/types/meta_map.rs
@@ -60,7 +60,7 @@ impl DerefMut for MetaMap {
 }
 
 /// The key type used by [MetaMaps](crate::MetaMap)
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub enum MetaKey {
     /// A binary operation
     ///

--- a/core/runtime/src/vm.rs
+++ b/core/runtime/src/vm.rs
@@ -993,19 +993,19 @@ impl Vm {
     ) -> Result<()> {
         use Value::Number;
 
-        let start = match start_register.map(|register| self.get_register(register)) {
-            Some(Number(n)) => Some(isize::from(n)),
-            None => None,
-            Some(unexpected) => return type_error("Number for range start", unexpected),
-        };
+        let start = start_register.map(|r| self.get_register(r));
+        let end = end_register.map(|r| self.get_register(r));
 
-        let end = match end_register.map(|register| self.get_register(register)) {
-            Some(Number(n)) => Some((isize::from(n), inclusive)),
-            None => None,
-            Some(unexpected) => return type_error("Number for range end", unexpected),
+        let range = match (start, end) {
+            (Some(Number(start)), Some(Number(end))) => {
+                IntRange::bounded(start.into(), end.into(), inclusive)
+            }
+            (Some(Number(start)), None) => IntRange::from(start.into()),
+            (None, Some(Number(end))) => IntRange::to(end.into(), inclusive),
+            (Some(unexpected), _) => return type_error("Number for range start", unexpected),
+            (_, Some(unexpected)) => return type_error("Number for range end", unexpected),
+            (None, None) => IntRange::unbounded(),
         };
-
-        let range = IntRange { start, end };
 
         self.set_register(register, range.into());
         Ok(())
@@ -1043,7 +1043,7 @@ impl Vm {
                 }
             }
             Iterator(_) => iterable,
-            Range(r) if temp_iterator && r.is_bounded() => iterable,
+            Range(ref r) if temp_iterator && r.is_bounded() => iterable,
             Tuple(_) | Str(_) | TemporaryTuple(_) if temp_iterator => {
                 // Immutable sequences can be iterated over directly when used in temporary
                 // situations like argument unpacking.

--- a/core/runtime/src/vm.rs
+++ b/core/runtime/src/vm.rs
@@ -594,6 +594,8 @@ impl Vm {
                         }
                     }
 
+                    dbg!(&test_name);
+
                     let test_result =
                         self.run_instance_function(self_arg.clone(), test, CallArgs::None);
 

--- a/core/runtime/tests/iterator_tests.rs
+++ b/core/runtime/tests/iterator_tests.rs
@@ -434,6 +434,18 @@ y.next()
 mod string {
     use super::*;
 
+    mod graphemes {
+        use super::*;
+
+        #[test]
+        fn next_back() {
+            let script = "
+'abc'.next_back()
+";
+            test_script(script, "c");
+        }
+    }
+
     mod bytes {
         use super::*;
 

--- a/core/runtime/tests/vm_tests.rs
+++ b/core/runtime/tests/vm_tests.rs
@@ -187,16 +187,16 @@ a %= 5
 
         #[test]
         fn range() {
-            test_script("0..10", Range(IntRange::with_bounds(0, 10, false)));
-            test_script("0..-10", Range(IntRange::with_bounds(0, -10, false)));
-            test_script("1 + 1..2 + 2", Range(IntRange::with_bounds(2, 4, false)));
+            test_script("0..10", Range(IntRange::bounded(0, 10, false)));
+            test_script("0..-10", Range(IntRange::bounded(0, -10, false)));
+            test_script("1 + 1..2 + 2", Range(IntRange::bounded(2, 4, false)));
         }
 
         #[test]
         fn range_inclusive() {
-            test_script("10..=20", Range(IntRange::with_bounds(10, 20, true)));
-            test_script("4..=0", Range(IntRange::with_bounds(4, 0, true)));
-            test_script("2 * 2..=3 * 3", Range(IntRange::with_bounds(4, 9, true)));
+            test_script("10..=20", Range(IntRange::bounded(10, 20, true)));
+            test_script("4..=0", Range(IntRange::bounded(4, 0, true)));
+            test_script("2 * 2..=3 * 3", Range(IntRange::bounded(4, 9, true)));
         }
     }
 


### PR DESCRIPTION
This is the first part of an overall effort to reduce the size of `Value` from 40 to 24 bytes. 

To make this possible all variants need to be brought down to 16 bytes. 

After this PR the function variants are still larger than 16 bytes, and will be dealt with in a following PR. 
