### PR TITLE
Don't implicitly treat the first print arg as a format string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,19 +44,22 @@ The Koto project adheres to
 - `iterator.once` has been added.
 
 ### Changed
+
 #### Core Library
 
+- `io.print` no longer implicitly treats its first argument as a format string. 
+  `string.format` should be explicitly used instead.
+- `iterator.next`/`next_back` and `Peekble.peek`/`peek_back` now return
+  `IteratorOutput` for output values, and `null` when the iterator is exhausted.
+  - `.get()` needs to be called on the output to get the underlying value.
+- `map.with_meta_map` has been renamed to `with_meta`, and `get_meta_map` has
+  been renamed to `get_meta`.
 - `string.to_number` changes:
   - `0x`, `0o`, and `0b` prefixes are understood for parsing hex, octal, or
     binary numbers respectively.
   - An overload has been added that accepts a number base between 2 and 36.
   - If the string doesn't contain a number, `null` is now returned instead of an
     exception being thrown.
-- `map.with_meta_map` has been renamed to `with_meta`, and `get_meta_map` has
-  been renamed to `get_meta`.
-- `iterator.next`/`next_back` and `Peekble.peek`/`peek_back` now return
-  `IteratorOutput` for output values, and `null` when the iterator is exhausted.
-  - `.get()` needs to be called on the output to get the underlying value.
 
 #### API
 

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -1,6 +1,5 @@
 //! The `io` core library module
 
-use super::string::format;
 use crate::{derive::*, prelude::*, BufferedFile, Error, Ptr, Result};
 use std::{
     fmt, fs,
@@ -78,14 +77,6 @@ pub fn make_module() -> KMap {
     result.add_fn("print", |ctx| {
         let result = match ctx.args() {
             [Str(s)] => ctx.vm.stdout().write_line(s.as_str()),
-            [Str(format), format_args @ ..] => {
-                let format = format.clone();
-                let format_args = format_args.to_vec();
-                match format::format_string(ctx.vm, &format, &format_args) {
-                    Ok(result) => ctx.vm.stdout().write_line(&result),
-                    Err(error) => Err(error),
-                }
-            }
             [value] => {
                 let value = value.clone();
                 match ctx.vm.run_unary_op(crate::UnaryOp::Display, value)? {

--- a/crates/runtime/tests/stdout.rs
+++ b/crates/runtime/tests/stdout.rs
@@ -55,7 +55,7 @@ mod vm {
     fn print_loop() {
         let script = "
 for i in 0..5
-  print 'foo {}', i
+  print 'foo $i'
 ";
         check_logged_output(
             script,

--- a/docs/core_lib/io.md
+++ b/docs/core_lib/io.md
@@ -97,12 +97,6 @@ f.exists()
 ## print
 
 ```kototype
-|String, Value...| -> Null
-```
-
-Prints a formatted string to the active output. 
-See [`string.format`](../string/#format) for the formatting syntax.
-
 ```kototype
 |Value| -> Null
 ```
@@ -113,11 +107,13 @@ Prints a single value to the active output.
 |Value, Value...| -> Null
 ```
 
-Prints a series of values to the active output. 
+Prints a series of values to the active output as a tuple.
 
 ### Note
 
-The output for `print` depends on the configuration of the runtime, by default this is stdout.
+- To print formatted strings, see [`string.format`](./string#format).
+- The output for `print` depends on the configuration of the runtime.
+  The default output is `stdout`.
 
 ## read_to_string
 

--- a/docs/language/value_unpacking.md
+++ b/docs/language/value_unpacking.md
@@ -26,9 +26,9 @@ a, b, c = 1..10
 print! a, b, c
 check! (1, 2, 3)
 
-x, y, z = (a, b, c).each |x| x * 10
+x, y, z = 'a-b-c'.split '-'
 print! x, y, z
-check! (10, 20, 30)
+check! ('a', 'b', 'c')
 ```
 
 If the value being unpacked doesn't contain enough values for the assignment,


### PR DESCRIPTION
Since interpolated strings were added this is less useful than it used to be, and this avoids the footgun of trying to print a tuple where the first argument is a non-format string.
