### PR TITLE
Some API tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,19 @@ The Koto project adheres to
 - The `+` operator has been reintroduced for tuples, lists, and maps.
 - Raw strings are now supported. Any string prefixed with `r` will skip
   character escaping and string interpolation.
-- `as` is now available in import expressions for more ergonomic item renaming.
+- `import` expressions can now use `as` for more ergonomic item renaming.
 - Assignments can now be used in `while`/`until` conditions.
 
 #### API
 
 - The `koto_derive` crate has been introduced containing derive macros that make
   it easier to implement `KotoObject`s.
+- `Koto::run_instance_function` has been added.
+- `Ptr`/`PtrMut` now have an associated `ref_count` function.
+
+#### Libs
+
+- A `regex` module has been added, thanks to [@jasal92](https://github.com/jasal82).
 
 ### Changed
 
@@ -35,6 +41,12 @@ The Koto project adheres to
     exception being thrown.
 - Objects can be compared with `null` on the LHS without having to implement 
   `KotoObject::equal` and/or `not_equal`.
+
+#### API
+
+- `Vm` has been renamed to `KotoVm` for the sake of clarity.
+- `Value` has been renamed to `KValue` for consistency with the other core
+  runtime value types, and to avoid polluting the prelude with a generic name.
 
 #### Internals
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -264,15 +264,15 @@ fn load_config(config_path: Option<&String>) -> Result<Config> {
             Ok(_) => {
                 let exports = koto.exports().data();
                 match exports.get("repl") {
-                    Some(Value::Map(repl_config)) => {
+                    Some(KValue::Map(repl_config)) => {
                         let repl_config = repl_config.data();
                         match repl_config.get("colored_output") {
-                            Some(Value::Bool(value)) => config.colored_output = *value,
+                            Some(KValue::Bool(value)) => config.colored_output = *value,
                             Some(_) => bail!("expected bool for colored_output setting"),
                             None => {}
                         }
                         match repl_config.get("edit_mode") {
-                            Some(Value::Str(value)) => match value.as_str() {
+                            Some(KValue::Str(value)) => match value.as_str() {
                                 "emacs" => config.edit_mode = EditMode::Emacs,
                                 "vi" => config.edit_mode = EditMode::Vi,
                                 other => {
@@ -286,7 +286,7 @@ fn load_config(config_path: Option<&String>) -> Result<Config> {
                             None => {}
                         }
                         match repl_config.get("max_history") {
-                            Some(Value::Number(value)) => match value.as_i64() {
+                            Some(KValue::Number(value)) => match value.as_i64() {
                                 value if value > 0 => config.max_history = value as usize,
                                 _ => bail!("expected positive number for max_history setting"),
                             },

--- a/crates/derive/src/koto_impl.rs
+++ b/crates/derive/src/koto_impl.rs
@@ -82,7 +82,7 @@ pub(crate) fn generate_koto_lookup_entries(attr: TokenStream, item: TokenStream)
 
         #[automatically_derived]
         impl #runtime::KotoLookup for #struct_ident {
-            fn lookup(&self, key: &#runtime::ValueKey) -> Option<#runtime::Value> {
+            fn lookup(&self, key: &#runtime::ValueKey) -> Option<#runtime::KValue> {
                 #entries_map_name.with(|entries| entries.get(key).cloned())
             }
         }
@@ -131,7 +131,7 @@ fn wrap_method(
             let wrapped_call = match return_type {
                 MethodReturnType::None => quote! {
                     #call;
-                    Ok(#runtime::Value::Null)
+                    Ok(#runtime::KValue::Null)
                 },
                 MethodReturnType::Value => quote! { Ok(#call) },
                 MethodReturnType::Result => call,
@@ -139,9 +139,9 @@ fn wrap_method(
 
             quote! {
                 match ctx.instance_and_args(
-                    |i| matches!(i, #runtime::Value::Object(_)), #type_name)?
+                    |i| matches!(i, #runtime::KValue::Object(_)), #type_name)?
                 {
-                    (#runtime::Value::Object(o), #args_match) => {
+                    (#runtime::KValue::Object(o), #args_match) => {
                         match o.#cast::<#struct_ident>() {
                             Ok(#instance) => {
                                 #wrapped_call
@@ -159,7 +159,7 @@ fn wrap_method(
             let wrapped_call = match return_type {
                 MethodReturnType::None => quote! {
                     #call;
-                    Ok(#runtime::Value::Null)
+                    Ok(#runtime::KValue::Null)
                 },
                 MethodReturnType::Value => quote! { Ok(#call) },
                 MethodReturnType::Result => call,
@@ -167,9 +167,9 @@ fn wrap_method(
 
             quote! {
                 match ctx.instance_and_args(
-                    |i| matches!(i, #runtime::Value::Object(_)), #type_name)?
+                    |i| matches!(i, #runtime::KValue::Object(_)), #type_name)?
                 {
-                    (#runtime::Value::Object(o), extra_args) => { #wrapped_call }
+                    (#runtime::KValue::Object(o), extra_args) => { #wrapped_call }
                     (_, other) => #runtime::type_error_with_slice(#type_name, other),
                 }
             }
@@ -178,7 +178,7 @@ fn wrap_method(
 
     let wrapper = quote! {
         #[automatically_derived]
-        fn #wrapper_name(ctx: &mut #runtime::CallContext) -> #runtime::Result<#runtime::Value> {
+        fn #wrapper_name(ctx: &mut #runtime::CallContext) -> #runtime::Result<#runtime::KValue> {
             #wrapper_body
         }
     };
@@ -211,14 +211,14 @@ fn lookup_insert(
             .expect("failed to parse koto_method attribute");
 
         quote! {
-            let f = #runtime::Value::NativeFunction(#runtime::KNativeFunction::new(#wrapper_name));
+            let f = #runtime::KValue::NativeFunction(#runtime::KNativeFunction::new(#wrapper_name));
             #(result.insert(#fn_names.into(), f.clone());)*
         }
     } else {
         quote! {
             result.insert(
                 #fn_name.into(),
-                #runtime::Value::NativeFunction(#runtime::KNativeFunction::new(#wrapper_name)));
+                #runtime::KValue::NativeFunction(#runtime::KNativeFunction::new(#wrapper_name)));
         }
     }
 }
@@ -234,7 +234,7 @@ fn detect_return_type(return_type: &ReturnType) -> MethodReturnType {
         ReturnType::Default => MethodReturnType::None,
         ReturnType::Type(_, ty) => match ty.as_ref() {
             Type::Tuple(t) if t.elems.is_empty() => MethodReturnType::None,
-            Type::Path(p) if p.path.is_ident("Value") => MethodReturnType::Value,
+            Type::Path(p) if p.path.is_ident("KValue") => MethodReturnType::Value,
             // Default to expecting a Result to be the return value
             // Ideally we would detect that this is precisely koto_runtime::Result,
             // but in practice type aliases may be used so we should just let the compiler complain

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -119,6 +119,18 @@ impl Koto {
             .map_err(|e| e.into())
     }
 
+    /// Runs an instance function with the given arguments
+    pub fn run_instance_function(
+        &mut self,
+        instance: Value,
+        function: Value,
+        args: CallArgs,
+    ) -> Result<Value> {
+        self.runtime
+            .run_instance_function(instance, function, args)
+            .map_err(|e| e.into())
+    }
+
     /// Runs a function in the runtime's exports map
     ///
     /// ```

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Error, Result};
+use crate::{prelude::*, Error, Ptr, Result};
 use dunce::canonicalize;
 use koto_bytecode::CompilerSettings;
 use koto_runtime::{KotoVm, ModuleImportedCallback};

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -1,12 +1,12 @@
 use crate::{prelude::*, Error, Result};
 use dunce::canonicalize;
 use koto_bytecode::CompilerSettings;
-use koto_runtime::ModuleImportedCallback;
+use koto_runtime::{KotoVm, ModuleImportedCallback};
 use std::path::PathBuf;
 
 /// The main interface for the Koto language.
 ///
-/// This provides a high-level API for compiling and executing Koto scripts in a Koto [Vm].
+/// This provides a high-level API for compiling and executing Koto scripts in a Koto [Vm](KotoVm).
 ///
 /// Example:
 ///
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 /// }
 /// ```
 pub struct Koto {
-    runtime: Vm,
+    runtime: KotoVm,
     run_tests: bool,
     export_top_level_ids: bool,
     script_path: Option<PathBuf>,
@@ -49,7 +49,7 @@ impl Koto {
     /// Creates a new instance of Koto with the given settings
     pub fn with_settings(settings: KotoSettings) -> Self {
         Self {
-            runtime: Vm::with_settings(VmSettings {
+            runtime: KotoVm::with_settings(KotoVmSettings {
                 stdin: settings.stdin,
                 stdout: settings.stdout,
                 stderr: settings.stderr,
@@ -329,7 +329,7 @@ impl KotoSettings {
 
 impl Default for KotoSettings {
     fn default() -> Self {
-        let default_vm_settings = VmSettings::default();
+        let default_vm_settings = KotoVmSettings::default();
         Self {
             run_tests: true,
             run_import_tests: true,

--- a/crates/koto/src/lib.rs
+++ b/crates/koto/src/lib.rs
@@ -35,7 +35,7 @@ pub mod prelude;
 pub use koto_bytecode as bytecode;
 pub use koto_parser as parser;
 pub use koto_runtime as runtime;
-pub use koto_runtime::derive;
+pub use koto_runtime::{derive, Borrow, BorrowMut, Ptr, PtrMut};
 
 pub use crate::error::{Error, Result};
 pub use crate::koto::{Koto, KotoSettings};

--- a/crates/koto/src/lib.rs
+++ b/crates/koto/src/lib.rs
@@ -13,7 +13,7 @@
 //! match koto.compile("1 + 2") {
 //!     Ok(_) => match koto.run() {
 //!         Ok(result) => match result {
-//!             Value::Number(n) => println!("{n}"), // 3.0
+//!             KValue::Number(n) => println!("{n}"), // 3.0
 //!             other => panic!("Unexpected result type: {}", other.type_as_string()),
 //!         },
 //!         Err(runtime_error) => {

--- a/crates/koto/tests/docs_examples.rs
+++ b/crates/koto/tests/docs_examples.rs
@@ -1,4 +1,4 @@
-use koto::{prelude::*, runtime::Result};
+use koto::{prelude::*, runtime::Result, Ptr, PtrMut};
 use std::{
     ops::Deref,
     path::{Path, PathBuf},

--- a/crates/koto/tests/koto_tests.rs
+++ b/crates/koto/tests/koto_tests.rs
@@ -1,4 +1,4 @@
-use koto::prelude::*;
+use koto::{prelude::*, PtrMut};
 use std::{
     fs::read_to_string,
     path::{Path, PathBuf},

--- a/crates/koto/tests/repl_mode_tests.rs
+++ b/crates/koto/tests/repl_mode_tests.rs
@@ -5,7 +5,7 @@
 //! The exports map gets populated with any top-level assigned IDs, and is then made available to
 //! each subsequent chunk.
 
-use koto::{prelude::*, runtime::Result};
+use koto::{prelude::*, runtime::Result, Ptr, PtrMut};
 
 fn run_repl_mode_test(inputs_and_expected_outputs: &[(&str, &str)]) {
     let output = PtrMut::from(String::new());

--- a/crates/memory/src/arc/ptr.rs
+++ b/crates/memory/src/arc/ptr.rs
@@ -39,6 +39,13 @@ impl<T: ?Sized> Ptr<T> {
     pub fn address(this: &Self) -> Address {
         Arc::as_ptr(&this.0).into()
     }
+
+    /// Returns the number of references to the allocated memory
+    ///
+    /// Only strong references are counted, weak references don't get added to the result.
+    pub fn ref_count(this: &Self) -> usize {
+        Arc::strong_count(&this.0)
+    }
 }
 
 impl<T: Clone> Ptr<T> {

--- a/crates/memory/src/rc/ptr.rs
+++ b/crates/memory/src/rc/ptr.rs
@@ -46,6 +46,13 @@ impl<T: ?Sized> Ptr<T> {
     pub fn address(this: &Self) -> Address {
         Rc::as_ptr(&this.0).into()
     }
+
+    /// Returns the number of references to the allocated memory
+    ///
+    /// Only strong references are counted, weak references don't get added to the result.
+    pub fn ref_count(this: &Self) -> usize {
+        Rc::strong_count(&this.0)
+    }
 }
 
 impl<T: Clone> Ptr<T> {

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -1,7 +1,7 @@
 //! The `io` core library module
 
 use super::string::format;
-use crate::{derive::*, prelude::*, BufferedFile, Error, KotoVm, MethodContext, Result};
+use crate::{derive::*, prelude::*, BufferedFile, Error, KotoVm, MethodContext, Ptr, Result};
 use std::{
     fmt, fs,
     io::{self, BufRead, Read, Seek, SeekFrom, Write},

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -1,7 +1,7 @@
 //! The `io` core library module
 
 use super::string::format;
-use crate::{derive::*, prelude::*, BufferedFile, Error, MethodContext, Result};
+use crate::{derive::*, prelude::*, BufferedFile, Error, KotoVm, MethodContext, Result};
 use std::{
     fmt, fs,
     io::{self, BufRead, Read, Seek, SeekFrom, Write},
@@ -165,15 +165,15 @@ impl File {
         Self(make_ptr!(BufferedSystemFile::new(file, path))).into()
     }
 
-    fn stderr(vm: &Vm) -> KValue {
+    fn stderr(vm: &KotoVm) -> KValue {
         Self(vm.stderr().clone()).into()
     }
 
-    fn stdin(vm: &Vm) -> KValue {
+    fn stdin(vm: &KotoVm) -> KValue {
         Self(vm.stdin().clone()).into()
     }
 
-    fn stdout(vm: &Vm) -> KValue {
+    fn stdout(vm: &KotoVm) -> KValue {
         Self(vm.stdout().clone()).into()
     }
 

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -10,7 +10,7 @@ use std::{
 
 /// The initializer for the io module
 pub fn make_module() -> KMap {
-    use Value::{Bool, Null, Str};
+    use KValue::{Bool, Null, Str};
 
     let result = KMap::with_type("core.io");
 
@@ -97,7 +97,7 @@ pub fn make_module() -> KMap {
                 let tuple_data = Vec::from(values);
                 match ctx
                     .vm
-                    .run_unary_op(crate::UnaryOp::Display, Value::Tuple(tuple_data.into()))?
+                    .run_unary_op(crate::UnaryOp::Display, KValue::Tuple(tuple_data.into()))?
                 {
                     Str(s) => ctx.vm.stdout().write_line(s.as_str()),
                     unexpected => return type_error("string from @display", &unexpected),
@@ -129,7 +129,7 @@ pub fn make_module() -> KMap {
             [Str(path)] => {
                 let path = Path::new(path.as_str());
                 match fs::remove_file(path) {
-                    Ok(_) => Ok(Value::Null),
+                    Ok(_) => Ok(KValue::Null),
                     Err(error) => runtime_error!(
                         "io.remove_file: Error while removing file '{}': {error}",
                         path.to_string_lossy(),
@@ -158,63 +158,63 @@ pub struct File(Ptr<dyn KotoFile>);
 #[koto_impl(runtime = crate)]
 impl File {
     /// Wraps a file that implements traits typical of a system file in a buffered reader/writer
-    pub fn system_file<T>(file: T, path: PathBuf) -> Value
+    pub fn system_file<T>(file: T, path: PathBuf) -> KValue
     where
         T: Read + Write + Seek + KotoSend + KotoSync + 'static,
     {
         Self(make_ptr!(BufferedSystemFile::new(file, path))).into()
     }
 
-    fn stderr(vm: &Vm) -> Value {
+    fn stderr(vm: &Vm) -> KValue {
         Self(vm.stderr().clone()).into()
     }
 
-    fn stdin(vm: &Vm) -> Value {
+    fn stdin(vm: &Vm) -> KValue {
         Self(vm.stdin().clone()).into()
     }
 
-    fn stdout(vm: &Vm) -> Value {
+    fn stdout(vm: &Vm) -> KValue {
         Self(vm.stdout().clone()).into()
     }
 
     #[koto_method]
-    fn flush(&mut self) -> Result<Value> {
-        self.0.flush().map(|_| Value::Null)
+    fn flush(&mut self) -> Result<KValue> {
+        self.0.flush().map(|_| KValue::Null)
     }
 
     #[koto_method]
-    fn path(&self) -> Result<Value> {
-        self.0.path().map(Value::from)
+    fn path(&self) -> Result<KValue> {
+        self.0.path().map(KValue::from)
     }
 
     #[koto_method]
-    fn read_line(&mut self) -> Result<Value> {
+    fn read_line(&mut self) -> Result<KValue> {
         self.0.read_line().map(|result| match result {
             Some(result) => {
                 if !result.is_empty() {
                     let newline_bytes = if result.ends_with("\r\n") { 2 } else { 1 };
                     result[..result.len() - newline_bytes].into()
                 } else {
-                    Value::Null
+                    KValue::Null
                 }
             }
-            None => Value::Null,
+            None => KValue::Null,
         })
     }
 
     #[koto_method]
-    fn read_to_string(&mut self) -> Result<Value> {
-        self.0.read_to_string().map(Value::from)
+    fn read_to_string(&mut self) -> Result<KValue> {
+        self.0.read_to_string().map(KValue::from)
     }
 
     #[koto_method]
-    fn seek(&mut self, args: &[Value]) -> Result<Value> {
+    fn seek(&mut self, args: &[KValue]) -> Result<KValue> {
         match args {
-            [Value::Number(n)] => {
+            [KValue::Number(n)] => {
                 if *n < 0.0 {
                     return runtime_error!("Negative seek positions not allowed");
                 }
-                self.0.seek(n.into()).map(|_| Value::Null)
+                self.0.seek(n.into()).map(|_| KValue::Null)
             }
             unexpected => {
                 type_error_with_slice("a non-negative Number as the seek position", unexpected)
@@ -223,7 +223,7 @@ impl File {
     }
 
     #[koto_method]
-    fn write(ctx: MethodContext<Self>) -> Result<Value> {
+    fn write(ctx: MethodContext<Self>) -> Result<KValue> {
         match ctx.args {
             [value] => {
                 let mut display_context = DisplayContext::with_vm(ctx.vm);
@@ -231,14 +231,14 @@ impl File {
                 ctx.instance_mut()?
                     .0
                     .write(display_context.result().as_bytes())
-                    .map(|_| Value::Null)
+                    .map(|_| KValue::Null)
             }
             unexpected => type_error_with_slice("a single argument", unexpected),
         }
     }
 
     #[koto_method]
-    fn write_line(ctx: MethodContext<Self>) -> Result<Value> {
+    fn write_line(ctx: MethodContext<Self>) -> Result<KValue> {
         let mut display_context = DisplayContext::with_vm(ctx.vm);
         match ctx.args {
             [] => {}
@@ -249,7 +249,7 @@ impl File {
         ctx.instance_mut()?
             .0
             .write(display_context.result().as_bytes())
-            .map(|_| Value::Null)
+            .map(|_| KValue::Null)
     }
 }
 
@@ -260,7 +260,7 @@ impl KotoObject for File {
     }
 }
 
-impl From<File> for Value {
+impl From<File> for KValue {
     fn from(file: File) -> Self {
         KObject::from(file).into()
     }

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -13,7 +13,7 @@ pub fn make_module() -> KMap {
     result.add_fn("all", |ctx| {
         let expected_error = "an iterable and predicate function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
                 let iterable = iterable.clone();
                 let predicate = predicate.clone();
@@ -30,7 +30,7 @@ pub fn make_module() -> KMap {
                     };
 
                     match predicate_result {
-                        Ok(Value::Bool(result)) => {
+                        Ok(KValue::Bool(result)) => {
                             if !result {
                                 return Ok(false.into());
                             }
@@ -54,7 +54,7 @@ pub fn make_module() -> KMap {
     result.add_fn("any", |ctx| {
         let expected_error = "an iterable and predicate function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
                 let iterable = iterable.clone();
                 let predicate = predicate.clone();
@@ -71,7 +71,7 @@ pub fn make_module() -> KMap {
                     };
 
                     match predicate_result {
-                        Ok(Value::Bool(result)) => {
+                        Ok(KValue::Bool(result)) => {
                             if result {
                                 return Ok(true.into());
                             }
@@ -94,7 +94,7 @@ pub fn make_module() -> KMap {
 
     result.add_fn("chain", |ctx| {
         let expected_error = "two iterable values";
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable_a, [iterable_b]) if iterable_b.is_iterable() => {
                 let iterable_a = iterable_a.clone();
                 let iterable_b = iterable_b.clone();
@@ -103,7 +103,7 @@ pub fn make_module() -> KMap {
                     ctx.vm.make_iterator(iterable_b)?,
                 ));
 
-                Ok(Value::Iterator(result))
+                Ok(KValue::Iterator(result))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -112,8 +112,8 @@ pub fn make_module() -> KMap {
     result.add_fn("chunks", |ctx| {
         let expected_error = "an iterable and a chunk size greater than zero";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
-            (iterable, [Value::Number(n)]) => {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+            (iterable, [KValue::Number(n)]) => {
                 let iterable = iterable.clone();
                 let n = *n;
                 match adaptors::Chunks::new(ctx.vm.make_iterator(iterable)?, n.into()) {
@@ -128,7 +128,7 @@ pub fn make_module() -> KMap {
     result.add_fn("consume", |ctx| {
         let expected_error = "an iterable value (and optional consumer function)";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 for output in ctx.vm.make_iterator(iterable)? {
@@ -136,7 +136,7 @@ pub fn make_module() -> KMap {
                         return Err(error);
                     }
                 }
-                Ok(Value::Null)
+                Ok(KValue::Null)
             }
             (iterable, [f]) if f.is_callable() => {
                 let iterable = iterable.clone();
@@ -152,7 +152,7 @@ pub fn make_module() -> KMap {
                         Output::Error(error) => return Err(error),
                     }
                 }
-                Ok(Value::Null)
+                Ok(KValue::Null)
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -161,7 +161,7 @@ pub fn make_module() -> KMap {
     result.add_fn("count", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let mut result = 0;
@@ -171,7 +171,7 @@ pub fn make_module() -> KMap {
                     }
                     result += 1;
                 }
-                Ok(Value::Number(result.into()))
+                Ok(KValue::Number(result.into()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -180,7 +180,7 @@ pub fn make_module() -> KMap {
     result.add_fn("each", |ctx| {
         let expected_error = "an iterable and function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [f]) if f.is_callable() => {
                 let iterable = iterable.clone();
                 let f = f.clone();
@@ -199,7 +199,7 @@ pub fn make_module() -> KMap {
     result.add_fn("cycle", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let result = adaptors::Cycle::new(ctx.vm.make_iterator(iterable)?);
@@ -213,7 +213,7 @@ pub fn make_module() -> KMap {
     result.add_fn("enumerate", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let result = adaptors::Enumerate::new(ctx.vm.make_iterator(iterable)?);
@@ -226,7 +226,7 @@ pub fn make_module() -> KMap {
     result.add_fn("find", |ctx| {
         let expected_error = "an iterable and a predicate function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
                 let iterable = iterable.clone();
                 let predicate = predicate.clone();
@@ -238,7 +238,7 @@ pub fn make_module() -> KMap {
                                 .vm
                                 .run_function(predicate.clone(), CallArgs::Single(value.clone()))
                             {
-                                Ok(Value::Bool(result)) => {
+                                Ok(KValue::Bool(result)) => {
                                     if result {
                                         return Ok(value);
                                     }
@@ -257,7 +257,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::Null)
+                Ok(KValue::Null)
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -266,7 +266,7 @@ pub fn make_module() -> KMap {
     result.add_fn("flatten", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let result = adaptors::Flatten::new(
@@ -283,7 +283,7 @@ pub fn make_module() -> KMap {
     result.add_fn("fold", |ctx| {
         let expected_error = "an iterable, initial value, and folding function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [result, f]) if f.is_callable() => {
                 let iterable = iterable.clone();
                 let result = result.clone();
@@ -328,7 +328,7 @@ pub fn make_module() -> KMap {
             let result = generators::Generate::new(f.clone(), ctx.vm.spawn_shared_vm());
             Ok(KIterator::new(result).into())
         }
-        [Value::Number(n), f] if f.is_callable() => {
+        [KValue::Number(n), f] if f.is_callable() => {
             let result = generators::GenerateN::new(n.into(), f.clone(), ctx.vm.spawn_shared_vm());
             Ok(KIterator::new(result).into())
         }
@@ -338,7 +338,7 @@ pub fn make_module() -> KMap {
     result.add_fn("intersperse", |ctx| {
         let expected_error = "an iterable and a separator";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [separator_fn]) if separator_fn.is_callable() => {
                 let iterable = iterable.clone();
                 let separator_fn = separator_fn.clone();
@@ -364,10 +364,10 @@ pub fn make_module() -> KMap {
     result.add_fn("iter", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
-                Ok(Value::Iterator(ctx.vm.make_iterator(iterable)?))
+                Ok(KValue::Iterator(ctx.vm.make_iterator(iterable)?))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -376,7 +376,7 @@ pub fn make_module() -> KMap {
     result.add_fn("keep", |ctx| {
         let expected_error = "an iterable and a predicate function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
                 let iterable = iterable.clone();
                 let predicate = predicate.clone();
@@ -394,10 +394,10 @@ pub fn make_module() -> KMap {
     result.add_fn("last", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
-                let mut result = Value::Null;
+                let mut result = KValue::Null;
 
                 let mut iter = ctx.vm.make_iterator(iterable)?.map(collect_pair);
                 for output in &mut iter {
@@ -417,7 +417,7 @@ pub fn make_module() -> KMap {
     result.add_fn("max", |ctx| {
         let expected_error = "an iterable and an optional key function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 run_iterator_comparison(ctx.vm, iterable, InvertResult::Yes)
@@ -434,7 +434,7 @@ pub fn make_module() -> KMap {
     result.add_fn("min", |ctx| {
         let expected_error = "an iterable and an optional key function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 run_iterator_comparison(ctx.vm, iterable, InvertResult::No)
@@ -451,7 +451,7 @@ pub fn make_module() -> KMap {
     result.add_fn("min_max", |ctx| {
         let expected_error = "an iterable and an optional key function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let mut result = None;
@@ -472,8 +472,8 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(result.map_or(Value::Null, |(min, max)| {
-                    Value::Tuple(vec![min, max].into())
+                Ok(result.map_or(KValue::Null, |(min, max)| {
+                    KValue::Tuple(vec![min, max].into())
                 }))
             }
             (iterable, [key_fn]) if key_fn.is_callable() => {
@@ -512,8 +512,8 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(result.map_or(Value::Null, |((min, _), (max, _))| {
-                    Value::Tuple(vec![min, max].into())
+                Ok(result.map_or(KValue::Null, |((min, _), (max, _))| {
+                    KValue::Tuple(vec![min, max].into())
                 }))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -523,7 +523,7 @@ pub fn make_module() -> KMap {
     result.add_fn("next", |ctx| {
         let mut iter = match (ctx.instance(), ctx.args()) {
             // No need to call make_iterator when the argument is already an Iterator
-            (Some(Value::Iterator(i)), []) => i.clone(),
+            (Some(KValue::Iterator(i)), []) => i.clone(),
             (Some(iterable), []) | (None, [iterable]) if iterable.is_iterable() => {
                 ctx.vm.make_iterator(iterable.clone())?
             }
@@ -535,7 +535,7 @@ pub fn make_module() -> KMap {
 
     result.add_fn("next_back", |ctx| {
         let mut iter = match (ctx.instance(), ctx.args()) {
-            (Some(Value::Iterator(i)), []) => i.clone(),
+            (Some(KValue::Iterator(i)), []) => i.clone(),
             (Some(iterable), []) | (None, [iterable]) if iterable.is_iterable() => {
                 ctx.vm.make_iterator(iterable.clone())?
             }
@@ -548,7 +548,7 @@ pub fn make_module() -> KMap {
     result.add_fn("peekable", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 Ok(peekable::Peekable::make_value(
@@ -562,7 +562,7 @@ pub fn make_module() -> KMap {
     result.add_fn("position", |ctx| {
         let expected_error = "an iterable and a predicate function";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
                 let iterable = iterable.clone();
                 let predicate = predicate.clone();
@@ -579,7 +579,7 @@ pub fn make_module() -> KMap {
                     };
 
                     match predicate_result {
-                        Ok(Value::Bool(result)) => {
+                        Ok(KValue::Bool(result)) => {
                             if result {
                                 return Ok(i.into());
                             }
@@ -594,7 +594,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::Null)
+                Ok(KValue::Null)
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -604,8 +604,8 @@ pub fn make_module() -> KMap {
         let (iterable, initial_value) = {
             let expected_error = "an iterable and optional initial value";
 
-            match ctx.instance_and_args(Value::is_iterable, expected_error)? {
-                (iterable, []) => (iterable.clone(), Value::Number(1.into())),
+            match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+                (iterable, []) => (iterable.clone(), KValue::Number(1.into())),
                 (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
                 (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
             }
@@ -619,7 +619,7 @@ pub fn make_module() -> KMap {
             let result = generators::Repeat::new(value.clone());
             Ok(KIterator::new(result).into())
         }
-        [value, Value::Number(n)] => {
+        [value, KValue::Number(n)] => {
             let result = generators::RepeatN::new(value.clone(), n.into());
             Ok(KIterator::new(result).into())
         }
@@ -629,7 +629,7 @@ pub fn make_module() -> KMap {
     result.add_fn("reversed", |ctx| {
         let expected_error = "an iterable and non-negative number";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 match adaptors::Reversed::new(ctx.vm.make_iterator(iterable)?) {
@@ -644,8 +644,8 @@ pub fn make_module() -> KMap {
     result.add_fn("skip", |ctx| {
         let expected_error = "an iterable and non-negative number";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
-            (iterable, [Value::Number(n)]) if *n >= 0.0 => {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+            (iterable, [KValue::Number(n)]) if *n >= 0.0 => {
                 let iterable = iterable.clone();
                 let n = *n;
                 let mut iter = ctx.vm.make_iterator(iterable)?;
@@ -656,7 +656,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::Iterator(iter))
+                Ok(KValue::Iterator(iter))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -665,8 +665,8 @@ pub fn make_module() -> KMap {
     result.add_fn("step", |ctx| {
         let expected_error = "an iterable and positive step size";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
-            (iterable, [Value::Number(n)]) if *n > 0 => {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+            (iterable, [KValue::Number(n)]) if *n > 0 => {
                 let iterable = iterable.clone();
                 let step_size = n.into();
                 match adaptors::Step::new(ctx.vm.make_iterator(iterable)?, step_size) {
@@ -682,8 +682,8 @@ pub fn make_module() -> KMap {
         let (iterable, initial_value) = {
             let expected_error = "an iterable and optional initial value";
 
-            match ctx.instance_and_args(Value::is_iterable, expected_error)? {
-                (iterable, []) => (iterable.clone(), Value::Number(0.into())),
+            match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+                (iterable, []) => (iterable.clone(), KValue::Number(0.into())),
                 (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
                 (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
             }
@@ -695,8 +695,8 @@ pub fn make_module() -> KMap {
     result.add_fn("take", |ctx| {
         let expected_error = "an iterable and a count or predicate";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
-            (iterable, [Value::Number(n)]) if *n >= 0.0 => {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+            (iterable, [KValue::Number(n)]) if *n >= 0.0 => {
                 let iterable = iterable.clone();
                 let n = *n;
                 let result = adaptors::Take::new(ctx.vm.make_iterator(iterable)?, n.into());
@@ -719,7 +719,7 @@ pub fn make_module() -> KMap {
     result.add_fn("to_list", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
@@ -734,7 +734,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::List(KList::with_data(result)))
+                Ok(KValue::List(KList::with_data(result)))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -743,7 +743,7 @@ pub fn make_module() -> KMap {
     result.add_fn("to_map", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
@@ -753,19 +753,19 @@ pub fn make_module() -> KMap {
                 for output in iterator {
                     let (key, value) = match output {
                         Output::ValuePair(key, value) => (key, value),
-                        Output::Value(Value::Tuple(t)) if t.len() == 2 => {
+                        Output::Value(KValue::Tuple(t)) if t.len() == 2 => {
                             let key = t[0].clone();
                             let value = t[1].clone();
                             (key, value)
                         }
-                        Output::Value(value) => (value, Value::Null),
+                        Output::Value(value) => (value, KValue::Null),
                         Output::Error(error) => return Err(error),
                     };
 
                     result.insert(ValueKey::try_from(key)?, value);
                 }
 
-                Ok(Value::Map(KMap::with_data(result)))
+                Ok(KValue::Map(KMap::with_data(result)))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -774,7 +774,7 @@ pub fn make_module() -> KMap {
     result.add_fn("to_string", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
@@ -782,7 +782,7 @@ pub fn make_module() -> KMap {
                 let mut display_context = DisplayContext::with_vm_and_capacity(ctx.vm, size_hint);
                 for output in iterator.map(collect_pair) {
                     match output {
-                        Output::Value(Value::Str(s)) => display_context.append(s),
+                        Output::Value(KValue::Str(s)) => display_context.append(s),
                         Output::Value(value) => value.display(&mut display_context)?,
                         Output::Error(error) => return Err(error),
                         _ => unreachable!(),
@@ -798,7 +798,7 @@ pub fn make_module() -> KMap {
     result.add_fn("to_tuple", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
@@ -813,7 +813,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::Tuple(result.into()))
+                Ok(KValue::Tuple(result.into()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -822,8 +822,8 @@ pub fn make_module() -> KMap {
     result.add_fn("windows", |ctx| {
         let expected_error = "an iterable and a chunnk size greater than zero";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
-            (iterable, [Value::Number(n)]) => {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+            (iterable, [KValue::Number(n)]) => {
                 let iterable = iterable.clone();
                 let n = *n;
                 match adaptors::Windows::new(ctx.vm.make_iterator(iterable)?, n.into()) {
@@ -838,7 +838,7 @@ pub fn make_module() -> KMap {
     result.add_fn("zip", |ctx| {
         let expected_error = "an iterable";
 
-        match ctx.instance_and_args(Value::is_iterable, expected_error)? {
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable_a, [iterable_b]) if iterable_b.is_iterable() => {
                 let iterable_a = iterable_a.clone();
                 let iterable_b = iterable_b.clone();
@@ -857,26 +857,28 @@ pub fn make_module() -> KMap {
 
 pub(crate) fn collect_pair(iterator_output: Output) -> Output {
     match iterator_output {
-        Output::ValuePair(first, second) => Output::Value(Value::Tuple(vec![first, second].into())),
+        Output::ValuePair(first, second) => {
+            Output::Value(KValue::Tuple(vec![first, second].into()))
+        }
         _ => iterator_output,
     }
 }
 
-pub(crate) fn iter_output_to_result(iterator_output: Option<Output>) -> Result<Value> {
+pub(crate) fn iter_output_to_result(iterator_output: Option<Output>) -> Result<KValue> {
     match iterator_output {
         Some(Output::Value(value)) => Ok(value),
-        Some(Output::ValuePair(first, second)) => Ok(Value::Tuple(vec![first, second].into())),
+        Some(Output::ValuePair(first, second)) => Ok(KValue::Tuple(vec![first, second].into())),
         Some(Output::Error(error)) => Err(error),
-        None => Ok(Value::Null),
+        None => Ok(KValue::Null),
     }
 }
 
 fn fold_with_operator(
     vm: &mut Vm,
-    iterable: Value,
-    initial_value: Value,
+    iterable: KValue,
+    initial_value: KValue,
     operator: BinaryOp,
-) -> Result<Value> {
+) -> Result<KValue> {
     let mut result = initial_value;
 
     for output in vm.make_iterator(iterable)?.map(collect_pair) {
@@ -894,10 +896,10 @@ fn fold_with_operator(
 
 fn run_iterator_comparison(
     vm: &mut Vm,
-    iterable: Value,
+    iterable: KValue,
     invert_result: InvertResult,
-) -> Result<Value> {
-    let mut result: Option<Value> = None;
+) -> Result<KValue> {
+    let mut result: Option<KValue> = None;
 
     for iter_output in vm.make_iterator(iterable)?.map(collect_pair) {
         match iter_output {
@@ -919,11 +921,11 @@ fn run_iterator_comparison(
 
 fn run_iterator_comparison_by_key(
     vm: &mut Vm,
-    iterable: Value,
-    key_fn: Value,
+    iterable: KValue,
+    key_fn: KValue,
     invert_result: InvertResult,
-) -> Result<Value> {
-    let mut result_and_key: Option<(Value, Value)> = None;
+) -> Result<KValue> {
+    let mut result_and_key: Option<(KValue, KValue)> = None;
 
     for iter_output in vm.make_iterator(iterable)?.map(collect_pair) {
         match iter_output {
@@ -943,15 +945,20 @@ fn run_iterator_comparison_by_key(
         }
     }
 
-    Ok(result_and_key.map_or(Value::Null, |(value, _)| value))
+    Ok(result_and_key.map_or(KValue::Null, |(value, _)| value))
 }
 
 // Compares two values using BinaryOp::Less
 //
 // Returns the lesser of the two values, unless `invert_result` is set to Yes
-fn compare_values(vm: &mut Vm, a: Value, b: Value, invert_result: InvertResult) -> Result<Value> {
+fn compare_values(
+    vm: &mut Vm,
+    a: KValue,
+    b: KValue,
+    invert_result: InvertResult,
+) -> Result<KValue> {
     use InvertResult::*;
-    use Value::Bool;
+    use KValue::Bool;
 
     let comparison_result = vm.run_binary_op(BinaryOp::Less, a.clone(), b.clone())?;
 
@@ -972,12 +979,12 @@ fn compare_values(vm: &mut Vm, a: Value, b: Value, invert_result: InvertResult) 
 // Returns the lesser of the two values, unless `invert_result` is set to Yes
 fn compare_values_with_key(
     vm: &mut Vm,
-    a_and_key: (Value, Value),
-    b_and_key: (Value, Value),
+    a_and_key: (KValue, KValue),
+    b_and_key: (KValue, KValue),
     invert_result: InvertResult,
-) -> Result<(Value, Value)> {
+) -> Result<(KValue, KValue)> {
     use InvertResult::*;
-    use Value::Bool;
+    use KValue::Bool;
 
     let comparison_result =
         vm.run_binary_op(BinaryOp::Less, a_and_key.1.clone(), b_and_key.1.clone())?;

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -4,7 +4,7 @@ pub mod adaptors;
 pub mod generators;
 pub mod peekable;
 
-use crate::{prelude::*, KIteratorOutput as Output, Result};
+use crate::{prelude::*, KIteratorOutput as Output, KotoVm, Result};
 
 /// Initializes the `iterator` core library module
 pub fn make_module() -> KMap {
@@ -874,7 +874,7 @@ pub(crate) fn iter_output_to_result(iterator_output: Option<Output>) -> Result<K
 }
 
 fn fold_with_operator(
-    vm: &mut Vm,
+    vm: &mut KotoVm,
     iterable: KValue,
     initial_value: KValue,
     operator: BinaryOp,
@@ -895,7 +895,7 @@ fn fold_with_operator(
 }
 
 fn run_iterator_comparison(
-    vm: &mut Vm,
+    vm: &mut KotoVm,
     iterable: KValue,
     invert_result: InvertResult,
 ) -> Result<KValue> {
@@ -920,7 +920,7 @@ fn run_iterator_comparison(
 }
 
 fn run_iterator_comparison_by_key(
-    vm: &mut Vm,
+    vm: &mut KotoVm,
     iterable: KValue,
     key_fn: KValue,
     invert_result: InvertResult,
@@ -952,7 +952,7 @@ fn run_iterator_comparison_by_key(
 //
 // Returns the lesser of the two values, unless `invert_result` is set to Yes
 fn compare_values(
-    vm: &mut Vm,
+    vm: &mut KotoVm,
     a: KValue,
     b: KValue,
     invert_result: InvertResult,
@@ -978,7 +978,7 @@ fn compare_values(
 //
 // Returns the lesser of the two values, unless `invert_result` is set to Yes
 fn compare_values_with_key(
-    vm: &mut Vm,
+    vm: &mut KotoVm,
     a_and_key: (KValue, KValue),
     b_and_key: (KValue, KValue),
     invert_result: InvertResult,

--- a/crates/runtime/src/core_lib/iterator/adaptors.rs
+++ b/crates/runtime/src/core_lib/iterator/adaptors.rs
@@ -103,7 +103,7 @@ impl Iterator for Chunks {
         let mut chunk = None;
 
         for output in self.iter.clone().take(self.chunk_size) {
-            match Value::try_from(output) {
+            match KValue::try_from(output) {
                 Ok(value) => chunk
                     .get_or_insert_with(|| Vec::with_capacity(self.chunk_size))
                     .push(value),
@@ -148,7 +148,7 @@ pub enum ChunksError {
 /// An iterator that cycles through the adapted iterator infinitely
 pub struct Cycle {
     iter: KIterator,
-    cache: Vec<Value>,
+    cache: Vec<KValue>,
     cycle_index: usize,
 }
 
@@ -186,7 +186,7 @@ impl Iterator for Cycle {
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(output) = self.iter.next() {
-            match Value::try_from(output) {
+            match KValue::try_from(output) {
                 Ok(value) => {
                     self.cache.push(value.clone());
                     Some(value.into())
@@ -223,13 +223,13 @@ impl Iterator for Cycle {
 /// An iterator that runs a function on each output value from the adapted iterator
 pub struct Each {
     iter: KIterator,
-    function: Value,
+    function: KValue,
     vm: Vm,
 }
 
 impl Each {
     /// Creates a new [Each] adaptor
-    pub fn new(iter: KIterator, function: Value, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, function: KValue, vm: Vm) -> Self {
         Self { iter, function, vm }
     }
 
@@ -387,12 +387,12 @@ pub struct Intersperse {
     iter: KIterator,
     peeked: Option<Output>,
     next_is_separator: bool,
-    separator: Value,
+    separator: KValue,
 }
 
 impl Intersperse {
     /// Creates a new [Intersperse] adaptor
-    pub fn new(iter: KIterator, separator: Value) -> Self {
+    pub fn new(iter: KIterator, separator: KValue) -> Self {
         Self {
             iter,
             peeked: None,
@@ -447,13 +447,13 @@ pub struct IntersperseWith {
     iter: KIterator,
     peeked: Option<Output>,
     next_is_separator: bool,
-    separator_function: Value,
+    separator_function: KValue,
     vm: Vm,
 }
 
 impl IntersperseWith {
     /// Creates a new [IntersperseWith] adaptor
-    pub fn new(iter: KIterator, separator_function: Value, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, separator_function: KValue, vm: Vm) -> Self {
         Self {
             iter,
             peeked: None,
@@ -524,13 +524,13 @@ fn intersperse_size_hint(iter: &KIterator, next_is_separator: bool) -> (usize, O
 /// An iterator that skips over values that fail a predicate, and keeps those that pass
 pub struct Keep {
     iter: KIterator,
-    predicate: Value,
+    predicate: KValue,
     vm: Vm,
 }
 
 impl Keep {
     /// Creates a new [Keep] adaptor
-    pub fn new(iter: KIterator, predicate: Value, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, predicate: KValue, vm: Vm) -> Self {
         Self {
             iter,
             predicate,
@@ -567,8 +567,8 @@ impl Iterator for Keep {
             };
 
             let result = match predicate_result {
-                Ok(Value::Bool(false)) => continue,
-                Ok(Value::Bool(true)) => output,
+                Ok(KValue::Bool(false)) => continue,
+                Ok(KValue::Bool(true)) => output,
                 Ok(unexpected) => Output::Error(
                     format!(
                     "iterator.keep: Expected a Bool to be returned from the predicate, found '{}'",
@@ -823,14 +823,14 @@ impl Iterator for Take {
 /// An adaptor that yields values from an iterator while they pass a predicate
 pub struct TakeWhile {
     iter: KIterator,
-    predicate: Value,
+    predicate: KValue,
     vm: Vm,
     finished: bool,
 }
 
 impl TakeWhile {
     /// Creates a new [Keep] adaptor
-    pub fn new(iter: KIterator, predicate: Value, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, predicate: KValue, vm: Vm) -> Self {
         Self {
             iter,
             predicate,
@@ -873,8 +873,8 @@ impl Iterator for TakeWhile {
         };
 
         let result = match predicate_result {
-            Ok(Value::Bool(true)) => iter_output,
-            Ok(Value::Bool(false)) => {
+            Ok(KValue::Bool(true)) => iter_output,
+            Ok(KValue::Bool(false)) => {
                 self.finished = true;
                 return None;
             }
@@ -900,7 +900,7 @@ impl Iterator for TakeWhile {
 /// An iterator that splits the incoming iterator into overlapping iterators of size N
 pub struct Windows {
     iter: KIterator,
-    cache: VecDeque<Value>,
+    cache: VecDeque<KValue>,
     window_size: usize,
 }
 
@@ -941,7 +941,7 @@ impl Iterator for Windows {
                 break;
             };
 
-            match Value::try_from(output) {
+            match KValue::try_from(output) {
                 Ok(value) => self.cache.push_back(value),
                 Err(error) => return Some(Output::Error(error)),
             }

--- a/crates/runtime/src/core_lib/iterator/adaptors.rs
+++ b/crates/runtime/src/core_lib/iterator/adaptors.rs
@@ -1,7 +1,7 @@
 //! Adapators used by the `iterator` core library module
 
 use super::collect_pair;
-use crate::{prelude::*, Error, KIteratorOutput as Output, Result};
+use crate::{prelude::*, Error, KIteratorOutput as Output, KotoVm, Result};
 use std::{collections::VecDeque, result::Result as StdResult};
 use thiserror::Error;
 
@@ -224,12 +224,12 @@ impl Iterator for Cycle {
 pub struct Each {
     iter: KIterator,
     function: KValue,
-    vm: Vm,
+    vm: KotoVm,
 }
 
 impl Each {
     /// Creates a new [Each] adaptor
-    pub fn new(iter: KIterator, function: KValue, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, function: KValue, vm: KotoVm) -> Self {
         Self { iter, function, vm }
     }
 
@@ -325,14 +325,14 @@ impl Iterator for Enumerate {
 
 /// An iterator that flattens the output of nested iterators
 pub struct Flatten {
-    vm: Vm,
+    vm: KotoVm,
     iter: KIterator,
     nested: Option<KIterator>,
 }
 
 impl Flatten {
     /// Creates a new [Flatten] adaptor
-    pub fn new(iter: KIterator, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, vm: KotoVm) -> Self {
         Self {
             vm,
             iter,
@@ -448,12 +448,12 @@ pub struct IntersperseWith {
     peeked: Option<Output>,
     next_is_separator: bool,
     separator_function: KValue,
-    vm: Vm,
+    vm: KotoVm,
 }
 
 impl IntersperseWith {
     /// Creates a new [IntersperseWith] adaptor
-    pub fn new(iter: KIterator, separator_function: KValue, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, separator_function: KValue, vm: KotoVm) -> Self {
         Self {
             iter,
             peeked: None,
@@ -525,12 +525,12 @@ fn intersperse_size_hint(iter: &KIterator, next_is_separator: bool) -> (usize, O
 pub struct Keep {
     iter: KIterator,
     predicate: KValue,
-    vm: Vm,
+    vm: KotoVm,
 }
 
 impl Keep {
     /// Creates a new [Keep] adaptor
-    pub fn new(iter: KIterator, predicate: KValue, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, predicate: KValue, vm: KotoVm) -> Self {
         Self {
             iter,
             predicate,
@@ -824,13 +824,13 @@ impl Iterator for Take {
 pub struct TakeWhile {
     iter: KIterator,
     predicate: KValue,
-    vm: Vm,
+    vm: KotoVm,
     finished: bool,
 }
 
 impl TakeWhile {
     /// Creates a new [Keep] adaptor
-    pub fn new(iter: KIterator, predicate: KValue, vm: Vm) -> Self {
+    pub fn new(iter: KIterator, predicate: KValue, vm: KotoVm) -> Self {
         Self {
             iter,
             predicate,

--- a/crates/runtime/src/core_lib/iterator/generators.rs
+++ b/crates/runtime/src/core_lib/iterator/generators.rs
@@ -4,12 +4,12 @@ use crate::{prelude::*, KIteratorOutput as Output, Result};
 
 /// An iterator that repeatedly yields the same value
 pub struct Repeat {
-    value: Value,
+    value: KValue,
 }
 
 impl Repeat {
     /// Creates a new [Repeat] generator
-    pub fn new(value: Value) -> Self {
+    pub fn new(value: KValue) -> Self {
         Self { value }
     }
 }
@@ -34,12 +34,12 @@ impl Iterator for Repeat {
 /// An iterator that yields the same value N times
 pub struct RepeatN {
     remaining: usize,
-    value: Value,
+    value: KValue,
 }
 
 impl RepeatN {
     /// Creates a new [RepeatN] generator
-    pub fn new(value: Value, n: usize) -> Self {
+    pub fn new(value: KValue, n: usize) -> Self {
         Self {
             remaining: n,
             value,
@@ -76,13 +76,13 @@ impl Iterator for RepeatN {
 
 /// An iterator that repeatedly yields the result of calling a function
 pub struct Generate {
-    function: Value,
+    function: KValue,
     vm: Vm,
 }
 
 impl Generate {
     /// Creates a new [Generate] generator
-    pub fn new(function: Value, vm: Vm) -> Self {
+    pub fn new(function: KValue, vm: Vm) -> Self {
         Self { function, vm }
     }
 }
@@ -113,13 +113,13 @@ impl Iterator for Generate {
 /// An iterator that yields the result of calling a function N times
 pub struct GenerateN {
     remaining: usize,
-    function: Value,
+    function: KValue,
     vm: Vm,
 }
 
 impl GenerateN {
     /// Creates a new [GenerateN] generator
-    pub fn new(n: usize, function: Value, vm: Vm) -> Self {
+    pub fn new(n: usize, function: KValue, vm: Vm) -> Self {
         Self {
             remaining: n,
             function,

--- a/crates/runtime/src/core_lib/iterator/generators.rs
+++ b/crates/runtime/src/core_lib/iterator/generators.rs
@@ -1,6 +1,6 @@
 //! Generators used by the `iterator` core library module
 
-use crate::{prelude::*, KIteratorOutput as Output, Result};
+use crate::{prelude::*, KIteratorOutput as Output, KotoVm, Result};
 
 /// An iterator that repeatedly yields the same value
 pub struct Repeat {
@@ -77,12 +77,12 @@ impl Iterator for RepeatN {
 /// An iterator that repeatedly yields the result of calling a function
 pub struct Generate {
     function: KValue,
-    vm: Vm,
+    vm: KotoVm,
 }
 
 impl Generate {
     /// Creates a new [Generate] generator
-    pub fn new(function: KValue, vm: Vm) -> Self {
+    pub fn new(function: KValue, vm: KotoVm) -> Self {
         Self { function, vm }
     }
 }
@@ -114,12 +114,12 @@ impl Iterator for Generate {
 pub struct GenerateN {
     remaining: usize,
     function: KValue,
-    vm: Vm,
+    vm: KotoVm,
 }
 
 impl GenerateN {
     /// Creates a new [GenerateN] generator
-    pub fn new(n: usize, function: KValue, vm: Vm) -> Self {
+    pub fn new(n: usize, function: KValue, vm: KotoVm) -> Self {
         Self {
             remaining: n,
             function,

--- a/crates/runtime/src/core_lib/iterator/peekable.rs
+++ b/crates/runtime/src/core_lib/iterator/peekable.rs
@@ -9,8 +9,8 @@ use crate::{prelude::*, KIteratorOutput as Output, Result};
 #[derive(Clone, KotoCopy, KotoType)]
 pub struct Peekable {
     iter: KIterator,
-    peeked_front: Option<Value>,
-    peeked_back: Option<Value>,
+    peeked_front: Option<KValue>,
+    peeked_back: Option<KValue>,
 }
 
 #[koto_impl(runtime = crate)]
@@ -25,7 +25,7 @@ impl Peekable {
     }
 
     /// Makes an instance of Peekable along with a meta map that allows it be used as a Koto Value
-    pub fn make_value(iter: KIterator) -> Value {
+    pub fn make_value(iter: KIterator) -> KValue {
         KObject::from(Self::new(iter)).into()
     }
 
@@ -46,11 +46,11 @@ impl Peekable {
     }
 
     #[koto_method]
-    fn peek(&mut self) -> Result<Value> {
+    fn peek(&mut self) -> Result<KValue> {
         match self.peeked_front.clone() {
             Some(peeked) => Ok(peeked),
             None => match iter_output_to_result(self.next())? {
-                Value::Null => Ok(Value::Null),
+                KValue::Null => Ok(KValue::Null),
                 peeked => {
                     self.peeked_front = Some(peeked.clone());
                     Ok(peeked)
@@ -60,11 +60,11 @@ impl Peekable {
     }
 
     #[koto_method]
-    fn peek_back(&mut self) -> Result<Value> {
+    fn peek_back(&mut self) -> Result<KValue> {
         match self.peeked_back.clone() {
             Some(peeked) => Ok(peeked),
             None => match iter_output_to_result(self.next_back())? {
-                Value::Null => Ok(Value::Null),
+                KValue::Null => Ok(KValue::Null),
                 peeked => {
                     self.peeked_back = Some(peeked.clone());
                     Ok(peeked)

--- a/crates/runtime/src/core_lib/iterator/peekable.rs
+++ b/crates/runtime/src/core_lib/iterator/peekable.rs
@@ -3,7 +3,7 @@
 use koto_derive::*;
 
 use super::iter_output_to_result;
-use crate::{prelude::*, KIteratorOutput as Output, Result};
+use crate::{prelude::*, KIteratorOutput as Output, KotoVm, Result};
 
 /// A double-ended peekable iterator for Koto
 #[derive(Clone, KotoCopy, KotoType)]
@@ -83,7 +83,7 @@ impl KotoObject for Peekable {
         }
     }
 
-    fn iterator_next(&mut self, _vm: &mut Vm) -> Option<Output> {
+    fn iterator_next(&mut self, _vm: &mut KotoVm) -> Option<Output> {
         self.peeked_front.take().map(Output::Value).or_else(|| {
             self.iter
                 .next()
@@ -91,7 +91,7 @@ impl KotoObject for Peekable {
         })
     }
 
-    fn iterator_next_back(&mut self, _vm: &mut Vm) -> Option<Output> {
+    fn iterator_next_back(&mut self, _vm: &mut KotoVm) -> Option<Output> {
         self.peeked_back.take().map(Output::Value).or_else(|| {
             self.iter
                 .next_back()

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -7,19 +7,19 @@ use std::hash::{Hash, Hasher};
 pub fn make_module() -> KMap {
     let result = KMap::with_type("core.koto");
 
-    result.insert("args", Value::Tuple(KTuple::default()));
+    result.insert("args", KValue::Tuple(KTuple::default()));
 
     result.add_fn("copy", |ctx| match ctx.args() {
-        [Value::Iterator(iter)] => Ok(iter.make_copy()?.into()),
-        [Value::List(l)] => Ok(KList::with_data(l.data().clone()).into()),
-        [Value::Map(m)] => {
+        [KValue::Iterator(iter)] => Ok(iter.make_copy()?.into()),
+        [KValue::List(l)] => Ok(KList::with_data(l.data().clone()).into()),
+        [KValue::Map(m)] => {
             let result = KMap::with_contents(
                 m.data().clone(),
                 m.meta_map().map(|meta| meta.borrow().clone()),
             );
             Ok(result.into())
         }
-        [Value::Object(o)] => o.try_borrow().map(|o| o.copy().into()),
+        [KValue::Object(o)] => o.try_borrow().map(|o| o.copy().into()),
         [other] => Ok(other.clone()),
         unexpected => type_error_with_slice("a single argument", unexpected),
     });
@@ -29,7 +29,7 @@ pub fn make_module() -> KMap {
         unexpected => type_error_with_slice("a single argument", unexpected),
     });
 
-    result.add_fn("exports", |ctx| Ok(Value::Map(ctx.vm.exports().clone())));
+    result.add_fn("exports", |ctx| Ok(KValue::Map(ctx.vm.exports().clone())));
 
     result.add_fn("hash", |ctx| match ctx.args() {
         [value] => match ValueKey::try_from(value.clone()) {
@@ -38,13 +38,13 @@ pub fn make_module() -> KMap {
                 key.hash(&mut hasher);
                 Ok(hasher.finish().into())
             }
-            Err(_) => Ok(Value::Null),
+            Err(_) => Ok(KValue::Null),
         },
         unexpected => type_error_with_slice("a single argument", unexpected),
     });
 
-    result.insert("script_dir", Value::Null);
-    result.insert("script_path", Value::Null);
+    result.insert("script_dir", KValue::Null);
+    result.insert("script_path", KValue::Null);
 
     result.add_fn("type", |ctx| match ctx.args() {
         [value] => Ok(value.type_as_string().into()),

--- a/crates/runtime/src/core_lib/list.rs
+++ b/crates/runtime/src/core_lib/list.rs
@@ -15,9 +15,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => {
+            (KValue::List(l), []) => {
                 l.data_mut().clear();
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -27,7 +27,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a List and a Value";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [value]) => {
+            (KValue::List(l), [value]) => {
                 let l = l.clone();
                 let value = value.clone();
                 for candidate in l.data().iter() {
@@ -35,8 +35,8 @@ pub fn make_module() -> KMap {
                         .vm
                         .run_binary_op(BinaryOp::Equal, value.clone(), candidate.clone())
                     {
-                        Ok(Value::Bool(false)) => {}
-                        Ok(Value::Bool(true)) => return Ok(true.into()),
+                        Ok(KValue::Bool(false)) => {}
+                        Ok(KValue::Bool(true)) => return Ok(true.into()),
                         Ok(unexpected) => {
                             return runtime_error!(
                                 "list.contains: Expected Bool from comparison, found '{}'",
@@ -56,15 +56,15 @@ pub fn make_module() -> KMap {
         let expected_error = "a List and iterable";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [Value::List(other)]) => {
+            (KValue::List(l), [KValue::List(other)]) => {
                 l.data_mut().extend(other.data().iter().cloned());
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
-            (Value::List(l), [Value::Tuple(other)]) => {
+            (KValue::List(l), [KValue::Tuple(other)]) => {
                 l.data_mut().extend(other.iter().cloned());
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
-            (Value::List(l), [iterable]) if iterable.is_iterable() => {
+            (KValue::List(l), [iterable]) if iterable.is_iterable() => {
                 let l = l.clone();
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
@@ -83,7 +83,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::List(l))
+                Ok(KValue::List(l))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -93,11 +93,11 @@ pub fn make_module() -> KMap {
         let expected_error = "a List and a Value";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [value]) => {
+            (KValue::List(l), [value]) => {
                 for v in l.data_mut().iter_mut() {
                     *v = value.clone();
                 }
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -107,9 +107,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => match l.data().first() {
+            (KValue::List(l), []) => match l.data().first() {
                 Some(value) => Ok(value.clone()),
-                None => Ok(Value::Null),
+                None => Ok(KValue::Null),
             },
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -120,8 +120,8 @@ pub fn make_module() -> KMap {
             let expected_error = "a List and a Number (with optional default value)";
 
             match ctx.instance_and_args(is_list, expected_error)? {
-                (Value::List(list), [Value::Number(n)]) => (list, n, &Value::Null),
-                (Value::List(list), [Value::Number(n), default]) => (list, n, default),
+                (KValue::List(list), [KValue::Number(n)]) => (list, n, &KValue::Null),
+                (KValue::List(list), [KValue::Number(n), default]) => (list, n, default),
                 (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
             }
         };
@@ -136,14 +136,14 @@ pub fn make_module() -> KMap {
         let expected_error = "a List, a non-negative Number, and a Value";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [Value::Number(n), value]) if *n >= 0.0 => {
+            (KValue::List(l), [KValue::Number(n), value]) if *n >= 0.0 => {
                 let index: usize = n.into();
                 if index > l.data().len() {
                     return runtime_error!("list.insert: Index out of bounds");
                 }
 
                 l.data_mut().insert(index, value.clone());
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -153,7 +153,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => Ok(l.data().is_empty().into()),
+            (KValue::List(l), []) => Ok(l.data().is_empty().into()),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -162,9 +162,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => match l.data().last() {
+            (KValue::List(l), []) => match l.data().last() {
                 Some(value) => Ok(value.clone()),
-                None => Ok(Value::Null),
+                None => Ok(KValue::Null),
             },
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -174,9 +174,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => match l.data_mut().pop() {
+            (KValue::List(l), []) => match l.data_mut().pop() {
                 Some(value) => Ok(value),
-                None => Ok(Value::Null),
+                None => Ok(KValue::Null),
             },
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -186,9 +186,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [value]) => {
+            (KValue::List(l), [value]) => {
                 l.data_mut().push(value.clone());
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -198,7 +198,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [Value::Number(n)]) if *n >= 0.0 => {
+            (KValue::List(l), [KValue::Number(n)]) if *n >= 0.0 => {
                 let index: usize = n.into();
                 if index >= l.data().len() {
                     return runtime_error!(
@@ -218,13 +218,13 @@ pub fn make_module() -> KMap {
         let expected_error = "a List, a non-negative Number, and an optional Value";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [Value::Number(n)]) if *n >= 0.0 => {
-                l.data_mut().resize(n.into(), Value::Null);
-                Ok(Value::List(l.clone()))
+            (KValue::List(l), [KValue::Number(n)]) if *n >= 0.0 => {
+                l.data_mut().resize(n.into(), KValue::Null);
+                Ok(KValue::List(l.clone()))
             }
-            (Value::List(l), [Value::Number(n), value]) if *n >= 0.0 => {
+            (KValue::List(l), [KValue::Number(n), value]) if *n >= 0.0 => {
                 l.data_mut().resize(n.into(), value.clone());
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -234,7 +234,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a List, a non-negative Number, and a function";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [Value::Number(n), f]) if *n >= 0.0 && f.is_callable() => {
+            (KValue::List(l), [KValue::Number(n), f]) if *n >= 0.0 && f.is_callable() => {
                 let new_size = usize::from(n);
                 let len = l.len();
                 let l = l.clone();
@@ -252,7 +252,7 @@ pub fn make_module() -> KMap {
                     Ordering::Equal => {}
                 }
 
-                Ok(Value::List(l))
+                Ok(KValue::List(l))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -263,7 +263,7 @@ pub fn make_module() -> KMap {
             let expected_error = "a List, and either a predicate function or matching Value";
 
             match ctx.instance_and_args(is_list, expected_error)? {
-                (Value::List(l), [f]) if f.is_callable() => {
+                (KValue::List(l), [f]) if f.is_callable() => {
                     let l = l.clone();
                     let f = f.clone();
 
@@ -274,7 +274,7 @@ pub fn make_module() -> KMap {
                             .vm
                             .run_function(f.clone(), CallArgs::Single(value.clone()))
                         {
-                            Ok(Value::Bool(result)) => {
+                            Ok(KValue::Bool(result)) => {
                                 if result {
                                     l.data_mut()[write_index] = value;
                                     write_index += 1;
@@ -289,10 +289,10 @@ pub fn make_module() -> KMap {
                             Err(error) => return Err(error),
                         }
                     }
-                    l.data_mut().resize(write_index, Value::Null);
+                    l.data_mut().resize(write_index, KValue::Null);
                     l
                 }
-                (Value::List(l), [value]) => {
+                (KValue::List(l), [value]) => {
                     let l = l.clone();
                     let value = value.clone();
 
@@ -305,8 +305,8 @@ pub fn make_module() -> KMap {
                             .vm
                             .run_binary_op(BinaryOp::Equal, x.clone(), value.clone())
                         {
-                            Ok(Value::Bool(true)) => true,
-                            Ok(Value::Bool(false)) => false,
+                            Ok(KValue::Bool(true)) => true,
+                            Ok(KValue::Bool(false)) => false,
                             Ok(unexpected) => {
                                 error = Some(type_error_with_slice(
                                     "a Bool from the equality comparison",
@@ -329,16 +329,16 @@ pub fn make_module() -> KMap {
             }
         };
 
-        Ok(Value::List(result))
+        Ok(KValue::List(result))
     });
 
     result.add_fn("reverse", |ctx| {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => {
+            (KValue::List(l), []) => {
                 l.data_mut().reverse();
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -348,7 +348,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => Ok(Value::Number(l.len().into())),
+            (KValue::List(l), []) => Ok(KValue::Number(l.len().into())),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -357,13 +357,13 @@ pub fn make_module() -> KMap {
         let expected_error = "a List, and an optional key function";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => {
+            (KValue::List(l), []) => {
                 let l = l.clone();
                 let mut data = l.data_mut();
                 sort_values(ctx.vm, &mut data)?;
-                Ok(Value::List(l.clone()))
+                Ok(KValue::List(l.clone()))
             }
-            (Value::List(l), [f]) if f.is_callable() => {
+            (KValue::List(l), [f]) if f.is_callable() => {
                 let l = l.clone();
                 let f = f.clone();
 
@@ -409,7 +409,7 @@ pub fn make_module() -> KMap {
                     .map(|(_key, value)| value.clone())
                     .collect::<_>();
 
-                Ok(Value::List(l))
+                Ok(KValue::List(l))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -419,9 +419,9 @@ pub fn make_module() -> KMap {
         let expected_error = "two Lists";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(a), [Value::List(b)]) => {
+            (KValue::List(a), [KValue::List(b)]) => {
                 std::mem::swap(a.data_mut().deref_mut(), b.data_mut().deref_mut());
-                Ok(Value::Null)
+                Ok(KValue::Null)
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -431,7 +431,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a List";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), []) => Ok(Value::Tuple(l.data().as_slice().into())),
+            (KValue::List(l), []) => Ok(KValue::Tuple(l.data().as_slice().into())),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -440,7 +440,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a List and a function";
 
         match ctx.instance_and_args(is_list, expected_error)? {
-            (Value::List(l), [f]) if f.is_callable() => {
+            (KValue::List(l), [f]) if f.is_callable() => {
                 let l = l.clone();
                 let f = f.clone();
 
@@ -454,7 +454,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::List(l))
+                Ok(KValue::List(l))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -463,6 +463,6 @@ pub fn make_module() -> KMap {
     result
 }
 
-fn is_list(value: &Value) -> bool {
-    matches!(value, Value::List(_))
+fn is_list(value: &KValue) -> bool {
+    matches!(value, KValue::List(_))
 }

--- a/crates/runtime/src/core_lib/map.rs
+++ b/crates/runtime/src/core_lib/map.rs
@@ -1,7 +1,7 @@
 //! The `map` core library module
 
 use super::{iterator::adaptors, value_sort::compare_values};
-use crate::{prelude::*, Result};
+use crate::{prelude::*, KotoVm, Result};
 use std::cmp::Ordering;
 
 /// Initializes the `map` core library module
@@ -232,7 +232,7 @@ pub fn make_module() -> KMap {
                 let f = f.clone();
                 let mut error = None;
 
-                let get_sort_key = |vm: &mut Vm,
+                let get_sort_key = |vm: &mut KotoVm,
                                     cache: &mut ValueMap,
                                     key: &ValueKey,
                                     value: &KValue|
@@ -344,7 +344,7 @@ fn do_map_update(
     key: ValueKey,
     default: KValue,
     f: KValue,
-    vm: &mut Vm,
+    vm: &mut KotoVm,
 ) -> Result<KValue> {
     if !map.data().contains_key(&key) {
         map.data_mut().insert(key.clone(), default);

--- a/crates/runtime/src/core_lib/map.rs
+++ b/crates/runtime/src/core_lib/map.rs
@@ -12,9 +12,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), []) => {
+            (KValue::Map(m), []) => {
                 m.data_mut().clear();
-                Ok(Value::Map(m.clone()))
+                Ok(KValue::Map(m.clone()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -24,7 +24,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map and key";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), [key]) => {
+            (KValue::Map(m), [key]) => {
                 let result = m.data().contains_key(&ValueKey::try_from(key.clone())?);
                 Ok(result.into())
             }
@@ -36,16 +36,16 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map and an iterable";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), [Value::Map(other)]) => {
+            (KValue::Map(m), [KValue::Map(other)]) => {
                 m.data_mut().extend(
                     other
                         .data()
                         .iter()
                         .map(|(key, value)| (key.clone(), value.clone())),
                 );
-                Ok(Value::Map(m.clone()))
+                Ok(KValue::Map(m.clone()))
             }
-            (Value::Map(m), [iterable]) if iterable.is_iterable() => {
+            (KValue::Map(m), [iterable]) if iterable.is_iterable() => {
                 let m = m.clone();
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
@@ -59,12 +59,12 @@ pub fn make_module() -> KMap {
                         use KIteratorOutput as Output;
                         let (key, value) = match output {
                             Output::ValuePair(key, value) => (key, value),
-                            Output::Value(Value::Tuple(t)) if t.len() == 2 => {
+                            Output::Value(KValue::Tuple(t)) if t.len() == 2 => {
                                 let key = t[0].clone();
                                 let value = t[1].clone();
                                 (key, value)
                             }
-                            Output::Value(value) => (value, Value::Null),
+                            Output::Value(value) => (value, KValue::Null),
                             Output::Error(error) => return Err(error),
                         };
 
@@ -72,7 +72,7 @@ pub fn make_module() -> KMap {
                     }
                 }
 
-                Ok(Value::Map(m))
+                Ok(KValue::Map(m))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -83,8 +83,8 @@ pub fn make_module() -> KMap {
             let expected_error = "a Map and a key, with an optional default value";
 
             match map_instance_and_args(ctx, expected_error)? {
-                (Value::Map(map), [key]) => (map, key, &Value::Null),
-                (Value::Map(map), [key, default]) => (map, key, default),
+                (KValue::Map(map), [key]) => (map, key, &KValue::Null),
+                (KValue::Map(map), [key, default]) => (map, key, default),
                 (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
             }
         };
@@ -100,14 +100,14 @@ pub fn make_module() -> KMap {
             let expected_error = "a Map and a non-negative number";
 
             match map_instance_and_args(ctx, expected_error)? {
-                (Value::Map(map), [Value::Number(n)]) => (map, n, &Value::Null),
-                (Value::Map(map), [Value::Number(n), default]) => (map, n, default),
+                (KValue::Map(map), [KValue::Number(n)]) => (map, n, &KValue::Null),
+                (KValue::Map(map), [KValue::Number(n), default]) => (map, n, default),
                 (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
             }
         };
 
         match map.data().get_index(index.into()) {
-            Some((key, value)) => Ok(Value::Tuple(
+            Some((key, value)) => Ok(KValue::Tuple(
                 vec![key.value().clone(), value.clone()].into(),
             )),
             None => Ok(default.clone()),
@@ -118,14 +118,14 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(map), []) => {
+            (KValue::Map(map), []) => {
                 if map.meta_map().is_some() {
-                    Ok(Value::Map(KMap::from_data_and_meta_maps(
+                    Ok(KValue::Map(KMap::from_data_and_meta_maps(
                         &KMap::default(),
                         map,
                     )))
                 } else {
-                    Ok(Value::Null)
+                    Ok(KValue::Null)
                 }
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -136,20 +136,20 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map and key (with optional Value to insert)";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), [key]) => match m
+            (KValue::Map(m), [key]) => match m
                 .data_mut()
-                .insert(ValueKey::try_from(key.clone())?, Value::Null)
+                .insert(ValueKey::try_from(key.clone())?, KValue::Null)
             {
                 Some(old_value) => Ok(old_value),
-                None => Ok(Value::Null),
+                None => Ok(KValue::Null),
             },
-            (Value::Map(m), [key, value]) => {
+            (KValue::Map(m), [key, value]) => {
                 match m
                     .data_mut()
                     .insert(ValueKey::try_from(key.clone())?, value.clone())
                 {
                     Some(old_value) => Ok(old_value),
-                    None => Ok(Value::Null),
+                    None => Ok(KValue::Null),
                 }
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -160,7 +160,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), []) => Ok(m.is_empty().into()),
+            (KValue::Map(m), []) => Ok(m.is_empty().into()),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -169,7 +169,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), []) => {
+            (KValue::Map(m), []) => {
                 let result = adaptors::PairFirst::new(KIterator::with_map(m.clone()));
                 Ok(KIterator::new(result).into())
             }
@@ -181,10 +181,10 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map and key";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), [key]) => {
+            (KValue::Map(m), [key]) => {
                 match m.data_mut().shift_remove(&ValueKey::try_from(key.clone())?) {
                     Some(old_value) => Ok(old_value),
-                    None => Ok(Value::Null),
+                    None => Ok(KValue::Null),
                 }
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -195,7 +195,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), []) => Ok(Value::Number(m.len().into())),
+            (KValue::Map(m), []) => Ok(KValue::Number(m.len().into())),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -204,7 +204,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map and optional sort key function";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), []) => {
+            (KValue::Map(m), []) => {
                 let mut error = None;
                 m.data_mut().sort_by(|key_a, _, key_b, _| {
                     if error.is_some() {
@@ -224,10 +224,10 @@ pub fn make_module() -> KMap {
                 if let Some(error) = error {
                     error
                 } else {
-                    Ok(Value::Map(m.clone()))
+                    Ok(KValue::Map(m.clone()))
                 }
             }
-            (Value::Map(m), [f]) if f.is_callable() => {
+            (KValue::Map(m), [f]) if f.is_callable() => {
                 let m = m.clone();
                 let f = f.clone();
                 let mut error = None;
@@ -235,8 +235,8 @@ pub fn make_module() -> KMap {
                 let get_sort_key = |vm: &mut Vm,
                                     cache: &mut ValueMap,
                                     key: &ValueKey,
-                                    value: &Value|
-                 -> Result<Value> {
+                                    value: &KValue|
+                 -> Result<KValue> {
                     let value = vm.run_function(
                         f.clone(),
                         CallArgs::Separate(&[key.value().clone(), value.clone()]),
@@ -257,7 +257,7 @@ pub fn make_module() -> KMap {
                             Ok(val) => val,
                             Err(e) => {
                                 error.get_or_insert(Err(e));
-                                Value::Null
+                                KValue::Null
                             }
                         },
                     };
@@ -267,7 +267,7 @@ pub fn make_module() -> KMap {
                             Ok(val) => val,
                             Err(e) => {
                                 error.get_or_insert(Err(e));
-                                Value::Null
+                                KValue::Null
                             }
                         },
                     };
@@ -284,7 +284,7 @@ pub fn make_module() -> KMap {
                 if let Some(error) = error {
                     error
                 } else {
-                    Ok(Value::Map(m))
+                    Ok(KValue::Map(m))
                 }
             }
             (_, unexpected) => type_error_with_slice("a Map ", unexpected),
@@ -295,14 +295,14 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map, key, optional default Value, and update function";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), [key, f]) if f.is_callable() => do_map_update(
+            (KValue::Map(m), [key, f]) if f.is_callable() => do_map_update(
                 m.clone(),
                 ValueKey::try_from(key.clone())?,
-                Value::Null,
+                KValue::Null,
                 f.clone(),
                 ctx.vm,
             ),
-            (Value::Map(m), [key, default, f]) if f.is_callable() => do_map_update(
+            (KValue::Map(m), [key, default, f]) if f.is_callable() => do_map_update(
                 m.clone(),
                 ValueKey::try_from(key.clone())?,
                 default.clone(),
@@ -317,7 +317,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Map";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(m), []) => {
+            (KValue::Map(m), []) => {
                 let result = adaptors::PairSecond::new(KIterator::with_map(m.clone()));
                 Ok(KIterator::new(result).into())
             }
@@ -329,8 +329,8 @@ pub fn make_module() -> KMap {
         let expected_error = "two Maps";
 
         match map_instance_and_args(ctx, expected_error)? {
-            (Value::Map(data), [Value::Map(meta)]) => {
-                Ok(Value::Map(KMap::from_data_and_meta_maps(data, meta)))
+            (KValue::Map(data), [KValue::Map(meta)]) => {
+                Ok(KValue::Map(KMap::from_data_and_meta_maps(data, meta)))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -339,7 +339,13 @@ pub fn make_module() -> KMap {
     result
 }
 
-fn do_map_update(map: KMap, key: ValueKey, default: Value, f: Value, vm: &mut Vm) -> Result<Value> {
+fn do_map_update(
+    map: KMap,
+    key: ValueKey,
+    default: KValue,
+    f: KValue,
+    vm: &mut Vm,
+) -> Result<KValue> {
     if !map.data().contains_key(&key) {
         map.data_mut().insert(key.clone(), default);
     }
@@ -356,8 +362,8 @@ fn do_map_update(map: KMap, key: ValueKey, default: Value, f: Value, vm: &mut Vm
 fn map_instance_and_args<'a>(
     ctx: &'a CallContext<'_>,
     expected_error: &str,
-) -> Result<(&'a Value, &'a [Value])> {
-    use Value::Map;
+) -> Result<(&'a KValue, &'a [KValue])> {
+    use KValue::Map;
 
     // For core.map ops, allow using maps with metamaps when the ops are used as standalone
     // functions.

--- a/crates/runtime/src/core_lib/number.rs
+++ b/crates/runtime/src/core_lib/number.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 
 /// Initializes the `number` core library module
 pub fn make_module() -> KMap {
-    use Value::Number;
+    use KValue::Number;
 
     let result = KMap::with_type("core.number");
 
@@ -219,10 +219,10 @@ pub fn make_module() -> KMap {
     result
 }
 
-fn is_number(value: &Value) -> bool {
-    matches!(value, Value::Number(_))
+fn is_number(value: &KValue) -> bool {
+    matches!(value, KValue::Number(_))
 }
 
-fn is_integer(value: &Value) -> bool {
-    matches!(value, Value::Number(KNumber::I64(_)))
+fn is_integer(value: &KValue) -> bool {
+    matches!(value, KValue::Number(KNumber::I64(_)))
 }

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -6,7 +6,7 @@ use instant::Instant;
 
 /// Initializes the `os` core library module
 pub fn make_module() -> KMap {
-    use Value::Number;
+    use KValue::Number;
 
     let result = KMap::with_type("core.os");
 
@@ -35,15 +35,15 @@ pub struct DateTime(chrono::DateTime<Local>);
 
 #[koto_impl(runtime = crate)]
 impl DateTime {
-    fn with_chrono_datetime(time: chrono::DateTime<Local>) -> Value {
+    fn with_chrono_datetime(time: chrono::DateTime<Local>) -> KValue {
         KObject::from(Self(time)).into()
     }
 
-    fn now() -> Value {
+    fn now() -> KValue {
         Self::with_chrono_datetime(Local::now())
     }
 
-    fn from_seconds(seconds: f64, maybe_offset: Option<i64>) -> Result<Value> {
+    fn from_seconds(seconds: f64, maybe_offset: Option<i64>) -> Result<KValue> {
         let seconds_i64 = seconds as i64;
         let sub_nanos = (seconds.fract() * 1.0e9) as u32;
         let offset = match maybe_offset {
@@ -62,54 +62,54 @@ impl DateTime {
     }
 
     #[koto_method]
-    fn day(&self) -> Value {
+    fn day(&self) -> KValue {
         self.0.day().into()
     }
 
     #[koto_method]
-    fn hour(&self) -> Value {
+    fn hour(&self) -> KValue {
         self.0.hour().into()
     }
 
     #[koto_method]
-    fn minute(&self) -> Value {
+    fn minute(&self) -> KValue {
         self.0.minute().into()
     }
 
     #[koto_method]
-    fn month(&self) -> Value {
+    fn month(&self) -> KValue {
         self.0.month().into()
     }
 
     #[koto_method]
-    fn second(&self) -> Value {
+    fn second(&self) -> KValue {
         self.0.second().into()
     }
 
     #[koto_method]
-    fn nanosecond(&self) -> Value {
+    fn nanosecond(&self) -> KValue {
         self.0.nanosecond().into()
     }
 
     #[koto_method]
-    fn timestamp(&self) -> Value {
+    fn timestamp(&self) -> KValue {
         let seconds = self.0.timestamp() as f64;
         let sub_nanos = self.0.timestamp_subsec_nanos();
         (seconds + sub_nanos as f64 / 1.0e9).into()
     }
 
     #[koto_method]
-    fn timezone_offset(&self) -> Value {
+    fn timezone_offset(&self) -> KValue {
         self.0.offset().local_minus_utc().into()
     }
 
     #[koto_method]
-    fn timezone_string(&self) -> Value {
+    fn timezone_string(&self) -> KValue {
         self.0.format("%z").to_string().into()
     }
 
     #[koto_method]
-    fn year(&self) -> Value {
+    fn year(&self) -> KValue {
         self.0.year().into()
     }
 }
@@ -127,7 +127,7 @@ pub struct Timer(Instant);
 
 #[koto_impl(runtime = crate)]
 impl Timer {
-    fn now() -> Value {
+    fn now() -> KValue {
         let timer = Self(Instant::now());
         KObject::from(timer).into()
     }
@@ -137,7 +137,7 @@ impl Timer {
     }
 
     #[koto_method]
-    fn elapsed(&self) -> Value {
+    fn elapsed(&self) -> KValue {
         self.elapsed_seconds().into()
     }
 }
@@ -148,9 +148,9 @@ impl KotoObject for Timer {
         Ok(())
     }
 
-    fn subtract(&self, rhs: &Value) -> Result<Value> {
+    fn subtract(&self, rhs: &KValue) -> Result<KValue> {
         match rhs {
-            Value::Object(o) if o.is_a::<Self>() => {
+            KValue::Object(o) if o.is_a::<Self>() => {
                 let rhs = o.cast::<Self>().unwrap();
 
                 let result = if self.0 >= rhs.0 {

--- a/crates/runtime/src/core_lib/range.rs
+++ b/crates/runtime/src/core_lib/range.rs
@@ -10,8 +10,8 @@ pub fn make_module() -> KMap {
         let expected_error = "a Range, and a Number or another Range";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(r), [Value::Number(n)]) => Ok(r.contains(*n).into()),
-            (Value::Range(a), [Value::Range(b)]) => {
+            (KValue::Range(r), [KValue::Number(n)]) => Ok(r.contains(*n).into()),
+            (KValue::Range(a), [KValue::Range(b)]) => {
                 let r_a = a.as_sorted_range();
                 let r_b = b.as_sorted_range();
                 let result = r_b.start >= r_a.start && r_b.end <= r_a.end;
@@ -25,8 +25,8 @@ pub fn make_module() -> KMap {
         let expected_error = "a Range";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(r), []) => {
-                Ok(r.end().map_or(Value::Null, |(end, _inclusive)| end.into()))
+            (KValue::Range(r), []) => {
+                Ok(r.end().map_or(KValue::Null, |(end, _inclusive)| end.into()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -36,7 +36,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Range and Number";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(r), [Value::Number(n)]) => match (r.start(), r.end()) {
+            (KValue::Range(r), [KValue::Number(n)]) => match (r.start(), r.end()) {
                 (Some(start), Some((end, inclusive))) => {
                     let n = i64::from(n);
                     let result = if r.is_ascending() {
@@ -56,9 +56,9 @@ pub fn make_module() -> KMap {
         let expected_error = "two Ranges";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(a), [Value::Range(b)]) => Ok(a
+            (KValue::Range(a), [KValue::Range(b)]) => Ok(a
                 .intersection(b)
-                .map_or(Value::Null, |result| result.into())),
+                .map_or(KValue::Null, |result| result.into())),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -67,7 +67,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Range";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(r), []) => {
+            (KValue::Range(r), []) => {
                 Ok(r.end().map_or(false, |(_end, inclusive)| inclusive).into())
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -78,7 +78,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Range";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(r), []) => match r.size() {
+            (KValue::Range(r), []) => match r.size() {
                 Some(size) => Ok(size.into()),
                 None => runtime_error!("range.size can't be used with '{r}'"),
             },
@@ -90,7 +90,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Range";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(r), []) => Ok(r.start().map_or(Value::Null, Value::from)),
+            (KValue::Range(r), []) => Ok(r.start().map_or(KValue::Null, KValue::from)),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -99,7 +99,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Range, and a Number or another Range";
 
         match ctx.instance_and_args(is_range, expected_error)? {
-            (Value::Range(r), [Value::Number(n)]) => {
+            (KValue::Range(r), [KValue::Number(n)]) => {
                 let n = i64::from(n);
                 match (r.start(), r.end()) {
                     (Some(start), Some((end, inclusive))) => {
@@ -113,7 +113,7 @@ pub fn make_module() -> KMap {
                     _ => runtime_error!("range.union can't be used with '{r}'"),
                 }
             }
-            (Value::Range(a), [Value::Range(b)]) => match (a.start(), a.end()) {
+            (KValue::Range(a), [KValue::Range(b)]) => match (a.start(), a.end()) {
                 (Some(start), Some((end, inclusive))) => {
                     let r_b = b.as_sorted_range();
                     let result = if start <= end {
@@ -132,6 +132,6 @@ pub fn make_module() -> KMap {
     result
 }
 
-fn is_range(value: &Value) -> bool {
-    matches!(value, Value::Range(_))
+fn is_range(value: &KValue) -> bool {
+    matches!(value, KValue::Range(_))
 }

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -16,7 +16,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => {
+            (KValue::Str(s), []) => {
                 let result = iterators::Bytes::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
@@ -28,7 +28,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => Ok(Value::Iterator(KIterator::with_string(s.clone()))),
+            (KValue::Str(s), []) => Ok(KValue::Iterator(KIterator::with_string(s.clone()))),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -37,7 +37,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s1), [Value::Str(s2)]) => Ok(s1.contains(s2.as_str()).into()),
+            (KValue::Str(s1), [KValue::Str(s2)]) => Ok(s1.contains(s2.as_str()).into()),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -46,7 +46,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), [Value::Str(pattern)]) => {
+            (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().ends_with(pattern.as_str()).into())
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -57,7 +57,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => Ok(s.escape_default().to_string().into()),
+            (KValue::Str(s), []) => Ok(s.escape_default().to_string().into()),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -66,8 +66,8 @@ pub fn make_module() -> KMap {
         let expected_error = "a String optionally followed by additional values";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => Ok(Value::Str(s.clone())),
-            (Value::Str(format), format_args) => {
+            (KValue::Str(s), []) => Ok(KValue::Str(s.clone())),
+            (KValue::Str(format), format_args) => {
                 let format = format.clone();
                 let format_args = format_args.to_vec();
                 match format::format_string(ctx.vm, &format, &format_args) {
@@ -89,7 +89,7 @@ pub fn make_module() -> KMap {
             for output in iterator.map(collect_pair) {
                 use KIteratorOutput as Output;
                 match output {
-                    Output::Value(Value::Number(n)) => match u8::try_from(n.as_i64()) {
+                    Output::Value(KValue::Number(n)) => match u8::try_from(n.as_i64()) {
                         Ok(byte) => bytes.push(byte),
                         Err(_) => return runtime_error!("'{n}' is out of the valid byte range"),
                     },
@@ -111,7 +111,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => Ok(s.is_empty().into()),
+            (KValue::Str(s), []) => Ok(s.is_empty().into()),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -120,7 +120,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => {
+            (KValue::Str(s), []) => {
                 let result = iterators::Lines::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
@@ -132,7 +132,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String, followed by pattern and replacement Strings";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(input), [Value::Str(pattern), Value::Str(replace)]) => {
+            (KValue::Str(input), [KValue::Str(pattern), KValue::Str(replace)]) => {
                 Ok(input.replace(pattern.as_str(), replace).into())
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -143,7 +143,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => Ok(s.graphemes(true).count().into()),
+            (KValue::Str(s), []) => Ok(s.graphemes(true).count().into()),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -153,11 +153,11 @@ pub fn make_module() -> KMap {
             let expected_error = "a String, and either a String or a predicate function";
 
             match ctx.instance_and_args(is_string, expected_error)? {
-                (Value::Str(input), [Value::Str(pattern)]) => {
+                (KValue::Str(input), [KValue::Str(pattern)]) => {
                     let result = iterators::Split::new(input.clone(), pattern.clone());
                     KIterator::new(result)
                 }
-                (Value::Str(input), [predicate]) if predicate.is_callable() => {
+                (KValue::Str(input), [predicate]) if predicate.is_callable() => {
                     let result = iterators::SplitWith::new(
                         input.clone(),
                         predicate.clone(),
@@ -169,14 +169,14 @@ pub fn make_module() -> KMap {
             }
         };
 
-        Ok(Value::Iterator(iterator))
+        Ok(KValue::Iterator(iterator))
     });
 
     result.add_fn("starts_with", |ctx| {
         let expected_error = "two Strings";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), [Value::Str(pattern)]) => {
+            (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().starts_with(pattern.as_str()).into())
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -187,7 +187,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => {
+            (KValue::Str(s), []) => {
                 let result = s.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
                 Ok(result.into())
             }
@@ -199,7 +199,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => {
+            (KValue::Str(s), []) => {
                 let maybe_integer = if let Some(hex) = s.strip_prefix("0x") {
                     i64::from_str_radix(hex, 16)
                 } else if let Some(octal) = s.strip_prefix("0o") {
@@ -215,10 +215,10 @@ pub fn make_module() -> KMap {
                 } else if let Ok(float) = s.parse::<f64>() {
                     Ok(float.into())
                 } else {
-                    Ok(Value::Null)
+                    Ok(KValue::Null)
                 }
             }
-            (Value::Str(s), [Value::Number(n)]) => {
+            (KValue::Str(s), [KValue::Number(n)]) => {
                 let base = n.into();
                 if !(2..=36).contains(&base) {
                     return runtime_error!("Number base must be within 2..=36");
@@ -227,7 +227,7 @@ pub fn make_module() -> KMap {
                 if let Ok(result) = i64::from_str_radix(s, base) {
                     Ok(result.into())
                 } else {
-                    Ok(Value::Null)
+                    Ok(KValue::Null)
                 }
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
@@ -238,7 +238,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => {
+            (KValue::Str(s), []) => {
                 let result = s.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
                 Ok(result.into())
             }
@@ -250,7 +250,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a String";
 
         match ctx.instance_and_args(is_string, expected_error)? {
-            (Value::Str(s), []) => {
+            (KValue::Str(s), []) => {
                 let result = match s.find(|c: char| !c.is_whitespace()) {
                     Some(start) => {
                         let end = s.rfind(|c: char| !c.is_whitespace()).unwrap();
@@ -268,6 +268,6 @@ pub fn make_module() -> KMap {
     result
 }
 
-fn is_string(value: &Value) -> bool {
-    matches!(value, Value::Str(_))
+fn is_string(value: &KValue) -> bool {
+    matches!(value, KValue::Str(_))
 }

--- a/crates/runtime/src/core_lib/string/format.rs
+++ b/crates/runtime/src/core_lib/string/format.rs
@@ -2,7 +2,7 @@
 
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::{runtime_error, KValue, UnaryOp, Vm};
+use crate::{runtime_error, KValue, KotoVm, UnaryOp};
 use koto_lexer::{is_id_continue, is_id_start};
 use std::{iter::Peekable, str::Chars};
 
@@ -296,7 +296,7 @@ impl<'a> Iterator for FormatLexer<'a> {
 
 /// Formats a string, used by `string.format` and `io.print`
 pub fn format_string(
-    vm: &mut Vm,
+    vm: &mut KotoVm,
     format_string: &str,
     format_args: &[KValue],
 ) -> crate::Result<String> {
@@ -334,7 +334,11 @@ pub fn format_string(
     Ok(result)
 }
 
-fn value_to_string(vm: &mut Vm, value: &KValue, format_spec: FormatSpec) -> crate::Result<String> {
+fn value_to_string(
+    vm: &mut KotoVm,
+    value: &KValue,
+    format_spec: FormatSpec,
+) -> crate::Result<String> {
     let result = match value {
         KValue::Number(n) => match format_spec.precision {
             Some(precision) => {
@@ -541,7 +545,7 @@ mod tests {
         use super::*;
 
         fn check_format_output(format: &str, args: &[KValue], expected: &str) {
-            let mut vm = Vm::default();
+            let mut vm = KotoVm::default();
             match format_string(&mut vm, format, args) {
                 Ok(result) => assert_eq!(result, expected),
                 Err(error) => panic!("format_string failed: '{error}'"),

--- a/crates/runtime/src/core_lib/string/format.rs
+++ b/crates/runtime/src/core_lib/string/format.rs
@@ -2,7 +2,7 @@
 
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::{runtime_error, UnaryOp, Value, Vm};
+use crate::{runtime_error, KValue, UnaryOp, Vm};
 use koto_lexer::{is_id_continue, is_id_start};
 use std::{iter::Peekable, str::Chars};
 
@@ -298,7 +298,7 @@ impl<'a> Iterator for FormatLexer<'a> {
 pub fn format_string(
     vm: &mut Vm,
     format_string: &str,
-    format_args: &[Value],
+    format_args: &[KValue],
 ) -> crate::Result<String> {
     let mut arg_iter = format_args.iter();
     let mut result = String::with_capacity(format_string.len());
@@ -315,7 +315,7 @@ pub fn format_string(
                 None => return runtime_error!("Missing argument for index {n}"),
             },
             FormatToken::Identifier(id, format_spec) => match format_args.first() {
-                Some(Value::Map(map)) => match map.data().get(id) {
+                Some(KValue::Map(map)) => match map.data().get(id) {
                     Some(value) => result.push_str(&value_to_string(vm, value, format_spec)?),
                     None => return runtime_error!("Key '{id}' not found in map"),
                 },
@@ -334,9 +334,9 @@ pub fn format_string(
     Ok(result)
 }
 
-fn value_to_string(vm: &mut Vm, value: &Value, format_spec: FormatSpec) -> crate::Result<String> {
+fn value_to_string(vm: &mut Vm, value: &KValue, format_spec: FormatSpec) -> crate::Result<String> {
     let result = match value {
-        Value::Number(n) => match format_spec.precision {
+        KValue::Number(n) => match format_spec.precision {
             Some(precision) => {
                 if n.is_f64() || n.is_i64_in_f64_range() {
                     format!("{:.*}", precision as usize, f64::from(n))
@@ -347,7 +347,7 @@ fn value_to_string(vm: &mut Vm, value: &Value, format_spec: FormatSpec) -> crate
             None => n.to_string(),
         },
         _ => match vm.run_unary_op(UnaryOp::Display, value.clone())? {
-            Value::Str(result) => {
+            KValue::Str(result) => {
                 match format_spec.precision {
                     Some(precision) => {
                         // precision acts as a maximum width for non-number values
@@ -391,7 +391,7 @@ fn value_to_string(vm: &mut Vm, value: &Value, format_spec: FormatSpec) -> crate
                     }
                     Some(FormatAlign::Right) => fill.repeat(fill_chars) + &result,
                     None => {
-                        if matches!(value, Value::Number(_)) {
+                        if matches!(value, KValue::Number(_)) {
                             fill.repeat(fill_chars) + &result
                         } else {
                             result + &fill.repeat(fill_chars)
@@ -540,7 +540,7 @@ mod tests {
     mod format_string {
         use super::*;
 
-        fn check_format_output(format: &str, args: &[Value], expected: &str) {
+        fn check_format_output(format: &str, args: &[KValue], expected: &str) {
             let mut vm = Vm::default();
             match format_string(&mut vm, format, args) {
                 Ok(result) => assert_eq!(result, expected),
@@ -550,31 +550,31 @@ mod tests {
 
         #[test]
         fn positional_placeholders() {
-            check_format_output("{} foo {0}", &[Value::Number(1.into())], "1 foo 1");
+            check_format_output("{} foo {0}", &[KValue::Number(1.into())], "1 foo 1");
             check_format_output(
                 "{1} - {0} {} - {}",
-                &[Value::Number(2.into()), Value::Null],
+                &[KValue::Number(2.into()), KValue::Null],
                 "null - 2 2 - null",
             );
         }
 
         #[test]
         fn positional_with_precision() {
-            let one = Value::Number(1.into());
-            let one_third = Value::Number((1.0 / 3.0).into());
+            let one = KValue::Number(1.into());
+            let one_third = KValue::Number((1.0 / 3.0).into());
             check_format_output("{:.0}", &[one.clone()], "1");
             check_format_output("{:.2}", &[one.clone()], "1.00");
             check_format_output("{:.2}", &[one_third.clone()], "0.33");
-            check_format_output("{:.3}", &[Value::Str("abcdef".into())], "abc");
+            check_format_output("{:.3}", &[KValue::Str("abcdef".into())], "abc");
             check_format_output("{0:.1}, {1:.3}", &[one, one_third], "1.0, 0.333");
         }
 
         #[test]
         fn identifier_placeholders() {
             let mut map_data = ValueMap::default();
-            map_data.insert("x".into(), Value::Number(42.into()));
-            map_data.insert("y".into(), Value::Number(i64::from(-1).into()));
-            let map = Value::Map(KMap::with_data(map_data));
+            map_data.insert("x".into(), KValue::Number(42.into()));
+            map_data.insert("y".into(), KValue::Number(i64::from(-1).into()));
+            let map = KValue::Map(KMap::with_data(map_data));
 
             check_format_output("{x} - {y}", &[map.clone()], "42 - -1");
             check_format_output("{x:.2} - {y:.1}", &[map], "42.00 - -1.0");
@@ -582,7 +582,7 @@ mod tests {
 
         #[test]
         fn fill_and_align_string() {
-            let s = &[Value::Str("abcd".into())];
+            let s = &[KValue::Str("abcd".into())];
             check_format_output("{:8}", s, "abcd    ");
             check_format_output("{:<8}", s, "abcd    ");
             check_format_output("{:^8}", s, "  abcd  ");
@@ -603,8 +603,8 @@ mod tests {
 
         #[test]
         fn fill_and_align_number() {
-            let n = &[Value::Number((1.0 / 3.0).into())];
-            let n_negative = &[Value::Number((-1.0 / 3.0).into())];
+            let n = &[KValue::Number((1.0 / 3.0).into())];
+            let n_negative = &[KValue::Number((-1.0 / 3.0).into())];
             check_format_output("{:8.2}", n, "    0.33");
             check_format_output("{:8.3}", n, "   0.333");
             check_format_output("{:®^8.3}", n, "®0.333®®");

--- a/crates/runtime/src/core_lib/string/iterators.rs
+++ b/crates/runtime/src/core_lib/string/iterators.rs
@@ -1,7 +1,7 @@
 //! A collection of string iterators
 
 use crate::{
-    CallArgs, KIterator, KIteratorOutput as Output, KString, KotoIterator, Result, Value, Vm,
+    CallArgs, KIterator, KIteratorOutput as Output, KString, KValue, KotoIterator, Result, Vm,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -89,7 +89,7 @@ impl Iterator for Lines {
                 None => self.input.len(),
             };
 
-            let result = Value::Str(self.input.with_bounds(start..end).unwrap());
+            let result = KValue::Str(self.input.with_bounds(start..end).unwrap());
             self.start = end + newline_bytes;
             Some(Output::Value(result))
         } else {
@@ -139,7 +139,7 @@ impl Iterator for Split {
                 None => self.input.len(),
             };
 
-            let output = Value::Str(self.input.with_bounds(start..end).unwrap());
+            let output = KValue::Str(self.input.with_bounds(start..end).unwrap());
             self.start = end + self.pattern.len();
             Some(Output::Value(output))
         } else {
@@ -156,14 +156,14 @@ impl Iterator for Split {
 /// An iterator that splits up a string into parts, separated when a char passes a predicate
 pub struct SplitWith {
     input: KString,
-    predicate: Value,
+    predicate: KValue,
     vm: Vm,
     start: usize,
 }
 
 impl SplitWith {
     /// Creates a new [SplitWith] iterator
-    pub fn new(input: KString, predicate: Value, vm: Vm) -> Self {
+    pub fn new(input: KString, predicate: KValue, vm: Vm) -> Self {
         Self {
             input,
             predicate,
@@ -189,7 +189,7 @@ impl Iterator for SplitWith {
     type Item = Output;
 
     fn next(&mut self) -> Option<Self::Item> {
-        use Value::{Bool, Str};
+        use KValue::{Bool, Str};
 
         let start = self.start;
         if start < self.input.len() {

--- a/crates/runtime/src/core_lib/string/iterators.rs
+++ b/crates/runtime/src/core_lib/string/iterators.rs
@@ -1,7 +1,7 @@
 //! A collection of string iterators
 
 use crate::{
-    CallArgs, KIterator, KIteratorOutput as Output, KString, KValue, KotoIterator, Result, Vm,
+    CallArgs, KIterator, KIteratorOutput as Output, KString, KValue, KotoIterator, KotoVm, Result,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -157,13 +157,13 @@ impl Iterator for Split {
 pub struct SplitWith {
     input: KString,
     predicate: KValue,
-    vm: Vm,
+    vm: KotoVm,
     start: usize,
 }
 
 impl SplitWith {
     /// Creates a new [SplitWith] iterator
-    pub fn new(input: KString, predicate: KValue, vm: Vm) -> Self {
+    pub fn new(input: KString, predicate: KValue, vm: KotoVm) -> Self {
         Self {
             input,
             predicate,

--- a/crates/runtime/src/core_lib/test.rs
+++ b/crates/runtime/src/core_lib/test.rs
@@ -9,7 +9,7 @@ pub fn make_module() -> KMap {
     result.add_fn("assert", |ctx| {
         for value in ctx.args().iter() {
             match value {
-                Value::Bool(b) => {
+                KValue::Bool(b) => {
                     if !b {
                         return runtime_error!("Assertion failed");
                     }
@@ -17,7 +17,7 @@ pub fn make_module() -> KMap {
                 unexpected => return type_error("Bool as argument", unexpected),
             }
         }
-        Ok(Value::Null)
+        Ok(KValue::Null)
     });
 
     result.add_fn("assert_eq", |ctx| match ctx.args() {
@@ -26,8 +26,8 @@ pub fn make_module() -> KMap {
             let b = b.clone();
             let result = ctx.vm.run_binary_op(BinaryOp::Equal, a.clone(), b.clone());
             match result {
-                Ok(Value::Bool(true)) => Ok(Value::Null),
-                Ok(Value::Bool(false)) => {
+                Ok(KValue::Bool(true)) => Ok(KValue::Null),
+                Ok(KValue::Bool(false)) => {
                     runtime_error!(
                         "Assertion failed, '{}' is not equal to '{}'",
                         ctx.vm.value_to_string(&a)?,
@@ -49,8 +49,8 @@ pub fn make_module() -> KMap {
                 .vm
                 .run_binary_op(BinaryOp::NotEqual, a.clone(), b.clone());
             match result {
-                Ok(Value::Bool(true)) => Ok(Value::Null),
-                Ok(Value::Bool(false)) => {
+                Ok(KValue::Bool(true)) => Ok(KValue::Null),
+                Ok(KValue::Bool(false)) => {
                     runtime_error!(
                         "Assertion failed, '{}' should not be equal to '{}'",
                         ctx.vm.value_to_string(&a)?,
@@ -65,8 +65,8 @@ pub fn make_module() -> KMap {
     });
 
     result.add_fn("assert_near", |ctx| match ctx.args() {
-        [Value::Number(a), Value::Number(b)] => number_near(*a, *b, 1.0e-12),
-        [Value::Number(a), Value::Number(b), Value::Number(allowed_diff)] => {
+        [KValue::Number(a), KValue::Number(b)] => number_near(*a, *b, 1.0e-12),
+        [KValue::Number(a), KValue::Number(b), KValue::Number(allowed_diff)] => {
             number_near(*a, *b, allowed_diff.into())
         }
         unexpected => type_error_with_slice(
@@ -77,7 +77,7 @@ pub fn make_module() -> KMap {
     });
 
     result.add_fn("run_tests", |ctx| match ctx.args() {
-        [Value::Map(tests)] => {
+        [KValue::Map(tests)] => {
             let tests = tests.clone();
             ctx.vm.run_tests(tests)
         }
@@ -91,9 +91,9 @@ fn f64_near(a: f64, b: f64, allowed_diff: f64) -> bool {
     (a - b).abs() <= allowed_diff
 }
 
-fn number_near(a: KNumber, b: KNumber, allowed_diff: f64) -> Result<Value> {
+fn number_near(a: KNumber, b: KNumber, allowed_diff: f64) -> Result<KValue> {
     if f64_near(a.into(), b.into(), allowed_diff) {
-        Ok(Value::Null)
+        Ok(KValue::Null)
     } else {
         runtime_error!(
             "Assertion failed, '{a}' and '{b}' are not within {allowed_diff} of each other"

--- a/crates/runtime/src/core_lib/tuple.rs
+++ b/crates/runtime/src/core_lib/tuple.rs
@@ -11,7 +11,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Tuple and a Value";
 
         match ctx.instance_and_args(is_tuple, expected_error)? {
-            (Value::Tuple(t), [value]) => {
+            (KValue::Tuple(t), [value]) => {
                 let t = t.clone();
                 let value = value.clone();
                 for candidate in t.iter() {
@@ -19,8 +19,8 @@ pub fn make_module() -> KMap {
                         .vm
                         .run_binary_op(BinaryOp::Equal, value.clone(), candidate.clone())
                     {
-                        Ok(Value::Bool(false)) => {}
-                        Ok(Value::Bool(true)) => return Ok(true.into()),
+                        Ok(KValue::Bool(false)) => {}
+                        Ok(KValue::Bool(true)) => return Ok(true.into()),
                         Ok(unexpected) => {
                             return type_error_with_slice(
                                 "a Bool from the equality comparison",
@@ -40,9 +40,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a Tuple";
 
         match ctx.instance_and_args(is_tuple, expected_error)? {
-            (Value::Tuple(t), []) => match t.first() {
+            (KValue::Tuple(t), []) => match t.first() {
                 Some(value) => Ok(value.clone()),
-                None => Ok(Value::Null),
+                None => Ok(KValue::Null),
             },
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -53,8 +53,8 @@ pub fn make_module() -> KMap {
             let expected_error = "a Tuple and Number (with optional default Value)";
 
             match ctx.instance_and_args(is_tuple, expected_error)? {
-                (Value::Tuple(tuple), [Value::Number(n)]) => (tuple, n, &Value::Null),
-                (Value::Tuple(tuple), [Value::Number(n), default]) => (tuple, n, default),
+                (KValue::Tuple(tuple), [KValue::Number(n)]) => (tuple, n, &KValue::Null),
+                (KValue::Tuple(tuple), [KValue::Number(n), default]) => (tuple, n, default),
                 (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
             }
         };
@@ -69,9 +69,9 @@ pub fn make_module() -> KMap {
         let expected_error = "a Tuple";
 
         match ctx.instance_and_args(is_tuple, expected_error)? {
-            (Value::Tuple(t), []) => match t.last() {
+            (KValue::Tuple(t), []) => match t.last() {
                 Some(value) => Ok(value.clone()),
-                None => Ok(Value::Null),
+                None => Ok(KValue::Null),
             },
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -81,7 +81,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Tuple";
 
         match ctx.instance_and_args(is_tuple, expected_error)? {
-            (Value::Tuple(t), []) => Ok(Value::Number(t.len().into())),
+            (KValue::Tuple(t), []) => Ok(KValue::Number(t.len().into())),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -90,12 +90,12 @@ pub fn make_module() -> KMap {
         let expected_error = "a Tuple";
 
         match ctx.instance_and_args(is_tuple, expected_error)? {
-            (Value::Tuple(t), []) => {
+            (KValue::Tuple(t), []) => {
                 let mut result = t.to_vec();
 
                 sort_values(ctx.vm, &mut result)?;
 
-                Ok(Value::Tuple(result.into()))
+                Ok(KValue::Tuple(result.into()))
             }
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
@@ -105,7 +105,7 @@ pub fn make_module() -> KMap {
         let expected_error = "a Tuple";
 
         match ctx.instance_and_args(is_tuple, expected_error)? {
-            (Value::Tuple(t), []) => Ok(Value::List(KList::from_slice(t))),
+            (KValue::Tuple(t), []) => Ok(KValue::List(KList::from_slice(t))),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });
@@ -113,6 +113,6 @@ pub fn make_module() -> KMap {
     result
 }
 
-fn is_tuple(value: &Value) -> bool {
-    matches!(value, Value::Tuple(_))
+fn is_tuple(value: &KValue) -> bool {
+    matches!(value, KValue::Tuple(_))
 }

--- a/crates/runtime/src/core_lib/value_sort.rs
+++ b/crates/runtime/src/core_lib/value_sort.rs
@@ -4,10 +4,10 @@
 
 use std::cmp::Ordering;
 
-use crate::{runtime_error, BinaryOp, Error, KValue, Vm};
+use crate::{runtime_error, BinaryOp, Error, KValue, KotoVm};
 
 /// Sorts values in a slice using Koto operators for comparison.
-pub fn sort_values(vm: &mut Vm, arr: &mut [KValue]) -> Result<(), Error> {
+pub fn sort_values(vm: &mut KotoVm, arr: &mut [KValue]) -> Result<(), Error> {
     let mut error = None;
 
     arr.sort_by(|a, b| {
@@ -32,7 +32,7 @@ pub fn sort_values(vm: &mut Vm, arr: &mut [KValue]) -> Result<(), Error> {
 }
 
 /// Compares values using Koto operators.
-pub fn compare_values(vm: &mut Vm, a: &KValue, b: &KValue) -> Result<Ordering, Error> {
+pub fn compare_values(vm: &mut KotoVm, a: &KValue, b: &KValue) -> Result<Ordering, Error> {
     use KValue::Bool;
 
     match vm.run_binary_op(BinaryOp::Less, a.clone(), b.clone())? {

--- a/crates/runtime/src/core_lib/value_sort.rs
+++ b/crates/runtime/src/core_lib/value_sort.rs
@@ -4,10 +4,10 @@
 
 use std::cmp::Ordering;
 
-use crate::{runtime_error, BinaryOp, Error, Value, Vm};
+use crate::{runtime_error, BinaryOp, Error, KValue, Vm};
 
 /// Sorts values in a slice using Koto operators for comparison.
-pub fn sort_values(vm: &mut Vm, arr: &mut [Value]) -> Result<(), Error> {
+pub fn sort_values(vm: &mut Vm, arr: &mut [KValue]) -> Result<(), Error> {
     let mut error = None;
 
     arr.sort_by(|a, b| {
@@ -32,12 +32,14 @@ pub fn sort_values(vm: &mut Vm, arr: &mut [Value]) -> Result<(), Error> {
 }
 
 /// Compares values using Koto operators.
-pub fn compare_values(vm: &mut Vm, a: &Value, b: &Value) -> Result<Ordering, Error> {
+pub fn compare_values(vm: &mut Vm, a: &KValue, b: &KValue) -> Result<Ordering, Error> {
+    use KValue::Bool;
+
     match vm.run_binary_op(BinaryOp::Less, a.clone(), b.clone())? {
-        Value::Bool(true) => Ok(Ordering::Less),
-        Value::Bool(false) => match vm.run_binary_op(BinaryOp::Greater, a.clone(), b.clone())? {
-            Value::Bool(true) => Ok(Ordering::Greater),
-            Value::Bool(false) => Ok(Ordering::Equal),
+        Bool(true) => Ok(Ordering::Less),
+        Bool(false) => match vm.run_binary_op(BinaryOp::Greater, a.clone(), b.clone())? {
+            Bool(true) => Ok(Ordering::Greater),
+            Bool(false) => Ok(Ordering::Equal),
             unexpected => runtime_error!(
                 "Expected Bool from > comparison, found '{}'",
                 unexpected.type_as_string()

--- a/crates/runtime/src/display_context.rs
+++ b/crates/runtime/src/display_context.rs
@@ -2,13 +2,13 @@ use std::fmt;
 
 use koto_memory::Address;
 
-use crate::{KString, Vm};
+use crate::{KString, KotoVm};
 
 /// A helper for converting Koto values to strings
 #[derive(Default)]
 pub struct DisplayContext<'a> {
     result: String,
-    vm: Option<&'a Vm>,
+    vm: Option<&'a KotoVm>,
     // A contained value might need to be displayed differently,
     // - Strings should be displayed with quotes when they're inside a container.
     // - Containers should check the parent list to avoid recursive display operations.
@@ -17,7 +17,7 @@ pub struct DisplayContext<'a> {
 
 impl<'a> DisplayContext<'a> {
     /// Makes a display context with the given VM
-    pub fn with_vm(vm: &'a Vm) -> Self {
+    pub fn with_vm(vm: &'a KotoVm) -> Self {
         Self {
             result: String::default(),
             vm: Some(vm),
@@ -26,7 +26,7 @@ impl<'a> DisplayContext<'a> {
     }
 
     /// Makes a display context with the given VM and reserved capacity
-    pub fn with_vm_and_capacity(vm: &'a Vm, capacity: usize) -> Self {
+    pub fn with_vm_and_capacity(vm: &'a KotoVm, capacity: usize) -> Self {
         Self {
             result: String::with_capacity(capacity),
             vm: Some(vm),
@@ -45,7 +45,7 @@ impl<'a> DisplayContext<'a> {
     }
 
     /// Returns a reference to the context's VM
-    pub fn vm(&self) -> &Option<&'a Vm> {
+    pub fn vm(&self) -> &Option<&'a KotoVm> {
         &self.vm
     }
 

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -17,19 +17,19 @@ pub(crate) enum ErrorKind {
     #[error("{}", display_thrown_value(thrown_value, vm))]
     KotoError {
         /// The thrown value
-        thrown_value: Value,
+        thrown_value: KValue,
         /// A VM that should be used to format the thrown value
         vm: Vm,
     },
     #[error("Expected {expected}, but found {}", get_value_types(unexpected))]
     UnexpectedType {
         expected: String,
-        unexpected: Vec<Value>,
+        unexpected: Vec<KValue>,
     },
     #[error("Unable to perform operation '{op}' with '{}' and '{}'", lhs.type_as_string(), rhs.type_as_string())]
     InvalidBinaryOp {
-        lhs: Value,
-        rhs: Value,
+        lhs: KValue,
+        rhs: KValue,
         op: BinaryOp,
     },
     #[error("Empty call stack")]
@@ -40,7 +40,7 @@ pub(crate) enum ErrorKind {
     MissingStringBuilder,
 }
 
-fn display_thrown_value(value: &Value, vm: &Vm) -> String {
+fn display_thrown_value(value: &KValue, vm: &Vm) -> String {
     let mut display_context = DisplayContext::with_vm(vm);
 
     if value.display(&mut display_context).is_ok() {
@@ -73,7 +73,7 @@ impl Error {
     }
 
     /// Initializes an error from a thrown Koto value
-    pub(crate) fn from_koto_value(thrown_value: Value, vm: Vm) -> Self {
+    pub(crate) fn from_koto_value(thrown_value: KValue, vm: Vm) -> Self {
         Self::new(ErrorKind::KotoError { thrown_value, vm })
     }
 
@@ -168,19 +168,19 @@ macro_rules! runtime_error {
 }
 
 /// Creates an error that describes a type mismatch
-pub fn type_error<T>(expected_str: &str, unexpected: &Value) -> Result<T> {
+pub fn type_error<T>(expected_str: &str, unexpected: &KValue) -> Result<T> {
     type_error_with_slice(expected_str, &[unexpected.clone()])
 }
 
-/// Creates an error that describes a type mismatch with a slice of [Value]s
-pub fn type_error_with_slice<T>(expected_str: &str, unexpected: &[Value]) -> Result<T> {
+/// Creates an error that describes a type mismatch with a slice of [KValue]s
+pub fn type_error_with_slice<T>(expected_str: &str, unexpected: &[KValue]) -> Result<T> {
     runtime_error!(ErrorKind::UnexpectedType {
         expected: expected_str.into(),
         unexpected: unexpected.into(),
     })
 }
 
-fn get_value_types(values: &[Value]) -> String {
+fn get_value_types(values: &[KValue]) -> String {
     match values {
         [] => "no args".to_string(),
         [single_value] => single_value.type_as_string().to_string(),

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{prelude::*, KotoVm};
 use koto_bytecode::Chunk;
 use koto_parser::format_source_excerpt;
 use std::{error, fmt};
@@ -19,7 +19,7 @@ pub(crate) enum ErrorKind {
         /// The thrown value
         thrown_value: KValue,
         /// A VM that should be used to format the thrown value
-        vm: Vm,
+        vm: KotoVm,
     },
     #[error("Expected {expected}, but found {}", get_value_types(unexpected))]
     UnexpectedType {
@@ -40,7 +40,7 @@ pub(crate) enum ErrorKind {
     MissingStringBuilder,
 }
 
-fn display_thrown_value(value: &KValue, vm: &Vm) -> String {
+fn display_thrown_value(value: &KValue, vm: &KotoVm) -> String {
     let mut display_context = DisplayContext::with_vm(vm);
 
     if value.display(&mut display_context).is_ok() {
@@ -73,7 +73,7 @@ impl Error {
     }
 
     /// Initializes an error from a thrown Koto value
-    pub(crate) fn from_koto_value(thrown_value: KValue, vm: Vm) -> Self {
+    pub(crate) fn from_koto_value(thrown_value: KValue, vm: KotoVm) -> Self {
         Self::new(ErrorKind::KotoError { thrown_value, vm })
     }
 

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, KotoVm};
+use crate::{prelude::*, KotoVm, Ptr};
 use koto_bytecode::Chunk;
 use koto_parser::format_source_excerpt;
 use std::{error, fmt};

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -19,9 +19,9 @@ pub use crate::{
     send_sync::{KotoSend, KotoSync},
     types::{
         BinaryOp, CallContext, IsIterable, KCaptureFunction, KFunction, KIterator, KIteratorOutput,
-        KList, KMap, KNativeFunction, KNumber, KObject, KRange, KString, KTuple, KotoCopy,
+        KList, KMap, KNativeFunction, KNumber, KObject, KRange, KString, KTuple, KValue, KotoCopy,
         KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject, KotoType, MetaKey, MetaMap,
-        MethodContext, UnaryOp, Value, ValueKey, ValueMap, ValueVec,
+        MethodContext, UnaryOp, ValueKey, ValueMap, ValueVec,
     },
     vm::{CallArgs, ModuleImportedCallback, Vm, VmSettings},
 };

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
         KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject, KotoType, MetaKey, MetaMap,
         MethodContext, UnaryOp, ValueKey, ValueMap, ValueVec,
     },
-    vm::{CallArgs, ModuleImportedCallback, Vm, VmSettings},
+    vm::{CallArgs, KotoVm, KotoVmSettings, ModuleImportedCallback},
 };
 pub use koto_derive as derive;
 pub use koto_memory::{make_ptr, make_ptr_mut, Borrow, BorrowMut, KCell, Ptr, PtrMut};

--- a/crates/runtime/src/prelude.rs
+++ b/crates/runtime/src/prelude.rs
@@ -2,10 +2,10 @@
 
 #[doc(inline)]
 pub use crate::{
-    make_ptr, make_ptr_mut, runtime_error, type_error, type_error_with_slice, BinaryOp, Borrow,
-    BorrowMut, CallArgs, CallContext, DisplayContext, IsIterable, KCell, KIterator,
-    KIteratorOutput, KList, KMap, KNativeFunction, KNumber, KObject, KRange, KString, KTuple,
-    KValue, KotoCopy, KotoFile, KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject,
-    KotoRead, KotoSend, KotoSync, KotoType, KotoWrite, MetaKey, MetaMap, MethodContext, Ptr,
-    PtrMut, UnaryOp, ValueKey, ValueMap, ValueVec, Vm, VmSettings,
+    make_ptr, make_ptr_mut, runtime_error, type_error, type_error_with_slice, BinaryOp, CallArgs,
+    CallContext, DisplayContext, IsIterable, KCell, KIterator, KIteratorOutput, KList, KMap,
+    KNativeFunction, KNumber, KObject, KRange, KString, KTuple, KValue, KotoCopy, KotoFile,
+    KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject, KotoRead, KotoSend, KotoSync,
+    KotoType, KotoWrite, MetaKey, MetaMap, MethodContext, Ptr, PtrMut, UnaryOp, ValueKey, ValueMap,
+    ValueVec, Vm, VmSettings,
 };

--- a/crates/runtime/src/prelude.rs
+++ b/crates/runtime/src/prelude.rs
@@ -6,6 +6,6 @@ pub use crate::{
     CallContext, DisplayContext, IsIterable, KCell, KIterator, KIteratorOutput, KList, KMap,
     KNativeFunction, KNumber, KObject, KRange, KString, KTuple, KValue, KotoCopy, KotoFile,
     KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject, KotoRead, KotoSend, KotoSync,
-    KotoType, KotoWrite, MetaKey, MetaMap, MethodContext, Ptr, PtrMut, UnaryOp, ValueKey, ValueMap,
-    ValueVec, Vm, VmSettings,
+    KotoType, KotoVm, KotoVmSettings, KotoWrite, MetaKey, MetaMap, MethodContext, Ptr, PtrMut,
+    UnaryOp, ValueKey, ValueMap, ValueVec,
 };

--- a/crates/runtime/src/prelude.rs
+++ b/crates/runtime/src/prelude.rs
@@ -6,6 +6,6 @@ pub use crate::{
     CallContext, DisplayContext, IsIterable, KCell, KIterator, KIteratorOutput, KList, KMap,
     KNativeFunction, KNumber, KObject, KRange, KString, KTuple, KValue, KotoCopy, KotoFile,
     KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject, KotoRead, KotoSend, KotoSync,
-    KotoType, KotoVm, KotoVmSettings, KotoWrite, MetaKey, MetaMap, MethodContext, Ptr, PtrMut,
-    UnaryOp, ValueKey, ValueMap, ValueVec,
+    KotoType, KotoVm, KotoVmSettings, KotoWrite, MetaKey, MetaMap, MethodContext, UnaryOp,
+    ValueKey, ValueMap, ValueVec,
 };

--- a/crates/runtime/src/prelude.rs
+++ b/crates/runtime/src/prelude.rs
@@ -5,7 +5,7 @@ pub use crate::{
     make_ptr, make_ptr_mut, runtime_error, type_error, type_error_with_slice, BinaryOp, Borrow,
     BorrowMut, CallArgs, CallContext, DisplayContext, IsIterable, KCell, KIterator,
     KIteratorOutput, KList, KMap, KNativeFunction, KNumber, KObject, KRange, KString, KTuple,
-    KotoCopy, KotoFile, KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject, KotoRead,
-    KotoSend, KotoSync, KotoType, KotoWrite, MetaKey, MetaMap, MethodContext, Ptr, PtrMut, UnaryOp,
-    Value, ValueKey, ValueMap, ValueVec, Vm, VmSettings,
+    KValue, KotoCopy, KotoFile, KotoFunction, KotoHasher, KotoIterator, KotoLookup, KotoObject,
+    KotoRead, KotoSend, KotoSync, KotoType, KotoWrite, MetaKey, MetaMap, MethodContext, Ptr,
+    PtrMut, UnaryOp, ValueKey, ValueMap, ValueVec, Vm, VmSettings,
 };

--- a/crates/runtime/src/types/function.rs
+++ b/crates/runtime/src/types/function.rs
@@ -7,7 +7,7 @@ use koto_memory::Ptr;
 /// See also:
 /// * [KCaptureFunction]
 /// * [KNativeFunction](crate::KNativeFunction)
-/// * [Value::Function](crate::Value::Function)
+/// * [KValue::Function](crate::KValue::Function)
 #[derive(Clone, Debug, PartialEq)]
 pub struct KFunction {
     /// The [Chunk] in which the function can be found.
@@ -35,7 +35,7 @@ pub struct KFunction {
 /// See also:
 /// * [KFunction]
 /// * [KNativeFunction](crate::KNativeFunction)
-/// * [Value::CaptureFunction](crate::Value::CaptureFunction)
+/// * [KValue::CaptureFunction](crate::KValue::CaptureFunction)
 #[derive(Clone)]
 pub struct KCaptureFunction {
     /// The function's properties

--- a/crates/runtime/src/types/iterator.rs
+++ b/crates/runtime/src/types/iterator.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Error, KotoVm, Result};
+use crate::{prelude::*, Error, KotoVm, PtrMut, Result};
 use std::{fmt, ops::DerefMut, result::Result as StdResult};
 
 /// The trait used to implement iterators in Koto

--- a/crates/runtime/src/types/iterator.rs
+++ b/crates/runtime/src/types/iterator.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Error, Result};
+use crate::{prelude::*, Error, KotoVm, Result};
 use std::{fmt, ops::DerefMut, result::Result as StdResult};
 
 /// The trait used to implement iterators in Koto
@@ -116,17 +116,17 @@ impl KIterator {
     }
 
     /// Creates a new KIterator from a Vm, used to implement generators
-    pub fn with_vm(vm: Vm) -> Self {
+    pub fn with_vm(vm: KotoVm) -> Self {
         Self::new(GeneratorIterator::new(vm))
     }
 
     /// Creates a new KIterator from a Value that has an implementation of `@next`
-    pub fn with_meta_next(vm: Vm, iterator: KValue) -> Result<Self> {
+    pub fn with_meta_next(vm: KotoVm, iterator: KValue) -> Result<Self> {
         Ok(Self::new(MetaIterator::new(vm, iterator)?))
     }
 
     /// Creates a new KIterator from an Object that implements [KotoIterator]
-    pub fn with_object(vm: Vm, o: KObject) -> Result<Self> {
+    pub fn with_object(vm: KotoVm, o: KObject) -> Result<Self> {
         Ok(Self::new(ObjectIterator::new(vm, o)?))
     }
 
@@ -396,13 +396,13 @@ impl Iterator for MapIterator {
 
 #[derive(Clone)]
 struct MetaIterator {
-    vm: Vm,
+    vm: KotoVm,
     iterator: KValue,
     is_bidirectional: bool,
 }
 
 impl MetaIterator {
-    fn new(vm: Vm, iterator: KValue) -> Result<Self> {
+    fn new(vm: KotoVm, iterator: KValue) -> Result<Self> {
         match iterator.get_meta_value(&UnaryOp::Next.into()) {
             Some(op) if op.is_callable() => {}
             Some(op) => return type_error("Callable function from @next", &op),
@@ -458,12 +458,12 @@ impl Iterator for MetaIterator {
 
 #[derive(Clone)]
 struct ObjectIterator {
-    vm: Vm,
+    vm: KotoVm,
     object: KObject,
 }
 
 impl ObjectIterator {
-    fn new(vm: Vm, object: KObject) -> Result<Self> {
+    fn new(vm: KotoVm, object: KObject) -> Result<Self> {
         use IsIterable::*;
 
         if matches!(
@@ -551,11 +551,11 @@ impl Iterator for StringIterator {
 
 #[derive(Clone)]
 pub struct GeneratorIterator {
-    vm: Vm,
+    vm: KotoVm,
 }
 
 impl GeneratorIterator {
-    pub fn new(vm: Vm) -> Self {
+    pub fn new(vm: KotoVm) -> Self {
         Self { vm }
     }
 }

--- a/crates/runtime/src/types/list.rs
+++ b/crates/runtime/src/types/list.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Result};
+use crate::{prelude::*, Borrow, BorrowMut, Result};
 
 /// The underlying Vec type used by [KList]
 pub type ValueVec = smallvec::SmallVec<[KValue; 4]>;

--- a/crates/runtime/src/types/list.rs
+++ b/crates/runtime/src/types/list.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Borrow, BorrowMut, Result};
+use crate::{prelude::*, Borrow, BorrowMut, PtrMut, Result};
 
 /// The underlying Vec type used by [KList]
 pub type ValueVec = smallvec::SmallVec<[KValue; 4]>;

--- a/crates/runtime/src/types/list.rs
+++ b/crates/runtime/src/types/list.rs
@@ -1,7 +1,7 @@
 use crate::{prelude::*, Result};
 
 /// The underlying Vec type used by [KList]
-pub type ValueVec = smallvec::SmallVec<[Value; 4]>;
+pub type ValueVec = smallvec::SmallVec<[KValue; 4]>;
 
 /// The Koto runtime's List type
 #[derive(Clone, Default)]
@@ -18,8 +18,8 @@ impl KList {
         Self(data.into())
     }
 
-    /// Creates a list containing the provided slice of [Values](crate::Value)
-    pub fn from_slice(data: &[Value]) -> Self {
+    /// Creates a list containing the provided slice of [Values](crate::KValue)
+    pub fn from_slice(data: &[KValue]) -> Self {
         Self(data.iter().cloned().collect::<ValueVec>().into())
     }
 

--- a/crates/runtime/src/types/map.rs
+++ b/crates/runtime/src/types/map.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Borrow, BorrowMut, Error, Result};
+use crate::{prelude::*, Borrow, BorrowMut, Error, PtrMut, Result};
 use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use std::{

--- a/crates/runtime/src/types/map.rs
+++ b/crates/runtime/src/types/map.rs
@@ -10,7 +10,7 @@ use std::{
 /// The hasher used throughout the Koto runtime
 pub type KotoHasher = FxHasher;
 
-type ValueMapType = IndexMap<ValueKey, Value, BuildHasherDefault<KotoHasher>>;
+type ValueMapType = IndexMap<ValueKey, KValue, BuildHasherDefault<KotoHasher>>;
 
 /// The (ValueKey -> Value) 'data' hashmap used by the Koto runtime
 ///
@@ -42,8 +42,8 @@ impl DerefMut for ValueMap {
     }
 }
 
-impl FromIterator<(ValueKey, Value)> for ValueMap {
-    fn from_iter<T: IntoIterator<Item = (ValueKey, Value)>>(iter: T) -> ValueMap {
+impl FromIterator<(ValueKey, KValue)> for ValueMap {
+    fn from_iter<T: IntoIterator<Item = (ValueKey, KValue)>>(iter: T) -> ValueMap {
         Self(ValueMapType::from_iter(iter))
     }
 }
@@ -124,19 +124,19 @@ impl KMap {
     }
 
     /// Returns a clone of the meta value corresponding to the given key
-    pub fn get_meta_value(&self, key: &MetaKey) -> Option<Value> {
+    pub fn get_meta_value(&self, key: &MetaKey) -> Option<KValue> {
         self.meta
             .as_ref()
             .and_then(|meta| meta.borrow().get(key).cloned())
     }
 
     /// Insert an entry into the KMap's data
-    pub fn insert(&self, key: impl Into<ValueKey>, value: impl Into<Value>) {
+    pub fn insert(&self, key: impl Into<ValueKey>, value: impl Into<KValue>) {
         self.data_mut().insert(key.into(), value.into());
     }
 
     /// Inserts a value into the meta map, initializing the meta map if it doesn't yet exist
-    pub fn insert_meta(&mut self, key: MetaKey, value: Value) {
+    pub fn insert_meta(&mut self, key: MetaKey, value: KValue) {
         self.meta
             .get_or_insert_with(Default::default)
             .borrow_mut()
@@ -145,7 +145,7 @@ impl KMap {
 
     /// Adds a function to the KMap's data map
     pub fn add_fn(&self, id: &str, f: impl KotoFunction) {
-        self.insert(id, Value::NativeFunction(KNativeFunction::new(f)));
+        self.insert(id, KValue::NativeFunction(KNativeFunction::new(f)));
     }
 
     /// Returns the number of entries in the KMap's data map
@@ -175,7 +175,7 @@ impl KMap {
                 .ok_or_else(|| Error::from("Missing VM in map display op"))?
                 .spawn_shared_vm();
             match vm.run_unary_op(UnaryOp::Display, self.clone().into())? {
-                Value::Str(display_result) => {
+                KValue::Str(display_result) => {
                     ctx.append(display_result);
                 }
                 unexpected => return type_error("String as @display result", &unexpected),
@@ -228,9 +228,9 @@ mod tests {
         let m = KMap::default();
 
         assert!(m.data().get("test").is_none());
-        m.insert("test", Value::Null);
+        m.insert("test", KValue::Null);
         assert!(m.data().get("test").is_some());
-        assert!(matches!(m.data_mut().remove("test"), Some(Value::Null)));
+        assert!(matches!(m.data_mut().remove("test"), Some(KValue::Null)));
         assert!(m.data().get("test").is_none());
     }
 }

--- a/crates/runtime/src/types/map.rs
+++ b/crates/runtime/src/types/map.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Error, Result};
+use crate::{prelude::*, Borrow, BorrowMut, Error, Result};
 use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use std::{

--- a/crates/runtime/src/types/meta_map.rs
+++ b/crates/runtime/src/types/meta_map.rs
@@ -7,7 +7,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-type MetaMapType = IndexMap<MetaKey, Value, BuildHasherDefault<KotoHasher>>;
+type MetaMapType = IndexMap<MetaKey, KValue, BuildHasherDefault<KotoHasher>>;
 
 /// The meta map used by [KMap](crate::KMap)
 ///
@@ -25,7 +25,7 @@ impl MetaMap {
     /// Adds a function to the meta map
     pub fn add_fn(&mut self, key: MetaKey, f: impl KotoFunction) {
         self.0
-            .insert(key, Value::NativeFunction(KNativeFunction::new(f)));
+            .insert(key, KValue::NativeFunction(KNativeFunction::new(f)));
     }
 }
 

--- a/crates/runtime/src/types/mod.rs
+++ b/crates/runtime/src/types/mod.rs
@@ -26,6 +26,6 @@ pub use self::{
     range::KRange,
     string::KString,
     tuple::KTuple,
-    value::Value,
+    value::KValue,
     value_key::ValueKey,
 };

--- a/crates/runtime/src/types/native_function.rs
+++ b/crates/runtime/src/types/native_function.rs
@@ -6,18 +6,18 @@ use std::{
 
 /// A trait for native functions used by the Koto runtime
 pub trait KotoFunction:
-    Fn(&mut CallContext) -> Result<Value> + KotoSend + KotoSync + 'static
+    Fn(&mut CallContext) -> Result<KValue> + KotoSend + KotoSync + 'static
 {
 }
 
 impl<T> KotoFunction for T where
-    T: Fn(&mut CallContext) -> Result<Value> + KotoSend + KotoSync + 'static
+    T: Fn(&mut CallContext) -> Result<KValue> + KotoSend + KotoSync + 'static
 {
 }
 
 /// An function that's defined outside of the Koto runtime
 ///
-/// See [Value::NativeFunction]
+/// See [KValue::NativeFunction]
 pub struct KNativeFunction {
     /// The function implementation that should be called when calling the external function
     //
@@ -92,13 +92,13 @@ impl<'a> CallContext<'a> {
     }
 
     /// Returns the `self` instance with which the function was called
-    pub fn instance(&self) -> Option<&Value> {
+    pub fn instance(&self) -> Option<&KValue> {
         self.instance_register
             .map(|register| self.vm.get_register(register))
     }
 
     /// Returns the function call's arguments
-    pub fn args(&self) -> &[Value] {
+    pub fn args(&self) -> &[KValue] {
         self.vm.register_slice(self.arg_register, self.arg_count)
     }
 
@@ -114,9 +114,9 @@ impl<'a> CallContext<'a> {
     /// contexts like `[1, 2, 3].to_tuple()`, or as standalone functions like `to_tuple [1, 2, 3]`.
     pub fn instance_and_args(
         &self,
-        instance_check: impl Fn(&Value) -> bool,
+        instance_check: impl Fn(&KValue) -> bool,
         expected_args_message: &str,
-    ) -> Result<(&Value, &[Value])> {
+    ) -> Result<(&KValue, &[KValue])> {
         match (self.instance(), self.args()) {
             (Some(instance), args) if instance_check(instance) => Ok((instance, args)),
             (_, [first, rest @ ..]) if instance_check(first) => Ok((first, rest)),

--- a/crates/runtime/src/types/native_function.rs
+++ b/crates/runtime/src/types/native_function.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, KotoVm, Result};
+use crate::{prelude::*, KotoVm, Ptr, Result};
 use std::{
     fmt,
     hash::{Hash, Hasher},

--- a/crates/runtime/src/types/native_function.rs
+++ b/crates/runtime/src/types/native_function.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Result};
+use crate::{prelude::*, KotoVm, Result};
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -64,12 +64,12 @@ impl Hash for KNativeFunction {
 pub struct CallContext<'a> {
     /// The VM making the call
     ///
-    /// The VM can be used for operations like [Vm::run_function], although
+    /// The VM can be used for operations like [KotoVm::run_function], although
     /// the [CallContext::args] and [CallContext::instance] functions return references,
     /// so the values need to be cloned before mutable operations can be called.
     ///
-    /// If a VM needs to be retained after the call, then see [Vm::spawn_shared_vm].
-    pub vm: &'a mut Vm,
+    /// If a VM needs to be retained after the call, then see [KotoVm::spawn_shared_vm].
+    pub vm: &'a mut KotoVm,
     instance_register: Option<u8>,
     arg_register: u8,
     arg_count: u8,
@@ -78,7 +78,7 @@ pub struct CallContext<'a> {
 impl<'a> CallContext<'a> {
     /// Returns a new context for calling external functions
     pub fn new(
-        vm: &'a mut Vm,
+        vm: &'a mut KotoVm,
         instance_register: Option<u8>,
         arg_register: u8,
         arg_count: u8,

--- a/crates/runtime/src/types/number.rs
+++ b/crates/runtime/src/types/number.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::KValue;
 use std::{
     cmp::Ordering,
     fmt,
@@ -233,13 +233,13 @@ macro_rules! number_traits_float {
             }
         }
 
-        impl From<$type> for Value {
+        impl From<$type> for KValue {
             fn from(value: $type) -> Self {
                 Self::Number(value.into())
             }
         }
 
-        impl From<&$type> for Value {
+        impl From<&$type> for KValue {
             fn from(value: &$type) -> Self {
                 Self::Number(value.into())
             }
@@ -281,13 +281,13 @@ macro_rules! number_traits_int {
             }
         }
 
-        impl From<$type> for Value {
+        impl From<$type> for KValue {
             fn from(value: $type) -> Self {
                 Self::Number(value.into())
             }
         }
 
-        impl From<&$type> for Value {
+        impl From<&$type> for KValue {
             fn from(value: &$type) -> Self {
                 Self::Number(value.into())
             }

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -132,7 +132,7 @@ pub trait KotoObject: KotoType + KotoCopy + KotoLookup + KotoSend + KotoSync + D
     }
 
     /// Defines the behavior of negation (e.g. `-x`)
-    fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
+    fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
         unimplemented_error("@negate", self.type_string())
     }
 
@@ -226,7 +226,7 @@ pub trait KotoObject: KotoType + KotoCopy + KotoLookup + KotoSend + KotoSync + D
     /// If [IsIterable::Iterable] is returned from [is_iterable](Self::is_iterable),
     /// then the runtime will call this function when the object is used in iterable contexts,
     /// expecting a [KIterator] to be returned.
-    fn make_iterator(&self, _vm: &mut Vm) -> Result<KIterator> {
+    fn make_iterator(&self, _vm: &mut KotoVm) -> Result<KIterator> {
         unimplemented_error("@iterator", self.type_string())
     }
 
@@ -237,7 +237,7 @@ pub trait KotoObject: KotoType + KotoCopy + KotoLookup + KotoSend + KotoSync + D
     /// [is_iterable](Self::is_iterable), then the object will be wrapped in a [KIterator]
     /// whenever it's used in an iterable context. This function will then be called each time
     /// [KIterator::next] is invoked.
-    fn iterator_next(&mut self, _vm: &mut Vm) -> Option<KIteratorOutput> {
+    fn iterator_next(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
         None
     }
 
@@ -247,7 +247,7 @@ pub trait KotoObject: KotoType + KotoCopy + KotoLookup + KotoSend + KotoSync + D
     /// [is_iterable](Self::is_iterable), then the object will be wrapped in a [KIterator]
     /// whenever it's used in an iterable context. This function will then be called each time
     /// [KIterator::next_back] is invoked.
-    fn iterator_next_back(&mut self, _vm: &mut Vm) -> Option<KIteratorOutput> {
+    fn iterator_next_back(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
         None
     }
 }
@@ -330,7 +330,7 @@ pub struct MethodContext<'a, T> {
     /// The method call arguments
     pub args: &'a [KValue],
     /// A VM that can be used by the method for operations that require a runtime
-    pub vm: &'a Vm,
+    pub vm: &'a KotoVm,
     // The instance of the object for the method call,
     // accessable via the context's `instance`/`instance_mut` functions
     object: &'a KObject,
@@ -340,7 +340,7 @@ pub struct MethodContext<'a, T> {
 
 impl<'a, T: KotoObject> MethodContext<'a, T> {
     /// Makes a new method context
-    pub fn new(object: &'a KObject, args: &'a [KValue], vm: &'a Vm) -> Self {
+    pub fn new(object: &'a KObject, args: &'a [KValue], vm: &'a KotoVm) -> Self {
         Self {
             object,
             args,

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -299,6 +299,11 @@ impl KObject {
     pub fn is_same_instance(&self, other: &Self) -> bool {
         PtrMut::ptr_eq(&self.object, &other.object)
     }
+
+    /// Returns the number of references currently held to the object
+    pub fn ref_count(&self) -> usize {
+        PtrMut::ref_count(&self.object)
+    }
 }
 
 impl<T: KotoObject> From<T> for KObject {

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -34,7 +34,7 @@ pub trait KotoCopy {
     /// How the object should behave when called from `koto.deep_copy`
     ///
     /// Deep copies should ensure that deep copies are performed for any Koto values that are owned
-    /// by the object (see [Value::deep_copy]).
+    /// by the object (see [KValue::deep_copy]).
     fn deep_copy(&self) -> KObject {
         self.copy()
     }
@@ -48,14 +48,14 @@ pub trait KotoCopy {
 /// lookup by using the `#[koto_method]` attribute, and derives an appropriate implementation of
 /// [KotoLookup].
 pub trait KotoLookup {
-    /// Returns a [Value] corresponding to the specified key within the object
+    /// Returns a [KValue] corresponding to the specified key within the object
     ///
     /// This method is used to retrieve a named entry attached to an object, providing a way to
     /// access the object's methods or associated values.
     ///
     /// The returned value should represent the data associated with the given key. If the key
     /// does not match any entry within the object, `None` should be returned.
-    fn lookup(&self, _key: &ValueKey) -> Option<Value> {
+    fn lookup(&self, _key: &ValueKey) -> Option<KValue> {
         None
     }
 }
@@ -63,7 +63,7 @@ pub trait KotoLookup {
 /// A trait for implementing objects that can be added to the Koto runtime
 ///
 /// [KotoObject]s are added to the Koto runtime by the [KObject] type, and stored as
-/// [Value::Object]s.
+/// [KValue::Object]s.
 ///
 /// ## Example
 ///
@@ -82,16 +82,16 @@ pub trait KotoLookup {
 ///     // Simple methods tagged with `#[koto_method]` can use a `&self` argument.
 ///     // The macro
 ///     #[koto_method(alias = "data")]
-///     fn get_data(&self) -> Value {
+///     fn get_data(&self) -> KValue {
 ///         self.data.into()
 ///     }
 ///
 ///     // An example of a more complex method that makes use of [MethodContext] to return the
 ///     // instance as the result, which allows for chaining of setter operations.
 ///     #[koto_method]
-///     fn set_data(ctx: MethodContext<Self>) -> Result<Value> {
+///     fn set_data(ctx: MethodContext<Self>) -> Result<KValue> {
 ///         match ctx.args {
-///             [Value::Number(n)] => ctx.instance_mut()?.data = n.into(),
+///             [KValue::Number(n)] => ctx.instance_mut()?.data = n.into(),
 ///             unexpected => return type_error_with_slice("a Number", unexpected),
 ///         }
 ///
@@ -122,97 +122,97 @@ pub trait KotoObject: KotoType + KotoCopy + KotoLookup + KotoSend + KotoSync + D
     }
 
     /// Called for indexing operations, e.g. `x[0]`
-    fn index(&self, _index: &Value) -> Result<Value> {
+    fn index(&self, _index: &KValue) -> Result<KValue> {
         unimplemented_error("@index", self.type_string())
     }
 
     /// Allows the object to behave as a function
-    fn call(&mut self, _ctx: &mut CallContext) -> Result<Value> {
+    fn call(&mut self, _ctx: &mut CallContext) -> Result<KValue> {
         unimplemented_error("@||", self.type_string())
     }
 
     /// Defines the behavior of negation (e.g. `-x`)
-    fn negate(&self, _vm: &mut Vm) -> Result<Value> {
+    fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
         unimplemented_error("@negate", self.type_string())
     }
 
     /// The `+` addition operator ()
-    fn add(&self, _rhs: &Value) -> Result<Value> {
+    fn add(&self, _rhs: &KValue) -> Result<KValue> {
         unimplemented_error("@+", self.type_string())
     }
 
     /// The `-` subtraction operator
-    fn subtract(&self, _rhs: &Value) -> Result<Value> {
+    fn subtract(&self, _rhs: &KValue) -> Result<KValue> {
         unimplemented_error("@-", self.type_string())
     }
 
     /// The `*` multiplication operator
-    fn multiply(&self, _rhs: &Value) -> Result<Value> {
+    fn multiply(&self, _rhs: &KValue) -> Result<KValue> {
         unimplemented_error("@*", self.type_string())
     }
 
     /// The `/` division operator
-    fn divide(&self, _rhs: &Value) -> Result<Value> {
+    fn divide(&self, _rhs: &KValue) -> Result<KValue> {
         unimplemented_error("@/", self.type_string())
     }
 
     /// The `%` remainder operator
-    fn remainder(&self, _rhs: &Value) -> Result<Value> {
+    fn remainder(&self, _rhs: &KValue) -> Result<KValue> {
         unimplemented_error("@%", self.type_string())
     }
 
     /// The `+=` in-place addition operator
-    fn add_assign(&mut self, _rhs: &Value) -> Result<()> {
+    fn add_assign(&mut self, _rhs: &KValue) -> Result<()> {
         unimplemented_error("@+=", self.type_string())
     }
 
     /// The `-=` in-place subtraction operator
-    fn subtract_assign(&mut self, _rhs: &Value) -> Result<()> {
+    fn subtract_assign(&mut self, _rhs: &KValue) -> Result<()> {
         unimplemented_error("@-=", self.type_string())
     }
 
     /// The `*=` in-place multiplication operator
-    fn multiply_assign(&mut self, _rhs: &Value) -> Result<()> {
+    fn multiply_assign(&mut self, _rhs: &KValue) -> Result<()> {
         unimplemented_error("@*=", self.type_string())
     }
 
     /// The `/=` in-place division operator
-    fn divide_assign(&mut self, _rhs: &Value) -> Result<()> {
+    fn divide_assign(&mut self, _rhs: &KValue) -> Result<()> {
         unimplemented_error("@/=", self.type_string())
     }
 
     /// The `%=` in-place remainder operator
-    fn remainder_assign(&mut self, _rhs: &Value) -> Result<()> {
+    fn remainder_assign(&mut self, _rhs: &KValue) -> Result<()> {
         unimplemented_error("@%=", self.type_string())
     }
 
     /// The `<` less-than operator
-    fn less(&self, _rhs: &Value) -> Result<bool> {
+    fn less(&self, _rhs: &KValue) -> Result<bool> {
         unimplemented_error("@<", self.type_string())
     }
 
     /// The `<=` less-than-or-equal operator
-    fn less_or_equal(&self, _rhs: &Value) -> Result<bool> {
+    fn less_or_equal(&self, _rhs: &KValue) -> Result<bool> {
         unimplemented_error("@<=", self.type_string())
     }
 
     /// The `>` greater-than operator
-    fn greater(&self, _rhs: &Value) -> Result<bool> {
+    fn greater(&self, _rhs: &KValue) -> Result<bool> {
         unimplemented_error("@>", self.type_string())
     }
 
     /// The `>=` greater-than-or-equal operator
-    fn greater_or_equal(&self, _rhs: &Value) -> Result<bool> {
+    fn greater_or_equal(&self, _rhs: &KValue) -> Result<bool> {
         unimplemented_error("@>=", self.type_string())
     }
 
     /// The `==` equality operator
-    fn equal(&self, _rhs: &Value) -> Result<bool> {
+    fn equal(&self, _rhs: &KValue) -> Result<bool> {
         unimplemented_error("@==", self.type_string())
     }
 
     /// The `!=` inequality operator
-    fn not_equal(&self, _rhs: &Value) -> Result<bool> {
+    fn not_equal(&self, _rhs: &KValue) -> Result<bool> {
         unimplemented_error("@!=", self.type_string())
     }
 
@@ -328,7 +328,7 @@ impl fmt::Debug for KObject {
 /// [KObject].
 pub struct MethodContext<'a, T> {
     /// The method call arguments
-    pub args: &'a [Value],
+    pub args: &'a [KValue],
     /// A VM that can be used by the method for operations that require a runtime
     pub vm: &'a Vm,
     // The instance of the object for the method call,
@@ -340,7 +340,7 @@ pub struct MethodContext<'a, T> {
 
 impl<'a, T: KotoObject> MethodContext<'a, T> {
     /// Makes a new method context
-    pub fn new(object: &'a KObject, args: &'a [Value], vm: &'a Vm) -> Self {
+    pub fn new(object: &'a KObject, args: &'a [KValue], vm: &'a Vm) -> Self {
         Self {
             object,
             args,
@@ -360,7 +360,7 @@ impl<'a, T: KotoObject> MethodContext<'a, T> {
     }
 
     /// Helper for methods that need to return a clone of the instance as the method result
-    pub fn instance_result(&self) -> Result<Value> {
+    pub fn instance_result(&self) -> Result<KValue> {
         Ok(self.object.clone().into())
     }
 }

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Borrow, BorrowMut, Result};
+use crate::{prelude::*, Borrow, BorrowMut, PtrMut, Result};
 use downcast_rs::{impl_downcast, Downcast};
 use std::{fmt, marker::PhantomData};
 

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Result};
+use crate::{prelude::*, Borrow, BorrowMut, Result};
 use downcast_rs::{impl_downcast, Downcast};
 use std::{fmt, marker::PhantomData};
 

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -1,6 +1,6 @@
 use crate::{prelude::*, Result};
 use downcast_rs::{impl_downcast, Downcast};
-use std::marker::PhantomData;
+use std::{fmt, marker::PhantomData};
 
 /// A trait for specifying a Koto object's type
 ///
@@ -311,6 +311,12 @@ impl<T: KotoObject> From<T> for KObject {
         Self {
             object: make_ptr_mut!(object),
         }
+    }
+}
+
+impl fmt::Debug for KObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "KObject ({:?})", PtrMut::address(&self.object))
     }
 }
 

--- a/crates/runtime/src/types/range.rs
+++ b/crates/runtime/src/types/range.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt, hash::Hash, ops::Range};
 
 /// The integer range type used by the Koto runtime
 ///
-/// See [Value::Range]
+/// See [KValue::Range]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct KRange(Inner);
 

--- a/crates/runtime/src/types/range.rs
+++ b/crates/runtime/src/types/range.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Error};
+use crate::{prelude::*, Error, Ptr};
 use std::{cmp::Ordering, fmt, hash::Hash, ops::Range};
 
 /// The integer range type used by the Koto runtime

--- a/crates/runtime/src/types/string.rs
+++ b/crates/runtime/src/types/string.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Result};
+use crate::{prelude::*, Ptr, Result};
 use std::{
     fmt,
     hash::{Hash, Hasher},

--- a/crates/runtime/src/types/tuple.rs
+++ b/crates/runtime/src/types/tuple.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Result};
+use crate::{prelude::*, Ptr, Result};
 use std::ops::{Deref, Range};
 
 /// The Tuple type used by the Koto runtime

--- a/crates/runtime/src/types/tuple.rs
+++ b/crates/runtime/src/types/tuple.rs
@@ -11,13 +11,13 @@ pub struct KTuple(Inner);
 // would have a size of 32 bytes.
 #[derive(Clone)]
 enum Inner {
-    Full(Ptr<[Value]>),
+    Full(Ptr<[KValue]>),
     Slice(Ptr<TupleSlice>),
 }
 
 #[derive(Clone)]
 struct TupleSlice {
-    data: Ptr<[Value]>,
+    data: Ptr<[KValue]>,
     bounds: Range<usize>,
 }
 
@@ -49,14 +49,14 @@ impl KTuple {
 
     /// Returns true if the tuple contains only immutable values
     pub fn is_hashable(&self) -> bool {
-        self.iter().all(Value::is_hashable)
+        self.iter().all(KValue::is_hashable)
     }
 
     /// Removes and returns the first value in the tuple
     ///
     /// The internal bounds of the tuple are adjusted to 'remove' the first element;
     /// no change is made to the underlying tuple data.
-    pub fn pop_front(&mut self) -> Option<Value> {
+    pub fn pop_front(&mut self) -> Option<KValue> {
         match &mut self.0 {
             Inner::Full(data) => {
                 if let Some(value) = data.first().cloned() {
@@ -84,7 +84,7 @@ impl KTuple {
     ///
     /// The internal bounds of the tuple are adjusted to 'remove' the first element;
     /// no change is made to the underlying tuple data.
-    pub fn pop_back(&mut self) -> Option<Value> {
+    pub fn pop_back(&mut self) -> Option<KValue> {
         match &mut self.0 {
             Inner::Full(data) => {
                 if let Some(value) = data.last().cloned() {
@@ -132,9 +132,9 @@ impl KTuple {
 }
 
 impl Deref for KTuple {
-    type Target = [Value];
+    type Target = [KValue];
 
-    fn deref(&self) -> &[Value] {
+    fn deref(&self) -> &[KValue] {
         match &self.0 {
             Inner::Full(data) => data,
             Inner::Slice(slice) => slice.deref(),
@@ -148,29 +148,29 @@ impl Default for KTuple {
     }
 }
 
-impl From<&[Value]> for KTuple {
-    fn from(data: &[Value]) -> Self {
+impl From<&[KValue]> for KTuple {
+    fn from(data: &[KValue]) -> Self {
         Self(Inner::Full(data.into()))
     }
 }
 
-impl From<Vec<Value>> for KTuple {
-    fn from(data: Vec<Value>) -> Self {
+impl From<Vec<KValue>> for KTuple {
+    fn from(data: Vec<KValue>) -> Self {
         Self(Inner::Full(data.into()))
     }
 }
 
 impl Deref for TupleSlice {
-    type Target = [Value];
+    type Target = [KValue];
 
-    fn deref(&self) -> &[Value] {
+    fn deref(&self) -> &[KValue] {
         // Safety: bounds have already been checked in the From impls and make_sub_tuple
         unsafe { self.data.get_unchecked(self.bounds.clone()) }
     }
 }
 
-impl From<Ptr<[Value]>> for TupleSlice {
-    fn from(data: Ptr<[Value]>) -> Self {
+impl From<Ptr<[KValue]>> for TupleSlice {
+    fn from(data: Ptr<[KValue]>) -> Self {
         let bounds = 0..data.len();
         Self { data, bounds }
     }

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -1,6 +1,6 @@
 //! The core value type used in the Koto runtime
 
-use crate::{prelude::*, KCaptureFunction, KFunction, KMap, KNativeFunction, Result};
+use crate::{prelude::*, KCaptureFunction, KFunction, KMap, KNativeFunction, Ptr, Result};
 use std::fmt::{self, Write};
 
 /// The core Value type for Koto

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -1,7 +1,7 @@
 //! The core value type used in the Koto runtime
 
 use crate::{prelude::*, KCaptureFunction, KFunction, KMap, KNativeFunction, Result};
-use std::fmt::Write;
+use std::fmt::{self, Write};
 
 /// The core Value type for Koto
 #[derive(Clone, Default)]
@@ -255,6 +255,12 @@ thread_local! {
     static TYPE_GENERATOR: KString = "Generator".into();
     static TYPE_ITERATOR: KString = "Iterator".into();
     static TYPE_TEMPORARY_TUPLE: KString = "TemporaryTuple".into();
+}
+
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.type_as_string())
+    }
 }
 
 impl From<()> for Value {

--- a/crates/runtime/src/types/value_key.rs
+++ b/crates/runtime/src/types/value_key.rs
@@ -8,21 +8,21 @@ use std::{
 
 /// The key type used by [ValueMap](crate::ValueMap)
 ///
-/// Only hashable values can be used as keys, see [Value::is_hashable]
+/// Only hashable values can be used as keys, see [KValue::is_hashable]
 #[derive(Clone)]
-pub struct ValueKey(Value);
+pub struct ValueKey(KValue);
 
 impl ValueKey {
     /// Returns a reference to the key's value
-    pub fn value(&self) -> &Value {
+    pub fn value(&self) -> &KValue {
         &self.0
     }
 }
 
-impl TryFrom<Value> for ValueKey {
+impl TryFrom<KValue> for ValueKey {
     type Error = Error;
 
-    fn try_from(value: Value) -> Result<Self, Self::Error> {
+    fn try_from(value: KValue) -> Result<Self, Self::Error> {
         if value.is_hashable() {
             Ok(Self(value))
         } else {
@@ -33,7 +33,7 @@ impl TryFrom<Value> for ValueKey {
 
 impl PartialEq for ValueKey {
     fn eq(&self, other: &Self) -> bool {
-        use Value::*;
+        use KValue::*;
 
         match (&self.0, &other.0) {
             (Number(a), Number(b)) => a == b,
@@ -55,7 +55,7 @@ impl Eq for ValueKey {}
 
 impl Hash for ValueKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        use Value::*;
+        use KValue::*;
 
         match &self.0 {
             Null => {}
@@ -75,7 +75,7 @@ impl Hash for ValueKey {
 
 impl PartialOrd for ValueKey {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        use Value::*;
+        use KValue::*;
 
         match (&self.0, &other.0) {
             (Null, Null) => Some(Ordering::Equal),
@@ -104,7 +104,7 @@ impl PartialOrd for ValueKey {
 
 impl fmt::Display for ValueKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        use Value::*;
+        use KValue::*;
 
         match &self.0 {
             Null => f.write_str("null"),
@@ -129,7 +129,7 @@ impl fmt::Display for ValueKey {
 
 impl From<KString> for ValueKey {
     fn from(value: KString) -> Self {
-        Self(Value::Str(value))
+        Self(KValue::Str(value))
     }
 }
 
@@ -138,13 +138,13 @@ where
     KNumber: From<T>,
 {
     fn from(value: T) -> Self {
-        Self(Value::Number(value.into()))
+        Self(KValue::Number(value.into()))
     }
 }
 
 impl From<&str> for ValueKey {
     fn from(value: &str) -> Self {
-        Self(Value::Str(value.into()))
+        Self(KValue::Str(value.into()))
     }
 }
 
@@ -152,7 +152,7 @@ impl From<&str> for ValueKey {
 impl Equivalent<ValueKey> for str {
     fn equivalent(&self, other: &ValueKey) -> bool {
         match &other.0 {
-            Value::Str(s) => self == s.as_str(),
+            KValue::Str(s) => self == s.as_str(),
             _ => false,
         }
     }
@@ -161,7 +161,7 @@ impl Equivalent<ValueKey> for str {
 impl Equivalent<ValueKey> for KString {
     fn equivalent(&self, other: &ValueKey) -> bool {
         match &other.0 {
-            Value::Str(s) => self == s,
+            KValue::Str(s) => self == s,
             _ => false,
         }
     }

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{Error, ErrorKind},
     prelude::*,
     types::{meta_id_to_key, value::RegisterSlice},
-    DefaultStderr, DefaultStdin, DefaultStdout, KCaptureFunction, KFunction, Result,
+    DefaultStderr, DefaultStdin, DefaultStdout, KCaptureFunction, KFunction, Ptr, Result,
 };
 use koto_bytecode::{Chunk, Instruction, InstructionReader, Loader, TypeId};
 use koto_parser::{ConstantIndex, MetaKeyId};

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -36,8 +36,8 @@ macro_rules! call_binary_op_or_else {
 #[derive(Clone)]
 pub enum ControlFlow {
     Continue,
-    Return(Value),
-    Yield(Value),
+    Return(KValue),
+    Yield(KValue),
 }
 
 /// State shared between concurrent VMs
@@ -119,11 +119,11 @@ pub struct Vm {
     // The VM's instruction reader, containing a pointer to the bytecode chunk that's being executed
     reader: InstructionReader,
     // The VM's register stack
-    registers: Vec<Value>,
+    registers: Vec<KValue>,
     // The VM's call stack
     call_stack: Vec<Frame>,
     // A stack of sequences that are currently under construction
-    sequence_builders: Vec<Vec<Value>>,
+    sequence_builders: Vec<Vec<KValue>>,
     // A stack of strings that are currently under construction
     string_builders: Vec<String>,
     // The ip that produced the most recently read instruction, used for debug and error traces
@@ -205,7 +205,7 @@ impl Vm {
     }
 
     /// Returns the named value from the exports map, or None if no matching value is found
-    pub fn get_exported_value(&self, id: &str) -> Option<Value> {
+    pub fn get_exported_value(&self, id: &str) -> Option<KValue> {
         self.exports.data().get(id).cloned()
     }
 
@@ -213,20 +213,20 @@ impl Vm {
     ///
     /// None is returned if no matching value is found, or if a matching value is found which isn't
     /// a callable function.
-    pub fn get_exported_function(&self, id: &str) -> Option<Value> {
+    pub fn get_exported_function(&self, id: &str) -> Option<KValue> {
         match self.get_exported_value(id) {
             Some(function) if function.is_callable() => Some(function),
             _ => None,
         }
     }
 
-    /// Runs the provided [Chunk], returning the resulting [Value]
-    pub fn run(&mut self, chunk: Ptr<Chunk>) -> Result<Value> {
+    /// Runs the provided [Chunk], returning the resulting [KValue]
+    pub fn run(&mut self, chunk: Ptr<Chunk>) -> Result<KValue> {
         // Set up an execution frame to run the chunk in
         let result_register = self.next_register();
         let frame_base = result_register + 1;
-        self.registers.push(Value::Null); // result register
-        self.registers.push(Value::Null); // instance register
+        self.registers.push(KValue::Null); // result register
+        self.registers.push(KValue::Null); // instance register
         self.push_frame(chunk, 0, frame_base, result_register);
 
         // Ensure that execution stops here if an error is thrown
@@ -243,35 +243,35 @@ impl Vm {
     ///
     /// This is currently used to support generators, which yield incremental results and then
     /// leave the VM in a suspended state.
-    pub fn continue_running(&mut self) -> Result<Value> {
+    pub fn continue_running(&mut self) -> Result<KValue> {
         if self.call_stack.is_empty() {
-            Ok(Value::Null)
+            Ok(KValue::Null)
         } else {
             self.execute_instructions()
         }
     }
 
     /// Runs a function with some given arguments
-    pub fn run_function(&mut self, function: Value, args: CallArgs) -> Result<Value> {
+    pub fn run_function(&mut self, function: KValue, args: CallArgs) -> Result<KValue> {
         self.call_and_run_function(None, function, args)
     }
 
     /// Runs an instance function with some given arguments
     pub fn run_instance_function(
         &mut self,
-        instance: Value,
-        function: Value,
+        instance: KValue,
+        function: KValue,
         args: CallArgs,
-    ) -> Result<Value> {
+    ) -> Result<KValue> {
         self.call_and_run_function(Some(instance), function, args)
     }
 
     fn call_and_run_function(
         &mut self,
-        instance: Option<Value>,
-        function: Value,
+        instance: Option<KValue>,
+        function: KValue,
         args: CallArgs,
-    ) -> Result<Value> {
+    ) -> Result<KValue> {
         if !function.is_callable() {
             return runtime_error!("run_function: the provided value isn't a function");
         }
@@ -285,7 +285,7 @@ impl Vm {
             None
         };
 
-        self.registers.push(Value::Null); // result register
+        self.registers.push(KValue::Null); // result register
         self.registers.push(instance.unwrap_or_default()); // frame base
         let (arg_count, temp_tuple_values) = match args {
             CallArgs::None => (0, None),
@@ -312,8 +312,8 @@ impl Vm {
                 // already in. This is redundant work, but more efficient than allocating a
                 // non-temporary Tuple for the values.
                 match &function {
-                    Value::Function(f) if f.arg_is_unpacked_tuple => {
-                        let temp_tuple = Value::TemporaryTuple(RegisterSlice {
+                    KValue::Function(f) if f.arg_is_unpacked_tuple => {
+                        let temp_tuple = KValue::TemporaryTuple(RegisterSlice {
                             // The unpacked tuple contents go into the registers after the
                             // the temp tuple and instance registers.
                             start: 2,
@@ -322,8 +322,8 @@ impl Vm {
                         self.registers.push(temp_tuple);
                         (1, Some(args))
                     }
-                    Value::CaptureFunction(f) if f.info.arg_is_unpacked_tuple => {
-                        let temp_tuple = Value::TemporaryTuple(RegisterSlice {
+                    KValue::CaptureFunction(f) if f.info.arg_is_unpacked_tuple => {
+                        let temp_tuple = KValue::TemporaryTuple(RegisterSlice {
                             // The unpacked tuple contents go into the registers after the
                             // captures, which are placed after the temp tuple and instance
                             // registers.
@@ -336,7 +336,7 @@ impl Vm {
                     }
                     _ => {
                         let tuple_contents = Vec::from(args);
-                        self.registers.push(Value::Tuple(tuple_contents.into()));
+                        self.registers.push(KValue::Tuple(tuple_contents.into()));
                         (1, None)
                     }
                 }
@@ -366,7 +366,7 @@ impl Vm {
             self.frame_mut().execution_barrier = true;
             let result = self.execute_instructions();
             if result.is_err() {
-                self.pop_frame(Value::Null)?;
+                self.pop_frame(KValue::Null)?;
             }
             result
         };
@@ -376,21 +376,21 @@ impl Vm {
     }
 
     /// Returns a displayable string for the given value
-    pub fn value_to_string(&mut self, value: &Value) -> Result<String> {
+    pub fn value_to_string(&mut self, value: &KValue) -> Result<String> {
         let mut display_context = DisplayContext::with_vm(self);
         value.display(&mut display_context)?;
         Ok(display_context.result())
     }
 
-    /// Provides the result of running a unary operation on a Value
-    pub fn run_unary_op(&mut self, op: UnaryOp, value: Value) -> Result<Value> {
+    /// Provides the result of running a unary operation on a KValue
+    pub fn run_unary_op(&mut self, op: UnaryOp, value: KValue) -> Result<KValue> {
         use UnaryOp::*;
 
         let old_frame_count = self.call_stack.len();
         let result_register = self.next_register();
         let value_register = result_register + 1;
 
-        self.registers.push(Value::Null); // result_register
+        self.registers.push(KValue::Null); // result_register
         self.registers.push(value); // value_register
 
         match op {
@@ -421,7 +421,7 @@ impl Vm {
             self.frame_mut().execution_barrier = true;
             let result = self.execute_instructions();
             if result.is_err() {
-                self.pop_frame(Value::Null)?;
+                self.pop_frame(KValue::Null)?;
             }
             result
         };
@@ -431,13 +431,13 @@ impl Vm {
     }
 
     /// Provides the result of running a binary operation on a pair of Values
-    pub fn run_binary_op(&mut self, op: BinaryOp, lhs: Value, rhs: Value) -> Result<Value> {
+    pub fn run_binary_op(&mut self, op: BinaryOp, lhs: KValue, rhs: KValue) -> Result<KValue> {
         let old_frame_count = self.call_stack.len();
         let result_register = self.next_register();
         let lhs_register = result_register + 1;
         let rhs_register = result_register + 2;
 
-        self.registers.push(Value::Null); // result register
+        self.registers.push(KValue::Null); // result register
         self.registers.push(lhs);
         self.registers.push(rhs);
 
@@ -492,7 +492,7 @@ impl Vm {
             self.frame_mut().execution_barrier = true;
             let result = self.execute_instructions();
             if result.is_err() {
-                self.pop_frame(Value::Null)?;
+                self.pop_frame(KValue::Null)?;
             }
             result
         };
@@ -502,8 +502,8 @@ impl Vm {
     }
 
     /// Makes a KIterator that iterates over the provided value's contents
-    pub fn make_iterator(&mut self, value: Value) -> Result<KIterator> {
-        use Value::*;
+    pub fn make_iterator(&mut self, value: KValue) -> Result<KIterator> {
+        use KValue::*;
 
         match value {
             _ if value.contains_meta_key(&UnaryOp::Next.into()) => {
@@ -545,8 +545,8 @@ impl Vm {
     /// Runs any tests that are contained in the map's @tests meta entry
     ///
     /// Any test failure will be returned as an error.
-    pub fn run_tests(&mut self, tests: KMap) -> Result<Value> {
-        use Value::{Map, Null};
+    pub fn run_tests(&mut self, tests: KMap) -> Result<KValue> {
+        use KValue::{Map, Null};
 
         // It's important throughout this function to make sure we don't hang on to any references
         // to the internal test map data while calling the test functions, otherwise we'll end up in
@@ -621,8 +621,8 @@ impl Vm {
         Ok(Null)
     }
 
-    fn execute_instructions(&mut self) -> Result<Value> {
-        let mut result = Value::Null;
+    fn execute_instructions(&mut self) -> Result<KValue> {
+        let mut result = KValue::Null;
 
         self.instruction_ip = self.ip();
 
@@ -651,7 +651,7 @@ impl Vm {
                                 return Err(error);
                             }
 
-                            self.pop_frame(Value::Null)?;
+                            self.pop_frame(KValue::Null)?;
 
                             if !self.call_stack.is_empty() {
                                 error.extend_trace(self.chunk(), self.instruction_ip);
@@ -665,7 +665,7 @@ impl Vm {
 
                     let catch_value = match error.error {
                         ErrorKind::KotoError { thrown_value, .. } => thrown_value,
-                        _ => Value::Str(error.to_string().into()),
+                        _ => KValue::Str(error.to_string().into()),
                     };
                     self.set_register(register, catch_value);
                     self.set_ip(ip);
@@ -686,7 +686,7 @@ impl Vm {
         match instruction {
             Error { message } => runtime_error!(message)?,
             Copy { target, source } => self.set_register(target, self.clone_register(source)),
-            SetNull { register } => self.set_register(register, Value::Null),
+            SetNull { register } => self.set_register(register, KValue::Null),
             SetBool { register, value } => self.set_register(register, value.into()),
             SetNumber { register, value } => self.set_register(register, value.into()),
             LoadFloat { register, constant } => {
@@ -710,7 +710,7 @@ impl Vm {
                 count,
             } => self.set_register(
                 register,
-                Value::TemporaryTuple(RegisterSlice { start, count }),
+                KValue::TemporaryTuple(RegisterSlice { start, count }),
             ),
             TempTupleToTuple { register, source } => {
                 self.run_temp_tuple_to_tuple(register, source)?
@@ -828,7 +828,7 @@ impl Vm {
                 let thrown_value = self.clone_register(register);
 
                 match &thrown_value {
-                    Value::Str(_) => {}
+                    KValue::Str(_) => {}
                     _ if thrown_value.contains_meta_key(&UnaryOp::Display.into()) => {}
                     other => {
                         return type_error("a String or a value that implements @display", other);
@@ -842,11 +842,11 @@ impl Vm {
             }
             Size { register, value } => self.run_size(register, value),
             IsTuple { register, value } => {
-                let result = matches!(self.get_register(value), Value::Tuple(_));
+                let result = matches!(self.get_register(value), KValue::Tuple(_));
                 self.set_register(register, result.into());
             }
             IsList { register, value } => {
-                let result = matches!(self.get_register(value), Value::List(_));
+                let result = matches!(self.get_register(value), KValue::List(_));
                 self.set_register(register, result.into());
             }
             IterNext {
@@ -909,7 +909,7 @@ impl Vm {
                 key,
             } => {
                 let key_string = match self.clone_register(key) {
-                    Value::Str(s) => s,
+                    KValue::Str(s) => s,
                     other => return type_error("a String", &other),
                 };
                 self.run_access(register, value, key_string)?;
@@ -960,10 +960,10 @@ impl Vm {
 
     fn run_temp_tuple_to_tuple(&mut self, register: u8, source_register: u8) -> Result<()> {
         match self.clone_register(source_register) {
-            Value::TemporaryTuple(temp_registers) => {
+            KValue::TemporaryTuple(temp_registers) => {
                 let tuple =
                     KTuple::from(self.register_slice(temp_registers.start, temp_registers.count));
-                self.set_register(register, Value::Tuple(tuple));
+                self.set_register(register, KValue::Tuple(tuple));
             }
             _ => unreachable!(),
         }
@@ -977,7 +977,7 @@ impl Vm {
         end_register: Option<u8>,
         inclusive: bool,
     ) -> Result<()> {
-        use Value::Number;
+        use KValue::Number;
 
         let start = start_register.map(|r| self.get_register(r));
         let end = end_register.map(|r| self.get_register(r));
@@ -1009,7 +1009,7 @@ impl Vm {
         iterable_register: u8,
         temp_iterator: bool,
     ) -> Result<()> {
-        use Value::*;
+        use KValue::*;
 
         let iterable = self.clone_register(iterable_register);
 
@@ -1068,7 +1068,7 @@ impl Vm {
         jump_offset: u16,
         output_is_temporary: bool,
     ) -> Result<()> {
-        use Value::*;
+        use KValue::*;
 
         let output = match self.clone_register(iterable_register) {
             Iterator(mut iterator) => {
@@ -1116,7 +1116,7 @@ impl Vm {
                         Ok(Null) => None,
                         Ok(output) => Some(output),
                         Err(error) => {
-                            self.pop_frame(Value::Null)?;
+                            self.pop_frame(KValue::Null)?;
                             return Err(error);
                         }
                     }
@@ -1128,7 +1128,7 @@ impl Vm {
                 let (output, new_iterable) = match other {
                     Range(mut r) => {
                         let output = r.pop_front()?;
-                        (output.map(Value::from), Range(r))
+                        (output.map(KValue::from), Range(r))
                     }
                     Tuple(mut t) => {
                         let output = t.pop_front();
@@ -1136,7 +1136,7 @@ impl Vm {
                     }
                     Str(mut s) => {
                         let output = s.pop_front();
-                        (output.map(Value::from), Str(s))
+                        (output.map(KValue::from), Str(s))
                     }
                     TemporaryTuple(RegisterSlice { start, count }) => {
                         if count > 0 {
@@ -1180,7 +1180,7 @@ impl Vm {
     }
 
     fn run_temp_index(&mut self, result: u8, value: u8, index: i8) -> Result<()> {
-        use Value::*;
+        use KValue::*;
 
         let index_op = BinaryOp::Index.into();
 
@@ -1215,7 +1215,7 @@ impl Vm {
     }
 
     fn run_slice(&mut self, register: u8, value: u8, index: i8, is_slice_to: bool) -> Result<()> {
-        use Value::*;
+        use KValue::*;
 
         let result = match self.get_register(value) {
             List(list) => {
@@ -1247,7 +1247,7 @@ impl Vm {
     }
 
     fn run_make_function(&mut self, function_instruction: Instruction) {
-        use Value::*;
+        use KValue::*;
 
         match function_instruction {
             Instruction::Function {
@@ -1300,7 +1300,7 @@ impl Vm {
         };
 
         match function {
-            Value::CaptureFunction(f) => {
+            KValue::CaptureFunction(f) => {
                 f.captures.data_mut()[capture_index as usize] = self.clone_register(value);
                 Ok(())
             }
@@ -1309,8 +1309,8 @@ impl Vm {
     }
 
     fn run_negate(&mut self, result: u8, value: u8) -> Result<()> {
+        use KValue::*;
         use UnaryOp::Negate;
-        use Value::*;
 
         let result_value = match self.clone_register(value) {
             Number(n) => Number(-n),
@@ -1327,8 +1327,8 @@ impl Vm {
     }
 
     fn run_not(&mut self, result: u8, value: u8) -> Result<()> {
+        use KValue::*;
         use UnaryOp::Not;
-        use Value::*;
 
         let result_value = match &self.get_register(value) {
             Null => Bool(true),
@@ -1367,7 +1367,7 @@ impl Vm {
 
     fn run_add(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Add;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1415,7 +1415,7 @@ impl Vm {
 
     fn run_subtract(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Subtract;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1436,7 +1436,7 @@ impl Vm {
 
     fn run_multiply(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Multiply;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1458,7 +1458,7 @@ impl Vm {
 
     fn run_divide(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Divide;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1479,7 +1479,7 @@ impl Vm {
 
     fn run_remainder(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Remainder;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1505,7 +1505,7 @@ impl Vm {
 
     fn run_add_assign(&mut self, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::AddAssign;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1532,7 +1532,7 @@ impl Vm {
 
     fn run_subtract_assign(&mut self, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::SubtractAssign;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1559,7 +1559,7 @@ impl Vm {
 
     fn run_multiply_assign(&mut self, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::MultiplyAssign;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1586,7 +1586,7 @@ impl Vm {
 
     fn run_divide_assign(&mut self, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::DivideAssign;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1613,7 +1613,7 @@ impl Vm {
 
     fn run_remainder_assign(&mut self, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::RemainderAssign;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1640,7 +1640,7 @@ impl Vm {
 
     fn run_less(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Less;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1662,7 +1662,7 @@ impl Vm {
 
     fn run_less_or_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::LessOrEqual;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1684,7 +1684,7 @@ impl Vm {
 
     fn run_greater(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Greater;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1706,7 +1706,7 @@ impl Vm {
 
     fn run_greater_or_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::GreaterOrEqual;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1728,7 +1728,7 @@ impl Vm {
 
     fn run_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::Equal;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1788,7 +1788,7 @@ impl Vm {
 
     fn run_not_equal(&mut self, result: u8, lhs: u8, rhs: u8) -> Result<()> {
         use BinaryOp::NotEqual;
-        use Value::*;
+        use KValue::*;
 
         let lhs_value = self.get_register(lhs);
         let rhs_value = self.get_register(rhs);
@@ -1845,15 +1845,15 @@ impl Vm {
     }
 
     // Called from run_equal / run_not_equal to compare the contents of lists and tuples
-    fn compare_value_ranges(&mut self, range_a: &[Value], range_b: &[Value]) -> Result<bool> {
+    fn compare_value_ranges(&mut self, range_a: &[KValue], range_b: &[KValue]) -> Result<bool> {
         if range_a.len() != range_b.len() {
             return Ok(false);
         }
 
         for (value_a, value_b) in range_a.iter().zip(range_b.iter()) {
             match self.run_binary_op(BinaryOp::Equal, value_a.clone(), value_b.clone())? {
-                Value::Bool(true) => {}
-                Value::Bool(false) => return Ok(false),
+                KValue::Bool(true) => {}
+                KValue::Bool(false) => return Ok(false),
                 other => {
                     return runtime_error!(
                         "Expected Bool from equality comparison, found '{}'",
@@ -1877,8 +1877,8 @@ impl Vm {
                 return Ok(false);
             };
             match self.run_binary_op(BinaryOp::Equal, value_a.clone(), value_b)? {
-                Value::Bool(true) => {}
-                Value::Bool(false) => return Ok(false),
+                KValue::Bool(true) => {}
+                KValue::Bool(false) => return Ok(false),
                 other => {
                     return runtime_error!(
                         "Expected Bool from equality comparison, found '{}'",
@@ -1895,17 +1895,17 @@ impl Vm {
         &mut self,
         result_register: u8,
         value_register: u8,
-        op: Value,
+        op: KValue,
     ) -> Result<()> {
         // Ensure that the result register is present in the stack, otherwise it might be lost after
         // the call to the op, which expects a frame base at or after the result register.
         if self.register_index(result_register) >= self.registers.len() {
-            self.set_register(result_register, Value::Null);
+            self.set_register(result_register, KValue::Null);
         }
 
         // Set up the call registers at the end of the stack
         let frame_base = self.new_frame_base()?;
-        self.registers.push(Value::Null); // frame_base
+        self.registers.push(KValue::Null); // frame_base
         self.call_callable(
             &CallInfo {
                 result_register,
@@ -1922,18 +1922,18 @@ impl Vm {
         &mut self,
         result_register: u8,
         lhs_register: u8,
-        rhs: Value,
-        op: Value,
+        rhs: KValue,
+        op: KValue,
     ) -> Result<()> {
         // Ensure that the result register is present in the stack, otherwise it might be lost after
         // the call to the op, which expects a frame base at or after the result register.
         if self.register_index(result_register) >= self.registers.len() {
-            self.set_register(result_register, Value::Null);
+            self.set_register(result_register, KValue::Null);
         }
 
         // Set up the call registers at the end of the stack
         let frame_base = self.new_frame_base()?;
-        self.registers.push(Value::Null); // frame_base
+        self.registers.push(KValue::Null); // frame_base
         self.registers.push(rhs); // arg
         self.call_callable(
             &CallInfo {
@@ -1949,8 +1949,8 @@ impl Vm {
 
     fn run_jump_if_true(&mut self, register: u8, offset: u32) -> Result<()> {
         match &self.get_register(register) {
-            Value::Null => {}
-            Value::Bool(b) if !b => {}
+            KValue::Null => {}
+            KValue::Bool(b) if !b => {}
             _ => self.jump_ip(offset),
         }
         Ok(())
@@ -1958,8 +1958,8 @@ impl Vm {
 
     fn run_jump_if_false(&mut self, register: u8, offset: u32) -> Result<()> {
         match &self.get_register(register) {
-            Value::Null => self.jump_ip(offset),
-            Value::Bool(b) if !b => self.jump_ip(offset),
+            KValue::Null => self.jump_ip(offset),
+            KValue::Bool(b) if !b => self.jump_ip(offset),
             _ => {}
         }
         Ok(())
@@ -1967,13 +1967,13 @@ impl Vm {
 
     fn run_size(&mut self, register: u8, value: u8) {
         let result = self.get_register(value).size();
-        self.set_register(register, Value::Number(result.into()));
+        self.set_register(register, KValue::Number(result.into()));
     }
 
     fn run_import(&mut self, import_register: u8) -> Result<()> {
         let import_name = match self.clone_register(import_register) {
-            Value::Str(s) => s,
-            value @ Value::Map(_) => {
+            KValue::Str(s) => s,
+            value @ KValue::Map(_) => {
                 self.set_register(import_register, value);
                 return Ok(());
             }
@@ -2021,7 +2021,7 @@ impl Vm {
                 return runtime_error!("Recursive import of module '{import_name}'");
             }
             Some(Some(cached_exports)) if compile_result.loaded_from_cache => {
-                self.set_register(import_register, Value::Map(cached_exports));
+                self.set_register(import_register, KValue::Map(cached_exports));
                 return Ok(());
             }
             _ => {}
@@ -2052,7 +2052,7 @@ impl Vm {
                 if self.context.settings.run_import_tests {
                     let maybe_tests = self.exports.get_meta_value(&MetaKey::Tests);
                     match maybe_tests {
-                        Some(Value::Map(tests)) => {
+                        Some(KValue::Map(tests)) => {
                             self.run_tests(tests)?;
                         }
                         Some(other) => {
@@ -2089,7 +2089,7 @@ impl Vm {
                 .imported_modules
                 .borrow_mut()
                 .insert(compile_result.path, Some(module_exports.clone()));
-            self.set_register(import_register, Value::Map(module_exports));
+            self.set_register(import_register, KValue::Map(module_exports));
         } else {
             // If there was an error while importing the module then make sure that the
             // placeholder is removed from the imported modules cache.
@@ -2110,7 +2110,7 @@ impl Vm {
         index_register: u8,
         value_register: u8,
     ) -> Result<()> {
-        use Value::*;
+        use KValue::*;
 
         let indexable = self.clone_register(indexable_register);
         let index_value = self.clone_register(index_register);
@@ -2164,7 +2164,7 @@ impl Vm {
         index_register: u8,
     ) -> Result<()> {
         use BinaryOp::Index;
-        use Value::*;
+        use KValue::*;
 
         let value = self.clone_register(value_register);
         let index = self.clone_register(index_register);
@@ -2227,7 +2227,7 @@ impl Vm {
         let value = self.clone_register(value_register);
 
         match self.get_register_mut(map_register) {
-            Value::Map(map) => {
+            KValue::Map(map) => {
                 map.data_mut().insert(key, value);
                 Ok(())
             }
@@ -2243,7 +2243,7 @@ impl Vm {
         };
 
         match self.get_register_mut(map_register) {
-            Value::Map(map) => {
+            KValue::Map(map) => {
                 map.insert_meta(meta_key, value);
                 Ok(())
             }
@@ -2261,7 +2261,7 @@ impl Vm {
         let value = self.clone_register(value_register);
 
         let meta_key = match self.clone_register(name_register) {
-            Value::Str(name) => match meta_id_to_key(meta_id, Some(name)) {
+            KValue::Str(name) => match meta_id_to_key(meta_id, Some(name)) {
                 Ok(key) => key,
                 Err(error) => return runtime_error!("Error while preparing meta key: {error}"),
             },
@@ -2269,7 +2269,7 @@ impl Vm {
         };
 
         match self.get_register_mut(map_register) {
-            Value::Map(map) => {
+            KValue::Map(map) => {
                 map.insert_meta(meta_key, value);
                 Ok(())
             }
@@ -2297,7 +2297,7 @@ impl Vm {
         let value = self.clone_register(value_register);
 
         let meta_key = match self.clone_register(name_register) {
-            Value::Str(name) => match meta_id_to_key(meta_id, Some(name)) {
+            KValue::Str(name) => match meta_id_to_key(meta_id, Some(name)) {
                 Ok(key) => key,
                 Err(error) => return runtime_error!("Error while preparing meta key: {error}"),
             },
@@ -2314,7 +2314,7 @@ impl Vm {
         value_register: u8,
         key_string: KString,
     ) -> Result<()> {
-        use Value::*;
+        use KValue::*;
 
         let accessed_value = self.clone_register(value_register);
         let key = ValueKey::from(key_string.clone());
@@ -2419,7 +2419,7 @@ impl Vm {
         module: &KMap,
         iterator_fallback: bool,
         module_name: &str,
-    ) -> Result<Value> {
+    ) -> Result<KValue> {
         let maybe_op = match module.data().get(key).cloned() {
             None if iterator_fallback => self.context.core_lib.iterator.data().get(key).cloned(),
             maybe_op => maybe_op,
@@ -2460,7 +2460,7 @@ impl Vm {
         call_info: &CallInfo,
         f: &KFunction,
         captures: Option<&KList>,
-        temp_tuple_values: Option<&[Value]>,
+        temp_tuple_values: Option<&[KValue]>,
     ) -> Result<()> {
         // Spawn a VM for the generator
         let mut generator_vm = self.spawn_shared_vm();
@@ -2503,7 +2503,7 @@ impl Vm {
         // Ensure that registers for missing arguments are set to Null
         if call_info.arg_count < expected_arg_count {
             for arg_index in call_info.arg_count..expected_arg_count {
-                generator_vm.set_register(arg_index + arg_offset, Value::Null);
+                generator_vm.set_register(arg_index + arg_offset, KValue::Null);
             }
         }
 
@@ -2516,10 +2516,10 @@ impl Vm {
                 let varargs_start = call_info.frame_base + 1 + expected_arg_count;
                 let varargs_count = call_info.arg_count - expected_arg_count;
                 let varargs =
-                    Value::Tuple(self.register_slice(varargs_start, varargs_count).into());
+                    KValue::Tuple(self.register_slice(varargs_start, varargs_count).into());
                 generator_vm.set_register(variadic_register, varargs);
             } else {
-                generator_vm.set_register(variadic_register, Value::Null);
+                generator_vm.set_register(variadic_register, KValue::Null);
             }
         }
         // Place any captures in the registers following the arguments
@@ -2551,7 +2551,7 @@ impl Vm {
         call_info: &CallInfo,
         f: &KFunction,
         captures: Option<&KList>,
-        temp_tuple_values: Option<&[Value]>,
+        temp_tuple_values: Option<&[KValue]>,
     ) -> Result<()> {
         if f.generator {
             return self.call_generator(call_info, f, captures, temp_tuple_values);
@@ -2577,7 +2577,7 @@ impl Vm {
             let arg_base = call_info.frame_base + 1;
             let varargs_start = arg_base + expected_arg_count;
             let varargs_count = call_info.arg_count - expected_arg_count;
-            let varargs = Value::Tuple(self.register_slice(varargs_start, varargs_count).into());
+            let varargs = KValue::Tuple(self.register_slice(varargs_start, varargs_count).into());
             self.set_register(varargs_start, varargs);
             self.truncate_registers(varargs_start + 1);
         }
@@ -2593,7 +2593,7 @@ impl Vm {
         // If there are extra args, truncating is necessary at this point. Extra args have either
         // been bundled into a variadic Tuple or they can be ignored.
         self.registers
-            .resize(arg_base_index + f.arg_count as usize, Value::Null);
+            .resize(arg_base_index + f.arg_count as usize, KValue::Null);
 
         if let Some(captures) = captures {
             // Copy the captures list into the registers following the args
@@ -2619,10 +2619,10 @@ impl Vm {
     fn call_callable(
         &mut self,
         info: &CallInfo,
-        function: Value,
-        temp_tuple_values: Option<&[Value]>,
+        function: KValue,
+        temp_tuple_values: Option<&[KValue]>,
     ) -> Result<()> {
-        use Value::*;
+        use KValue::*;
 
         match function {
             Function(f) => self.call_function(info, &f, None, temp_tuple_values),
@@ -2653,7 +2653,7 @@ impl Vm {
     fn run_debug(&mut self, register: u8, expression_constant: ConstantIndex) -> Result<()> {
         let value = self.clone_register(register);
         let value_string = match self.run_unary_op(UnaryOp::Display, value)? {
-            Value::Str(s) => s,
+            KValue::Str(s) => s,
             other => {
                 return runtime_error!(
                     "debug: Expected string to display, found '{}'",
@@ -2685,12 +2685,12 @@ impl Vm {
         let value = self.get_register(register);
         match type_id {
             TypeId::List => {
-                if !matches!(value, Value::List(_)) {
+                if !matches!(value, KValue::List(_)) {
                     return type_error("List", value);
                 }
             }
             TypeId::Tuple => {
-                if !matches!(value, Value::Tuple(_) | Value::TemporaryTuple(_)) {
+                if !matches!(value, KValue::Tuple(_) | KValue::TemporaryTuple(_)) {
                     return type_error("Tuple", value);
                 }
             }
@@ -2755,7 +2755,7 @@ impl Vm {
         let value = self.clone_register(value_register);
 
         match self.run_unary_op(UnaryOp::Display, value)? {
-            Value::Str(string) => {
+            KValue::Str(string) => {
                 if let Some(builder) = self.string_builders.last_mut() {
                     builder.push_str(&string);
                     Ok(())
@@ -2829,7 +2829,7 @@ impl Vm {
         self.set_chunk_and_ip(chunk, ip);
     }
 
-    fn pop_frame(&mut self, return_value: Value) -> Result<Option<Value>> {
+    fn pop_frame(&mut self, return_value: KValue) -> Result<Option<KValue>> {
         self.truncate_registers(0);
 
         match self.call_stack.pop() {
@@ -2877,21 +2877,21 @@ impl Vm {
         (self.registers.len() - self.register_base()) as u8
     }
 
-    fn set_register(&mut self, register: u8, value: Value) {
+    fn set_register(&mut self, register: u8, value: KValue) {
         let index = self.register_index(register);
 
         if index >= self.registers.len() {
-            self.registers.resize(index + 1, Value::Null);
+            self.registers.resize(index + 1, KValue::Null);
         }
 
         self.registers[index] = value;
     }
 
-    fn clone_register(&self, register: u8) -> Value {
+    fn clone_register(&self, register: u8) -> KValue {
         self.get_register(register).clone()
     }
 
-    pub(crate) fn get_register(&self, register: u8) -> &Value {
+    pub(crate) fn get_register(&self, register: u8) -> &KValue {
         let index = self.register_index(register);
         match self.registers.get(index) {
             Some(value) => value,
@@ -2904,17 +2904,17 @@ impl Vm {
         }
     }
 
-    pub(crate) fn get_register_safe(&self, register: u8) -> Option<&Value> {
+    pub(crate) fn get_register_safe(&self, register: u8) -> Option<&KValue> {
         let index = self.register_index(register);
         self.registers.get(index)
     }
 
-    fn get_register_mut(&mut self, register: u8) -> &mut Value {
+    fn get_register_mut(&mut self, register: u8) -> &mut KValue {
         let index = self.register_index(register);
         &mut self.registers[index]
     }
 
-    pub(crate) fn register_slice(&self, register: u8, count: u8) -> &[Value] {
+    pub(crate) fn register_slice(&self, register: u8, count: u8) -> &[KValue] {
         if count > 0 {
             let start = self.register_index(register);
             &self.registers[start..start + count as usize]
@@ -2947,7 +2947,7 @@ impl fmt::Debug for Vm {
     }
 }
 
-fn binary_op_error(lhs: &Value, rhs: &Value, op: BinaryOp) -> Result<()> {
+fn binary_op_error(lhs: &KValue, rhs: &KValue, op: BinaryOp) -> Result<()> {
     runtime_error!(ErrorKind::InvalidBinaryOp {
         lhs: lhs.clone(),
         rhs: rhs.clone(),
@@ -2972,7 +2972,7 @@ fn signed_index_to_unsigned(index: i8, size: usize) -> usize {
 pub(crate) fn clone_generator_vm(vm: &Vm) -> Result<Vm> {
     let mut result = vm.clone();
     for value in result.registers.iter_mut() {
-        if let Value::Iterator(ref mut i) = value {
+        if let KValue::Iterator(ref mut i) = value {
             *i = i.make_copy()?;
         }
     }
@@ -2989,16 +2989,16 @@ pub enum CallArgs<'a> {
     None,
 
     /// Represents a function call with a single argument.
-    Single(Value),
+    Single(KValue),
 
     /// Arguments are provided separately and are passed directly to the function.
-    Separate(&'a [Value]),
+    Separate(&'a [KValue]),
 
     /// Arguments are bundled together as a tuple and then passed to the function.
     ///
     /// If the function unpacks the tuple in its arguments list then a temporary tuple will be used,
     /// which avoids the creation of an allocated tuple.
-    AsTuple(&'a [Value]),
+    AsTuple(&'a [KValue]),
 }
 
 // A cache of the export maps of imported modules

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -1,7 +1,7 @@
 mod runtime_test_utils;
 
 use crate::runtime_test_utils::*;
-use koto_runtime::Value;
+use koto_runtime::KValue;
 
 mod iterator {
     use super::*;
@@ -84,7 +84,7 @@ generator()
             let script = "
 [].cycle().next()
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -208,7 +208,7 @@ y.next()
 
     mod peekable {
         use super::*;
-        use Value::Null;
+        use KValue::Null;
 
         #[test]
         fn peek() {

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -136,7 +136,7 @@ mod objects {
             Ok(self.x.into())
         }
 
-        fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
+        fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
             Ok(Self::make_value(-self.x))
         }
 
@@ -208,7 +208,7 @@ mod objects {
             IsIterable::Iterable
         }
 
-        fn make_iterator(&self, vm: &mut Vm) -> Result<KIterator> {
+        fn make_iterator(&self, vm: &mut KotoVm) -> Result<KIterator> {
             KIterator::with_object(vm.spawn_shared_vm(), TestIterator::make_object(self.x))
         }
     }
@@ -231,19 +231,19 @@ mod objects {
             IsIterable::BidirectionalIterator
         }
 
-        fn iterator_next(&mut self, _vm: &mut Vm) -> Option<KIteratorOutput> {
+        fn iterator_next(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
             self.x += 1;
             Some(self.x.into())
         }
 
-        fn iterator_next_back(&mut self, _vm: &mut Vm) -> Option<KIteratorOutput> {
+        fn iterator_next_back(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
             self.x -= 1;
             Some(self.x.into())
         }
     }
 
     fn test_object_script(script: &str, expected_output: impl Into<KValue>) {
-        let vm = Vm::default();
+        let vm = KotoVm::default();
         let prelude = vm.prelude();
 
         prelude.add_fn("make_object", |ctx| match ctx.args() {

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -14,12 +14,12 @@ mod objects {
 
     #[koto_impl(runtime = koto_runtime)]
     impl TestObject {
-        fn make_value(x: i64) -> Value {
+        fn make_value(x: i64) -> KValue {
             KObject::from(Self { x }).into()
         }
 
         #[koto_method]
-        fn to_number(&self) -> Value {
+        fn to_number(&self) -> KValue {
             self.x.into()
         }
 
@@ -29,23 +29,23 @@ mod objects {
         }
 
         #[koto_method(alias = "absorb1", alias = "absorb2")]
-        fn absorb_values(&mut self, args: &[Value]) -> Result<Value> {
+        fn absorb_values(&mut self, args: &[KValue]) -> Result<KValue> {
             for arg in args.iter() {
                 match arg {
-                    Value::Number(n) => self.x += i64::from(n),
+                    KValue::Number(n) => self.x += i64::from(n),
                     other => return type_error("Number", other),
                 }
             }
-            Ok(Value::Null)
+            Ok(KValue::Null)
         }
 
         #[koto_method]
-        fn set_all_instances(ctx: MethodContext<Self>) -> Result<Value> {
+        fn set_all_instances(ctx: MethodContext<Self>) -> Result<KValue> {
             match ctx.args {
-                [Value::Object(b)] if b.is_a::<TestObject>() => {
+                [KValue::Object(b)] if b.is_a::<TestObject>() => {
                     let b_x = b.cast::<TestObject>().unwrap().x;
                     ctx.instance_mut()?.x = b_x;
-                    Ok(Value::Null)
+                    Ok(KValue::Null)
                 }
                 unexpected => type_error_with_slice("TestExternal", unexpected),
             }
@@ -55,7 +55,7 @@ mod objects {
     macro_rules! arithmetic_op {
         ($self:ident, $rhs:expr, $op:tt) => {
             {
-                use Value::*;
+                use KValue::*;
                 match $rhs {
                     Object(rhs) if rhs.is_a::<Self>() => {
                         let rhs = rhs.cast::<Self>().unwrap();
@@ -75,7 +75,7 @@ mod objects {
     macro_rules! assignment_op {
         ($self:ident, $rhs:expr, $op:tt) => {
             {
-                use Value::*;
+                use KValue::*;
                 match $rhs {
                     Object(rhs) if rhs.is_a::<Self>() => {
                         let rhs = rhs.cast::<Self>().unwrap();
@@ -97,7 +97,7 @@ mod objects {
     macro_rules! comparison_op {
         ($self:ident, $rhs:expr, $op:tt) => {
             {
-                use Value::*;
+                use KValue::*;
                 match $rhs {
                     Object(rhs) if rhs.is_a::<Self>() => {
                         let rhs = rhs.cast::<Self>().unwrap();
@@ -122,9 +122,9 @@ mod objects {
             Ok(())
         }
 
-        fn index(&self, index: &Value) -> Result<Value> {
+        fn index(&self, index: &KValue) -> Result<KValue> {
             match index {
-                Value::Number(index) => {
+                KValue::Number(index) => {
                     let result = self.x + i64::from(index);
                     Ok(result.into())
                 }
@@ -132,75 +132,75 @@ mod objects {
             }
         }
 
-        fn call(&mut self, _ctx: &mut CallContext) -> Result<Value> {
+        fn call(&mut self, _ctx: &mut CallContext) -> Result<KValue> {
             Ok(self.x.into())
         }
 
-        fn negate(&self, _vm: &mut Vm) -> Result<Value> {
+        fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
             Ok(Self::make_value(-self.x))
         }
 
-        fn add(&self, rhs: &Value) -> Result<Value> {
+        fn add(&self, rhs: &KValue) -> Result<KValue> {
             arithmetic_op!(self, rhs, +)
         }
 
-        fn subtract(&self, rhs: &Value) -> Result<Value> {
+        fn subtract(&self, rhs: &KValue) -> Result<KValue> {
             arithmetic_op!(self, rhs, -)
         }
 
-        fn multiply(&self, rhs: &Value) -> Result<Value> {
+        fn multiply(&self, rhs: &KValue) -> Result<KValue> {
             arithmetic_op!(self, rhs, *)
         }
 
-        fn divide(&self, rhs: &Value) -> Result<Value> {
+        fn divide(&self, rhs: &KValue) -> Result<KValue> {
             arithmetic_op!(self, rhs, /)
         }
 
-        fn remainder(&self, rhs: &Value) -> Result<Value> {
+        fn remainder(&self, rhs: &KValue) -> Result<KValue> {
             arithmetic_op!(self, rhs, %)
         }
 
-        fn add_assign(&mut self, rhs: &Value) -> Result<()> {
+        fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
             assignment_op!(self, rhs, +=)
         }
 
-        fn subtract_assign(&mut self, rhs: &Value) -> Result<()> {
+        fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
             assignment_op!(self, rhs, -=)
         }
 
-        fn multiply_assign(&mut self, rhs: &Value) -> Result<()> {
+        fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
             assignment_op!(self, rhs, *=)
         }
 
-        fn divide_assign(&mut self, rhs: &Value) -> Result<()> {
+        fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
             assignment_op!(self, rhs, /=)
         }
 
-        fn remainder_assign(&mut self, rhs: &Value) -> Result<()> {
+        fn remainder_assign(&mut self, rhs: &KValue) -> Result<()> {
             assignment_op!(self, rhs, %=)
         }
 
-        fn less(&self, rhs: &Value) -> Result<bool> {
+        fn less(&self, rhs: &KValue) -> Result<bool> {
             comparison_op!(self, rhs, <)
         }
 
-        fn less_or_equal(&self, rhs: &Value) -> Result<bool> {
+        fn less_or_equal(&self, rhs: &KValue) -> Result<bool> {
             comparison_op!(self, rhs, <=)
         }
 
-        fn greater(&self, rhs: &Value) -> Result<bool> {
+        fn greater(&self, rhs: &KValue) -> Result<bool> {
             comparison_op!(self, rhs, >)
         }
 
-        fn greater_or_equal(&self, rhs: &Value) -> Result<bool> {
+        fn greater_or_equal(&self, rhs: &KValue) -> Result<bool> {
             comparison_op!(self, rhs, >=)
         }
 
-        fn equal(&self, rhs: &Value) -> Result<bool> {
+        fn equal(&self, rhs: &KValue) -> Result<bool> {
             comparison_op!(self, rhs, ==)
         }
 
-        fn not_equal(&self, rhs: &Value) -> Result<bool> {
+        fn not_equal(&self, rhs: &KValue) -> Result<bool> {
             comparison_op!(self, rhs, !=)
         }
 
@@ -242,12 +242,12 @@ mod objects {
         }
     }
 
-    fn test_object_script(script: &str, expected_output: impl Into<Value>) {
+    fn test_object_script(script: &str, expected_output: impl Into<KValue>) {
         let vm = Vm::default();
         let prelude = vm.prelude();
 
         prelude.add_fn("make_object", |ctx| match ctx.args() {
-            [Value::Number(x)] => Ok(TestObject::make_value(x.into())),
+            [KValue::Number(x)] => Ok(TestObject::make_value(x.into())),
             _ => runtime_error!("make_object: Expected a Number"),
         });
 

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -1,9 +1,9 @@
 mod runtime {
     use koto_bytecode::{Chunk, CompilerSettings, Loader};
-    use koto_runtime::Vm;
+    use koto_runtime::KotoVm;
 
     fn check_script_fails(script: &str) {
-        let mut vm = Vm::default();
+        let mut vm = KotoVm::default();
 
         let print_chunk = |script: &str, chunk| {
             println!("{script}\n");

--- a/crates/runtime/tests/runtime_test_utils.rs
+++ b/crates/runtime/tests/runtime_test_utils.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
 use koto_bytecode::{Chunk, CompilerSettings, Loader};
-use koto_runtime::{prelude::*, KValue::*, KotoVm, Result};
+use koto_runtime::{prelude::*, KValue::*, KotoVm, Ptr, PtrMut, Result};
 use std::{cell::RefCell, rc::Rc};
 
 pub fn test_script(script: &str, expected_output: impl Into<KValue>) {

--- a/crates/runtime/tests/runtime_test_utils.rs
+++ b/crates/runtime/tests/runtime_test_utils.rs
@@ -1,10 +1,10 @@
 #![allow(unused)]
 
 use koto_bytecode::{Chunk, CompilerSettings, Loader};
-use koto_runtime::{prelude::*, Result, Value::*};
+use koto_runtime::{prelude::*, KValue::*, Result};
 use std::{cell::RefCell, rc::Rc};
 
-pub fn test_script(script: &str, expected_output: impl Into<Value>) {
+pub fn test_script(script: &str, expected_output: impl Into<KValue>) {
     let output = PtrMut::from(String::new());
 
     let vm = Vm::with_settings(VmSettings {
@@ -26,7 +26,7 @@ pub fn test_script(script: &str, expected_output: impl Into<Value>) {
     }
 }
 
-pub fn run_script_with_vm(mut vm: Vm, script: &str, expected_output: Value) -> Result<()> {
+pub fn run_script_with_vm(mut vm: Vm, script: &str, expected_output: KValue) -> Result<()> {
     let mut loader = Loader::default();
     let chunk = match loader.compile_script(script, &None, CompilerSettings::default()) {
         Ok(chunk) => chunk,
@@ -39,8 +39,8 @@ pub fn run_script_with_vm(mut vm: Vm, script: &str, expected_output: Value) -> R
     match vm.run(chunk) {
         Ok(result) => {
             match vm.run_binary_op(BinaryOp::Equal, result.clone(), expected_output.clone()) {
-                Ok(Value::Bool(true)) => Ok(()),
-                Ok(Value::Bool(false)) => {
+                Ok(KValue::Bool(true)) => Ok(()),
+                Ok(KValue::Bool(false)) => {
                     print_chunk(script, vm.chunk());
                     Err(format!(
                         "Unexpected result - expected: {}, result: {}",
@@ -81,7 +81,7 @@ pub fn print_chunk(script: &str, chunk: Ptr<Chunk>) {
     );
 }
 
-pub fn number<T>(value: T) -> Value
+pub fn number<T>(value: T) -> KValue
 where
     T: Copy,
     f64: From<T>,
@@ -89,7 +89,7 @@ where
     f64::from(value).into()
 }
 
-pub fn number_list<T>(values: &[T]) -> Value
+pub fn number_list<T>(values: &[T]) -> KValue
 where
     T: Copy,
     i64: From<T>,
@@ -101,7 +101,7 @@ where
     list(&values)
 }
 
-pub fn number_tuple<T>(values: &[T]) -> Value
+pub fn number_tuple<T>(values: &[T]) -> KValue
 where
     T: Copy,
     i64: From<T>,
@@ -113,15 +113,15 @@ where
     tuple(&values)
 }
 
-pub fn list(values: &[Value]) -> Value {
+pub fn list(values: &[KValue]) -> KValue {
     KList::from_slice(values).into()
 }
 
-pub fn tuple(values: &[Value]) -> Value {
+pub fn tuple(values: &[KValue]) -> KValue {
     KTuple::from(values).into()
 }
 
-pub fn string(s: &str) -> Value {
+pub fn string(s: &str) -> KValue {
     KString::from(s).into()
 }
 

--- a/crates/runtime/tests/runtime_test_utils.rs
+++ b/crates/runtime/tests/runtime_test_utils.rs
@@ -1,13 +1,13 @@
 #![allow(unused)]
 
 use koto_bytecode::{Chunk, CompilerSettings, Loader};
-use koto_runtime::{prelude::*, KValue::*, Result};
+use koto_runtime::{prelude::*, KValue::*, KotoVm, Result};
 use std::{cell::RefCell, rc::Rc};
 
 pub fn test_script(script: &str, expected_output: impl Into<KValue>) {
     let output = PtrMut::from(String::new());
 
-    let vm = Vm::with_settings(VmSettings {
+    let vm = KotoVm::with_settings(KotoVmSettings {
         stdout: make_ptr!(TestStdout {
             output: output.clone(),
         }),
@@ -26,7 +26,7 @@ pub fn test_script(script: &str, expected_output: impl Into<KValue>) {
     }
 }
 
-pub fn run_script_with_vm(mut vm: Vm, script: &str, expected_output: KValue) -> Result<()> {
+pub fn run_script_with_vm(mut vm: KotoVm, script: &str, expected_output: KValue) -> Result<()> {
     let mut loader = Loader::default();
     let chunk = match loader.compile_script(script, &None, CompilerSettings::default()) {
         Ok(chunk) => chunk,

--- a/crates/runtime/tests/stdout.rs
+++ b/crates/runtime/tests/stdout.rs
@@ -10,7 +10,7 @@ mod vm {
     fn check_logged_output(script: &str, expected_output: &str) {
         let output = PtrMut::from(String::new());
 
-        let mut vm = Vm::with_settings(VmSettings {
+        let mut vm = KotoVm::with_settings(KotoVmSettings {
             stdout: make_ptr!(TestStdout {
                 output: output.clone(),
             }),

--- a/crates/runtime/tests/stdout.rs
+++ b/crates/runtime/tests/stdout.rs
@@ -2,7 +2,7 @@ mod runtime_test_utils;
 
 use crate::runtime_test_utils::TestStdout;
 use koto_bytecode::{Chunk, CompilerSettings, Loader};
-use koto_runtime::prelude::*;
+use koto_runtime::{prelude::*, Ptr, PtrMut};
 
 mod vm {
     use super::*;

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -11,8 +11,8 @@ mod vm {
 
         #[test]
         fn null() {
-            test_script("null", Value::Null);
-            test_script("()", Value::Null);
+            test_script("null", KValue::Null);
+            test_script("()", KValue::Null);
         }
 
         #[test]
@@ -64,7 +64,7 @@ a = 99
 
         #[test]
         fn remainder_negative() {
-            test_script("assert_near 10 % -1.2, 0.4", Value::Null);
+            test_script("assert_near 10 % -1.2, 0.4", KValue::Null);
         }
 
         #[test]
@@ -438,7 +438,7 @@ x[0], x[1] = -1, 42";
         #[test]
         fn unpack_list() {
             let script = "a, b, c = [7, 8]";
-            test_script(script, tuple(&[7.into(), 8.into(), Value::Null]));
+            test_script(script, tuple(&[7.into(), 8.into(), KValue::Null]));
         }
 
         #[test]
@@ -446,14 +446,14 @@ x[0], x[1] = -1, 42";
             let script = "a, b, c = [1, 2], [3, 4]";
             test_script(
                 script,
-                tuple(&[number_list(&[1, 2]), number_list(&[3, 4]), Value::Null]),
+                tuple(&[number_list(&[1, 2]), number_list(&[3, 4]), KValue::Null]),
             );
         }
 
         #[test]
         fn iterator() {
             let script = "a, b, c = (1, 2).each |x| x * 10";
-            test_script(script, tuple(&[10.into(), 20.into(), Value::Null]));
+            test_script(script, tuple(&[10.into(), 20.into(), KValue::Null]));
         }
 
         #[test]
@@ -499,7 +499,7 @@ a, b, c = 1..=3
 a, b, c = 1..=2
 c
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
     }
 
@@ -551,7 +551,7 @@ x";
 if 5 < 4
   42
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -564,7 +564,7 @@ else if 2 == 3
 else if false
   99
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -852,7 +852,7 @@ x = match a, b
   3, 4 then 3, 4
 x
 "#;
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -905,7 +905,7 @@ x = switch
   3 == 4 then 3, 4
 x
 "#;
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -924,7 +924,7 @@ x
     mod prelude {
         use super::*;
 
-        fn test_script_with_prelude(script: &str, expected_output: Value) {
+        fn test_script_with_prelude(script: &str, expected_output: KValue) {
             let vm = Vm::default();
             let prelude = vm.prelude();
 
@@ -932,7 +932,7 @@ x
             prelude.add_fn("assert", |ctx| {
                 for value in ctx.args().iter() {
                     match value {
-                        Value::Bool(b) => {
+                        KValue::Bool(b) => {
                             if !b {
                                 return runtime_error!("Assertion failed");
                             }
@@ -945,7 +945,7 @@ x
                         }
                     }
                 }
-                Ok(Value::Null)
+                Ok(KValue::Null)
             });
 
             if let Err(e) = run_script_with_vm(vm, script, expected_output) {
@@ -962,13 +962,13 @@ x
         #[test]
         fn function() {
             let script = "assert 1 + 1 == 2";
-            test_script_with_prelude(script, Value::Null);
+            test_script_with_prelude(script, KValue::Null);
         }
 
         #[test]
         fn function_two_args() {
             let script = "assert 1 + 1 == 2, 2 < 3";
-            test_script_with_prelude(script, Value::Null);
+            test_script_with_prelude(script, KValue::Null);
         }
     }
 
@@ -1015,7 +1015,7 @@ add(5, 6)";
 foo = |a, b| b
 foo 42
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -1197,7 +1197,7 @@ f (f 5, 10, 20, 30), 40, 50";
             let script = "
 f = |a, b...| b
 f()";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -1274,7 +1274,7 @@ f = |x|
     return
   x
 f -42";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -1588,7 +1588,7 @@ for i in 1..10
   if i == 5
     break
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -1642,7 +1642,7 @@ for i in (1, 2)
   else 
     i
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -1741,7 +1741,7 @@ while (i += 1) < 5
   else 
     i
 ";
-            test_script(script, Value::Null);
+            test_script(script, KValue::Null);
         }
 
         #[test]
@@ -1896,7 +1896,7 @@ result";
 
         #[test]
         fn empty() {
-            test_script("{}", Value::Map(KMap::new()));
+            test_script("{}", KValue::Map(KMap::new()));
         }
 
         #[test]
@@ -1905,7 +1905,7 @@ result";
             expected.insert("foo", 42);
             expected.insert("bar", "baz");
 
-            test_script("{foo: 42, bar: 'baz'}", Value::Map(expected));
+            test_script("{foo: 42, bar: 'baz'}", KValue::Map(expected));
         }
 
         #[test]
@@ -3170,7 +3170,7 @@ x =
 a, b, c = x
 a, b, c
 ";
-            test_script(script, tuple(&[10.into(), 20.into(), Value::Null]));
+            test_script(script, tuple(&[10.into(), 20.into(), KValue::Null]));
         }
     }
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -925,7 +925,7 @@ x
         use super::*;
 
         fn test_script_with_prelude(script: &str, expected_output: KValue) {
-            let vm = Vm::default();
+            let vm = KotoVm::default();
             let prelude = vm.prelude();
 
             prelude.insert("test_value", 42);

--- a/crates/serialize/src/lib.rs
+++ b/crates/serialize/src/lib.rs
@@ -1,10 +1,10 @@
 //! Serde serialization support for Koto value types
 
-use koto_runtime::Value;
+use koto_runtime::KValue;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 /// A newtype that allows us to implement support for Serde serialization
-pub struct SerializableValue<'a>(pub &'a Value);
+pub struct SerializableValue<'a>(pub &'a KValue);
 
 impl<'a> Serialize for SerializableValue<'a> {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
@@ -12,37 +12,37 @@ impl<'a> Serialize for SerializableValue<'a> {
         S: Serializer,
     {
         match self.0 {
-            Value::Null => s.serialize_unit(),
-            Value::Bool(b) => s.serialize_bool(*b),
-            Value::Number(n) => {
+            KValue::Null => s.serialize_unit(),
+            KValue::Bool(b) => s.serialize_bool(*b),
+            KValue::Number(n) => {
                 if n.is_f64() {
                     s.serialize_f64(f64::from(n))
                 } else {
                     s.serialize_i64(i64::from(n))
                 }
             }
-            Value::List(l) => {
+            KValue::List(l) => {
                 let mut seq = s.serialize_seq(Some(l.len()))?;
                 for element in l.data().iter() {
                     seq.serialize_element(&SerializableValue(element))?;
                 }
                 seq.end()
             }
-            Value::Tuple(t) => {
+            KValue::Tuple(t) => {
                 let mut seq = s.serialize_seq(Some(t.len()))?;
                 for element in t.iter() {
                     seq.serialize_element(&SerializableValue(element))?;
                 }
                 seq.end()
             }
-            Value::Map(m) => {
+            KValue::Map(m) => {
                 let mut seq = s.serialize_map(Some(m.len()))?;
                 for (key, value) in m.data().iter() {
                     seq.serialize_entry(&key.to_string(), &SerializableValue(value))?;
                 }
                 seq.end()
             }
-            Value::Str(string) => s.serialize_str(string),
+            KValue::Str(string) => s.serialize_str(string),
             // TODO, is it ok to do nothing for non-fundamental types, e.g. External Values?
             _ => s.serialize_unit(),
         }

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -29,7 +29,7 @@ impl KotoObject for KotoPoetry {
         IsIterable::ForwardIterator
     }
 
-    fn iterator_next(&mut self, _vm: &mut Vm) -> Option<KIteratorOutput> {
+    fn iterator_next(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
         self.0
             .next_word()
             .map(|word| KIteratorOutput::Value(word.as_ref().into()))

--- a/examples/poetry/src/koto_bindings.rs
+++ b/examples/poetry/src/koto_bindings.rs
@@ -6,7 +6,7 @@ pub fn make_module() -> KMap {
 
     result.add_fn("new", {
         |ctx| match ctx.args() {
-            [Value::Str(text)] => {
+            [KValue::Str(text)] => {
                 let mut poetry = Poetry::default();
                 poetry.add_source_material(text);
                 Ok(KObject::from(KotoPoetry(poetry)).into())

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use koto::{prelude::*, runtime::Result};
+use koto::{prelude::*, runtime::Result, PtrMut};
 use wasm_bindgen::prelude::*;
 
 // Captures output from Koto in a String

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -291,7 +291,7 @@ impl KotoObject for Color {
         IsIterable::Iterable
     }
 
-    fn make_iterator(&self, _vm: &mut Vm) -> Result<KIterator> {
+    fn make_iterator(&self, _vm: &mut KotoVm) -> Result<KIterator> {
         let c = *self;
 
         let iter = (0..=3).map(move |i| {

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -59,11 +59,11 @@ macro_rules! color_arithmetic_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {
-                Value::Object(rhs) if rhs.is_a::<Self>() => {
+                KValue::Object(rhs) if rhs.is_a::<Self>() => {
                     let rhs = rhs.cast::<Self>().unwrap();
                     Ok((*$self $op *rhs).into())
                 }
-                Value::Number(n) => {
+                KValue::Number(n) => {
                     Ok((*$self $op f32::from(n)).into())
                 }
                 unexpected => {
@@ -79,12 +79,12 @@ macro_rules! color_arithmetic_assign_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {
-                Value::Object(rhs) if rhs.is_a::<Self>() => {
+                KValue::Object(rhs) if rhs.is_a::<Self>() => {
                     let rhs = rhs.cast::<Self>().unwrap();
                     *$self $op *rhs;
                     Ok(())
                 }
-                Value::Number(n) => {
+                KValue::Number(n) => {
                     *$self $op f32::from(n);
                     Ok(())
                 }
@@ -101,7 +101,7 @@ macro_rules! color_comparison_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {
-                Value::Object(rhs) if rhs.is_a::<Self>() => {
+                KValue::Object(rhs) if rhs.is_a::<Self>() => {
                     let rhs = rhs.cast::<Self>().unwrap();
                     Ok(*$self $op *rhs)
                 }
@@ -144,29 +144,29 @@ impl Color {
     }
 
     #[koto_method(alias = "r")]
-    pub fn red(&self) -> Value {
+    pub fn red(&self) -> KValue {
         self.0.color.red.into()
     }
 
     #[koto_method(alias = "g")]
-    pub fn green(&self) -> Value {
+    pub fn green(&self) -> KValue {
         self.0.color.green.into()
     }
 
     #[koto_method(alias = "b")]
-    pub fn blue(&self) -> Value {
+    pub fn blue(&self) -> KValue {
         self.0.color.blue.into()
     }
 
     #[koto_method(alias = "a")]
-    pub fn alpha(&self) -> Value {
+    pub fn alpha(&self) -> KValue {
         self.0.alpha.into()
     }
 
     #[koto_method(alias = "set_r")]
-    pub fn set_red(ctx: MethodContext<Self>) -> Result<Value> {
+    pub fn set_red(ctx: MethodContext<Self>) -> Result<KValue> {
         match ctx.args {
-            [Value::Number(n)] => {
+            [KValue::Number(n)] => {
                 ctx.instance_mut()?.0.color.red = n.into();
                 ctx.instance_result()
             }
@@ -175,9 +175,9 @@ impl Color {
     }
 
     #[koto_method(alias = "set_g")]
-    pub fn set_green(ctx: MethodContext<Self>) -> Result<Value> {
+    pub fn set_green(ctx: MethodContext<Self>) -> Result<KValue> {
         match ctx.args {
-            [Value::Number(n)] => {
+            [KValue::Number(n)] => {
                 ctx.instance_mut()?.0.color.green = n.into();
                 ctx.instance_result()
             }
@@ -186,9 +186,9 @@ impl Color {
     }
 
     #[koto_method(alias = "set_b")]
-    pub fn set_blue(ctx: MethodContext<Self>) -> Result<Value> {
+    pub fn set_blue(ctx: MethodContext<Self>) -> Result<KValue> {
         match ctx.args {
-            [Value::Number(n)] => {
+            [KValue::Number(n)] => {
                 ctx.instance_mut()?.0.color.blue = n.into();
                 ctx.instance_result()
             }
@@ -197,9 +197,9 @@ impl Color {
     }
 
     #[koto_method(alias = "set_a")]
-    pub fn set_alpha(ctx: MethodContext<Self>) -> Result<Value> {
+    pub fn set_alpha(ctx: MethodContext<Self>) -> Result<KValue> {
         match ctx.args {
-            [Value::Number(n)] => {
+            [KValue::Number(n)] => {
                 ctx.instance_mut()?.0.alpha = n.into();
                 ctx.instance_result()
             }
@@ -208,15 +208,15 @@ impl Color {
     }
 
     #[koto_method]
-    pub fn mix(ctx: MethodContext<Self>) -> Result<Value> {
+    pub fn mix(ctx: MethodContext<Self>) -> Result<KValue> {
         match ctx.args {
-            [Value::Object(b)] if b.is_a::<Color>() => {
+            [KValue::Object(b)] if b.is_a::<Color>() => {
                 let a = ctx.instance()?;
                 let b = b.cast::<Color>()?;
 
                 Ok(Color::from(a.0.mix(b.0, 0.5)).into())
             }
-            [Value::Object(b), Value::Number(x)] if b.is_a::<Color>() => {
+            [KValue::Object(b), KValue::Number(x)] if b.is_a::<Color>() => {
                 let a = ctx.instance()?;
                 let b = b.cast::<Color>()?;
                 let n = f32::from(x);
@@ -234,49 +234,49 @@ impl KotoObject for Color {
         Ok(())
     }
 
-    fn add(&self, rhs: &Value) -> Result<Value> {
+    fn add(&self, rhs: &KValue) -> Result<KValue> {
         color_arithmetic_op!(self, rhs, +)
     }
 
-    fn subtract(&self, rhs: &Value) -> Result<Value> {
+    fn subtract(&self, rhs: &KValue) -> Result<KValue> {
         color_arithmetic_op!(self, rhs, -)
     }
 
-    fn multiply(&self, rhs: &Value) -> Result<Value> {
+    fn multiply(&self, rhs: &KValue) -> Result<KValue> {
         color_arithmetic_op!(self, rhs, *)
     }
 
-    fn divide(&self, rhs: &Value) -> Result<Value> {
+    fn divide(&self, rhs: &KValue) -> Result<KValue> {
         color_arithmetic_op!(self, rhs, /)
     }
 
-    fn add_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
         color_arithmetic_assign_op!(self, rhs, +=)
     }
 
-    fn subtract_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
         color_arithmetic_assign_op!(self, rhs, -=)
     }
 
-    fn multiply_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
         color_arithmetic_assign_op!(self, rhs, *=)
     }
 
-    fn divide_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
         color_arithmetic_assign_op!(self, rhs, /=)
     }
 
-    fn equal(&self, rhs: &Value) -> Result<bool> {
+    fn equal(&self, rhs: &KValue) -> Result<bool> {
         color_comparison_op!(self, rhs, ==)
     }
 
-    fn not_equal(&self, rhs: &Value) -> Result<bool> {
+    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
         color_comparison_op!(self, rhs, !=)
     }
 
-    fn index(&self, index: &Value) -> Result<Value> {
+    fn index(&self, index: &KValue) -> Result<KValue> {
         match index {
-            Value::Number(n) => match usize::from(n) {
+            KValue::Number(n) => match usize::from(n) {
                 0 => Ok(self.red()),
                 1 => Ok(self.green()),
                 2 => Ok(self.blue()),
@@ -309,7 +309,7 @@ impl KotoObject for Color {
     }
 }
 
-impl From<Color> for Value {
+impl From<Color> for KValue {
     fn from(color: Color) -> Self {
         KObject::from(color).into()
     }

--- a/libs/color/src/lib.rs
+++ b/libs/color/src/lib.rs
@@ -8,7 +8,7 @@ use koto_runtime::{prelude::*, Result};
 use palette::{Hsl, Hsv};
 
 pub fn make_module() -> KMap {
-    use Value::{Number, Str};
+    use KValue::{Number, Str};
     let mut result = KMap::default();
 
     result.add_fn("hsl", |ctx| match ctx.args() {
@@ -56,17 +56,17 @@ pub fn make_module() -> KMap {
     result
 }
 
-fn named(name: &str) -> Result<Value> {
+fn named(name: &str) -> Result<KValue> {
     match Color::named(name) {
         Some(c) => Ok(c.into()),
-        None => Ok(Value::Null),
+        None => Ok(KValue::Null),
     }
 }
 
-fn rgb(r: &KNumber, g: &KNumber, b: &KNumber) -> Result<Value> {
+fn rgb(r: &KNumber, g: &KNumber, b: &KNumber) -> Result<KValue> {
     Ok(Color::rgb(r.into(), g.into(), b.into()).into())
 }
 
-fn rgba(r: &KNumber, g: &KNumber, b: &KNumber, a: &KNumber) -> Result<Value> {
+fn rgba(r: &KNumber, g: &KNumber, b: &KNumber, a: &KNumber) -> Result<KValue> {
     Ok(Color::rgba(r.into(), g.into(), b.into(), a.into()).into())
 }

--- a/libs/geometry/src/lib.rs
+++ b/libs/geometry/src/lib.rs
@@ -13,7 +13,7 @@ pub use vec3::Vec3;
 use koto_runtime::prelude::*;
 
 pub fn make_module() -> KMap {
-    use Value::{Number, Object};
+    use KValue::{Number, Object};
 
     let result = KMap::with_type("geometry");
 

--- a/libs/geometry/src/macros.rs
+++ b/libs/geometry/src/macros.rs
@@ -64,11 +64,11 @@ macro_rules! geometry_arithmetic_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {
-                Value::Object(rhs) if rhs.is_a::<Self>() => {
+                KValue::Object(rhs) if rhs.is_a::<Self>() => {
                     let rhs = rhs.cast::<Self>().unwrap();
                     Ok((*$self $op *rhs).into())
                 }
-                Value::Number(n) => {
+                KValue::Number(n) => {
                     Ok((*$self $op f64::from(n)).into())
                 }
                 unexpected => {
@@ -84,12 +84,12 @@ macro_rules! geometry_arithmetic_assign_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {
-                Value::Object(rhs) if rhs.is_a::<Self>() => {
+                KValue::Object(rhs) if rhs.is_a::<Self>() => {
                     let rhs = rhs.cast::<Self>().unwrap();
                     *$self $op *rhs;
                     Ok(())
                 }
-                Value::Number(n) => {
+                KValue::Number(n) => {
                     *$self $op f64::from(n);
                     Ok(())
                 }
@@ -106,7 +106,7 @@ macro_rules! geometry_comparison_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {
-                Value::Object(rhs) if rhs.is_a::<Self>() => {
+                KValue::Object(rhs) if rhs.is_a::<Self>() => {
                     let rhs = rhs.cast::<Self>().unwrap();
                     Ok(*$self $op *rhs)
                 }

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -15,54 +15,54 @@ impl Rect {
     }
 
     #[koto_method]
-    fn left(&self) -> Value {
+    fn left(&self) -> KValue {
         self.0.left().into()
     }
 
     #[koto_method]
-    fn right(&self) -> Value {
+    fn right(&self) -> KValue {
         self.0.right().into()
     }
 
     #[koto_method]
-    fn top(&self) -> Value {
+    fn top(&self) -> KValue {
         self.0.top().into()
     }
 
     #[koto_method]
-    fn bottom(&self) -> Value {
+    fn bottom(&self) -> KValue {
         self.0.bottom().into()
     }
 
     #[koto_method]
-    fn width(&self) -> Value {
+    fn width(&self) -> KValue {
         self.0.w().into()
     }
 
     #[koto_method]
-    fn height(&self) -> Value {
+    fn height(&self) -> KValue {
         self.0.h().into()
     }
 
     #[koto_method]
-    fn center(&self) -> Value {
+    fn center(&self) -> KValue {
         Vec2::from(self.0.xy()).into()
     }
 
     #[koto_method]
-    fn x(&self) -> Value {
+    fn x(&self) -> KValue {
         self.0.x().into()
     }
 
     #[koto_method]
-    fn y(&self) -> Value {
+    fn y(&self) -> KValue {
         self.0.y().into()
     }
 
     #[koto_method]
-    fn contains(&self, args: &[Value]) -> Result<Value> {
+    fn contains(&self, args: &[KValue]) -> Result<KValue> {
         match args {
-            [Value::Object(p)] if p.is_a::<Vec2>() => {
+            [KValue::Object(p)] if p.is_a::<Vec2>() => {
                 let p = p.cast::<Vec2>().unwrap();
                 let result = self.0.contains(p.inner());
                 Ok(result.into())
@@ -72,8 +72,8 @@ impl Rect {
     }
 
     #[koto_method]
-    fn set_center(ctx: MethodContext<Self>) -> Result<Value> {
-        use Value::{Number, Object};
+    fn set_center(ctx: MethodContext<Self>) -> Result<KValue> {
+        use KValue::{Number, Object};
 
         let (x, y) = match ctx.args {
             [Number(x), Number(y)] => (x.into(), y.into()),
@@ -97,11 +97,11 @@ impl KotoObject for Rect {
         Ok(())
     }
 
-    fn equal(&self, rhs: &Value) -> Result<bool> {
+    fn equal(&self, rhs: &KValue) -> Result<bool> {
         geometry_comparison_op!(self, rhs, ==)
     }
 
-    fn not_equal(&self, rhs: &Value) -> Result<bool> {
+    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
         geometry_comparison_op!(self, rhs, !=)
     }
 
@@ -139,7 +139,7 @@ impl From<(f64, f64, f64, f64)> for Rect {
     }
 }
 
-impl From<Rect> for Value {
+impl From<Rect> for KValue {
     fn from(point: Rect) -> Self {
         KObject::from(point).into()
     }

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -109,7 +109,7 @@ impl KotoObject for Rect {
         IsIterable::Iterable
     }
 
-    fn make_iterator(&self, _vm: &mut Vm) -> Result<KIterator> {
+    fn make_iterator(&self, _vm: &mut KotoVm) -> Result<KIterator> {
         let r = *self;
 
         let iter = (0..=3).map(move |i| {

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -18,22 +18,22 @@ impl Vec2 {
     }
 
     #[koto_method]
-    fn angle(&self) -> Value {
+    fn angle(&self) -> KValue {
         Inner::X.angle_between(self.0).into()
     }
 
     #[koto_method]
-    fn length(&self) -> Value {
+    fn length(&self) -> KValue {
         self.0.length().into()
     }
 
     #[koto_method]
-    fn x(&self) -> Value {
+    fn x(&self) -> KValue {
         self.0.x.into()
     }
 
     #[koto_method]
-    fn y(&self) -> Value {
+    fn y(&self) -> KValue {
         self.0.y.into()
     }
 }
@@ -44,53 +44,53 @@ impl KotoObject for Vec2 {
         Ok(())
     }
 
-    fn negate(&self, _vm: &mut Vm) -> Result<Value> {
+    fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
         Ok(Self(-self.0).into())
     }
 
-    fn add(&self, rhs: &Value) -> Result<Value> {
+    fn add(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, +)
     }
 
-    fn subtract(&self, rhs: &Value) -> Result<Value> {
+    fn subtract(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, -)
     }
 
-    fn multiply(&self, rhs: &Value) -> Result<Value> {
+    fn multiply(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, *)
     }
 
-    fn divide(&self, rhs: &Value) -> Result<Value> {
+    fn divide(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, /)
     }
 
-    fn add_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, +=)
     }
 
-    fn subtract_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, -=)
     }
 
-    fn multiply_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, *=)
     }
 
-    fn divide_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, /=)
     }
 
-    fn equal(&self, rhs: &Value) -> Result<bool> {
+    fn equal(&self, rhs: &KValue) -> Result<bool> {
         geometry_comparison_op!(self, rhs, ==)
     }
 
-    fn not_equal(&self, rhs: &Value) -> Result<bool> {
+    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
         geometry_comparison_op!(self, rhs, !=)
     }
 
-    fn index(&self, index: &Value) -> Result<Value> {
+    fn index(&self, index: &KValue) -> Result<KValue> {
         match index {
-            Value::Number(n) => match usize::from(n) {
+            KValue::Number(n) => match usize::from(n) {
                 0 => Ok(self.x()),
                 1 => Ok(self.y()),
                 other => runtime_error!("index out of range (got {other}, should be <= 1)"),
@@ -125,7 +125,7 @@ impl From<Inner> for Vec2 {
     }
 }
 
-impl From<Vec2> for Value {
+impl From<Vec2> for KValue {
     fn from(point: Vec2) -> Self {
         KObject::from(point).into()
     }

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -44,7 +44,7 @@ impl KotoObject for Vec2 {
         Ok(())
     }
 
-    fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
+    fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
         Ok(Self(-self.0).into())
     }
 
@@ -103,7 +103,7 @@ impl KotoObject for Vec2 {
         IsIterable::Iterable
     }
 
-    fn make_iterator(&self, _vm: &mut Vm) -> Result<KIterator> {
+    fn make_iterator(&self, _vm: &mut KotoVm) -> Result<KIterator> {
         let v = *self;
 
         let iter = (0..=1).map(move |i| {

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -13,23 +13,23 @@ impl Vec3 {
     }
 
     #[koto_method]
-    fn angle(&self) -> Value {
+    fn angle(&self) -> KValue {
         let v = self.0;
         (v.x + v.y + v.z).into()
     }
 
     #[koto_method]
-    fn x(&self) -> Value {
+    fn x(&self) -> KValue {
         self.0.x.into()
     }
 
     #[koto_method]
-    fn y(&self) -> Value {
+    fn y(&self) -> KValue {
         self.0.y.into()
     }
 
     #[koto_method]
-    fn z(&self) -> Value {
+    fn z(&self) -> KValue {
         self.0.z.into()
     }
 }
@@ -40,53 +40,53 @@ impl KotoObject for Vec3 {
         Ok(())
     }
 
-    fn negate(&self, _vm: &mut Vm) -> Result<Value> {
+    fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
         Ok(Self(-self.0).into())
     }
 
-    fn add(&self, rhs: &Value) -> Result<Value> {
+    fn add(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, +)
     }
 
-    fn subtract(&self, rhs: &Value) -> Result<Value> {
+    fn subtract(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, -)
     }
 
-    fn multiply(&self, rhs: &Value) -> Result<Value> {
+    fn multiply(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, *)
     }
 
-    fn divide(&self, rhs: &Value) -> Result<Value> {
+    fn divide(&self, rhs: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, rhs, /)
     }
 
-    fn add_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, +=)
     }
 
-    fn subtract_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, -=)
     }
 
-    fn multiply_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, *=)
     }
 
-    fn divide_assign(&mut self, rhs: &Value) -> Result<()> {
+    fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
         geometry_arithmetic_assign_op!(self, rhs, /=)
     }
 
-    fn equal(&self, rhs: &Value) -> Result<bool> {
+    fn equal(&self, rhs: &KValue) -> Result<bool> {
         geometry_comparison_op!(self, rhs, ==)
     }
 
-    fn not_equal(&self, rhs: &Value) -> Result<bool> {
+    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
         geometry_comparison_op!(self, rhs, !=)
     }
 
-    fn index(&self, index: &Value) -> Result<Value> {
+    fn index(&self, index: &KValue) -> Result<KValue> {
         match index {
-            Value::Number(n) => match usize::from(n) {
+            KValue::Number(n) => match usize::from(n) {
                 0 => Ok(self.x()),
                 1 => Ok(self.y()),
                 2 => Ok(self.z()),
@@ -129,7 +129,7 @@ impl From<(f64, f64, f64)> for Vec3 {
     }
 }
 
-impl From<Vec3> for Value {
+impl From<Vec3> for KValue {
     fn from(vec3: Vec3) -> Self {
         KObject::from(vec3).into()
     }

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -40,7 +40,7 @@ impl KotoObject for Vec3 {
         Ok(())
     }
 
-    fn negate(&self, _vm: &mut Vm) -> Result<KValue> {
+    fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
         Ok(Self(-self.0).into())
     }
 
@@ -100,7 +100,7 @@ impl KotoObject for Vec3 {
         IsIterable::Iterable
     }
 
-    fn make_iterator(&self, _vm: &mut Vm) -> Result<KIterator> {
+    fn make_iterator(&self, _vm: &mut KotoVm) -> Result<KIterator> {
         let v = *self;
 
         let iter = (0..=2).map(move |i| {

--- a/libs/json/src/lib.rs
+++ b/libs/json/src/lib.rs
@@ -4,25 +4,25 @@ use koto_runtime::prelude::*;
 use koto_serialize::SerializableValue;
 use serde_json::Value as JsonValue;
 
-pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<Value, String> {
+pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<KValue, String> {
     let result = match value {
-        JsonValue::Null => Value::Null,
-        JsonValue::Bool(b) => Value::Bool(*b),
+        JsonValue::Null => KValue::Null,
+        JsonValue::Bool(b) => KValue::Bool(*b),
         JsonValue::Number(n) => match n.as_i64() {
-            Some(n64) => Value::Number(n64.into()),
+            Some(n64) => KValue::Number(n64.into()),
             None => match n.as_f64() {
-                Some(n64) => Value::Number(n64.into()),
+                Some(n64) => KValue::Number(n64.into()),
                 None => return Err(format!("Number is out of range: {n}")),
             },
         },
-        JsonValue::String(s) => Value::Str(s.as_str().into()),
+        JsonValue::String(s) => KValue::Str(s.as_str().into()),
         JsonValue::Array(a) => {
             match a
                 .iter()
                 .map(json_value_to_koto_value)
                 .collect::<Result<ValueVec, String>>()
             {
-                Ok(result) => Value::List(KList::with_data(result)),
+                Ok(result) => KValue::List(KList::with_data(result)),
                 Err(e) => return Err(e),
             }
         }
@@ -31,7 +31,7 @@ pub fn json_value_to_koto_value(value: &serde_json::Value) -> Result<Value, Stri
             for (key, value) in o.iter() {
                 map.insert(key.as_str(), json_value_to_koto_value(value)?);
             }
-            Value::Map(map)
+            KValue::Map(map)
         }
     };
 
@@ -42,7 +42,7 @@ pub fn make_module() -> KMap {
     let result = KMap::with_type("json");
 
     result.add_fn("from_string", |ctx| match ctx.args() {
-        [Value::Str(s)] => match serde_json::from_str(s) {
+        [KValue::Str(s)] => match serde_json::from_str(s) {
             Ok(value) => match json_value_to_koto_value(&value) {
                 Ok(result) => Ok(result),
                 Err(e) => runtime_error!("json.from_string: Error while parsing input: {e}"),

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -15,7 +15,7 @@ pub fn make_module() -> KMap {
             // No seed, make RNG from entropy
             [] => ChaCha8Rng::from_entropy(),
             // RNG from seed
-            [Value::Number(n)] => ChaCha8Rng::seed_from_u64(n.to_bits()),
+            [KValue::Number(n)] => ChaCha8Rng::seed_from_u64(n.to_bits()),
             unexpected => {
                 return type_error_with_slice("an optional seed Number as argument", unexpected)
             }
@@ -43,23 +43,23 @@ struct ChaChaRng(ChaCha8Rng);
 
 #[koto_impl(runtime = koto_runtime)]
 impl ChaChaRng {
-    fn make_value(rng: ChaCha8Rng) -> Value {
+    fn make_value(rng: ChaCha8Rng) -> KValue {
         KObject::from(Self(rng)).into()
     }
 
     #[koto_method]
-    fn bool(&mut self) -> Result<Value> {
+    fn bool(&mut self) -> Result<KValue> {
         Ok(self.0.gen::<bool>().into())
     }
 
     #[koto_method]
-    fn number(&mut self) -> Result<Value> {
+    fn number(&mut self) -> Result<KValue> {
         Ok(self.0.gen::<f64>().into())
     }
 
     #[koto_method]
-    fn pick(&mut self, args: &[Value]) -> Result<Value> {
-        use Value::*;
+    fn pick(&mut self, args: &[KValue]) -> Result<KValue> {
+        use KValue::*;
 
         match args {
             [List(l)] => {
@@ -89,8 +89,8 @@ impl ChaChaRng {
     }
 
     #[koto_method]
-    fn seed(&mut self, args: &[Value]) -> Result<Value> {
-        use Value::*;
+    fn seed(&mut self, args: &[KValue]) -> Result<KValue> {
+        use KValue::*;
         match args {
             [Number(n)] => {
                 self.0 = ChaCha8Rng::seed_from_u64(n.to_bits());

--- a/libs/regex/src/lib.rs
+++ b/libs/regex/src/lib.rs
@@ -1,4 +1,4 @@
-use koto_runtime::{derive::*, prelude::*, Result};
+use koto_runtime::{derive::*, prelude::*, Ptr, Result};
 
 pub fn make_module() -> KMap {
     let result = KMap::with_type("regex");

--- a/libs/regex/src/lib.rs
+++ b/libs/regex/src/lib.rs
@@ -4,7 +4,7 @@ pub fn make_module() -> KMap {
     let result = KMap::with_type("regex");
 
     result.add_fn("new", |ctx| match ctx.args() {
-        [Value::Str(pattern)] => Ok(Regex::new(pattern)?.into()),
+        [KValue::Str(pattern)] => Ok(Regex::new(pattern)?.into()),
         unexpected => type_error_with_slice("a regex pattern as string", unexpected),
     });
 
@@ -24,17 +24,17 @@ impl Regex {
     }
 
     #[koto_method]
-    fn is_match(&self, args: &[Value]) -> Result<Value> {
+    fn is_match(&self, args: &[KValue]) -> Result<KValue> {
         match args {
-            [Value::Str(text)] => Ok(self.0.is_match(text).into()),
+            [KValue::Str(text)] => Ok(self.0.is_match(text).into()),
             unexpected => type_error_with_slice("a string", unexpected),
         }
     }
 
     #[koto_method]
-    fn find_all(&self, args: &[Value]) -> Result<Value> {
+    fn find_all(&self, args: &[KValue]) -> Result<KValue> {
         match args {
-            [Value::Str(text)] => {
+            [KValue::Str(text)] => {
                 let matches = self.0.find_iter(text);
                 Ok(Matches {
                     text: text.clone(),
@@ -48,13 +48,13 @@ impl Regex {
     }
 
     #[koto_method]
-    fn find(&self, args: &[Value]) -> Result<Value> {
+    fn find(&self, args: &[KValue]) -> Result<KValue> {
         match args {
-            [Value::Str(text)] => {
+            [KValue::Str(text)] => {
                 let m = self.0.find(text);
                 match m {
                     Some(m) => Ok(Match::make_value(text.clone(), m.start(), m.end())),
-                    None => Ok(Value::Null),
+                    None => Ok(KValue::Null),
                 }
             }
             unexpected => type_error_with_slice("a string", unexpected),
@@ -62,9 +62,9 @@ impl Regex {
     }
 
     #[koto_method]
-    fn captures(&self, args: &[Value]) -> Result<Value> {
+    fn captures(&self, args: &[KValue]) -> Result<KValue> {
         match args {
-            [Value::Str(text)] => {
+            [KValue::Str(text)] => {
                 match self.0.captures(text) {
                     Some(captures) => {
                         let mut result = ValueMap::with_capacity(captures.len());
@@ -84,13 +84,13 @@ impl Regex {
                                     result.insert(name.into(), match_);
                                 }
                             } else {
-                                result.insert(i.into(), Value::Null);
+                                result.insert(i.into(), KValue::Null);
                             }
                         }
 
                         Ok(KMap::from(result).into())
                     }
-                    None => Ok(Value::Null),
+                    None => Ok(KValue::Null),
                 }
             }
             unexpected => type_error_with_slice("a string", unexpected),
@@ -98,9 +98,9 @@ impl Regex {
     }
 
     #[koto_method]
-    fn replace_all(&self, args: &[Value]) -> Result<Value> {
+    fn replace_all(&self, args: &[KValue]) -> Result<KValue> {
         match args {
-            [Value::Str(text), Value::Str(replacement)] => {
+            [KValue::Str(text), KValue::Str(replacement)] => {
                 let result = self.0.replace_all(text, replacement.as_str());
                 Ok(result.to_string().into())
             }
@@ -111,7 +111,7 @@ impl Regex {
 
 impl KotoObject for Regex {}
 
-impl From<Regex> for Value {
+impl From<Regex> for KValue {
     fn from(regex: Regex) -> Self {
         KObject::from(regex).into()
     }
@@ -153,7 +153,7 @@ impl KotoObject for Matches {
     }
 }
 
-impl From<Matches> for Value {
+impl From<Matches> for KValue {
     fn from(matches: Matches) -> Self {
         KObject::from(matches).into()
     }
@@ -167,9 +167,9 @@ pub struct Match {
 
 #[koto_impl(runtime = koto_runtime)]
 impl Match {
-    pub fn make_value(matched: KString, start: usize, end: usize) -> Value {
+    pub fn make_value(matched: KString, start: usize, end: usize) -> KValue {
         let Some(text) = matched.with_bounds(start..end) else {
-            return Value::Null;
+            return KValue::Null;
         };
 
         Self {
@@ -180,12 +180,12 @@ impl Match {
     }
 
     #[koto_method]
-    fn text(&self) -> Value {
+    fn text(&self) -> KValue {
         self.text.clone().into()
     }
 
     #[koto_method]
-    fn range(&self) -> Value {
+    fn range(&self) -> KValue {
         self.bounds.clone().into()
     }
 }
@@ -197,7 +197,7 @@ impl KotoObject for Match {
     }
 }
 
-impl From<Match> for Value {
+impl From<Match> for KValue {
     fn from(match_: Match) -> Self {
         KObject::from(match_).into()
     }

--- a/libs/regex/src/lib.rs
+++ b/libs/regex/src/lib.rs
@@ -133,7 +133,7 @@ impl KotoObject for Matches {
         IsIterable::ForwardIterator
     }
 
-    fn iterator_next(&mut self, _vm: &mut Vm) -> Option<KIteratorOutput> {
+    fn iterator_next(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
         if self.last_index >= self.matches.len() {
             self.last_index = 0;
             None


### PR DESCRIPTION
- Add `Koto::run_instance_function`
- Add `KObject::ref_count`
- Implement `Debug` for `KObject`
- Reintroduce a basic implementation of `Debug` for `Value`
- Rename `Value` -> `KValue` for consitency with other core runtime types
- Remove `Borrow`/`BorrowMut` from the runtime prelude
- Rename `Vm` -> `KotoVm`
- Remove `Ptr`/`PtrMut` from the runtime prelude
- Update the changelog
