### PR TITLE
Compound assignment improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ The Koto project adheres to
     # 1006
     ```
 - Meta map improvements
-  - Arithmetic-assignment operators (`@+=`, `@*=`, etc.) can now be implemented 
+  - Compound assignment operators (`@+=`, `@*=`, etc.) can now be implemented 
     in meta maps and external values.
   - The function call operator (`@||`) can be implemented to values that behave 
     like functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ The Koto project adheres to
 - `iterator.once` has been added.
 
 ### Changed
-
 #### Core Library
 
 - `string.to_number` changes:
@@ -90,6 +89,13 @@ The Koto project adheres to
 - `ObjectEntryBuilder` has been replaced with macros from `koto_derive`.
 - `KMap::add_map` and `KMap::add_value` have been removed, `KMap::insert` now
   accepts any value that implements `Into<Value>` and can be used instead.
+
+### Fixed
+
+#### Language
+
+- Chained compound assignment operators are now right-associative and all share 
+  the same precedence.
 
 
 ## [0.12.0] 2023.10.18

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -1475,7 +1475,7 @@ impl Compiler {
                 self.compile_arithmetic_op(op, lhs, rhs, ctx)
             }
             AddAssign | SubtractAssign | MultiplyAssign | DivideAssign | RemainderAssign => {
-                self.compile_arithmetic_assign_op(op, lhs, rhs, ctx)
+                self.compile_compound_assignment_op(op, lhs, rhs, ctx)
             }
             Less | LessOrEqual | Greater | GreaterOrEqual | Equal | NotEqual => {
                 self.compile_comparison_op(op, lhs, rhs, ctx)
@@ -1532,7 +1532,7 @@ impl Compiler {
         Ok(result)
     }
 
-    fn compile_arithmetic_assign_op(
+    fn compile_compound_assignment_op(
         &mut self,
         ast_op: AstBinaryOp,
         lhs: AstIndex,
@@ -1549,7 +1549,7 @@ impl Compiler {
             RemainderAssign => Op::RemainderAssign,
             _ => {
                 return self.error(ErrorKind::InvalidBinaryOp {
-                    kind: "arithmetic assignment".into(),
+                    kind: "compound assignment".into(),
                     op: ast_op,
                 })
             }

--- a/crates/lexer/src/lexer.rs
+++ b/crates/lexer/src/lexer.rs
@@ -1370,7 +1370,7 @@ r#''bar''#
         }
 
         #[test]
-        fn modify_assign() {
+        fn compound_assignment() {
             let input = "\
 a += 1
 b -= 2

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -3237,8 +3237,9 @@ fn operator_precedence(op: Token) -> Option<(u8, u8)> {
     use Token::*;
     let priority = match op {
         Pipe => (1, 2),
-        AddAssign | SubtractAssign => (4, MIN_PRECEDENCE_AFTER_PIPE),
-        MultiplyAssign | DivideAssign | RemainderAssign => (6, 5),
+        AddAssign | SubtractAssign | MultiplyAssign | DivideAssign | RemainderAssign => {
+            (4, MIN_PRECEDENCE_AFTER_PIPE)
+        }
         Or => (7, 8),
         And => (9, 10),
         // Chained comparisons require right-associativity

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1275,7 +1275,7 @@ x";
         }
 
         #[test]
-        fn modify_assign() {
+        fn compound_assignment() {
             let source = "\
 x += 0
 x -= 1

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -159,15 +159,27 @@ a %= 5
         }
 
         #[test]
-        fn compound_assignment_chain() {
+        fn compound_assignment_chain_add_first() {
             let script = "
-a = 1
-b = 2
-c = 3
+a = 10
+b = 20
+c = 30
 a += b *= c
 a, b, c
 ";
-            test_script(script, number_tuple(&[7, 6, 3]));
+            test_script(script, number_tuple(&[610, 600, 30]));
+        }
+
+        #[test]
+        fn compound_assignment_chain_multiply_first() {
+            let script = "
+a = 10
+b = 20
+c = 30
+a *= b += c
+a, b, c
+";
+            test_script(script, number_tuple(&[500, 50, 30]));
         }
     }
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -71,29 +71,6 @@ a = 99
         fn remainder_with_a_divisor_of_zero() {
             test_script("(1 % 0).is_nan()", true);
         }
-
-        #[test]
-        fn modify_assignment() {
-            let script = "
-a = 1
-a += 6  # 7
-a -= 4  # 3
-a *= 10 # 30
-a /= 3  # 10
-a %= 4  # 2
-";
-            test_script(script, 2);
-        }
-
-        #[test]
-        fn modify_assignment_chain() {
-            let script = "
-a = 1
-b = 2
-c = 3
-a += b *= c";
-            test_script(script, 7);
-        }
     }
 
     mod logic {
@@ -170,7 +147,7 @@ y = y = 2
         }
 
         #[test]
-        fn assignment_ops() {
+        fn compound_assignment_ops() {
             let script = "
 a = 10
 a += 1 # 11
@@ -179,6 +156,18 @@ a /= 2 # 33
 a %= 5
 ";
             test_script(script, 3);
+        }
+
+        #[test]
+        fn compound_assignment_chain() {
+            let script = "
+a = 1
+b = 2
+c = 3
+a += b *= c
+a, b, c
+";
+            test_script(script, number_tuple(&[7, 6, 3]));
         }
     }
 
@@ -2879,7 +2868,7 @@ z.x
         }
 
         #[test]
-        fn arithmetic_assignment() {
+        fn compound_assignment() {
             let script = "
 locals = {}
 foo = |x| {x}.with_meta locals.foo_meta

--- a/docs/language/basics.md
+++ b/docs/language/basics.md
@@ -136,7 +136,7 @@ print! x
 check! true
 ```
 
-Arithmetic assignment operators are available, e.g. `x *= y` is shorthand for 
+Compound assignment operators are available, e.g. `x *= y` is shorthand for 
 `x = x * y`.
 
 ```koto

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -15,7 +15,7 @@ globals.foo_meta =
   @/: |other| foo self.x / other.x
   @%: |other| foo self.x % other.x
 
-  # Modify-Assignment operators
+  # Compound assignment operators
   @+=: |other|
     self.x += other
     self

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -29,7 +29,7 @@ macro_rules! impl_arithmetic_op {
     };
 }
 
-macro_rules! impl_arithmetic_assign_op {
+macro_rules! impl_compound_assign_op {
     ($trait:ident, $trait_fn:ident, $op:tt) => {
         impl ops::$trait for Color {
             fn $trait_fn(&mut self, other: Color) -> () {
@@ -49,10 +49,10 @@ impl_arithmetic_op!(Add, add, +);
 impl_arithmetic_op!(Sub, sub, -);
 impl_arithmetic_op!(Mul, mul, *);
 impl_arithmetic_op!(Div, div, /);
-impl_arithmetic_assign_op!(AddAssign, add_assign, +=);
-impl_arithmetic_assign_op!(SubAssign, sub_assign, -=);
-impl_arithmetic_assign_op!(MulAssign, mul_assign, *=);
-impl_arithmetic_assign_op!(DivAssign, div_assign, /=);
+impl_compound_assign_op!(AddAssign, add_assign, +=);
+impl_compound_assign_op!(SubAssign, sub_assign, -=);
+impl_compound_assign_op!(MulAssign, mul_assign, *=);
+impl_compound_assign_op!(DivAssign, div_assign, /=);
 
 #[macro_export]
 macro_rules! color_arithmetic_op {
@@ -75,7 +75,7 @@ macro_rules! color_arithmetic_op {
 }
 
 #[macro_export]
-macro_rules! color_arithmetic_assign_op {
+macro_rules! color_compound_assign_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {
@@ -251,19 +251,19 @@ impl KotoObject for Color {
     }
 
     fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
-        color_arithmetic_assign_op!(self, rhs, +=)
+        color_compound_assign_op!(self, rhs, +=)
     }
 
     fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
-        color_arithmetic_assign_op!(self, rhs, -=)
+        color_compound_assign_op!(self, rhs, -=)
     }
 
     fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
-        color_arithmetic_assign_op!(self, rhs, *=)
+        color_compound_assign_op!(self, rhs, *=)
     }
 
     fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
-        color_arithmetic_assign_op!(self, rhs, /=)
+        color_compound_assign_op!(self, rhs, /=)
     }
 
     fn equal(&self, rhs: &KValue) -> Result<bool> {

--- a/libs/geometry/src/macros.rs
+++ b/libs/geometry/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! impl_arithmetic_op {
 }
 
 #[macro_export]
-macro_rules! impl_arithmetic_assign_op {
+macro_rules! impl_compound_assign_op {
     ($type:ident, $trait:ident, $trait_fn:ident, $op:tt) => {
         impl ops::$trait for $type {
             fn $trait_fn(&mut self, other: $type) -> () {
@@ -39,15 +39,15 @@ macro_rules! impl_arithmetic_assign_op {
 #[macro_export]
 macro_rules! impl_arithmetic_ops {
     ($type:ident)=> {
-        use $crate::{impl_arithmetic_op, impl_arithmetic_assign_op};
+        use $crate::{impl_arithmetic_op, impl_compound_assign_op};
         impl_arithmetic_op!($type, Add, add, +);
         impl_arithmetic_op!($type, Sub, sub, -);
         impl_arithmetic_op!($type, Mul, mul, *);
         impl_arithmetic_op!($type, Div, div, /);
-        impl_arithmetic_assign_op!($type, AddAssign, add_assign, +=);
-        impl_arithmetic_assign_op!($type, SubAssign, sub_assign, -=);
-        impl_arithmetic_assign_op!($type, MulAssign, mul_assign, *=);
-        impl_arithmetic_assign_op!($type, DivAssign, div_assign, /=);
+        impl_compound_assign_op!($type, AddAssign, add_assign, +=);
+        impl_compound_assign_op!($type, SubAssign, sub_assign, -=);
+        impl_compound_assign_op!($type, MulAssign, mul_assign, *=);
+        impl_compound_assign_op!($type, DivAssign, div_assign, /=);
 
         impl ops::Neg for $type {
             type Output = Self;
@@ -80,7 +80,7 @@ macro_rules! geometry_arithmetic_op {
 }
 
 #[macro_export]
-macro_rules! geometry_arithmetic_assign_op {
+macro_rules! geometry_compound_assign_op {
     ($self:ident, $rhs:expr, $op:tt) => {
         {
             match $rhs {

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -65,19 +65,19 @@ impl KotoObject for Vec2 {
     }
 
     fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, +=)
+        geometry_compound_assign_op!(self, rhs, +=)
     }
 
     fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, -=)
+        geometry_compound_assign_op!(self, rhs, -=)
     }
 
     fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, *=)
+        geometry_compound_assign_op!(self, rhs, *=)
     }
 
     fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, /=)
+        geometry_compound_assign_op!(self, rhs, /=)
     }
 
     fn equal(&self, rhs: &KValue) -> Result<bool> {

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -61,19 +61,19 @@ impl KotoObject for Vec3 {
     }
 
     fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, +=)
+        geometry_compound_assign_op!(self, rhs, +=)
     }
 
     fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, -=)
+        geometry_compound_assign_op!(self, rhs, -=)
     }
 
     fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, *=)
+        geometry_compound_assign_op!(self, rhs, *=)
     }
 
     fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_arithmetic_assign_op!(self, rhs, /=)
+        geometry_compound_assign_op!(self, rhs, /=)
     }
 
     fn equal(&self, rhs: &KValue) -> Result<bool> {


### PR DESCRIPTION
This PR fixes chained compound assignment operations so that an expression like:

```coffee
a, b, c = 1, 2, 3
a += b += c
```

doesn't get parsed as:

```coffee
(a += b) += c
```

...which results in `+= c` being assigned to a temporary.

Additionally, all compound assignment ops now share the same precedence so that left-to-right chaining isn't broken.
