### PR TITLE
REPL improvements

### DIFF
--- a/core/cli/src/help.rs
+++ b/core/cli/src/help.rs
@@ -38,6 +38,7 @@ impl Help {
             include_doc!("language/maps.md"),
             include_doc!("language/meta_maps.md"),
             include_doc!("language/modules.md"),
+            include_doc!("language/prelude.md"),
             include_doc!("language/ranges.md"),
             include_doc!("language/strings.md"),
             include_doc!("language/testing.md"),

--- a/core/cli/src/help.rs
+++ b/core/cli/src/help.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use std::iter::Peekable;
 
-const HELP_RESULT_STR: &str = "# ➝ ";
+const HELP_RESULT_STR: &str = "➝ ";
 const HELP_INDENT: usize = 2;
 
 struct HelpEntry {

--- a/core/cli/src/help.rs
+++ b/core/cli/src/help.rs
@@ -78,8 +78,8 @@ impl Help {
     pub fn get_help(&self, search: Option<&str>) -> String {
         match search {
             Some(search) => {
-                let search_lower = search.trim().to_lowercase();
-                match self.help_map.get(&search_lower) {
+                let search = text_to_key(search);
+                match self.help_map.get(&search) {
                     Some(entry) => {
                         let mut help = format!(
                             "{indent}{name}\n{indent}{underline}{help}",
@@ -89,7 +89,7 @@ impl Help {
                             help = entry.help
                         );
 
-                        let sub_match = format!("{search_lower}.");
+                        let sub_match = format!("{search}.");
                         let match_level = sub_match.chars().filter(|&c| c == '.').count();
                         let sub_entries = self
                             .help_map
@@ -125,7 +125,7 @@ impl Help {
                         let matches = self
                             .help_map
                             .iter()
-                            .filter(|(key, _)| key.contains(&search_lower))
+                            .filter(|(key, _)| key.contains(&search))
                             .collect::<Vec<_>>();
 
                         match matches.as_slice() {
@@ -200,7 +200,7 @@ impl Help {
         let (file_name, help) = consume_help_section(&mut parser, None);
         if !help.trim().is_empty() {
             self.help_map.insert(
-                file_name.to_lowercase().replace(' ', "_"),
+                text_to_key(&file_name),
                 HelpEntry {
                     name: file_name,
                     help,
@@ -212,7 +212,7 @@ impl Help {
         while parser.peek().is_some() {
             let (entry_name, help) = consume_help_section(&mut parser, None);
             self.help_map.insert(
-                entry_name.to_lowercase().replace(' ', "_"),
+                text_to_key(&entry_name),
                 HelpEntry {
                     name: entry_name,
                     help,
@@ -227,7 +227,7 @@ impl Help {
         let (module_name, help) = consume_help_section(&mut parser, None);
         if !help.trim().is_empty() {
             self.help_map.insert(
-                module_name.clone(),
+                text_to_key(&module_name),
                 HelpEntry {
                     name: module_name.clone(),
                     help,
@@ -240,7 +240,7 @@ impl Help {
         while parser.peek().is_some() {
             let (entry_name, help) = consume_help_section(&mut parser, Some(&module_name));
             self.help_map.insert(
-                entry_name.to_lowercase(),
+                text_to_key(&entry_name),
                 HelpEntry {
                     name: entry_name,
                     help,
@@ -248,6 +248,10 @@ impl Help {
             );
         }
     }
+}
+
+fn text_to_key(text: &str) -> String {
+    text.trim().to_lowercase().replace(' ', "_")
 }
 
 fn consume_help_section(

--- a/core/cli/src/repl.rs
+++ b/core/cli/src/repl.rs
@@ -251,7 +251,7 @@ impl Repl {
         } else if input.starts_with("help") {
             input
                 .split_once(char::is_whitespace)
-                .map(|(_, search_string)| format!("\n{}", self.get_help(Some(search_string))))
+                .map(|(_, search_string)| format!("\n{}\n", self.get_help(Some(search_string))))
         } else {
             None
         }

--- a/core/koto/tests/repl_mode_tests.rs
+++ b/core/koto/tests/repl_mode_tests.rs
@@ -93,7 +93,24 @@ mod repl_mode {
     }
 
     #[test]
-    fn import_print() {
+    fn import_single_item() {
+        run_repl_mode_test(&[
+            ("from string import to_number", ""),
+            ("print to_number '0x7f'", "127"),
+        ]);
+    }
+
+    #[test]
+    fn import_multiple_items() {
+        run_repl_mode_test(&[
+            ("from string import to_lowercase, to_uppercase", ""),
+            ("print to_lowercase 'HEY'", "hey"),
+            ("print to_uppercase 'hey'", "HEY"),
+        ]);
+    }
+
+    #[test]
+    fn import_with_assignment() {
         run_repl_mode_test(&[
             ("print2 = from io import print", ""),
             ("print2 'hello!'", "hello!"),

--- a/docs/language/prelude.md
+++ b/docs/language/prelude.md
@@ -3,7 +3,7 @@
 The prelude is a collection of items that are automatically available in a Koto
 script without needing to be imported.
 
-The core library modules are automatically available in the prelude, 
+The core library modules are automatically available in the prelude,
 along with the following functions from the core library.
 
 - [`io.print`](../../core/io#print)


### PR DESCRIPTION
- Fix importing items in the REPL
- Tweak the help docs result prefix
- Improve help search so that guide topics with spaces can be accessed directly
- Add a newline after displaying help
- Include the prelude docs in repl help
