### PR TITLE
Rename set_meta -> with_meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The Koto project adheres to
     exception being thrown.
 - Objects can be compared with `null` on the LHS without having to implement 
   `KotoObject::equal` and/or `not_equal`.
-- `map.with_meta_map` has been replaced with `set_meta`, and `get_meta_map` has
+- `map.with_meta_map` has been renamed to `with_meta`, and `get_meta_map` has
   been renamed to `get_meta`.
 
 #### API

--- a/crates/runtime/src/core_lib/map.rs
+++ b/crates/runtime/src/core_lib/map.rs
@@ -325,7 +325,7 @@ pub fn make_module() -> KMap {
         }
     });
 
-    result.add_fn("set_meta", |ctx| {
+    result.add_fn("with_meta", |ctx| {
         let expected_error = "two Maps";
 
         match map_instance_and_args(ctx, expected_error)? {

--- a/crates/runtime/src/types/map.rs
+++ b/crates/runtime/src/types/map.rs
@@ -112,6 +112,8 @@ impl KMap {
     }
 
     /// Sets the KMap's meta map
+    ///
+    /// Note that this change isn't shared with maps that share the same data.
     pub fn set_meta_map(&mut self, meta: Option<PtrMut<MetaMap>>) {
         self.meta = meta;
     }

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -2855,7 +2855,7 @@ catch _
         fn arithmetic() {
             let script = "
 locals = {}
-foo = |x| {x}.set_meta locals.foo_meta
+foo = |x| {x}.with_meta locals.foo_meta
 locals.foo_meta =
   @+: |other| foo self.x + other.x
   @-: |other| foo self.x - other.x
@@ -2873,7 +2873,7 @@ z.x
         fn arithmetic_assignment() {
             let script = "
 locals = {}
-foo = |x| {x}.set_meta locals.foo_meta
+foo = |x| {x}.with_meta locals.foo_meta
 locals.foo_meta =
   @+=: |y| self.x += y
   @-=: |y| self.x -= y
@@ -3216,7 +3216,7 @@ x.skip(3).reversed().take(3).to_tuple()
         fn basic_access() {
             let script = "
 locals = {}
-foo = |x| {x}.set_meta locals.foo_meta
+foo = |x| {x}.with_meta locals.foo_meta
 locals.foo_meta =
   @meta get_x: || self.x
 a = foo 10
@@ -3229,7 +3229,7 @@ a.x + a.get_x()
         fn lookup_order() {
             let script = "
 locals = {}
-foo = |x| {x, y: 100}.set_meta locals.foo_meta
+foo = |x| {x, y: 100}.with_meta locals.foo_meta
 locals.foo_meta =
   @meta y: 0
 a = foo 10

--- a/docs/core_lib/map.md
+++ b/docs/core_lib/map.md
@@ -152,7 +152,7 @@ check! My Map
 
 ### See also
 
-- [`map.set_meta`](#set-meta)
+- [`map.with_meta`](#with-meta)
 
 ## insert
 
@@ -447,14 +447,14 @@ check! null
 
 - [`map.keys`](#keys)
 
-## set_meta
+## with_meta
 
 ```kototype
 |Map, Map| -> Map
 ```
 
-Sets the first argument's meta map to be an instance of the meta map from the 
-second argument.
+Returns a new Map that contains the data from the first argument, 
+along with the Meta Map from the second argument.
 
 ### Example
 
@@ -462,7 +462,7 @@ second argument.
 my_meta =
   @type: 'MyMeta'
 
-x = {foo: 42}.set_meta my_meta
+x = {foo: 42}.with_meta my_meta
 
 print! koto.type x
 check! MyMeta

--- a/docs/language/meta_maps.md
+++ b/docs/language/meta_maps.md
@@ -280,7 +280,7 @@ check! ('data')
 
 ## Sharing Meta Maps
 
-If you're creating lots of values, then it will likely be more efficient to create a single map containing the meta logic, and then share it between instances using [`Map.set_meta`](../../core/map/#set-meta).
+If you're creating lots of values, then it will likely be more efficient to create a single map containing the meta logic, and then share it between instances using [`Map.with_meta`](../../core/map/#with-meta).
 
 ```koto
 # Create an empty map for global values
@@ -290,7 +290,7 @@ global = {}
 foo = |data|
   # Make a map that contains `data`, 
   # and then assign a shared copy of the meta map from foo_meta
-  {data}.set_meta global.foo_meta
+  {data}.with_meta global.foo_meta
 
 # Define some meta behaviour in foo_meta
 global.foo_meta =

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -3,7 +3,7 @@ globals = {}
 # foo acts as a constructor for the Foo type
 foo = |x|
   # Make a map that contains x, and return its data with the meta map from foo_meta
-  {x}.set_meta globals.foo_meta
+  {x}.with_meta globals.foo_meta
 
 # Declaring the overloaded operators once and then cloning the meta map into the foo
 # instance is more efficient than declaring them each time foo is called.


### PR DESCRIPTION
This is a partial reversion of `d191e7a1a0f24215a318ae86b9e7a4fea301e763`.

I overlooked that the result of the operation is a temporary, so the `with_meta` naming is more appropriate, hinting that the result needs to be assigned.
