### PR TITLE
Check for null on the LHS of equality comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ The Koto project adheres to
   - `0x`, `0o`, and `0b` prefixes are understood for parsing hex, octal, or
     binary numbers respectively.
   - An overload has been added that accepts a number base between 2 and 36.
-  - If the string doesn't contain a number null is now returned instead of an
+  - If the string doesn't contain a number, `null` is now returned instead of an
     exception being thrown.
+- Objects can be compared with `null` on the LHS without having to implement 
+  `KotoObject::equal` and/or `not_equal`.
 
 #### REPL
 

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -1732,11 +1732,12 @@ impl Vm {
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
         let result_value = match (lhs_value, rhs_value) {
+            (Null, Null) => true,
+            (Null, _) | (_, Null) => false,
             (Number(a), Number(b)) => a == b,
             (Bool(a), Bool(b)) => a == b,
             (Str(a), Str(b)) => a == b,
             (Range(a), Range(b)) => a == b,
-            (Null, Null) => true,
             (List(a), List(b)) => {
                 let a = a.clone();
                 let b = b.clone();
@@ -1791,11 +1792,12 @@ impl Vm {
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
         let result_value = match (lhs_value, rhs_value) {
+            (Null, Null) => false,
+            (Null, _) | (_, Null) => true,
             (Number(a), Number(b)) => a != b,
             (Bool(a), Bool(b)) => a != b,
             (Str(a), Str(b)) => a != b,
             (Range(a), Range(b)) => a != b,
-            (Null, Null) => false,
             (List(a), List(b)) => {
                 let a = a.clone();
                 let b = b.clone();

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -368,7 +368,6 @@ make_object(10)
 
     mod binary_op {
         use super::*;
-        use Value::Bool;
 
         #[test]
         fn add() {
@@ -523,25 +522,49 @@ x.to_number()
         #[test]
         fn less() {
             let script = "(make_object 1) < (make_object 2)";
-            test_object_script(script, Bool(true));
+            test_object_script(script, true);
         }
 
         #[test]
         fn less_or_equal() {
             let script = "(make_object 2) <= (make_object 2)";
-            test_object_script(script, Bool(true));
+            test_object_script(script, true);
         }
 
         #[test]
         fn equal() {
             let script = "(make_object 2) == (make_object 3)";
-            test_object_script(script, Bool(false));
+            test_object_script(script, false);
         }
 
         #[test]
         fn not_equal() {
             let script = "(make_object 2) != (make_object 3)";
-            test_object_script(script, Bool(true));
+            test_object_script(script, true);
+        }
+
+        #[test]
+        fn equal_null_lhs() {
+            let script = "(make_object 2) == null";
+            test_object_script(script, false);
+        }
+
+        #[test]
+        fn equal_null_rhs() {
+            let script = "null == (make_object 2)";
+            test_object_script(script, false);
+        }
+
+        #[test]
+        fn not_equal_null_lhs() {
+            let script = "(make_object 2) != null";
+            test_object_script(script, true);
+        }
+
+        #[test]
+        fn not_equal_null_rhs() {
+            let script = "null != (make_object 2)";
+            test_object_script(script, true);
         }
 
         #[test]


### PR DESCRIPTION
This PR changes the equality comparisons so that `null` on the LHS is treated as a special case, so that `Object`s don't have to implement `KotoObject::equal`/`not_equal` for `null` comparisons to work as expected.

Fixes #268.
