### PR TITLE
Some parser and compiler tweaks

### DIFF
--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -461,7 +461,7 @@ impl Compiler {
         };
 
         if let Some(entry_point) = ast.entry_point() {
-            compiler.compile_node(ResultRegister::None, entry_point, ast)?;
+            compiler.compile_node(ResultRegister::None, ast.node(entry_point), ast)?;
         }
 
         if compiler.bytes.len() <= u32::MAX as usize {

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -1,8 +1,8 @@
 use crate::{DebugInfo, FunctionFlags, Op, TypeId};
 use koto_parser::{
-    Ast, AstBinaryOp, AstFor, AstIf, AstIndex, AstNode, AstTry, AstUnaryOp, ConstantIndex,
-    Function, IdOrString, ImportItem, LookupNode, MapKey, MatchArm, MetaKeyId, Node, Span,
-    StringContents, StringNode, SwitchArm,
+    Ast, AstBinaryOp, AstFor, AstIf, AstIndex, AstTry, AstUnaryOp, ConstantIndex, Function,
+    IdOrString, ImportItem, LookupNode, MapKey, MatchArm, MetaKeyId, Node, Span, StringContents,
+    StringNode, SwitchArm,
 };
 use smallvec::SmallVec;
 use std::collections::HashSet;
@@ -461,7 +461,7 @@ impl Compiler {
         };
 
         if let Some(entry_point) = ast.entry_point() {
-            compiler.compile_node(ResultRegister::None, ast.node(entry_point), ast)?;
+            compiler.compile_node(ResultRegister::None, entry_point, ast)?;
         }
 
         if compiler.bytes.len() <= u32::MAX as usize {
@@ -474,10 +474,12 @@ impl Compiler {
     fn compile_node(
         &mut self,
         result_register: ResultRegister,
-        node: &AstNode,
+        node_index: AstIndex,
         ast: &Ast,
     ) -> CompileNodeResult {
         use Op::*;
+
+        let node = ast.node(node_index);
 
         self.span_stack.push(*ast.span(node.span));
 
@@ -493,7 +495,7 @@ impl Compiler {
                 }
                 result
             }
-            Node::Nested(nested) => self.compile_node(result_register, ast.node(*nested), ast)?,
+            Node::Nested(nested) => self.compile_node(result_register, *nested, ast)?,
             Node::Id(index) => self.compile_load_id(result_register, *index)?,
             Node::Lookup(lookup) => {
                 self.compile_lookup(result_register, lookup, None, None, None, ast)?
@@ -563,12 +565,10 @@ impl Compiler {
             } => match self.get_result_register(result_register)? {
                 Some(result) => {
                     let start_register = self
-                        .compile_node(ResultRegister::Any, ast.node(*start), ast)?
+                        .compile_node(ResultRegister::Any, *start, ast)?
                         .unwrap();
 
-                    let end_register = self
-                        .compile_node(ResultRegister::Any, ast.node(*end), ast)?
-                        .unwrap();
+                    let end_register = self.compile_node(ResultRegister::Any, *end, ast)?.unwrap();
 
                     let op = if *inclusive { RangeInclusive } else { Range };
                     self.push_op(
@@ -590,14 +590,14 @@ impl Compiler {
                     Some(result)
                 }
                 None => {
-                    self.compile_node(ResultRegister::None, ast.node(*start), ast)?;
-                    self.compile_node(ResultRegister::None, ast.node(*end), ast)?
+                    self.compile_node(ResultRegister::None, *start, ast)?;
+                    self.compile_node(ResultRegister::None, *end, ast)?
                 }
             },
             Node::RangeFrom { start } => match self.get_result_register(result_register)? {
                 Some(result) => {
                     let start_register = self
-                        .compile_node(ResultRegister::Any, ast.node(*start), ast)?
+                        .compile_node(ResultRegister::Any, *start, ast)?
                         .unwrap();
 
                     self.push_op(RangeFrom, &[result.register, start_register.register]);
@@ -608,13 +608,11 @@ impl Compiler {
 
                     Some(result)
                 }
-                None => self.compile_node(ResultRegister::None, ast.node(*start), ast)?,
+                None => self.compile_node(ResultRegister::None, *start, ast)?,
             },
             Node::RangeTo { end, inclusive } => match self.get_result_register(result_register)? {
                 Some(result) => {
-                    let end_register = self
-                        .compile_node(ResultRegister::Any, ast.node(*end), ast)?
-                        .unwrap();
+                    let end_register = self.compile_node(ResultRegister::Any, *end, ast)?.unwrap();
 
                     let op = if *inclusive {
                         RangeToInclusive
@@ -629,7 +627,7 @@ impl Compiler {
 
                     Some(result)
                 }
-                None => self.compile_node(ResultRegister::None, ast.node(*end), ast)?,
+                None => self.compile_node(ResultRegister::None, *end, ast)?,
             },
             Node::RangeFull => {
                 let result = self.get_result_register(result_register)?;
@@ -693,7 +691,7 @@ impl Compiler {
                         (Some(loop_result_register), Some(expression)) => {
                             self.compile_node(
                                 ResultRegister::Fixed(loop_result_register),
-                                ast.node(*expression),
+                                *expression,
                                 ast,
                             )?
                             .unwrap();
@@ -742,7 +740,7 @@ impl Compiler {
             },
             Node::Return(Some(expression)) => {
                 let expression_register = self
-                    .compile_node(ResultRegister::Any, ast.node(*expression), ast)?
+                    .compile_node(ResultRegister::Any, *expression, ast)?
                     .unwrap();
 
                 match result_register {
@@ -771,7 +769,7 @@ impl Compiler {
                 let result = self.get_result_register(result_register)?;
 
                 let expression_register = self
-                    .compile_node(ResultRegister::Any, ast.node(*expression), ast)?
+                    .compile_node(ResultRegister::Any, *expression, ast)?
                     .unwrap();
 
                 self.push_op(Yield, &[expression_register.register]);
@@ -792,7 +790,7 @@ impl Compiler {
                 let result = self.get_result_register(result_register)?;
 
                 let expression_register = self
-                    .compile_node(ResultRegister::Any, ast.node(*expression), ast)?
+                    .compile_node(ResultRegister::Any, *expression, ast)?
                     .unwrap();
 
                 self.push_op(Throw, &[expression_register.register]);
@@ -813,7 +811,7 @@ impl Compiler {
                 let result = self.get_result_register(result_register)?;
 
                 let expression_register = self
-                    .compile_node(ResultRegister::Any, ast.node(*expression), ast)?
+                    .compile_node(ResultRegister::Any, *expression, ast)?
                     .unwrap();
 
                 self.push_op(Debug, &[expression_register.register]);
@@ -1068,13 +1066,13 @@ impl Compiler {
                 }
                 None => return self.error(ErrorKind::MissingResultRegister),
             },
-            [expression] => self.compile_node(result_register, ast.node(*expression), ast)?,
+            [expression] => self.compile_node(result_register, *expression, ast)?,
             [expressions @ .., last_expression] => {
                 for expression in expressions.iter() {
-                    self.compile_node(ResultRegister::None, ast.node(*expression), ast)?;
+                    self.compile_node(ResultRegister::None, *expression, ast)?;
                 }
 
-                self.compile_node(result_register, ast.node(*last_expression), ast)?
+                self.compile_node(result_register, *last_expression, ast)?
             }
         };
 
@@ -1121,7 +1119,7 @@ impl Compiler {
         };
 
         let value_register = self
-            .compile_node(value_result_register, ast.node(expression), ast)?
+            .compile_node(value_result_register, expression, ast)?
             .unwrap();
 
         let target_node = ast.node(target);
@@ -1203,7 +1201,7 @@ impl Compiler {
         let rhs_node = ast.node(expression);
         let rhs_is_temp_tuple = matches!(rhs_node.node, Node::TempTuple(_));
         let rhs = self
-            .compile_node(ResultRegister::Any, rhs_node, ast)?
+            .compile_node(ResultRegister::Any, expression, ast)?
             .unwrap();
 
         // If the result is needed then prepare the creation of a tuple
@@ -1651,8 +1649,6 @@ impl Compiler {
             finally_block,
         } = &try_expression;
 
-        let try_node = ast.node(*try_block);
-
         let result = self.get_result_register(result_register)?;
 
         // The argument register for the catch block needs to be assigned now
@@ -1680,7 +1676,7 @@ impl Compiler {
             _ => ResultRegister::None,
         };
 
-        self.compile_node(try_result_register, try_node, ast)?;
+        self.compile_node(try_result_register, *try_block, ast)?;
 
         // Clear the catch point at the end of the try block
         // - if the end of the try block has been reached then the catch block is no longer needed.
@@ -1691,15 +1687,14 @@ impl Compiler {
         let finally_offset = self.push_offset_placeholder();
         self.update_offset_placeholder(catch_offset)?;
 
-        let catch_node = ast.node(*catch_block);
-        self.span_stack.push(*ast.span(catch_node.span));
+        self.span_stack.push(*ast.span(ast.node(*catch_block).span));
 
         // Clear the catch point at the start of the catch block
         // - if the catch block has been entered, then it needs to be de-registered in case there
         //   are errors thrown in the catch block.
         self.push_op(TryEnd, &[]);
 
-        self.compile_node(try_result_register, catch_node, ast)?;
+        self.compile_node(try_result_register, *catch_block, ast)?;
         self.span_stack.pop();
 
         if pop_catch_register {
@@ -1713,7 +1708,7 @@ impl Compiler {
                 Some(result) => ResultRegister::Fixed(result.register),
                 _ => ResultRegister::None,
             };
-            self.compile_node(finally_result_register, ast.node(*finally_block), ast)
+            self.compile_node(finally_result_register, *finally_block, ast)
         } else {
             Ok(result)
         }
@@ -1728,9 +1723,7 @@ impl Compiler {
     ) -> CompileNodeResult {
         let result = self.get_result_register(result_register)?;
 
-        let value_register = self
-            .compile_node(ResultRegister::Any, ast.node(value), ast)?
-            .unwrap();
+        let value_register = self.compile_node(ResultRegister::Any, value, ast)?.unwrap();
 
         if let Some(result) = result {
             let op_code = match op {
@@ -1758,18 +1751,15 @@ impl Compiler {
     ) -> CompileNodeResult {
         use AstBinaryOp::*;
 
-        let lhs_node = ast.node(lhs);
-        let rhs_node = ast.node(rhs);
-
         match op {
             Add | Subtract | Multiply | Divide | Remainder => {
-                self.compile_arithmetic_op(result_register, op, lhs_node, rhs_node, ast)
+                self.compile_arithmetic_op(result_register, op, lhs, rhs, ast)
             }
             AddAssign | SubtractAssign | MultiplyAssign | DivideAssign | RemainderAssign => {
-                self.compile_arithmetic_assign_op(result_register, op, lhs_node, rhs_node, ast)
+                self.compile_arithmetic_assign_op(result_register, op, lhs, rhs, ast)
             }
             Less | LessOrEqual | Greater | GreaterOrEqual | Equal | NotEqual => {
-                self.compile_comparison_op(result_register, op, lhs_node, rhs_node, ast)
+                self.compile_comparison_op(result_register, op, lhs, rhs, ast)
             }
             And | Or => self.compile_logic_op(result_register, op, lhs, rhs, ast),
             Pipe => self.compile_piped_call(result_register, lhs, rhs, ast),
@@ -1780,8 +1770,8 @@ impl Compiler {
         &mut self,
         result_register: ResultRegister,
         op: AstBinaryOp,
-        lhs_node: &AstNode,
-        rhs_node: &AstNode,
+        lhs: AstIndex,
+        rhs: AstIndex,
         ast: &Ast,
     ) -> CompileNodeResult {
         use AstBinaryOp::*;
@@ -1803,10 +1793,10 @@ impl Compiler {
         let result = match self.get_result_register(result_register)? {
             Some(result) => {
                 let lhs = self
-                    .compile_node(ResultRegister::Any, lhs_node, ast)?
+                    .compile_node(ResultRegister::Any, lhs, ast)?
                     .ok_or_else(|| self.make_error(ErrorKind::MissingBinaryOpLhs))?;
                 let rhs = self
-                    .compile_node(ResultRegister::Any, rhs_node, ast)?
+                    .compile_node(ResultRegister::Any, rhs, ast)?
                     .ok_or_else(|| self.make_error(ErrorKind::MissingBinaryOpRhs))?;
 
                 self.push_op(op, &[result.register, lhs.register, rhs.register]);
@@ -1821,8 +1811,8 @@ impl Compiler {
                 Some(result)
             }
             None => {
-                self.compile_node(ResultRegister::None, lhs_node, ast)?;
-                self.compile_node(ResultRegister::None, rhs_node, ast)?;
+                self.compile_node(ResultRegister::None, lhs, ast)?;
+                self.compile_node(ResultRegister::None, rhs, ast)?;
                 None
             }
         };
@@ -1834,8 +1824,8 @@ impl Compiler {
         &mut self,
         result_register: ResultRegister,
         ast_op: AstBinaryOp,
-        lhs_node: &AstNode,
-        rhs_node: &AstNode,
+        lhs: AstIndex,
+        rhs: AstIndex,
         ast: &Ast,
     ) -> CompileNodeResult {
         use AstBinaryOp::*;
@@ -1857,10 +1847,11 @@ impl Compiler {
         let result = self.get_result_register(result_register)?;
 
         let rhs = self
-            .compile_node(ResultRegister::Any, rhs_node, ast)?
+            .compile_node(ResultRegister::Any, rhs, ast)?
             .ok_or_else(|| self.make_error(ErrorKind::MissingBinaryOpRhs))?;
 
-        let result = if let Node::Lookup(lookup_node) = &lhs_node.node {
+        let lhs_node = &ast.node(lhs).node;
+        let result = if let Node::Lookup(lookup_node) = lhs_node {
             self.compile_lookup(
                 result_register,
                 lookup_node,
@@ -1871,15 +1862,15 @@ impl Compiler {
             )?
         } else {
             let lhs = self
-                .compile_node(ResultRegister::Any, lhs_node, ast)?
+                .compile_node(ResultRegister::Any, lhs, ast)?
                 .ok_or_else(|| self.make_error(ErrorKind::MissingBinaryOpLhs))?;
 
             self.push_op(op, &[lhs.register, rhs.register]);
 
             // If the LHS is a top-level ID and the export flag is enabled, then export the result
-            if let Node::Id(id) = lhs_node.node {
+            if let Node::Id(id) = lhs_node {
                 if self.settings.export_top_level_ids && self.frame_stack.len() == 1 {
-                    self.compile_value_export(id, lhs.register)?;
+                    self.compile_value_export(*id, lhs.register)?;
                 }
             }
 
@@ -1909,8 +1900,8 @@ impl Compiler {
         &mut self,
         result_register: ResultRegister,
         ast_op: AstBinaryOp,
-        lhs: &AstNode,
-        rhs: &AstNode,
+        lhs: AstIndex,
+        rhs: AstIndex,
         ast: &Ast,
     ) -> CompileNodeResult {
         use AstBinaryOp::*;
@@ -1954,7 +1945,7 @@ impl Compiler {
             op: rhs_ast_op,
             lhs: rhs_lhs,
             rhs: rhs_rhs,
-        } = rhs.node
+        } = ast.node(rhs).node
         {
             match rhs_ast_op {
                 Less | LessOrEqual | Greater | GreaterOrEqual | Equal | NotEqual => {
@@ -1969,7 +1960,7 @@ impl Compiler {
                     //   - chain the two comparisons together with an And
 
                     let rhs_lhs_register = self
-                        .compile_node(ResultRegister::Any, ast.node(rhs_lhs), ast)?
+                        .compile_node(ResultRegister::Any, rhs_lhs, ast)?
                         .unwrap()
                         .register;
 
@@ -1982,7 +1973,7 @@ impl Compiler {
                     jump_offsets.push(self.push_offset_placeholder());
 
                     lhs_register = rhs_lhs_register;
-                    rhs = ast.node(rhs_rhs);
+                    rhs = rhs_rhs;
                     ast_op = rhs_ast_op;
                 }
                 _ => break,
@@ -2027,7 +2018,7 @@ impl Compiler {
             None => self.push_register()?,
         };
 
-        self.compile_node(ResultRegister::Fixed(register), ast.node(lhs), ast)?;
+        self.compile_node(ResultRegister::Fixed(register), lhs, ast)?;
 
         let jump_op = match op {
             AstBinaryOp::And => Op::JumpIfFalse,
@@ -2038,7 +2029,7 @@ impl Compiler {
         self.push_op(jump_op, &[register]);
 
         // If the lhs caused a jump then that's the result, otherwise the result is the rhs
-        self.compile_node_with_jump_offset(ResultRegister::Fixed(register), ast.node(rhs), ast)?;
+        self.compile_node_with_jump_offset(ResultRegister::Fixed(register), rhs, ast)?;
 
         if result.is_none() {
             self.pop_register()?;
@@ -2118,7 +2109,7 @@ impl Compiler {
                                         let expression_result = self
                                             .compile_node(
                                                 ResultRegister::Any,
-                                                ast.node(*expression_node),
+                                                *expression_node,
                                                 ast,
                                             )?
                                             .unwrap();
@@ -2136,7 +2127,7 @@ impl Compiler {
                                         // so that side-effects can take place.
                                         self.compile_node(
                                             ResultRegister::None,
-                                            ast.node(*expression_node),
+                                            *expression_node,
                                             ast,
                                         )?;
                                     }
@@ -2165,11 +2156,7 @@ impl Compiler {
             Some(result) => {
                 for element in elements.iter() {
                     let element_register = self.push_register()?;
-                    self.compile_node(
-                        ResultRegister::Fixed(element_register),
-                        ast.node(*element),
-                        ast,
-                    )?;
+                    self.compile_node(ResultRegister::Fixed(element_register), *element, ast)?;
                 }
 
                 let start_register = self.peek_register(elements.len() - 1)?;
@@ -2187,7 +2174,7 @@ impl Compiler {
             None => {
                 // Compile the element nodes for side-effects
                 for element in elements.iter() {
-                    self.compile_node(ResultRegister::None, ast.node(*element), ast)?;
+                    self.compile_node(ResultRegister::None, *element, ast)?;
                 }
 
                 None
@@ -2222,7 +2209,7 @@ impl Compiler {
                     [] => {}
                     [single_element] => {
                         let element = self
-                            .compile_node(ResultRegister::Any, ast.node(*single_element), ast)?
+                            .compile_node(ResultRegister::Any, *single_element, ast)?
                             .unwrap();
                         self.push_op_without_span(SequencePush, &[element.register]);
                         if element.is_temporary {
@@ -2239,7 +2226,7 @@ impl Compiler {
                                 let element_register = self.push_register()?;
                                 self.compile_node(
                                     ResultRegister::Fixed(element_register),
-                                    ast.node(*element_node),
+                                    *element_node,
                                     ast,
                                 )?;
                             }
@@ -2263,7 +2250,7 @@ impl Compiler {
             None => {
                 // Compile the element nodes for side-effects
                 for element_node in elements.iter() {
-                    self.compile_node(ResultRegister::None, ast.node(*element_node), ast)?;
+                    self.compile_node(ResultRegister::None, *element_node, ast)?;
                 }
                 None
             }
@@ -2302,7 +2289,7 @@ impl Compiler {
                 let value = match (key, maybe_value_node) {
                     // A value has been provided for the entry
                     (_, Some(value_node)) => {
-                        let value_node = ast.node(*value_node);
+                        let value_node = *value_node;
                         self.compile_node(ResultRegister::Any, value_node, ast)?
                             .unwrap()
                     }
@@ -2329,7 +2316,7 @@ impl Compiler {
             // The map is unused, but the entry values should be compiled for side-effects
             for (_key, value_node) in entries.iter() {
                 if let Some(value_node) = value_node {
-                    self.compile_node(ResultRegister::None, ast.node(*value_node), ast)?;
+                    self.compile_node(ResultRegister::None, *value_node, ast)?;
                 }
             }
         }
@@ -2511,7 +2498,7 @@ impl Compiler {
                     }
 
                     let root = self
-                        .compile_node(ResultRegister::Any, ast.node(*root_node), ast)?
+                        .compile_node(ResultRegister::Any, *root_node, ast)?
                         .unwrap();
                     node_registers.push(root.register);
                 }
@@ -2565,7 +2552,7 @@ impl Compiler {
                     };
 
                     let index = self
-                        .compile_node(ResultRegister::Any, ast.node(*index_node), ast)?
+                        .compile_node(ResultRegister::Any, *index_node, ast)?
                         .unwrap();
 
                     let node_register = self.push_register()?;
@@ -2643,7 +2630,7 @@ impl Compiler {
         };
 
         let index = if let LookupNode::Index(index_node) = last_node {
-            self.compile_node(ResultRegister::Any, ast.node(index_node), ast)?
+            self.compile_node(ResultRegister::Any, index_node, ast)?
         } else {
             None
         };
@@ -2923,9 +2910,7 @@ impl Compiler {
         };
 
         // Next, compile the LHS to produce the value that should be piped into the call
-        let piped_value = self
-            .compile_node(ResultRegister::Any, ast.node(lhs), ast)?
-            .unwrap();
+        let piped_value = self.compile_node(ResultRegister::Any, lhs, ast)?.unwrap();
 
         let rhs_node = ast.node(rhs);
         let result = match &rhs_node.node {
@@ -2955,9 +2940,7 @@ impl Compiler {
             _ => {
                 // If the RHS is none of the above, then compile it assuming that the result will
                 // be a function.
-                let function = self
-                    .compile_node(ResultRegister::Any, rhs_node, ast)?
-                    .unwrap();
+                let function = self.compile_node(ResultRegister::Any, rhs, ast)?.unwrap();
                 let result = self.compile_call(
                     call_result_register,
                     function.register,
@@ -3044,7 +3027,7 @@ impl Compiler {
 
         for arg in args.iter() {
             let arg_register = self.push_register()?;
-            self.compile_node(ResultRegister::Fixed(arg_register), ast.node(*arg), ast)?;
+            self.compile_node(ResultRegister::Fixed(arg_register), *arg, ast)?;
         }
 
         if let Some(piped_arg) = piped_arg {
@@ -3117,7 +3100,7 @@ impl Compiler {
 
         // If
         let condition_register = self
-            .compile_node(ResultRegister::Any, ast.node(*condition), ast)?
+            .compile_node(ResultRegister::Any, *condition, ast)?
             .unwrap();
 
         self.push_op_without_span(JumpIfFalse, &[condition_register.register]);
@@ -3127,7 +3110,7 @@ impl Compiler {
             self.pop_register()?;
         }
 
-        self.compile_node(expression_result_register, ast.node(*then_node), ast)?;
+        self.compile_node(expression_result_register, *then_node, ast)?;
 
         let if_jump_ip = {
             if !else_if_blocks.is_empty() || else_node.is_some() || result.is_some() {
@@ -3147,7 +3130,7 @@ impl Compiler {
             .map(
                 |(else_if_condition, else_if_node)| -> Result<usize, CompilerError> {
                     let condition = self
-                        .compile_node(ResultRegister::Any, ast.node(*else_if_condition), ast)?
+                        .compile_node(ResultRegister::Any, *else_if_condition, ast)?
                         .unwrap();
 
                     self.push_op_without_span(JumpIfFalse, &[condition.register]);
@@ -3157,7 +3140,7 @@ impl Compiler {
                         self.pop_register()?;
                     }
 
-                    self.compile_node(expression_result_register, ast.node(*else_if_node), ast)?;
+                    self.compile_node(expression_result_register, *else_if_node, ast)?;
 
                     self.push_op_without_span(Jump, &[]);
                     let else_if_jump_ip = self.push_offset_placeholder();
@@ -3171,7 +3154,7 @@ impl Compiler {
 
         // Else - either compile the else block, or set the result to empty
         if let Some(else_node) = else_node {
-            self.compile_node(expression_result_register, ast.node(*else_node), ast)?;
+            self.compile_node(expression_result_register, *else_node, ast)?;
         } else if let Some(result) = result {
             self.push_op_without_span(SetNull, &[result.register]);
         }
@@ -3209,7 +3192,7 @@ impl Compiler {
         for arm in arms.iter() {
             let arm_end_jump_placeholder = if let Some(condition) = arm.condition {
                 let condition_register = self
-                    .compile_node(ResultRegister::Any, ast.node(condition), ast)?
+                    .compile_node(ResultRegister::Any, condition, ast)?
                     .unwrap();
 
                 self.push_op_without_span(Op::JumpIfFalse, &[condition_register.register]);
@@ -3223,7 +3206,7 @@ impl Compiler {
                 None
             };
 
-            self.compile_node(body_result_register, ast.node(arm.expression), ast)?;
+            self.compile_node(body_result_register, arm.expression, ast)?;
 
             // Add a jump instruction if this anything other than an `else` arm
             if !arm.is_else() {
@@ -3264,11 +3247,10 @@ impl Compiler {
 
         let stack_count = self.frame().register_stack.len();
 
-        let match_node = ast.node(match_expression);
         let match_register = self
-            .compile_node(ResultRegister::Any, match_node, ast)?
+            .compile_node(ResultRegister::Any, match_expression, ast)?
             .unwrap();
-        let match_len = match &match_node.node {
+        let match_len = match &ast.node(match_expression).node {
             Node::TempTuple(expressions) => expressions.len(),
             _ => 1,
         };
@@ -3397,7 +3379,7 @@ impl Compiler {
         //   x if x > 10 then 99
         if let Some(condition) = arm.condition {
             let condition_register = self
-                .compile_node(ResultRegister::Any, ast.node(condition), ast)?
+                .compile_node(ResultRegister::Any, condition, ast)?
                 .unwrap();
 
             self.push_op_without_span(Op::JumpIfFalse, &[condition_register.register]);
@@ -3414,7 +3396,7 @@ impl Compiler {
             ResultRegister::None
         };
 
-        self.compile_node(body_result_register, ast.node(arm.expression), ast)?;
+        self.compile_node(body_result_register, arm.expression, ast)?;
 
         // Jump to the end of the match expression, unless this is an `else` arm
         let result_jump_placeholder = if !arm.is_else() {
@@ -3461,8 +3443,8 @@ impl Compiler {
                 | Node::Float(_)
                 | Node::Str(_)
                 | Node::Lookup(_) => {
-                    let pattern = self.push_register()?;
-                    self.compile_node(ResultRegister::Fixed(pattern), pattern_node, ast)?;
+                    let pattern_register = self.push_register()?;
+                    self.compile_node(ResultRegister::Fixed(pattern_register), *pattern, ast)?;
                     let comparison = self.push_register()?;
 
                     if match_is_container {
@@ -3471,10 +3453,13 @@ impl Compiler {
                             TempIndex,
                             &[element, params.match_register, pattern_index as u8],
                         );
-                        self.push_op(Equal, &[comparison, pattern, element]);
+                        self.push_op(Equal, &[comparison, pattern_register, element]);
                         self.pop_register()?; // element
                     } else {
-                        self.push_op(Equal, &[comparison, pattern, params.match_register]);
+                        self.push_op(
+                            Equal,
+                            &[comparison, pattern_register, params.match_register],
+                        );
                     }
 
                     if params.is_last_alternative {
@@ -3729,14 +3714,13 @@ impl Compiler {
         let stack_count = self.frame().register_stack.len();
 
         let iterator_register = {
-            let iterator_node = ast.node(*iterable);
             let iterator_register = self.push_register()?;
             let iterable_register = self
-                .compile_node(ResultRegister::Any, iterator_node, ast)?
+                .compile_node(ResultRegister::Any, *iterable, ast)?
                 .unwrap();
 
             // Make the iterator, using the iterator's span in case of errors
-            self.span_stack.push(*ast.span(iterator_node.span));
+            self.span_stack.push(*ast.span(ast.node(*iterable).span));
             self.push_op(
                 MakeIterator,
                 &[iterator_register, iterable_register.register],
@@ -3819,7 +3803,7 @@ impl Compiler {
             body_result_register.map_or(ResultRegister::None, |register| {
                 ResultRegister::Fixed(register)
             }),
-            ast.node(*body),
+            *body,
             ast,
         )?;
 
@@ -3883,7 +3867,7 @@ impl Compiler {
         if let Some((condition, negate_condition)) = condition {
             // Condition
             let condition_register = self
-                .compile_node(ResultRegister::Any, ast.node(condition), ast)?
+                .compile_node(ResultRegister::Any, condition, ast)?
                 .unwrap();
             let op = if negate_condition {
                 JumpIfTrue
@@ -3901,7 +3885,7 @@ impl Compiler {
             body_result_register.map_or(ResultRegister::None, |register| {
                 ResultRegister::Fixed(register)
             }),
-            ast.node(body),
+            body,
             ast,
         )?;
 
@@ -3928,11 +3912,11 @@ impl Compiler {
     fn compile_node_with_jump_offset(
         &mut self,
         result_register: ResultRegister,
-        node: &AstNode,
+        node_index: AstIndex,
         ast: &Ast,
     ) -> CompileNodeResult {
         let offset_ip = self.push_offset_placeholder();
-        let result = self.compile_node(result_register, node, ast)?;
+        let result = self.compile_node(result_register, node_index, ast)?;
         self.update_offset_placeholder(offset_ip)?;
         Ok(result)
     }

--- a/crates/bytecode/src/loader.rs
+++ b/crates/bytecode/src/loader.rs
@@ -1,7 +1,7 @@
 use crate::{Chunk, Compiler, CompilerError, CompilerSettings};
 use dunce::canonicalize;
 use koto_memory::Ptr;
-use koto_parser::{format_source_excerpt, Parser, ParserError, Span};
+use koto_parser::{format_source_excerpt, Parser, Span};
 use rustc_hash::FxHasher;
 use std::{
     collections::HashMap, error, fmt, hash::BuildHasherDefault, io, ops::Deref, path::PathBuf,
@@ -13,7 +13,7 @@ use thiserror::Error;
 #[allow(missing_docs)]
 pub enum LoaderErrorKind {
     #[error("{0}")]
-    Parser(#[from] ParserError),
+    Parser(#[from] koto_parser::Error),
     #[error("{0}")]
     Compiler(#[from] CompilerError),
     #[error(transparent)]
@@ -40,7 +40,7 @@ struct LoaderErrorSource {
 
 impl LoaderError {
     pub(crate) fn from_parser_error(
-        error: ParserError,
+        error: koto_parser::Error,
         source: &str,
         source_path: Option<PathBuf>,
     ) -> Self {

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -38,19 +38,19 @@ impl Ast {
     }
 
     /// Pushes a node and corresponding span onto the tree
-    pub fn push(&mut self, node: Node, span: Span) -> Result<AstIndex, ParserError> {
+    pub fn push(&mut self, node: Node, span: Span) -> Result<AstIndex> {
         // We could potentially achieve some compression by
         // using a set for the spans, for now a Vec will do.
         self.spans.push(span);
         let span_index = AstIndex::try_from(self.spans.len() - 1)
-            .map_err(|_| ParserError::new(InternalError::AstCapacityOverflow.into(), span))?;
+            .map_err(|_| Error::new(InternalError::AstCapacityOverflow.into(), span))?;
 
         self.nodes.push(AstNode {
             node,
             span: span_index,
         });
         AstIndex::try_from(self.nodes.len() - 1)
-            .map_err(|_| ParserError::new(InternalError::AstCapacityOverflow.into(), span))
+            .map_err(|_| Error::new(InternalError::AstCapacityOverflow.into(), span))
     }
 
     /// Returns a node for a given node index

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -23,7 +23,6 @@ pub struct Ast {
     nodes: Vec<AstNode>,
     spans: Vec<Span>,
     constants: ConstantPool,
-    entry_point: AstIndex,
 }
 
 impl Ast {
@@ -33,7 +32,6 @@ impl Ast {
             nodes: Vec::with_capacity(capacity),
             spans: Vec::with_capacity(capacity),
             constants: ConstantPool::default(),
-            entry_point: 0,
         }
     }
 
@@ -81,16 +79,12 @@ impl Ast {
     }
 
     /// Returns the root node in the tree
-    pub fn entry_point(&self) -> Option<&AstNode> {
-        self.nodes.get(self.entry_point as usize)
-    }
-
-    // Sets the entry point for the AST
-    //
-    // In practice this will always be the last node in the nodes list,
-    // so this could likely be removed.
-    pub(crate) fn set_entry_point(&mut self, index: AstIndex) {
-        self.entry_point = index;
+    pub fn entry_point(&self) -> Option<AstIndex> {
+        if self.nodes.is_empty() {
+            None
+        } else {
+            Some((self.nodes.len() - 1) as AstIndex)
+        }
     }
 
     /// Used in testing to validate the tree's contents

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -23,7 +23,7 @@ pub struct Ast {
     nodes: Vec<AstNode>,
     spans: Vec<Span>,
     constants: ConstantPool,
-    entry_point: u32,
+    entry_point: AstIndex,
 }
 
 impl Ast {

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -196,7 +196,7 @@ pub enum SyntaxError {
 /// See [ParserError]
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
-pub enum ParserErrorKind {
+pub enum ErrorKind {
     #[error(transparent)]
     InternalError(#[from] InternalError),
     #[error(transparent)]
@@ -208,24 +208,27 @@ pub enum ParserErrorKind {
 /// An error that can be produced by the [Parser](crate::Parser)
 #[derive(Error, Clone, Debug)]
 #[error("{error}")]
-pub struct ParserError {
+pub struct Error {
     /// The error itself
-    pub error: ParserErrorKind,
+    pub error: ErrorKind,
     /// The span in the source string where the error occurred
     pub span: Span,
 }
 
-impl ParserError {
+impl Error {
     /// Initializes a parser error with the specific error type and its associated span
-    pub fn new(error: ParserErrorKind, span: Span) -> Self {
+    pub fn new(error: ErrorKind, span: Span) -> Self {
         Self { error, span }
     }
 
     /// Returns true if the error was caused by the expectation of indentation
     pub fn is_indentation_error(&self) -> bool {
-        matches!(self.error, ParserErrorKind::ExpectedIndentation(_))
+        matches!(self.error, ErrorKind::ExpectedIndentation(_))
     }
 }
+
+/// The result type used by the [Parser](crate::Parser)
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Renders the excerpt of the source corresponding to the given span
 pub fn format_source_excerpt(source: &str, span: &Span, source_path: &Option<PathBuf>) -> String {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -11,7 +11,7 @@ mod parser;
 pub use crate::{
     ast::*,
     constant_pool::{Constant, ConstantIndex, ConstantPool},
-    error::{format_source_excerpt, ParserError},
+    error::{format_source_excerpt, Error, Result},
     node::*,
     parser::Parser,
 };

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -17,7 +17,7 @@ pub enum Node {
     Id(ConstantIndex),
 
     /// A meta identifier, e.g. `@display` or `@test my_test`
-    Meta(MetaKeyId, Option<u32>),
+    Meta(MetaKeyId, Option<ConstantIndex>),
 
     /// A lookup node, and optionally the node that follows it in the lookup chain
     Lookup((LookupNode, Option<AstIndex>)), // lookup node, next node
@@ -27,7 +27,7 @@ pub enum Node {
     /// Calls with parentheses or on temporary values are parsed as Lookups
     NamedCall {
         /// The id of the function to be called
-        id: u32,
+        id: ConstantIndex,
         /// The arguments to pass to the function
         args: Vec<AstIndex>,
     },
@@ -42,10 +42,10 @@ pub enum Node {
     SmallInt(i16),
 
     /// An integer outside of the range -255..=255
-    Int(u32),
+    Int(ConstantIndex),
 
-    /// An float literal
-    Float(u32),
+    /// A float literal
+    Float(ConstantIndex),
 
     /// A string literal
     Str(AstString),
@@ -206,12 +206,12 @@ pub enum Node {
     /// in match expressions.
     ///
     /// Comes with an optional name, e.g. `_foo` will have `foo` stored as a constant.
-    Wildcard(Option<u32>),
+    Wildcard(Option<ConstantIndex>),
 
     /// The `...` operator
     ///
     /// Used when capturing variadic arguments, and when unpacking list or tuple values.
-    Ellipsis(Option<u32>),
+    Ellipsis(Option<ConstantIndex>),
 
     /// A `for` loop
     For(AstFor),
@@ -259,7 +259,7 @@ pub enum Node {
     /// A debug expression
     Debug {
         /// The stored string of the debugged expression to be used when printing the result
-        expression_string: u32,
+        expression_string: ConstantIndex,
         /// The expression that should be debugged
         expression: AstIndex,
     },
@@ -333,7 +333,7 @@ pub struct Function {
     /// Any ID (or lookup root) that's accessed in a function and which wasn't previously assigned
     /// locally, is either an export or the value needs to be captured. The compiler takes care of
     /// determining if an access is a capture or not at the moment the function is created.
-    pub accessed_non_locals: Vec<u32>,
+    pub accessed_non_locals: Vec<ConstantIndex>,
     /// The function's body
     pub body: AstIndex,
     /// A flag that indicates if the function arguments end with a variadic `...` argument
@@ -470,7 +470,7 @@ pub enum LookupNode {
     /// The root of the lookup chain
     Root(AstIndex),
     /// A `.` access using an identifier
-    Id(u32),
+    Id(ConstantIndex),
     /// A `.` access using a string
     Str(AstString),
     /// An index operation using square `[]` brackets.
@@ -630,13 +630,13 @@ impl TryFrom<u8> for MetaKeyId {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MapKey {
     /// An identifier
-    Id(u32),
+    Id(ConstantIndex),
     /// A string
     Str(AstString),
     /// A meta key
     ///
     /// Some meta keys require an additional identifier, e.g. @test test_name
-    Meta(MetaKeyId, Option<u32>),
+    Meta(MetaKeyId, Option<ConstantIndex>),
 }
 
 /// A node in an import item, see [Node::Import]

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     constant_pool::ConstantPoolBuilder,
-    error::{ExpectedIndentation, InternalError, ParserError, ParserErrorKind, SyntaxError},
+    error::{Error, ErrorKind, ExpectedIndentation, InternalError, SyntaxError},
     *,
 };
 use koto_lexer::{LexedToken, Lexer, Span, Token};
@@ -241,7 +241,7 @@ pub struct Parser<'source> {
 
 impl<'source> Parser<'source> {
     /// Takes in a source script, and produces an Ast
-    pub fn parse(source: &'source str) -> Result<Ast, ParserError> {
+    pub fn parse(source: &'source str) -> Result<Ast> {
         let capacity_guess = source.len() / 4;
         let mut parser = Parser {
             source,
@@ -261,7 +261,7 @@ impl<'source> Parser<'source> {
     }
 
     // Parses the main 'top-level' block
-    fn consume_main_block(&mut self) -> Result<AstIndex, ParserError> {
+    fn consume_main_block(&mut self) -> Result<AstIndex> {
         self.frame_stack.push(Frame::default());
 
         let start_span = self.current_span();
@@ -310,7 +310,7 @@ impl<'source> Parser<'source> {
     //   my_function = |x, y| # <- Here at entry
     //     x = y + 1          # | < indented block
     //     foo x              # | < indented block
-    fn parse_indented_block(&mut self) -> Result<Option<AstIndex>, ParserError> {
+    fn parse_indented_block(&mut self) -> Result<Option<AstIndex>> {
         let block_context = ExpressionContext::permissive();
 
         let start_indent = self.current_indent();
@@ -361,7 +361,7 @@ impl<'source> Parser<'source> {
     }
 
     // Parses expressions from the start of a line
-    fn parse_line(&mut self, context: &ExpressionContext) -> Result<Option<AstIndex>, ParserError> {
+    fn parse_line(&mut self, context: &ExpressionContext) -> Result<Option<AstIndex>> {
         self.parse_expressions(context, TempResult::No)
     }
 
@@ -376,7 +376,7 @@ impl<'source> Parser<'source> {
         &mut self,
         context: &ExpressionContext,
         temp_result: TempResult,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    ) -> Result<Option<AstIndex>> {
         let mut expression_context = ExpressionContext {
             allow_space_separated_call: true,
             ..*context
@@ -449,10 +449,7 @@ impl<'source> Parser<'source> {
     //
     // Unlike parse_expressions() (which will consume a comma-separated series of expressions),
     // parse_expression() will stop when a comma is encountered.
-    fn parse_expression(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    fn parse_expression(&mut self, context: &ExpressionContext) -> Result<Option<AstIndex>> {
         self.parse_expression_with_min_precedence(0, context)
     }
 
@@ -461,7 +458,7 @@ impl<'source> Parser<'source> {
         &mut self,
         min_precedence: u8,
         context: &ExpressionContext,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    ) -> Result<Option<AstIndex>> {
         let result = self.parse_expression_start(&[], min_precedence, context)?;
 
         match self.peek_next_token_on_same_line() {
@@ -480,7 +477,7 @@ impl<'source> Parser<'source> {
         previous_expressions: &[AstIndex],
         min_precedence: u8,
         context: &ExpressionContext,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    ) -> Result<Option<AstIndex>> {
         let entry_line = self.current_line;
 
         // Look ahead to get the indent of the first token in the expression.
@@ -534,7 +531,7 @@ impl<'source> Parser<'source> {
         previous_expressions: &[AstIndex],
         min_precedence: u8,
         context: &ExpressionContext,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    ) -> Result<Option<AstIndex>> {
         let start_line = self.current_line;
         let start_indent = self.current_indent();
 
@@ -649,7 +646,7 @@ impl<'source> Parser<'source> {
         lhs: AstIndex,
         previous_lhs: &[AstIndex],
         context: &ExpressionContext,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    ) -> Result<Option<AstIndex>> {
         match self
             .peek_token_with_context(context)
             .map(|token| token.token)
@@ -708,7 +705,7 @@ impl<'source> Parser<'source> {
     }
 
     // Peeks the next token and dispatches to the relevant parsing functions
-    fn parse_term(&mut self, context: &ExpressionContext) -> Result<Option<AstIndex>, ParserError> {
+    fn parse_term(&mut self, context: &ExpressionContext) -> Result<Option<AstIndex>> {
         use Node::*;
 
         let start_span = self.current_span();
@@ -865,7 +862,7 @@ impl<'source> Parser<'source> {
     // e.g.
     //   f = |x, y| x + y
     //   #   ^ You are here
-    fn consume_function(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_function(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         let start_indent = self.current_indent();
 
         self.consume_token_with_context(context); // Token::Function
@@ -1008,7 +1005,7 @@ impl<'source> Parser<'source> {
     fn parse_nested_function_args(
         &mut self,
         arg_ids: &mut Vec<ConstantIndex>,
-    ) -> Result<Vec<AstIndex>, ParserError> {
+    ) -> Result<Vec<AstIndex>> {
         let mut nested_args = Vec::new();
 
         let args_context = ExpressionContext::permissive();
@@ -1089,10 +1086,7 @@ impl<'source> Parser<'source> {
     // The resulting Vec will be empty if no arguments were encountered.
     //
     // See also parse_parenthesized_args.
-    fn parse_call_args(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<Vec<AstIndex>, ParserError> {
+    fn parse_call_args(&mut self, context: &ExpressionContext) -> Result<Vec<AstIndex>> {
         let mut args = Vec::new();
 
         if context.allow_space_separated_call {
@@ -1138,7 +1132,7 @@ impl<'source> Parser<'source> {
     fn parse_id(
         &mut self,
         context: &ExpressionContext,
-    ) -> Result<Option<(ConstantIndex, ExpressionContext)>, ParserError> {
+    ) -> Result<Option<(ConstantIndex, ExpressionContext)>> {
         match self.peek_token_with_context(context) {
             Some(PeekInfo {
                 token: Token::Id, ..
@@ -1152,7 +1146,7 @@ impl<'source> Parser<'source> {
     }
 
     // Parses a single `_` wildcard, along with its optional following id
-    fn consume_wildcard(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_wildcard(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context);
         let slice = self.current_token.slice(self.source);
         let maybe_id = if slice.len() > 1 {
@@ -1169,7 +1163,7 @@ impl<'source> Parser<'source> {
     fn parse_id_or_wildcard(
         &mut self,
         context: &ExpressionContext,
-    ) -> Result<Option<IdOrWildcard>, ParserError> {
+    ) -> Result<Option<IdOrWildcard>> {
         match self.peek_token_with_context(context) {
             Some(PeekInfo {
                 token: Token::Id, ..
@@ -1195,10 +1189,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn parse_id_or_string(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<Option<IdOrString>, ParserError> {
+    fn parse_id_or_string(&mut self, context: &ExpressionContext) -> Result<Option<IdOrString>> {
         let result = match self.parse_id(context)? {
             Some((id, _)) => Some(IdOrString::Id(id)),
             None => match self.parse_string(context)? {
@@ -1210,10 +1201,7 @@ impl<'source> Parser<'source> {
         Ok(result)
     }
 
-    fn consume_id_expression(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_id_expression(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         let start_span = self.current_span();
         let Some((constant_index, id_context)) = self.parse_id(context)? else {
             return self.consume_token_and_error(InternalError::UnexpectedToken);
@@ -1247,10 +1235,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn consume_self_expression(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_self_expression(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         let Some((_, self_context)) = self.consume_token_with_context(context) else {
             return self.error(SyntaxError::ExpectedCloseParen);
         };
@@ -1272,7 +1257,7 @@ impl<'source> Parser<'source> {
         &mut self,
         node: AstIndex,
         context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    ) -> Result<AstIndex> {
         let lookup_context = context.lookup_start();
         if self.next_token_is_lookup_start(&lookup_context) {
             self.consume_lookup(node, &lookup_context)
@@ -1315,11 +1300,7 @@ impl<'source> Parser<'source> {
     // e.g.
     //   y = x[0][1].foo()
     //   #    ^ You are here
-    fn consume_lookup(
-        &mut self,
-        root: AstIndex,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_lookup(&mut self, root: AstIndex, context: &ExpressionContext) -> Result<AstIndex> {
         let mut lookup = Vec::new();
         let mut lookup_line = self.current_line;
 
@@ -1461,7 +1442,7 @@ impl<'source> Parser<'source> {
     // e.g.
     //   foo.bar[10..20]
     //   #       ^ You are here
-    fn consume_index_expression(&mut self) -> Result<AstIndex, ParserError> {
+    fn consume_index_expression(&mut self) -> Result<AstIndex> {
         let index_context = ExpressionContext::restricted();
 
         let result = if let Some(index_expression) = self.parse_expression(&index_context)? {
@@ -1534,7 +1515,7 @@ impl<'source> Parser<'source> {
     // e.g.
     // foo[0].bar(1, 2, 3)
     // #          ^ You are here
-    fn parse_parenthesized_args(&mut self) -> Result<Vec<AstIndex>, ParserError> {
+    fn parse_parenthesized_args(&mut self) -> Result<Vec<AstIndex>> {
         let start_indent = self.current_indent();
         let mut args = Vec::new();
         let mut args_context = ExpressionContext::permissive();
@@ -1573,7 +1554,7 @@ impl<'source> Parser<'source> {
         &mut self,
         lhs: Option<AstIndex>,
         context: &ExpressionContext,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    ) -> Result<Option<AstIndex>> {
         use Node::{Range, RangeFrom, RangeFull, RangeTo};
 
         let mut start_span = self.current_span();
@@ -1611,7 +1592,7 @@ impl<'source> Parser<'source> {
             .map(Some)
     }
 
-    fn consume_export(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_export(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::Export
 
         let start_span = self.current_span();
@@ -1623,7 +1604,7 @@ impl<'source> Parser<'source> {
         self.push_node_with_start_span(Node::Export(expression), start_span)
     }
 
-    fn consume_throw_expression(&mut self) -> Result<AstIndex, ParserError> {
+    fn consume_throw_expression(&mut self) -> Result<AstIndex> {
         self.consume_next_token_on_same_line(); // Token::Throw
 
         let start_span = self.current_span();
@@ -1635,7 +1616,7 @@ impl<'source> Parser<'source> {
         self.push_node_with_start_span(Node::Throw(expression), start_span)
     }
 
-    fn consume_debug_expression(&mut self) -> Result<AstIndex, ParserError> {
+    fn consume_debug_expression(&mut self) -> Result<AstIndex> {
         self.consume_next_token_on_same_line(); // Token::Debug
 
         let start_position = self.current_span().start;
@@ -1667,11 +1648,7 @@ impl<'source> Parser<'source> {
         )
     }
 
-    fn consume_number(
-        &mut self,
-        negate: bool,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_number(&mut self, negate: bool, context: &ExpressionContext) -> Result<AstIndex> {
         use Node::*;
 
         self.consume_token_with_context(context); // Token::Number
@@ -1726,7 +1703,7 @@ impl<'source> Parser<'source> {
     //     - e.g. `(1 + 1)`
     //   - A comma-separated tuple
     //     - e.g. `(,)`, `(x,)`, `(1, 2)`
-    fn consume_tuple(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_tuple(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::RoundOpen
 
         let start_span = self.current_span();
@@ -1754,7 +1731,7 @@ impl<'source> Parser<'source> {
     }
 
     // Parses a list, e.g. `[1, 2, 3]`
-    fn consume_list(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_list(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::SquareOpen
 
         let start_span = self.current_span();
@@ -1779,10 +1756,7 @@ impl<'source> Parser<'source> {
     // Returns a Vec of entries along with a bool that's true if the last token before the end
     // was a comma, which is used by parse_tuple to determine how the entries should be
     // parsed.
-    fn parse_comma_separated_entries(
-        &mut self,
-        end_token: Token,
-    ) -> Result<(Vec<AstIndex>, bool), ParserError> {
+    fn parse_comma_separated_entries(&mut self, end_token: Token) -> Result<(Vec<AstIndex>, bool)> {
         let mut entries = Vec::new();
         let mut entry_context = ExpressionContext::braced_items_start();
         let mut last_token_was_a_comma = false;
@@ -1827,7 +1801,7 @@ impl<'source> Parser<'source> {
         first_key: MapKey,
         start_span: Span,
         context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    ) -> Result<AstIndex> {
         if !context.allow_map_block {
             return self.error(SyntaxError::ExpectedLineBreakBeforeMapBlock);
         }
@@ -1862,7 +1836,7 @@ impl<'source> Parser<'source> {
         self.push_node_with_start_span(Node::Map(entries), start_span)
     }
 
-    fn consume_map_block_value(&mut self) -> Result<AstIndex, ParserError> {
+    fn consume_map_block_value(&mut self) -> Result<AstIndex> {
         if let Some(value) = self.parse_indented_block()? {
             Ok(value)
         } else if let Some(value) = self.parse_line(&ExpressionContext::permissive())? {
@@ -1872,10 +1846,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn consume_map_with_braces(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_map_with_braces(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::CurlyOpen
 
         let start_indent = self.current_indent();
@@ -1899,9 +1870,7 @@ impl<'source> Parser<'source> {
         )
     }
 
-    fn parse_comma_separated_map_entries(
-        &mut self,
-    ) -> Result<Vec<(MapKey, Option<AstIndex>)>, ParserError> {
+    fn parse_comma_separated_map_entries(&mut self) -> Result<Vec<(MapKey, Option<AstIndex>)>> {
         let mut entries = Vec::new();
         let mut entry_context = ExpressionContext::braced_items_start();
 
@@ -1962,7 +1931,7 @@ impl<'source> Parser<'source> {
     //     regular_id: 1
     //     'string_id': 2
     //     @meta meta_key: 3
-    fn parse_map_key(&mut self) -> Result<Option<MapKey>, ParserError> {
+    fn parse_map_key(&mut self) -> Result<Option<MapKey>> {
         let result = if let Some((id, _)) = self.parse_id(&ExpressionContext::restricted())? {
             Some(MapKey::Id(id))
         } else if let Some(string_key) = self.parse_string(&ExpressionContext::restricted())? {
@@ -1977,9 +1946,7 @@ impl<'source> Parser<'source> {
     }
 
     // Attempts to parse a meta key
-    fn parse_meta_key(
-        &mut self,
-    ) -> Result<Option<(MetaKeyId, Option<ConstantIndex>)>, ParserError> {
+    fn parse_meta_key(&mut self) -> Result<Option<(MetaKeyId, Option<ConstantIndex>)>> {
         if self.peek_next_token_on_same_line() != Some(Token::At) {
             return Ok(None);
         }
@@ -2050,7 +2017,7 @@ impl<'source> Parser<'source> {
         Ok(Some((meta_key_id, meta_name)))
     }
 
-    fn consume_for_loop(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_for_loop(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::For
 
         let start_span = self.current_span();
@@ -2105,7 +2072,7 @@ impl<'source> Parser<'source> {
     }
 
     // Parses a loop declared with the `loop` keyword
-    fn consume_loop_block(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_loop_block(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::Loop
 
         if let Some(body) = self.parse_indented_block()? {
@@ -2115,7 +2082,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn consume_while_loop(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_while_loop(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::While
 
         let Some(condition) = self.parse_expression(&ExpressionContext::inline())? else {
@@ -2128,7 +2095,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn consume_until_loop(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_until_loop(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::Until
 
         let Some(condition) = self.parse_expression(&ExpressionContext::inline())? else {
@@ -2141,10 +2108,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn consume_if_expression(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_if_expression(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         use SyntaxError::*;
 
         self.consume_token_with_context(context); // Token::If
@@ -2254,7 +2218,7 @@ impl<'source> Parser<'source> {
     fn consume_switch_expression(
         &mut self,
         switch_context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    ) -> Result<AstIndex> {
         use SyntaxError::*;
 
         self.consume_token_with_context(switch_context); // Token::Switch
@@ -2323,17 +2287,14 @@ impl<'source> Parser<'source> {
             let last_arm = arm_index == arms.len() - 1;
 
             if arm.condition.is_none() && !last_arm {
-                return Err(ParserError::new(SwitchElseNotInLastArm.into(), switch_span));
+                return Err(Error::new(SwitchElseNotInLastArm.into(), switch_span));
             }
         }
 
         self.push_node_with_span(Node::Switch(arms), switch_span)
     }
 
-    fn consume_match_expression(
-        &mut self,
-        match_context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_match_expression(&mut self, match_context: &ExpressionContext) -> Result<AstIndex> {
         use SyntaxError::*;
 
         self.consume_token_with_context(match_context); // Token::Match
@@ -2460,7 +2421,7 @@ impl<'source> Parser<'source> {
             let last_arm = arm_index == arms.len() - 1;
 
             if arm.patterns.is_empty() && arm.condition.is_none() && !last_arm {
-                return Err(ParserError::new(MatchElseNotInLastArm.into(), match_span));
+                return Err(Error::new(MatchElseNotInLastArm.into(), match_span));
             }
         }
 
@@ -2474,10 +2435,7 @@ impl<'source> Parser<'source> {
     }
 
     // Parses a match arm's pattern
-    fn parse_match_pattern(
-        &mut self,
-        in_nested_patterns: bool,
-    ) -> Result<Option<AstIndex>, ParserError> {
+    fn parse_match_pattern(&mut self, in_nested_patterns: bool) -> Result<Option<AstIndex>> {
         use Token::*;
 
         let pattern_context = ExpressionContext::restricted();
@@ -2559,7 +2517,7 @@ impl<'source> Parser<'source> {
     //     (1, 2, [3, 4]) then ...
     //   #  ^ You are here
     //   #         ^...or here
-    fn parse_nested_match_patterns(&mut self) -> Result<Vec<AstIndex>, ParserError> {
+    fn parse_nested_match_patterns(&mut self) -> Result<Vec<AstIndex>> {
         let mut result = vec![];
 
         while let Some(pattern) = self.parse_match_pattern(true)? {
@@ -2574,7 +2532,7 @@ impl<'source> Parser<'source> {
         Ok(result)
     }
 
-    fn consume_import(&mut self, context: &ExpressionContext) -> Result<AstIndex, ParserError> {
+    fn consume_import(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         let importing_from = match self.consume_token_with_context(context) {
             Some((Token::Import, _)) => false,
             Some((Token::From, _)) => true,
@@ -2611,10 +2569,7 @@ impl<'source> Parser<'source> {
         self.push_node_with_start_span(Node::Import { from, items }, start_span)
     }
 
-    fn consume_from_path(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<Vec<IdOrString>, ParserError> {
+    fn consume_from_path(&mut self, context: &ExpressionContext) -> Result<Vec<IdOrString>> {
         let mut path = vec![];
 
         loop {
@@ -2656,10 +2611,7 @@ impl<'source> Parser<'source> {
     //   from baz.qux import foo, 'bar', 'x'
     //   #    ^ You are here, with nested items allowed
     //   #                   ^ Or here, with nested items disallowed
-    fn consume_import_items(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<Vec<ImportItem>, ParserError> {
+    fn consume_import_items(&mut self, context: &ExpressionContext) -> Result<Vec<ImportItem>> {
         let mut items = vec![];
         let mut context = *context;
 
@@ -2702,10 +2654,7 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn consume_try_expression(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<AstIndex, ParserError> {
+    fn consume_try_expression(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         let outer_context = match self.consume_token_with_context(context) {
             Some((Token::Try, outer_context)) => {
                 outer_context.with_expected_indentation(Indentation::Equal(self.current_indent()))
@@ -2763,10 +2712,7 @@ impl<'source> Parser<'source> {
         )
     }
 
-    fn parse_string(
-        &mut self,
-        context: &ExpressionContext,
-    ) -> Result<Option<ParseStringOutput>, ParserError> {
+    fn parse_string(&mut self, context: &ExpressionContext) -> Result<Option<ParseStringOutput>> {
         use SyntaxError::*;
         use Token::*;
 
@@ -2854,10 +2800,7 @@ impl<'source> Parser<'source> {
         self.error(UnterminatedString)
     }
 
-    fn escape_string_character(
-        &mut self,
-        chars: &mut Peekable<Chars>,
-    ) -> Result<Option<char>, ParserError> {
+    fn escape_string_character(&mut self, chars: &mut Peekable<Chars>) -> Result<Option<char>> {
         use SyntaxError::*;
 
         let Some(next) = chars.next() else {
@@ -2944,7 +2887,7 @@ impl<'source> Parser<'source> {
     fn consume_raw_string(
         &mut self,
         context: &ExpressionContext,
-    ) -> Result<Option<ParseStringOutput>, ParserError> {
+    ) -> Result<Option<ParseStringOutput>> {
         let (delimiter, string_context) = match self.consume_token_with_context(context) {
             Some((Token::StringStart(StringType::Raw(delimiter)), string_context)) => {
                 (delimiter, string_context)
@@ -2981,19 +2924,19 @@ impl<'source> Parser<'source> {
 
     //// Error helpers
 
-    fn error<E, T>(&mut self, error_type: E) -> Result<T, ParserError>
+    fn error<E, T>(&mut self, error_type: E) -> Result<T>
     where
-        E: Into<ParserErrorKind>,
+        E: Into<ErrorKind>,
     {
         Err(self.make_error(error_type))
     }
 
-    fn make_error<E>(&mut self, error_type: E) -> ParserError
+    fn make_error<E>(&mut self, error_type: E) -> Error
     where
-        E: Into<ParserErrorKind>,
+        E: Into<ErrorKind>,
     {
         #[allow(clippy::let_and_return)]
-        let error = ParserError::new(error_type.into(), self.current_span());
+        let error = Error::new(error_type.into(), self.current_span());
 
         #[cfg(feature = "panic_on_parser_error")]
         panic!("{error}");
@@ -3001,20 +2944,17 @@ impl<'source> Parser<'source> {
         error
     }
 
-    fn consume_token_on_same_line_and_error<E, T>(
-        &mut self,
-        error_type: E,
-    ) -> Result<T, ParserError>
+    fn consume_token_on_same_line_and_error<E, T>(&mut self, error_type: E) -> Result<T>
     where
-        E: Into<ParserErrorKind>,
+        E: Into<ErrorKind>,
     {
         self.consume_next_token_on_same_line();
         self.error(error_type)
     }
 
-    fn consume_token_and_error<E, T>(&mut self, error_type: E) -> Result<T, ParserError>
+    fn consume_token_and_error<E, T>(&mut self, error_type: E) -> Result<T>
     where
-        E: Into<ParserErrorKind>,
+        E: Into<ErrorKind>,
     {
         self.consume_token_with_context(&ExpressionContext::permissive());
         self.error(error_type)
@@ -3054,19 +2994,15 @@ impl<'source> Parser<'source> {
 
     //// Node push helpers
 
-    fn push_node(&mut self, node: Node) -> Result<AstIndex, ParserError> {
+    fn push_node(&mut self, node: Node) -> Result<AstIndex> {
         self.push_node_with_span(node, self.current_span())
     }
 
-    fn push_node_with_span(&mut self, node: Node, span: Span) -> Result<AstIndex, ParserError> {
+    fn push_node_with_span(&mut self, node: Node, span: Span) -> Result<AstIndex> {
         self.ast.push(node, span)
     }
 
-    fn push_node_with_start_span(
-        &mut self,
-        node: Node,
-        start_span: Span,
-    ) -> Result<AstIndex, ParserError> {
+    fn push_node_with_start_span(&mut self, node: Node, start_span: Span) -> Result<AstIndex> {
         self.push_node_with_span(node, self.span_with_start(start_span))
     }
 
@@ -3077,11 +3013,11 @@ impl<'source> Parser<'source> {
         }
     }
 
-    fn add_current_slice_as_string_constant(&mut self) -> Result<ConstantIndex, ParserError> {
+    fn add_current_slice_as_string_constant(&mut self) -> Result<ConstantIndex> {
         self.add_string_constant(self.current_token.slice(self.source))
     }
 
-    fn add_string_constant(&mut self, s: &str) -> Result<ConstantIndex, ParserError> {
+    fn add_string_constant(&mut self, s: &str) -> Result<ConstantIndex> {
         match self.constants.add_string(s) {
             Ok(result) => Ok(result),
             Err(_) => self.error(InternalError::ConstantPoolCapacityOverflow),
@@ -3261,20 +3197,20 @@ impl<'source> Parser<'source> {
         None
     }
 
-    fn frame(&self) -> Result<&Frame, ParserError> {
+    fn frame(&self) -> Result<&Frame> {
         match self.frame_stack.last() {
             Some(frame) => Ok(frame),
-            None => Err(ParserError::new(
+            None => Err(Error::new(
                 InternalError::MissingFrame.into(),
                 Span::default(),
             )),
         }
     }
 
-    fn frame_mut(&mut self) -> Result<&mut Frame, ParserError> {
+    fn frame_mut(&mut self) -> Result<&mut Frame> {
         match self.frame_stack.last_mut() {
             Some(frame) => Ok(frame),
-            None => Err(ParserError::new(
+            None => Err(Error::new(
                 InternalError::MissingFrame.into(),
                 Span::default(),
             )),

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -253,8 +253,7 @@ impl<'source> Parser<'source> {
             frame_stack: Vec::new(),
         };
 
-        let main_block = parser.consume_main_block()?;
-        parser.ast.set_entry_point(main_block);
+        parser.consume_main_block()?;
         parser.ast.set_constants(parser.constants.build());
 
         Ok(parser.ast)


### PR DESCRIPTION
- Rename ParserError -> koto_parser::Error, and introduce koto_parser::Result
- Make use of ConstantIndex and AstIndex where appropriate
- Infer the entry point for ASTs
- Refer to nodes by AstIndex in compile_node
- Extract helpers for working with the span stack
