### PR TITLE
Various tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The Koto project adheres to
 #### Libs
 
 - A `regex` module has been added, thanks to [@jasal92](https://github.com/jasal82).
+- `iterator.once` has been added.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The Koto project adheres to
   character escaping and string interpolation.
 - `import` expressions can now use `as` for more ergonomic item renaming.
 - Assignments can now be used in `while`/`until` conditions.
+- Unpacked assignments with a single value on the RHS are now accepted, 
+  with remaining values being set to `null`.
+  - e.g. `a, b, c = 42` will assign `42` to `a`, and `null` to `b` and `c`.
 
 #### API
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1842,11 +1842,15 @@ impl<'source> Parser<'source> {
             return self.error(InternalError::ExpectedMapColon);
         }
 
-        if let Some(value) = self.parse_expression(&ExpressionContext::permissive())? {
+        if let Some(value) = self.parse_line(&ExpressionContext::permissive())? {
             let entries = if context.allow_map_block {
                 let block_context = ExpressionContext::permissive()
                     .with_expected_indentation(Indentation::Equal(start_indent));
-                return self.parse_map_block((first_key, Some(value)), start_span, &block_context);
+                return self.consume_map_block(
+                    (first_key, Some(value)),
+                    start_span,
+                    &block_context,
+                );
             } else {
                 vec![(first_key, Some(value))]
             };
@@ -1857,7 +1861,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn parse_map_block(
+    fn consume_map_block(
         &mut self,
         first_entry: (MapKey, Option<AstIndex>),
         start_span: Span,
@@ -1876,9 +1880,9 @@ impl<'source> Parser<'source> {
                 return self.consume_token_and_error(SyntaxError::ExpectedMapColon);
             };
 
-            self.consume_next_token_on_same_line();
+            self.consume_next_token_on_same_line(); // ':'
 
-            if let Some(value) = self.parse_expression(&ExpressionContext::inline())? {
+            if let Some(value) = self.parse_line(&ExpressionContext::inline())? {
                 entries.push((key, Some(value)));
             } else {
                 // If a value wasn't found on the same line as the key,

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -737,11 +737,7 @@ impl<'source> Parser<'source> {
                 let string = self.parse_string(context)?.unwrap();
 
                 if self.peek_token() == Some(Token::Colon) {
-                    self.consume_braceless_map_start(
-                        MapKey::Str(string.string),
-                        start_span,
-                        &string.context,
-                    )
+                    self.consume_map_block(MapKey::Str(string.string), start_span, &string.context)
                 } else {
                     let string_node = self.push_node_with_span(Str(string.string), string.span)?;
                     self.check_for_lookup_after_node(string_node, &string.context)
@@ -766,7 +762,7 @@ impl<'source> Parser<'source> {
                         })
                     )
                 {
-                    self.consume_braceless_map_start(
+                    self.consume_map_block(
                         MapKey::Meta(meta_key_id, meta_name),
                         start_span,
                         &meta_context,
@@ -1224,7 +1220,7 @@ impl<'source> Parser<'source> {
         };
 
         if self.peek_token() == Some(Token::Colon) {
-            self.consume_braceless_map_start(MapKey::Id(constant_index), start_span, &id_context)
+            self.consume_map_block(MapKey::Id(constant_index), start_span, &id_context)
         } else {
             self.frame_mut()?.add_id_access(constant_index);
 
@@ -1826,51 +1822,29 @@ impl<'source> Parser<'source> {
         Ok((entries, last_token_was_a_comma))
     }
 
-    fn consume_braceless_map_start(
+    fn consume_map_block(
         &mut self,
         first_key: MapKey,
         start_span: Span,
         context: &ExpressionContext,
     ) -> Result<AstIndex, ParserError> {
-        let start_indent = self.current_indent();
-
         if !context.allow_map_block {
             return self.error(SyntaxError::ExpectedLineBreakBeforeMapBlock);
         }
+
+        let start_indent = self.current_indent();
 
         if self.consume_token() != Some(Token::Colon) {
             return self.error(InternalError::ExpectedMapColon);
         }
 
-        if let Some(value) = self.parse_line(&ExpressionContext::permissive())? {
-            let entries = if context.allow_map_block {
-                let block_context = ExpressionContext::permissive()
-                    .with_expected_indentation(Indentation::Equal(start_indent));
-                return self.consume_map_block(
-                    (first_key, Some(value)),
-                    start_span,
-                    &block_context,
-                );
-            } else {
-                vec![(first_key, Some(value))]
-            };
+        let mut entries = vec![(first_key, Some(self.consume_map_block_value()?))];
 
-            self.push_node_with_start_span(Node::Map(entries), start_span)
-        } else {
-            self.consume_token_and_error(SyntaxError::ExpectedMapValue)
-        }
-    }
+        let block_context = ExpressionContext::permissive()
+            .with_expected_indentation(Indentation::Equal(start_indent));
 
-    fn consume_map_block(
-        &mut self,
-        first_entry: (MapKey, Option<AstIndex>),
-        start_span: Span,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
-        let mut entries = vec![first_entry];
-
-        while self.peek_token_with_context(context).is_some() {
-            self.consume_until_token_with_context(context);
+        while self.peek_token_with_context(&block_context).is_some() {
+            self.consume_until_token_with_context(&block_context);
 
             let Some(key) = self.parse_map_key()? else {
                 return self.consume_token_and_error(SyntaxError::ExpectedMapEntry);
@@ -1882,20 +1856,20 @@ impl<'source> Parser<'source> {
 
             self.consume_next_token_on_same_line(); // ':'
 
-            if let Some(value) = self.parse_line(&ExpressionContext::inline())? {
-                entries.push((key, Some(value)));
-            } else {
-                // If a value wasn't found on the same line as the key,
-                // look for an indented value
-                if let Some(value) = self.parse_indented_block()? {
-                    entries.push((key, Some(value)));
-                } else {
-                    return self.consume_token_and_error(SyntaxError::ExpectedMapValue);
-                }
-            }
+            entries.push((key, Some(self.consume_map_block_value()?)));
         }
 
         self.push_node_with_start_span(Node::Map(entries), start_span)
+    }
+
+    fn consume_map_block_value(&mut self) -> Result<AstIndex, ParserError> {
+        if let Some(value) = self.parse_indented_block()? {
+            Ok(value)
+        } else if let Some(value) = self.parse_line(&ExpressionContext::permissive())? {
+            Ok(value)
+        } else {
+            self.consume_token_and_error(SyntaxError::ExpectedMapValue)
+        }
     }
 
     fn consume_map_with_braces(

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -619,7 +619,7 @@ x =
                     Map(vec![(
                         string_literal_map_key(1, StringQuote::Double),
                         Some(1),
-                    )]), // "foo", 42
+                    )]), // "foo": 42
                     Assign {
                         target: 0,
                         expression: 2,
@@ -665,6 +665,47 @@ x =
                     Constant::Str("foo"),
                     Constant::Str("bar"),
                 ]),
+            )
+        }
+
+        #[test]
+        fn map_block_first_entry_is_comma_separated_tuple() {
+            let sources = [
+                "
+x =
+    foo: 10, 20, 30
+",
+                "
+x =
+    foo: 10,
+         20,
+         30,
+",
+                "
+x =
+    foo:
+      10, 20, 30,
+",
+            ];
+            check_ast_for_equivalent_sources(
+                &sources,
+                &[
+                    Id(0), // x
+                    SmallInt(10),
+                    SmallInt(20),
+                    SmallInt(30),
+                    Tuple(vec![1, 2, 3]),
+                    Map(vec![(MapKey::Id(1), Some(4))]), // 5 - foo: 10, 20, 30
+                    Assign {
+                        target: 0,
+                        expression: 5,
+                    },
+                    MainBlock {
+                        body: vec![6],
+                        local_count: 1,
+                    },
+                ],
+                Some(&[Constant::Str("x"), Constant::Str("foo")]),
             )
         }
 

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -710,6 +710,59 @@ x =
         }
 
         #[test]
+        fn map_block_second_entry_is_paren_free_call() {
+            let sources = [
+                "
+x =
+  foo: 1
+  bar: baz 42
+",
+                "
+x =
+  foo: 1
+  bar:
+    baz 42
+",
+                "
+x =
+  foo: 1
+  bar: baz
+    42
+",
+            ];
+            check_ast_for_equivalent_sources(
+                &sources,
+                &[
+                    Id(0), // x
+                    SmallInt(1),
+                    SmallInt(42),
+                    NamedCall {
+                        id: 3,
+                        args: vec![2],
+                    },
+                    Map(vec![
+                        (MapKey::Id(1), Some(1)), // foo: 1
+                        (MapKey::Id(2), Some(3)), // bar: baz 42
+                    ]),
+                    Assign {
+                        target: 0,
+                        expression: 4,
+                    }, // 5
+                    MainBlock {
+                        body: vec![5],
+                        local_count: 1,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("x"),
+                    Constant::Str("foo"),
+                    Constant::Str("bar"),
+                    Constant::Str("baz"),
+                ]),
+            )
+        }
+
+        #[test]
         fn map_block_meta() {
             let source = r#"
 x =

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -194,17 +194,6 @@ x =
             }
 
             #[test]
-            fn block_value_with_multiple_expressions() {
-                let source = "
-x =
-  foo: 42
-  bar: 1, 2, 3
-  baz: 99
-";
-                check_parsing_fails(source);
-            }
-
-            #[test]
             fn inline_map_without_braces() {
                 let source = "
 x = foo: 42, bar: 99,

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -545,6 +545,11 @@ pub fn make_module() -> KMap {
         iter_output_to_result(iter.next_back())
     });
 
+    result.add_fn("once", |ctx| match ctx.args() {
+        [value] => Ok(KIterator::new(generators::Once::new(value.clone())).into()),
+        unexpected => type_error_with_slice("a single value", unexpected),
+    });
+
     result.add_fn("peekable", |ctx| {
         let expected_error = "an iterable";
 

--- a/crates/runtime/src/core_lib/iterator/generators.rs
+++ b/crates/runtime/src/core_lib/iterator/generators.rs
@@ -2,6 +2,33 @@
 
 use crate::{prelude::*, KIteratorOutput as Output, KotoVm, Result};
 
+/// An iterator that yields a value once
+#[derive(Clone)]
+pub struct Once {
+    value: Option<KValue>,
+}
+
+impl Once {
+    /// Creates a new [Once] generator
+    pub fn new(value: KValue) -> Self {
+        Self { value: Some(value) }
+    }
+}
+
+impl KotoIterator for Once {
+    fn make_copy(&self) -> Result<KIterator> {
+        Ok(KIterator::new(self.clone()))
+    }
+}
+
+impl Iterator for Once {
+    type Item = Output;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.value.take().map(Output::Value)
+    }
+}
+
 /// An iterator that repeatedly yields the same value
 pub struct Repeat {
     value: KValue,

--- a/crates/runtime/src/types/iterator.rs
+++ b/crates/runtime/src/types/iterator.rs
@@ -130,6 +130,13 @@ impl KIterator {
         Ok(Self::new(ObjectIterator::new(vm, o)?))
     }
 
+    /// Creates a new KIterator that yields a value once
+    pub fn once(value: KValue) -> Result<Self> {
+        Ok(Self::new(crate::core_lib::iterator::generators::Once::new(
+            value,
+        )))
+    }
+
     /// Makes a copy of the iterator
     ///
     /// See [KotoIterator::make_copy]

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -414,6 +414,12 @@ l2[1]";
         use super::*;
 
         #[test]
+        fn assign_single_value() {
+            let script = "a, b = 42";
+            test_script(script, tuple(&[42.into(), KValue::Null]));
+        }
+
+        #[test]
         fn assign_two_values() {
             let script = "a, b = 10, 20";
             test_script(script, number_tuple(&[10, 20]));

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -574,6 +574,24 @@ check! null
 - [`iterator.next`](#next)
 - [`iterator.reversed`](#reversed)
 
+## once
+
+```kototype
+|Value| -> Iterator
+```
+
+Returns an iterator that yields the given value a single time.
+
+### Example
+
+```koto
+print! iterator
+  .once 'x'
+  .chain 'abc'
+  .to_tuple()
+check! ('x', 'a', 'b', 'c')
+```
+
 ## peekable
 
 ```kototype

--- a/docs/language/value_unpacking.md
+++ b/docs/language/value_unpacking.md
@@ -25,16 +25,22 @@ assignment targets.
 a, b, c = [-1, -2]
 print! a, b, c
 check! (-1, -2, null)
+
+x, y, z = 42
+print! x, y, z
+check! (42, null, null)
 ```
 
 Unpacking works with any iterable value, including adapted iterators.
 
 ```koto
-a, b, c = 1..10
+r = 1..10
+
+a, b, c = r
 print! a, b, c
 check! (1, 2, 3)
 
-a, b, c = (1..10).each |x| x * 10
+a, b, c = r.each |x| x * 10
 print! a, b, c
 check! (10, 20, 30)
 ```


### PR DESCRIPTION
- Allow parentheses-free tuples in map block values
- Add `iterator.once`
- Allow single values to be used in unpacking assignments
- Allow indented function call args in map block values
