### PR TITLE
Reintroduce the `+` operator for containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The Koto project adheres to
 
 ## Unreleased
 
+### Added
+
+#### Language
+
+- The `+` operator has been reintroduced for tuples, lists, and maps.
+
 ### Changed
 
 - The REPL `config.koto` settings have all been moved into a `repl` sub-map.

--- a/core/runtime/tests/vm_tests.rs
+++ b/core/runtime/tests/vm_tests.rs
@@ -245,6 +245,11 @@ a %= 5
         fn tuple_slicing() {
             test_script("(0, 1, 2, 3, 4, 5)[2..=4]", number_tuple(&[2, 3, 4]));
         }
+
+        #[test]
+        fn addition() {
+            test_script("(1, 2, 3) + (4, 5, 6)", number_tuple(&[1, 2, 3, 4, 5, 6]));
+        }
     }
 
     mod lists {
@@ -397,6 +402,11 @@ l2 = copy l
 l[1] = -1
 l2[1]";
             test_script(script, 2);
+        }
+
+        #[test]
+        fn addition() {
+            test_script("[1, 2, 3] + [4, 5, 6]", number_list(&[1, 2, 3, 4, 5, 6]));
         }
     }
 
@@ -1992,6 +2002,17 @@ m.foo = -1
 m2.foo";
             test_script(script, 42);
         }
+
+        #[test]
+        fn addition() {
+            let script = "
+a = {foo: 42}
+b = {bar: 99}
+c = a + b
+c.foo + c.bar
+";
+            test_script(script, 141);
+        }
     }
 
     mod lookups {
@@ -2997,6 +3018,26 @@ foos = (0, 1)
 foos[0] == foos[1]
 ";
             test_script(script, true);
+        }
+
+        #[test]
+        fn map_addition_with_overloaded_operators() {
+            let script = "
+foo = |a, b|
+  @meta a: a
+  @meta b: b
+  get_a: || self.a
+  get_b: || self.b
+
+bar = |b|
+  @meta b: b
+
+a = foo 100, 42
+b = bar 1000
+c = a + b
+c.get_a() + c.get_b()
+";
+            test_script(script, 1100);
         }
     }
 

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -70,9 +70,9 @@ followed by the output of the second iterator.
 
 ```koto
 print! [1, 2]
-  .chain [3, 4, 5]
+  .chain 'abc'
   .to_tuple()
-check! (1, 2, 3, 4, 5)
+check! (1, 2, 'a', 'b', 'c')
 ```
 
 ## chunks

--- a/docs/language/lists.md
+++ b/docs/language/lists.md
@@ -32,3 +32,12 @@ y[1] = 99
 print! x # x and y share the same data
 check! [10, 99, 30]
 ```
+
+Lists can be joined together with the `+` operator.
+
+```koto
+a = ['a', 'b', 'c']
+b = a + [1, 2, 3]
+print! b
+check! ['a', 'b', 'c', 1, 2, 3]
+```

--- a/docs/language/maps.md
+++ b/docs/language/maps.md
@@ -38,6 +38,16 @@ print! m.hello.to.you
 check! -1
 ```
 
+Maps can be joined together with the `+` operator.
+
+```koto
+a = {red: 100, blue: 150}
+b = {green: 200}
+c = a + b
+print! c
+check! {red: 100, blue: 150, green: 200}
+```
+
 ## Shorthand Values
 
 When using inline syntax, if there's a value available that matches a key's name, then declaring the value is optional.

--- a/docs/language/tuples.md
+++ b/docs/language/tuples.md
@@ -24,6 +24,15 @@ print! x, y
 check! (('a', 10), ('b', 20))
 ```
 
+Tuples can be joined together with the `+` operator.
+
+```koto
+a = (1, 2, 3)
+b = a + (4, 5, 6)
+print! b
+check! (1, 2, 3, 4, 5, 6)
+```
+
 To create an empty Tuple, or a Tuple with a single entry, use a trailing `,` inside the parentheses.
 
 ```koto


### PR DESCRIPTION
The `+` operator was previously removed for containers in favour of using
`iterator.chain()` along with `to_container` calls.

This is rather cumbersome for simple use cases though, and having basic addition
support for matching container types seems like an overall usability win.
