### PR TITLE
Remove 'assume valid bytecode' logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           toolchain: stable
 
       - name: Build
-        run: cargo build --workspace --verbose
+        run: cargo build --all-targets --verbose
 
       - name: Run tests
-        run: cargo test --workspace --verbose
+        run: cargo test --all-targets --verbose
 
       - name: Run poetry example
         run: cargo run --example poetry -- -s examples/poetry/scripts/readme.koto
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Test with optimizations
-        run: cargo test --release --workspace --verbose
+        run: cargo test --release --all-features --all-targets --verbose
 
   code_checks:
     runs-on: ubuntu-latest

--- a/core/bytecode/Cargo.toml
+++ b/core/bytecode/Cargo.toml
@@ -10,7 +10,8 @@ homepage = "https://github.com/koto-lang/koto"
 repository = "https://github.com/koto-lang/koto"
 keywords = ["scripting", "language", "koto"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
 
 [dependencies]
 koto_memory = { path = "../memory", version = "^0.11.0" }

--- a/core/koto/Cargo.toml
+++ b/core/koto/Cargo.toml
@@ -19,7 +19,7 @@ koto_bytecode = { path = "../bytecode", version = "^0.11.0" }
 koto_parser = { path = "../parser", version = "^0.11.0" }
 koto_runtime = { path = "../runtime", version = "^0.11.0" }
 
-dunce.workspace = true
+dunce = { workspace = true }
 
 [dev-dependencies]
 koto_geometry = { path = "../../libs/geometry", version = "^0.11.0" }

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ temp:
   cargo run -- --tests -i temp.koto
 
 test:
-  cargo test --workspace
+  cargo test --all-targets
 
 test_benches:
   cargo test --benches

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -6,8 +6,8 @@ Adapted from the lua implementation:
 https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-lua-4.html
 -#
 
-import geometry.vec3
-import number.pi
+from geometry import vec3
+from number import pi
 
 solar_mass = 4 * pi * pi
 days_per_year = 365.24


### PR DESCRIPTION
- Fix the N-body benchmark, and use --all-targets instead of --workspace
- Remove the 'assume valid bytecode' paths
