### PR TITLE
CLI Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ The Koto project adheres to
 - `Ptr<T>` and `PtrMut<T>` wrappers have been introduced as the core memory
   types for the runtime, replacing uses of `Rc<T>` and `Rc<RefCell<T>>`.
 
+#### REPL
+
+- Added support for disabling colored output with the `NO_COLOR` environment
+  variable.
+- The REPL has been reimplemented with 
+  [rustyline](https://github.com/kkawakam/rustyline)
+  - History is now maintained between sessions.
+  - Emacs / VI key bindings have been added.
+- A `config.koto` file can be written to maintain REPL settings.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,10 +346,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if 1.0.0",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "filetime"
@@ -434,6 +472,15 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "hotwatch"
@@ -626,6 +673,7 @@ name = "koto_cli"
 version = "0.11.0"
 dependencies = [
  "crossterm",
+ "home",
  "indexmap 2.0.0",
  "jemallocator",
  "koto",
@@ -638,6 +686,7 @@ dependencies = [
  "koto_yaml",
  "pico-args",
  "pulldown-cmark",
+ "rustyline",
  "textwrap",
  "unicode-width",
 ]
@@ -936,6 +985,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1358,29 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustyline"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if 1.0.0",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1410,6 +1512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1647,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +678,7 @@ dependencies = [
 name = "koto_cli"
 version = "0.11.0"
 dependencies = [
+ "anyhow",
  "crossterm",
  "home",
  "indexmap 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ dunce = "1.0.2"
 getrandom = "0.2.4"
 # A simple and fast 3D math library for games and graphics
 glam = "0.22.0"
+# Shared definitions of home directories.
+home = "0.5.5"
 # A Rust library for conveniently watching and handling file changes.
 hotwatch = "0.4.5"
 # A hash table with consistent order and fast iteration.
@@ -41,6 +43,8 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 # A speedy, non-cryptographic hash used in rustc
 rustc-hash = "1.1.0"
+# Rustyline, a readline implementation
+rustyline = "12.0.0"
 # A generic serialization/deserialization framework
 serde = "1.0.0"
 # JSON support for serde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = ["core/*", "examples/*", "libs/*"]
 resolver = "2"
 
 [workspace.dependencies]
+# Flexible concrete Error type built on std::error::Error
+anyhow = "1.0.75"
 # Date and time library for Rust
 chrono = "0.4.31"
 # Statistics-driven micro-benchmarking library

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -28,9 +28,11 @@ koto_toml = { path = "../../libs/toml", version = "^0.11.0" }
 koto_yaml = { path = "../../libs/yaml", version = "^0.11.0" }
 
 crossterm = { workspace = true }
+home = { workspace = true }
 indexmap = { workspace = true }
 pico-args = { workspace = true }
 pulldown-cmark = { workspace = true }
+rustyline = { workspace = true }
 textwrap = { workspace = true }
 unicode-width = { workspace = true }
 

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -27,6 +27,7 @@ koto_tempfile = { path = "../../libs/tempfile", version = "^0.11.0" }
 koto_toml = { path = "../../libs/toml", version = "^0.11.0" }
 koto_yaml = { path = "../../libs/yaml", version = "^0.11.0" }
 
+anyhow = { workspace = true }
 crossterm = { workspace = true }
 home = { workspace = true }
 indexmap = { workspace = true }

--- a/core/cli/src/main.rs
+++ b/core/cli/src/main.rs
@@ -35,7 +35,8 @@ ARGS:
     <args>...    Arguments to pass into the script
 
 ENV VARS:
-    NO_COLOR     When set, colored output will be disabled (enabled by default)
+    KOTO_EDIT_MODE_VI   Enables the VI editing mode (Emacs bindings are enabled by default)
+    NO_COLOR            Disables colored output (enabled by default)
 ",
         version = version_string()
     )

--- a/core/cli/src/main.rs
+++ b/core/cli/src/main.rs
@@ -192,7 +192,8 @@ fn run() -> Result<(), ()> {
                 show_bytecode: args.show_bytecode,
             },
             koto_settings,
-        );
+        )
+        .map_err(|_| ())?;
         repl.run().map_err(|_| ())
     }
 }

--- a/core/cli/src/main.rs
+++ b/core/cli/src/main.rs
@@ -22,7 +22,7 @@ USAGE:
     koto [FLAGS] [script] [<args>...]
 
 FLAGS:
-    -e, --eval               Evaluate the script directly (rather than reading it from disk)
+    -e, --eval               Evaluate the script as a string instead of loading it from disk
     -i, --show_instructions  Show compiled instructions annotated with source lines
     -b, --show_bytecode      Show the script's compiled bytecode
     -t, --tests              Run the script's tests before running the script
@@ -33,6 +33,9 @@ FLAGS:
 ARGS:
     <script>     The koto script to run, as a file path, or as a string when --eval is set
     <args>...    Arguments to pass into the script
+
+ENV VARS:
+    NO_COLOR     When set, colored output will be disabled (enabled by default)
 ",
         version = version_string()
     )

--- a/core/cli/src/repl.rs
+++ b/core/cli/src/repl.rs
@@ -75,10 +75,16 @@ impl Repl {
         let koto = Koto::with_settings(koto_settings);
         super::add_modules(&koto);
 
+        let edit_mode = if env::var("KOTO_EDIT_MODE_VI").is_ok() {
+            EditMode::Vi
+        } else {
+            EditMode::Emacs
+        };
+
         let mut editor = DefaultEditor::with_config(
             Config::builder()
                 .max_history_size(MAX_HISTORY_ENTRIES)?
-                .edit_mode(EditMode::Emacs)
+                .edit_mode(edit_mode)
                 .build(),
         )?;
 

--- a/core/cli/src/repl.rs
+++ b/core/cli/src/repl.rs
@@ -1,27 +1,20 @@
-use crate::help::Help;
-use crossterm::{
-    cursor,
-    event::{read, Event, KeyCode, KeyEvent, KeyModifiers},
-    execute, queue, style,
-    terminal::{self, ClearType},
-    tty::IsTty,
-    Result,
-};
-use koto::{bytecode::Chunk, Koto, KotoSettings};
 use std::{
-    cmp::Ordering,
     fmt,
     io::{self, Stdout, Write},
+    path::PathBuf,
 };
-use unicode_width::UnicodeWidthChar;
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+use crossterm::{
+    execute, style,
+    terminal::{self},
+    tty::IsTty,
+};
+use koto::prelude::*;
+use rustyline::{error::ReadlineError, Config, DefaultEditor, EditMode};
 
-const PROMPT: &str = "» ";
-const CONTINUED_PROMPT: &str = "… ";
-const RESULT_PROMPT: &str = "➝ ";
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-const INDENT_SIZE: usize = 2;
+use crate::help::Help;
 
 macro_rules! print_wrapped {
     ($stdout:expr, $text:expr) => {
@@ -32,221 +25,128 @@ macro_rules! print_wrapped {
     };
 }
 
+const PROMPT: &str = "» ";
+const CONTINUED_PROMPT: &str = "… ";
+const RESULT_PROMPT: &str = "➝ ";
+const INDENT_SIZE: usize = 2;
+const HISTORY_DIR: &str = ".koto";
+const HISTORY_FILE: &str = "repl_history.txt";
+const MAX_HISTORY_ENTRIES: usize = 500;
+
 #[derive(Default)]
 pub struct ReplSettings {
     pub show_bytecode: bool,
     pub show_instructions: bool,
 }
 
-#[derive(Default)]
 pub struct Repl {
     koto: Koto,
     settings: ReplSettings,
     help: Option<Help>,
-    // The current input line
-    input: Vec<char>,
-    // The index into the input vec, or 1 past the last entry
-    cursor: usize,
+    editor: DefaultEditor,
     // A buffer of lines for expressions that continue over multiple lines
     continued_lines: Vec<String>,
-    // The previously entered lines
-    input_history: Vec<String>,
-    // The current index in the history
-    history_position: Option<usize>,
+    indent: usize,
+}
+
+fn history_dir() -> Option<PathBuf> {
+    home::home_dir().map(|mut path| {
+        path.push(HISTORY_DIR);
+        path
+    })
+}
+
+fn history_path() -> Option<PathBuf> {
+    history_dir().map(|mut path| {
+        path.push(HISTORY_FILE);
+        path
+    })
 }
 
 impl Repl {
-    pub fn with_settings(repl_settings: ReplSettings, mut koto_settings: KotoSettings) -> Self {
+    pub fn with_settings(
+        repl_settings: ReplSettings,
+        mut koto_settings: KotoSettings,
+    ) -> Result<Self> {
         koto_settings.export_top_level_ids = true;
 
         let koto = Koto::with_settings(koto_settings);
-
         super::add_modules(&koto);
 
-        Self {
+        let mut editor = DefaultEditor::with_config(
+            Config::builder()
+                .max_history_size(MAX_HISTORY_ENTRIES)?
+                .edit_mode(EditMode::Emacs)
+                .build(),
+        )?;
+
+        if let Some(path) = history_path() {
+            editor.load_history(&path).ok();
+        }
+
+        Ok(Self {
             koto,
             settings: repl_settings,
-            ..Self::default()
-        }
+            help: None,
+            editor,
+            continued_lines: Vec::new(),
+            indent: 0,
+        })
     }
 
     pub fn run(&mut self) -> Result<()> {
         let mut stdout = io::stdout();
 
-        write!(stdout, "Welcome to Koto v{VERSION}\r\n{PROMPT}").unwrap();
-        stdout.flush().unwrap();
-
         loop {
-            if stdout.is_tty() {
-                terminal::enable_raw_mode()?;
-            }
+            let result = if self.continued_lines.is_empty() {
+                self.editor.readline(PROMPT)
+            } else {
+                let indent = " ".repeat(self.indent);
+                self.editor
+                    .readline_with_initial(CONTINUED_PROMPT, (&indent, ""))
+            };
 
-            if let Event::Key(key_event) = read()? {
-                // Handle the keypress
-                let should_exit = self.on_keypress(key_event, &mut stdout)?;
-
-                if should_exit {
-                    return Ok(());
+            match result {
+                Ok(line) => {
+                    self.on_line(&line, &mut stdout)?;
                 }
-
-                // Show the prompt
-                if stdout.is_tty() {
-                    let (_, cursor_y) = cursor::position()?;
-
-                    let prompt = if self.continued_lines.is_empty() {
-                        PROMPT
-                    } else {
-                        CONTINUED_PROMPT
-                    };
-
-                    queue!(
-                        stdout,
-                        cursor::MoveTo(0, cursor_y),
-                        terminal::Clear(ClearType::CurrentLine),
-                        style::Print(prompt),
-                        style::Print(&self.input.iter().collect::<String>()),
-                    )?;
-
-                    // Is the cursor inside the input?
-                    if self.cursor < self.input.len() {
-                        let cursor_x = prompt.len()
-                            + self.input[..self.cursor]
-                                .iter()
-                                .map(|c| c.width().unwrap_or(0))
-                                .sum::<usize>()
-                            - 1;
-
-                        queue!(stdout, cursor::MoveTo(cursor_x as u16, cursor_y))?;
-                    }
-
-                    stdout.flush().unwrap();
+                Err(ReadlineError::Interrupted) => {
+                    writeln!(stdout, "^C")?;
+                    break;
+                }
+                Err(ReadlineError::Eof) => {
+                    writeln!(stdout, "^D")?;
+                    break;
+                }
+                Err(err) => {
+                    writeln!(stdout, "Error: {:?}", err)?;
+                    break;
                 }
             }
         }
+
+        if let Some(mut path) = history_dir() {
+            std::fs::create_dir_all(&path)?;
+            path.push(HISTORY_FILE);
+            self.editor.save_history(&path)?;
+        }
+
+        Ok(())
     }
 
-    // Handles a single input keypress
-    //
-    // Returns true if the REPL should exit
-    fn on_keypress(&mut self, event: KeyEvent, stdout: &mut Stdout) -> Result<bool> {
-        match event.code {
-            KeyCode::Up => {
-                if !self.input_history.is_empty() {
-                    let new_position = match self.history_position {
-                        Some(position) => {
-                            if position > 0 {
-                                position - 1
-                            } else {
-                                0
-                            }
-                        }
-                        None => self.input_history.len() - 1,
-                    };
-                    self.history_position = Some(new_position);
-                    self.input = self.input_history[new_position].chars().collect();
-                    self.cursor = self.input.len();
-                }
-            }
-            KeyCode::Down => {
-                self.history_position = match self.history_position {
-                    Some(position) => {
-                        if position < self.input_history.len() - 1 {
-                            Some(position + 1)
-                        } else {
-                            None
-                        }
-                    }
-                    None => None,
-                };
-                if let Some(position) = self.history_position {
-                    self.input = self.input_history[position].chars().collect();
-                } else {
-                    self.input.clear();
-                }
-                self.cursor = self.input.len();
-            }
-            KeyCode::Left => {
-                if self.cursor > 0 {
-                    self.cursor -= 1;
-                }
-            }
-            KeyCode::Right => {
-                if self.cursor < self.input.len() {
-                    self.cursor += 1;
-                }
-            }
-            KeyCode::Backspace => {
-                if self.cursor > 0 {
-                    self.cursor -= 1;
-                    self.input.remove(self.cursor);
-                }
-            }
-            KeyCode::Delete => {
-                if self.cursor < self.input.len() {
-                    match self.cursor.cmp(&(self.input.len() - 1)) {
-                        Ordering::Less => {
-                            self.input.remove(self.cursor);
-                        }
-                        Ordering::Equal => {
-                            self.input.pop();
-                        }
-                        Ordering::Greater => {}
-                    }
-                }
-            }
-            KeyCode::Enter => self.on_enter(stdout)?,
-            KeyCode::Char(c) if event.modifiers.contains(KeyModifiers::CONTROL) => match c {
-                'c' => {
-                    if self.input.is_empty() {
-                        write!(stdout, "^C\r\n").unwrap();
-                        stdout.flush().unwrap();
-                        if stdout.is_tty() {
-                            terminal::disable_raw_mode()?;
-                        }
-                        return Ok(true);
-                    } else {
-                        self.input.clear();
-                        self.cursor = 0;
-                    }
-                }
-                'd' if self.input.is_empty() => {
-                    write!(stdout, "^D\r\n").unwrap();
-                    stdout.flush().unwrap();
-                    if stdout.is_tty() {
-                        terminal::disable_raw_mode()?;
-                    }
-                    return Ok(true);
-                }
-                _ => {}
-            },
-            KeyCode::Char(c) => {
-                self.input.insert(self.cursor, c);
-                self.cursor += 1;
-            }
-            _ => {}
-        }
-
-        Ok(false)
-    }
-
-    fn on_enter(&mut self, stdout: &mut Stdout) -> Result<()> {
-        if stdout.is_tty() {
-            terminal::disable_raw_mode()?;
-        }
-
-        writeln!(stdout)?;
+    fn on_line(&mut self, line: &str, stdout: &mut Stdout) -> Result<()> {
+        let input_is_whitespace = line.chars().all(|c| c.is_whitespace());
 
         let mut indent_next_line = false;
-
-        let input_is_whitespace = self.input.iter().all(|c| c.is_whitespace());
-        let entered_input = self.input.iter().collect::<String>();
 
         if self.continued_lines.is_empty() || input_is_whitespace {
             let mut input = self.continued_lines.join("\n");
 
             if !input_is_whitespace {
-                input += &entered_input;
+                input += line;
             }
+
+            self.editor.add_history_entry(&input)?;
 
             match self.koto.compile(&input) {
                 Ok(chunk) => {
@@ -293,9 +193,11 @@ impl Repl {
                     } else if compile_error.is_indentation_error()
                         && self.continued_lines.is_empty()
                     {
-                        self.continued_lines.push(entered_input.clone());
+                        self.continued_lines.push(line.to_string());
                         indent_next_line = true;
                     } else {
+                        self.editor.add_history_entry(&input)?;
+
                         print_error(stdout, &compile_error.to_string())?;
                         self.continued_lines.clear();
                     }
@@ -303,7 +205,7 @@ impl Repl {
             }
         } else {
             // We're in a continued expression, so cache the input for execution later
-            self.continued_lines.push(entered_input.clone());
+            self.continued_lines.push(line.to_string());
 
             // Check if we should add indentation on the next line
             let input = self.continued_lines.join("\n");
@@ -314,34 +216,22 @@ impl Repl {
             }
         }
 
-        if !input_is_whitespace
-            && (self.input_history.is_empty()
-                || self.input_history.last().unwrap() != &entered_input)
-        {
-            self.input_history.push(entered_input);
-        }
-
-        let current_indent = if self.continued_lines.is_empty() {
-            0
+        if self.continued_lines.is_empty() {
+            self.indent = 0;
         } else {
-            self.continued_lines
+            let current_indent = self
+                .continued_lines
                 .last()
                 .unwrap()
                 .find(|c: char| !c.is_whitespace())
-                .unwrap_or(0)
+                .unwrap_or(0);
+
+            self.indent = if indent_next_line {
+                current_indent + INDENT_SIZE
+            } else {
+                current_indent
+            };
         };
-
-        let indent = if indent_next_line {
-            current_indent + INDENT_SIZE
-        } else {
-            current_indent
-        };
-
-        self.input.clear();
-        self.input.resize(indent, ' ');
-        self.cursor = self.input.len();
-
-        self.history_position = None;
 
         Ok(())
     }
@@ -390,10 +280,12 @@ fn print_result(stdout: &mut Stdout, result: &str) -> Result<()> {
                 RESULT_PROMPT
             )),
             SetAttribute(Attribute::Reset),
-        )
+        )?;
     } else {
-        print_wrapped!(stdout, "{RESULT_CHAR}{result}\n\n")
+        print_wrapped!(stdout, "{RESULT_CHAR}{result}\n\n")?;
     }
+
+    Ok(())
 }
 
 fn print_error<E>(stdout: &mut Stdout, error: &E) -> Result<()>
@@ -415,8 +307,10 @@ where
                 "error: "
             )),
             SetAttribute(Attribute::Reset),
-        )
+        )?;
     } else {
-        print_wrapped!(stdout, "{error:#}")
+        print_wrapped!(stdout, "{error:#}")?;
     }
+
+    Ok(())
 }

--- a/core/runtime/src/types/value_number.rs
+++ b/core/runtime/src/types/value_number.rs
@@ -57,6 +57,11 @@ impl ValueNumber {
         matches!(self, Self::F64(_))
     }
 
+    /// Returns true if the number is represented by an `i64`
+    pub fn is_i64(self) -> bool {
+        matches!(self, Self::I64(_))
+    }
+
     /// Returns true if the integer version of the number is representable by an `f64`
     pub fn is_i64_in_f64_range(&self) -> bool {
         if let Self::I64(n) = *self {


### PR DESCRIPTION
- Replace REPL implementation with Rustyline
- Disable colored REPL output when the NO_COLOR env var is set
  - Fixes #104
- Enable VI style editing in the repl
- Add support for loading a config file for the REPL
