### PR TITLE
Update string.to_number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ The Koto project adheres to
 
 ### Changed
 
+#### Core Library
+
+- `string.to_number` changes:
+  - `0x`, `0o`, and `0b` prefixes are understood for parsing hex, octal, or
+    binary numbers respectively.
+  - An overload has been added that accepts a number base between 2 and 36.
+  - If the string doesn't contain a number null is now returned instead of an
+    exception being thrown.
+
+#### REPL
+
 - The REPL `config.koto` settings have all been moved into a `repl` sub-map.
   - e.g. 
     `export { edit_mode: 'vi' }` is now `export { repl: { edit_mode: 'vi' }}`

--- a/docs/core_lib/string.md
+++ b/docs/core_lib/string.md
@@ -365,7 +365,23 @@ check! o_o
 |String| -> Number
 ```
 
-Returns the string parsed as a number.
+Returns the string converted into a number.
+- `0x`, `0o`, and `0b` prefixes will cause the parsing to treat the input as
+  containing a hexadecimal, octal, or binary number respectively.
+- Otherwise the number is assumed to be base 10, and the presence of a decimal
+  point will produce a float instead of an integer.
+
+If a number can't be produced then `Null` is returned.
+
+```kototype
+|String, Integer| -> Integer
+```
+
+Returns the string converted into an integer given the specified base.
+
+The base must be in the range `2..=36`, otherwise an error will be thrown.
+
+If the string contains non-numerical digits then `Null` is returned.
 
 ### Example
 
@@ -375,6 +391,15 @@ check! 123
 
 print! '-8.9'.to_number()
 check! -8.9
+
+print! '0x7f'.to_number()
+check! 127
+
+print! '0b10101'.to_number()
+check! 21
+
+print! '2N9C'.to_number(36)
+check! 123456
 ```
 
 ## to_uppercase

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -144,11 +144,17 @@ zzz
     assert_eq (string.to_lowercase "HÉLLÖ"), "héllö"
 
   @test to_number: ||
-    x = string.to_number "42"
-    assert_eq x, 42
-    assert_eq type(x), "Int"
+    check_int = |s, n|
+      x = s.to_number()
+      assert_eq x, n
+      assert_eq type(x), 'Int'
 
-    x = string.to_number "-1.5"
+    check_int '42', 42
+    check_int '0xdeadbeef', 3735928559
+    check_int '0b101010', 42
+    check_int '0o173', 123
+
+    x = '-1.5'.to_number()
     assert_eq x, -1.5
     assert_eq type(x), "Float"
 


### PR DESCRIPTION
- Add `0x`/`0o`/`0b` number parsing to `string.to_number`.
- Add an overload for providing a specific base.
- Return `null` when parsing fails rather than throwing an exception.
