### PR TITLE
Argument unpacking improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The Koto project adheres to
 - Unpacked assignments with a single value on the RHS are now accepted, 
   with remaining values being set to `null`.
   - e.g. `a, b, c = 42` will assign `42` to `a`, and `null` to `b` and `c`.
+- The `@size` metakey (along with `KObject::size`) has been added to allow 
+  custom value types to work with argument unpacking and pattern matching.
+  - The general rule is now that matching works with any value that declares a
+    size and supports indexing.
 
 #### API
 
@@ -33,10 +37,12 @@ The Koto project adheres to
 
 #### Core Library
 
-- `koto.load` has been added, which allows evaluating strings as Koto scripts 
-  which returns a `Chunk` type.
-- `koto.run` has been added, which allows evaluating strings as Koto scripts or 
-  running a `Chunk` type.
+- Dynamic compilation and evaluation features (`koto.load` and `koto.run`) have 
+  been added, thanks to [@alisomay](https://github.com/alisomay).
+- `koto.size` has been added (and added to the prelude), 
+  replacing the various type-specific `.size()` functions.
+- `string.char_indices` has been added to support the switch to byte-based
+  indexing.
 
 #### Libs
 
@@ -44,6 +50,17 @@ The Koto project adheres to
 - `iterator.once` has been added.
 
 ### Changed
+
+#### Language
+
+- Pattern matching and function argument unpacking now use parentheses for all
+  container types. 
+  - Any uses of `[]` brackets to match against lists can be updated to use
+    parentheses instead.
+- Indexing operations on strings now access bytes instead of grapheme clusters.
+  - This is to avoid the non-linear performance cost of indexing by cluster.
+  - To access clusters via indexing, `string.char_indices` can be called first to
+    retrieve valid indices. 
 
 #### Core Library
 
@@ -69,6 +86,8 @@ The Koto project adheres to
 - The VM-specific parts of `KotoSettings` are now defined via `KotoVmSettings`.
 - Objects can be compared with `null` on the LHS without having to implement 
   `KotoObject::equal` and/or `not_equal`.
+- `KRange` initialization has been revamped to support `From` for
+  `RangeBounds<i64>`.
 
 #### Internals
 

--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -258,14 +258,6 @@ pub enum Instruction {
         value: u8,
         index: i8,
     },
-    IsTuple {
-        register: u8,
-        value: u8,
-    },
-    IsList {
-        register: u8,
-        value: u8,
-    },
     Index {
         register: u8,
         value: u8,
@@ -320,10 +312,6 @@ pub enum Instruction {
         register: u8,
         constant: u32,
     },
-    CheckType {
-        register: u8,
-        type_id: TypeId,
-    },
     CheckSizeEqual {
         register: u8,
         size: usize,
@@ -341,27 +329,6 @@ pub enum Instruction {
     StringFinish {
         register: u8,
     },
-}
-
-#[derive(Debug)]
-#[repr(u8)]
-#[allow(missing_docs)]
-pub enum TypeId {
-    List,
-    Tuple,
-}
-
-impl TypeId {
-    /// Produces a [TypeId] from the given byte
-    pub fn from_byte(byte: u8) -> Result<Self, u8> {
-        if byte == Self::List as u8 {
-            Ok(Self::List)
-        } else if byte == Self::Tuple as u8 {
-            Ok(Self::Tuple)
-        } else {
-            Err(byte)
-        }
-    }
 }
 
 /// Flags used to define the properties of a Function
@@ -620,12 +587,6 @@ impl fmt::Debug for Instruction {
                 f,
                 "SliceTo\t\tresult: {register}\tvalue: {value}\tindex: {index}"
             ),
-            IsTuple { register, value } => {
-                write!(f, "IsTuple\t\tresult: {register}\tvalue: {value}")
-            }
-            IsList { register, value } => {
-                write!(f, "IsList\t\tresult: {register}\tvalue: {value}")
-            }
             Index {
                 register,
                 value,
@@ -698,9 +659,6 @@ impl fmt::Debug for Instruction {
             TryEnd => write!(f, "TryEnd"),
             Debug { register, constant } => {
                 write!(f, "Debug\t\tvalue: {register}\tconstant: {constant}")
-            }
-            CheckType { register, type_id } => {
-                write!(f, "CheckType\tvalue: {register}\ttype: {type_id:?}")
             }
             CheckSizeEqual { register, size } => {
                 write!(f, "CheckSizeEqual\tvalue: {register}\tsize: {size}")

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -1,4 +1,4 @@
-use crate::{Chunk, FunctionFlags, Instruction, Op, TypeId};
+use crate::{Chunk, FunctionFlags, Instruction, Op};
 use koto_memory::Ptr;
 
 /// An iterator that converts bytecode into a series of [Instruction]s
@@ -373,14 +373,6 @@ impl Iterator for InstructionReader {
                 value: get_u8!(),
                 index: get_u8!() as i8,
             }),
-            Op::IsTuple => Some(IsTuple {
-                register: get_u8!(),
-                value: get_u8!(),
-            }),
-            Op::IsList => Some(IsList {
-                register: get_u8!(),
-                value: get_u8!(),
-            }),
             Op::Index => Some(Index {
                 register: get_u8!(),
                 value: get_u8!(),
@@ -480,15 +472,6 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 constant: get_var_u32!(),
             }),
-            Op::CheckType => {
-                let register = get_u8!();
-                match TypeId::from_byte(get_u8!()) {
-                    Ok(type_id) => Some(CheckType { register, type_id }),
-                    Err(byte) => Some(Error {
-                        message: format!("Unexpected value for CheckType id: {byte}"),
-                    }),
-                }
-            }
             Op::CheckSizeEqual => Some(CheckSizeEqual {
                 register: get_u8!(),
                 size: get_u8!() as usize,

--- a/crates/bytecode/src/lib.rs
+++ b/crates/bytecode/src/lib.rs
@@ -13,7 +13,7 @@ mod op;
 pub use crate::{
     chunk::{Chunk, DebugInfo},
     compiler::{Compiler, CompilerError, CompilerSettings},
-    instruction::{FunctionFlags, Instruction, TypeId},
+    instruction::{FunctionFlags, Instruction},
     instruction_reader::InstructionReader,
     loader::{Loader, LoaderError},
     op::Op,

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -443,16 +443,6 @@ pub enum Op {
     /// `[*result, *value, *key]`
     AccessString,
 
-    /// Sets the result register to true if the value is a List
-    ///
-    /// `[*result, *value]`
-    IsList,
-
-    /// Sets the result register to true if the value is a Tuple
-    ///
-    /// `[*result, *value]`
-    IsTuple,
-
     /// Gets the size of a value
     ///
     /// `[*result, *value]`
@@ -477,15 +467,6 @@ pub enum Op {
     /// `[*value, @expression constant]`
     Debug,
 
-    /// Throws an error if the value doesn't match the expected type
-    ///
-    /// Used when matching function arguments.
-    ///
-    /// See [TypeId](crate::TypeId) for the list of types that are checked against.
-    ///
-    /// `[*value, type]`
-    CheckType,
-
     /// Throws an error if the value doesn't match the expected size
     ///
     /// Used when matching function arguments.
@@ -501,6 +482,9 @@ pub enum Op {
     CheckSizeMin,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
+    Unused82,
+    Unused83,
+    Unused84,
     Unused85,
     Unused86,
     Unused87,

--- a/crates/bytecode/tests/compile_failures.rs
+++ b/crates/bytecode/tests/compile_failures.rs
@@ -56,7 +56,7 @@ match 0
         fn match_ellipsis_out_of_position() {
             let source = "
 match [1, 2, 3]
-  [x, ..., y] then 0
+  (x, ..., y) then 0
 ";
             check_compilation_fails(source);
         }

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -584,6 +584,8 @@ pub enum MetaKeyId {
     Negate,
     /// @not
     Not,
+    /// @size
+    Size,
     /// @type
     Type,
     /// @base

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1945,6 +1945,7 @@ impl<'source> Parser<'source> {
                 "next" => MetaKeyId::Next,
                 "next_back" => MetaKeyId::NextBack,
                 "negate" => MetaKeyId::Negate,
+                "size" => MetaKeyId::Size,
                 "type" => MetaKeyId::Type,
                 "base" => MetaKeyId::Base,
                 "main" => MetaKeyId::Main,

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -3273,7 +3273,7 @@ y z";
         }
 
         #[test]
-        fn unpack_call_args_tuple() {
+        fn unpack_call_args() {
             let sources = [
                 "
 |a, (_, (others..., c, _d)), _e|
@@ -3317,57 +3317,6 @@ y z";
                 Some(&[
                     Constant::Str("a"),
                     Constant::Str("others"),
-                    Constant::Str("c"),
-                    Constant::Str("d"),
-                    Constant::Str("e"),
-                ]),
-            )
-        }
-
-        #[test]
-        fn unpack_call_args_list() {
-            let sources = [
-                "
-|a, [_, [c, _d, ...]], e|
-  a
-",
-                "
-| a, 
-  [ _, 
-    [c, _d, ...]
-  ], 
-  e
-|
-  a
-",
-            ];
-            check_ast_for_equivalent_sources(
-                &sources,
-                &[
-                    Id(0), // a
-                    Wildcard(None),
-                    Id(1),               // c
-                    Wildcard(Some(2)),   // d
-                    Ellipsis(None),      // ...
-                    List(vec![2, 3, 4]), // ast index 5
-                    List(vec![1, 5]),
-                    Id(3), // e
-                    Id(0),
-                    Function(koto_parser::Function {
-                        args: vec![0, 6, 7],
-                        local_count: 3,
-                        accessed_non_locals: vec![],
-                        body: 8,
-                        is_variadic: false,
-                        is_generator: false,
-                    }),
-                    MainBlock {
-                        body: vec![9],
-                        local_count: 0,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("a"),
                     Constant::Str("c"),
                     Constant::Str("d"),
                     Constant::Str("e"),

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -113,13 +113,13 @@ for x in y if f x
             }
 
             #[test]
-            fn missing_terminator_for_tuple_arg() {
+            fn missing_terminator_for_unpacked_arg() {
                 check_parsing_fails("f = |a, (b, c, d| a");
             }
 
             #[test]
-            fn missing_terminator_for_list_arg() {
-                check_parsing_fails("f = |a, [b, c, d| a");
+            fn square_brackets_used_for_unpacked_arg() {
+                check_parsing_fails("f = |a, [b, c]| a");
             }
 
             #[test]
@@ -288,6 +288,16 @@ match x
                 let source = "
 match
   0 if true then 1
+  else 2
+";
+                check_parsing_fails(source);
+            }
+
+            #[test]
+            fn square_brackets_used_for_unpacking() {
+                let source = "
+match [1, 2, 3]
+  [x, y, z] then x + y + z
   else 2
 ";
                 check_parsing_fails(source);

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -51,10 +51,7 @@ pub fn make_module() -> KMap {
     result.insert("script_path", KValue::Null);
 
     result.add_fn("size", |ctx| match ctx.args() {
-        [value] => match value.size()? {
-            Some(size) => Ok(size.into()),
-            None => type_error("a value with a defined size", value),
-        },
+        [value] => ctx.vm.run_unary_op(UnaryOp::Size, value.clone()),
         unexpected => type_error_with_slice("a single value", unexpected),
     });
 

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -50,6 +50,14 @@ pub fn make_module() -> KMap {
     result.insert("script_dir", KValue::Null);
     result.insert("script_path", KValue::Null);
 
+    result.add_fn("size", |ctx| match ctx.args() {
+        [value] => match value.size()? {
+            Some(size) => Ok(size.into()),
+            None => type_error("a value with a defined size", value),
+        },
+        unexpected => type_error_with_slice("a single value", unexpected),
+    });
+
     result.add_fn("type", |ctx| match ctx.args() {
         [value] => Ok(value.type_as_string().into()),
         unexpected => type_error_with_slice("a single argument", unexpected),

--- a/crates/runtime/src/core_lib/list.rs
+++ b/crates/runtime/src/core_lib/list.rs
@@ -344,15 +344,6 @@ pub fn make_module() -> KMap {
         }
     });
 
-    result.add_fn("size", |ctx| {
-        let expected_error = "a List";
-
-        match ctx.instance_and_args(is_list, expected_error)? {
-            (KValue::List(l), []) => Ok(KValue::Number(l.len().into())),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
-        }
-    });
-
     result.add_fn("sort", |ctx| {
         let expected_error = "a List, and an optional key function";
 

--- a/crates/runtime/src/core_lib/map.rs
+++ b/crates/runtime/src/core_lib/map.rs
@@ -191,15 +191,6 @@ pub fn make_module() -> KMap {
         }
     });
 
-    result.add_fn("size", |ctx| {
-        let expected_error = "a Map";
-
-        match map_instance_and_args(ctx, expected_error)? {
-            (KValue::Map(m), []) => Ok(KValue::Number(m.len().into())),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
-        }
-    });
-
     result.add_fn("sort", |ctx| {
         let expected_error = "a Map and optional sort key function";
 

--- a/crates/runtime/src/core_lib/mod.rs
+++ b/crates/runtime/src/core_lib/mod.rs
@@ -60,6 +60,7 @@ impl CoreLib {
         default_import!("print", io);
         default_import!("copy", koto);
         default_import!("deep_copy", koto);
+        default_import!("size", koto);
         default_import!("type", koto);
 
         result

--- a/crates/runtime/src/core_lib/range.rs
+++ b/crates/runtime/src/core_lib/range.rs
@@ -40,9 +40,9 @@ pub fn make_module() -> KMap {
                 (Some(start), Some((end, inclusive))) => {
                     let n = i64::from(n);
                     let result = if r.is_ascending() {
-                        KRange::bounded(start - n, end + n, inclusive)
+                        KRange::new(Some(start - n), Some((end + n, inclusive)))
                     } else {
-                        KRange::bounded(start + n, end - n, inclusive)
+                        KRange::new(Some(start + n), Some((end - n, inclusive)))
                     };
                     Ok(result.into())
                 }
@@ -104,9 +104,9 @@ pub fn make_module() -> KMap {
                 match (r.start(), r.end()) {
                     (Some(start), Some((end, inclusive))) => {
                         let result = if start <= end {
-                            KRange::bounded(start.min(n), end.max(n + 1), inclusive)
+                            KRange::new(Some(start.min(n)), Some((end.max(n + 1), inclusive)))
                         } else {
-                            KRange::bounded(start.max(n), end.min(n - 1), inclusive)
+                            KRange::new(Some(start.max(n)), Some((end.min(n - 1), inclusive)))
                         };
                         Ok(result.into())
                     }
@@ -117,9 +117,15 @@ pub fn make_module() -> KMap {
                 (Some(start), Some((end, inclusive))) => {
                     let r_b = b.as_sorted_range();
                     let result = if start <= end {
-                        KRange::bounded(start.min(r_b.start), end.max(r_b.end), inclusive)
+                        KRange::new(
+                            Some(start.min(r_b.start)),
+                            Some((end.max(r_b.end), inclusive)),
+                        )
                     } else {
-                        KRange::bounded(start.max(r_b.end - 1), end.min(r_b.start), inclusive)
+                        KRange::new(
+                            Some(start.max(r_b.end - 1)),
+                            Some((end.min(r_b.start), inclusive)),
+                        )
                     };
                     Ok(result.into())
                 }

--- a/crates/runtime/src/core_lib/range.rs
+++ b/crates/runtime/src/core_lib/range.rs
@@ -74,18 +74,6 @@ pub fn make_module() -> KMap {
         }
     });
 
-    result.add_fn("size", |ctx| {
-        let expected_error = "a Range";
-
-        match ctx.instance_and_args(is_range, expected_error)? {
-            (KValue::Range(r), []) => match r.size() {
-                Some(size) => Ok(size.into()),
-                None => runtime_error!("range.size can't be used with '{r}'"),
-            },
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
-        }
-    });
-
     result.add_fn("start", |ctx| {
         let expected_error = "a Range";
 

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -31,6 +31,18 @@ pub fn make_module() -> KMap {
         }
     });
 
+    result.add_fn("char_indices", |ctx| {
+        let expected_error = "a String";
+
+        match ctx.instance_and_args(is_string, expected_error)? {
+            (KValue::Str(s), []) => {
+                let result = iterators::CharIndices::new(s.clone());
+                Ok(KIterator::new(result).into())
+            }
+            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+        }
+    });
+
     result.add_fn("contains", |ctx| {
         let expected_error = "a String";
 

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -5,7 +5,6 @@ pub mod iterators;
 
 use super::iterator::collect_pair;
 use crate::prelude::*;
-use unicode_segmentation::UnicodeSegmentation;
 
 /// Initializes the `string` core library module
 pub fn make_module() -> KMap {
@@ -134,15 +133,6 @@ pub fn make_module() -> KMap {
             (KValue::Str(input), [KValue::Str(pattern), KValue::Str(replace)]) => {
                 Ok(input.replace(pattern.as_str(), replace).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
-        }
-    });
-
-    result.add_fn("size", |ctx| {
-        let expected_error = "a String";
-
-        match ctx.instance_and_args(is_string, expected_error)? {
-            (KValue::Str(s), []) => Ok(s.graphemes(true).count().into()),
             (_, unexpected) => type_error_with_slice(expected_error, unexpected),
         }
     });

--- a/crates/runtime/src/core_lib/tuple.rs
+++ b/crates/runtime/src/core_lib/tuple.rs
@@ -77,15 +77,6 @@ pub fn make_module() -> KMap {
         }
     });
 
-    result.add_fn("size", |ctx| {
-        let expected_error = "a Tuple";
-
-        match ctx.instance_and_args(is_tuple, expected_error)? {
-            (KValue::Tuple(t), []) => Ok(KValue::Number(t.len().into())),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
-        }
-    });
-
     result.add_fn("sort_copy", |ctx| {
         let expected_error = "a Tuple";
 

--- a/crates/runtime/src/core_lib/value_sort.rs
+++ b/crates/runtime/src/core_lib/value_sort.rs
@@ -1,4 +1,4 @@
-//! As operators can be overloaded, we can't treat values specifically (i.e. use `PartialOrd` and
+//! As operators can be overridden, we can't treat values specifically (i.e. use `PartialOrd` and
 //! `Ord` for example). So we always need to call operators to compare them. This module contains
 //! helpers for comparing and sorting [Value].
 

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -23,7 +23,7 @@ pub enum ErrorKind {
     },
     #[error("Execution timed out (the limit of {} seconds was reached)", .0.as_secs_f64())]
     Timeout(Duration),
-    #[error("Expected {expected}, but found {}", get_value_types(unexpected))]
+    #[error("Expected {expected}, but found '{}'", get_value_types(unexpected))]
     UnexpectedType {
         expected: String,
         unexpected: Vec<KValue>,

--- a/crates/runtime/src/types/iterator.rs
+++ b/crates/runtime/src/types/iterator.rs
@@ -410,13 +410,17 @@ struct MetaIterator {
 
 impl MetaIterator {
     fn new(vm: KotoVm, iterator: KValue) -> Result<Self> {
-        match iterator.get_meta_value(&UnaryOp::Next.into()) {
+        let KValue::Map(m) = &iterator else {
+            return runtime_error!("Expected Map with implementation of @next");
+        };
+
+        match m.get_meta_value(&UnaryOp::Next.into()) {
             Some(op) if op.is_callable() => {}
             Some(op) => return type_error("Callable function from @next", &op),
             None => return runtime_error!("Expected implementation of @next"),
         };
 
-        let is_bidirectional = match iterator.get_meta_value(&UnaryOp::NextBack.into()) {
+        let is_bidirectional = match m.get_meta_value(&UnaryOp::NextBack.into()) {
             Some(op) if op.is_callable() => true,
             Some(op) => return type_error("Callable function from @next_back", &op),
             None => false,

--- a/crates/runtime/src/types/map.rs
+++ b/crates/runtime/src/types/map.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use rustc_hash::FxHasher;
 use std::{
     hash::BuildHasherDefault,
-    ops::{Deref, DerefMut},
+    ops::{Deref, DerefMut, RangeBounds},
 };
 
 /// The hasher used throughout the Koto runtime
@@ -24,6 +24,17 @@ impl ValueMap {
             capacity,
             Default::default(),
         ))
+    }
+
+    /// Makes a new ValueMap containing a slice of the map's elements
+    pub fn make_data_slice(&self, range: impl RangeBounds<usize>) -> Option<Self> {
+        self.get_range(range).map(|entries| {
+            Self::from_iter(
+                entries
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            )
+        })
     }
 }
 

--- a/crates/runtime/src/types/meta_map.rs
+++ b/crates/runtime/src/types/meta_map.rs
@@ -87,7 +87,7 @@ pub enum MetaKey {
     Main,
     /// `@type`
     ///
-    /// Used to define a [KString](crate::KString) that declare the value's type.
+    /// Provides a [KString](crate::KString) that declares the value's type.
     Type,
     /// `@base`
     ///
@@ -207,6 +207,8 @@ pub enum UnaryOp {
     Negate,
     /// `@not`
     Not,
+    /// `@size`
+    Size,
 }
 
 /// Converts a [MetaKeyId](koto_parser::MetaKeyId) into a [MetaKey]
@@ -238,6 +240,7 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<KString>) -> Result<MetaKey> {
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
         MetaKeyId::Not => MetaKey::UnaryOp(Not),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),
+        MetaKeyId::Size => MetaKey::UnaryOp(Size),
         MetaKeyId::Call => MetaKey::Call,
         MetaKeyId::Named => {
             MetaKey::Named(name.ok_or_else(|| Error::from("Missing name for named meta entry"))?)

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -122,8 +122,22 @@ pub trait KotoObject: KotoType + KotoCopy + KotoLookup + KotoSend + KotoSync + D
     }
 
     /// Called for indexing operations, e.g. `x[0]`
+    ///
+    /// See also: [KotoObject::size]
     fn index(&self, _index: &KValue) -> Result<KValue> {
         unimplemented_error("@index", self.type_string())
+    }
+
+    /// Called when checking for the number of elements contained in the object
+    ///
+    /// The runtime defers to this function when the 'size' of an object is needed
+    /// e.g. when `koto.size` is called, or when unpacking function arguments.
+    ///
+    /// The size should represent the maximum valid index that can be passed to [KotoObject::index].
+    ///
+    /// See also: [KotoObject::index]
+    fn size(&self) -> Option<usize> {
+        None
     }
 
     /// Allows the object to behave as a function

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -139,34 +139,6 @@ impl KValue {
         }
     }
 
-    /// Returns the 'size' of the value
-    ///
-    /// A value's size is the number of elements that can used in unpacking expressions
-    /// e.g.
-    /// x = [1, 2, 3] # x has size 3
-    /// a, b, c = x
-    ///
-    /// See:
-    ///   - [Op::Size](koto_bytecode::Op::Size)
-    ///   - [Op::CheckSizeEqual](koto_bytecode::Op::CheckSizeEqual).
-    ///   - [Op::CheckSizeMin](koto_bytecode::Op::CheckSizeMin).
-    pub fn size(&self) -> Result<Option<usize>> {
-        use KValue::*;
-
-        let result = match &self {
-            List(l) => Some(l.len()),
-            Tuple(t) => Some(t.len()),
-            Str(l) => Some(l.len()),
-            Range(r) => r.size(),
-            Map(m) => Some(m.len()),
-            Object(o) => o.try_borrow()?.size(),
-            TemporaryTuple(RegisterSlice { count, .. }) => Some(*count as usize),
-            _ => None,
-        };
-
-        Ok(result)
-    }
-
     /// Returns the value's type as a [KString]
     pub fn type_as_string(&self) -> KString {
         use KValue::*;
@@ -199,7 +171,7 @@ impl KValue {
         }
     }
 
-    /// Returns true if the value is a Map or an External that contains the given meta key
+    /// Returns true if the value is a Map that contains the given meta key
     pub fn contains_meta_key(&self, key: &MetaKey) -> bool {
         use KValue::*;
         match &self {
@@ -208,7 +180,7 @@ impl KValue {
         }
     }
 
-    /// If the value is a Map or an External, returns a clone of the corresponding meta value
+    /// If the value is a Map, returns a clone of the corresponding meta value
     pub fn get_meta_value(&self, key: &MetaKey) -> Option<KValue> {
         use KValue::*;
         match &self {

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -151,7 +151,7 @@ impl KValue {
             Range { .. } => TYPE_RANGE.with(|x| x.clone()),
             Map(m) if m.meta_map().is_some() => match m.get_meta_value(&MetaKey::Type) {
                 Some(Str(s)) => s,
-                Some(_) => "Error: expected string for overloaded type".into(),
+                Some(_) => "Error: expected string as result of @type".into(),
                 None => TYPE_OBJECT.with(|x| x.clone()),
             },
             Map(_) => TYPE_MAP.with(|x| x.clone()),

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -171,24 +171,6 @@ impl KValue {
         }
     }
 
-    /// Returns true if the value is a Map that contains the given meta key
-    pub fn contains_meta_key(&self, key: &MetaKey) -> bool {
-        use KValue::*;
-        match &self {
-            Map(m) => m.contains_meta_key(key),
-            _ => false,
-        }
-    }
-
-    /// If the value is a Map, returns a clone of the corresponding meta value
-    pub fn get_meta_value(&self, key: &MetaKey) -> Option<KValue> {
-        use KValue::*;
-        match &self {
-            Map(m) => m.get_meta_value(key),
-            _ => None,
-        }
-    }
-
     /// Renders the value into the provided display context
     pub fn display(&self, ctx: &mut DisplayContext) -> Result<()> {
         use KValue::*;

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -992,13 +992,13 @@ impl KotoVm {
         let start = start_register.map(|r| self.get_register(r));
         let end = end_register.map(|r| self.get_register(r));
 
-        let range = match (start, end) {
+        let (range_start, range_end) = match (start, end) {
             (Some(Number(start)), Some(Number(end))) => {
-                KRange::bounded(start.into(), end.into(), inclusive)
+                (Some(start.into()), Some((end.into(), inclusive)))
             }
-            (Some(Number(start)), None) => KRange::from(start.into()),
-            (None, Some(Number(end))) => KRange::to(end.into(), inclusive),
-            (None, None) => KRange::unbounded(),
+            (Some(Number(start)), None) => (Some(start.into()), None),
+            (None, Some(Number(end))) => (None, Some((end.into(), inclusive))),
+            (None, None) => (None, None),
             (None | Some(Number(_)), Some(unexpected)) => {
                 return type_error("a Number for the range's end", unexpected)
             }
@@ -1007,7 +1007,7 @@ impl KotoVm {
             }
         };
 
-        self.set_register(register, range.into());
+        self.set_register(register, KRange::new(range_start, range_end).into());
         Ok(())
     }
 

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -859,7 +859,7 @@ impl KotoVm {
                     self.spawn_shared_vm(),
                 ));
             }
-            Size { register, value } => self.run_size(register, value),
+            Size { register, value } => self.run_size(register, value)?,
             IterNext {
                 result,
                 iterator,
@@ -2004,9 +2004,13 @@ impl KotoVm {
         Ok(())
     }
 
-    fn run_size(&mut self, register: u8, value: u8) {
-        let result = self.get_register(value).size();
-        self.set_register(register, KValue::Number(result.into()));
+    fn run_size(&mut self, register: u8, value: u8) -> Result<()> {
+        let result = self
+            .get_register(value)
+            .size()?
+            .map_or_else(|| (-1).into(), KNumber::from);
+        self.set_register(register, KValue::Number(result));
+        Ok(())
     }
 
     fn run_import(&mut self, import_register: u8) -> Result<()> {

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -490,6 +490,29 @@ y.next().get()
         }
     }
 
+    mod char_indices {
+        use super::*;
+
+        #[test]
+        fn text() {
+            let script = "
+'xßîहिं'.char_indices().to_tuple()
+";
+            test_script(
+                script,
+                tuple(&[range(0..1), range(1..3), range(3..5), range(5..14)]),
+            );
+        }
+
+        #[test]
+        fn emojis() {
+            let script = "
+'👍🫶🏽🫱🏼‍🫲🏾'.char_indices().to_tuple()
+";
+            test_script(script, tuple(&[range(0..4), range(4..12), range(12..31)]));
+        }
+    }
+
     mod lines {
         use super::*;
 

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -132,6 +132,10 @@ mod objects {
             }
         }
 
+        fn size(&self) -> Option<usize> {
+            Some(self.x.abs() as usize)
+        }
+
         fn call(&mut self, _ctx: &mut CallContext) -> Result<KValue> {
             Ok(self.x.into())
         }
@@ -574,6 +578,16 @@ x = make_object 100
 x[23]
 ";
             test_object_script(script, 123);
+        }
+
+        #[test]
+        fn size() {
+            let script = "
+x = make_object 42
+# Report x as the size
+koto.size x
+";
+            test_object_script(script, 42);
         }
     }
 

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -128,6 +128,17 @@ mod objects {
                     let result = self.x + i64::from(index);
                     Ok(result.into())
                 }
+                KValue::Range(range) => match (range.start(), range.end()) {
+                    (Some(start), Some((end, inclusive))) => {
+                        let end = if inclusive {
+                            self.x + end + 1
+                        } else {
+                            self.x + end
+                        };
+                        Ok(KRange::from((self.x + start)..end).into())
+                    }
+                    _ => unimplemented!(),
+                },
                 unexpected => type_error("Number as index", unexpected),
             }
         }
@@ -589,6 +600,26 @@ koto.size x
 ";
             test_object_script(script, 42);
         }
+
+        #[test]
+        fn function_argument_unpacking() {
+            let script = "
+f = |(a, b, c...)| a + b + size c
+x = make_object 10
+f x # 10 + 11 + 8
+";
+            test_object_script(script, 29);
+        }
+
+        #[test]
+        fn match_arm_unpacking() {
+            let script = "
+match make_object 10
+  (x, y) then -1
+  (rest..., y, z) then (size rest) + y + z # 8 + 18 + 19
+";
+            test_object_script(script, 45);
+        }
     }
 
     #[test]
@@ -604,7 +635,7 @@ x()
         use super::*;
 
         #[test]
-        fn overloaded_unary_op_as_lookup_root() {
+        fn overridden_unary_op_as_lookup_root() {
             let script = "
 x = make_object -100
 (-x).as_number()
@@ -613,7 +644,7 @@ x = make_object -100
         }
 
         #[test]
-        fn overloaded_binary_op_as_lookup_root() {
+        fn overridden_binary_op_as_lookup_root() {
             let script = "
 x = make_object 100
 y = make_object 100

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -134,15 +134,6 @@ f (1, 2, 3)
             }
 
             #[test]
-            fn list_unpacking_of_non_list() {
-                let script = r#"
-f = |[a, b]| a + b
-f (1, 2)
-"#;
-                check_script_fails(script);
-            }
-
-            #[test]
             fn list_unpacking_of_list_with_wrong_size() {
                 let script = r#"
 f = |[a, b]| a + b

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -134,15 +134,6 @@ f (1, 2, 3)
             }
 
             #[test]
-            fn list_unpacking_of_list_with_wrong_size() {
-                let script = r#"
-f = |[a, b]| a + b
-f [1, 2, 3]
-"#;
-                check_script_fails(script);
-            }
-
-            #[test]
             fn capturing_a_reserved_value_in_a_temporary_function() {
                 let script = "
 x = (1..10).find |n| n == x

--- a/crates/runtime/tests/runtime_test_utils.rs
+++ b/crates/runtime/tests/runtime_test_utils.rs
@@ -2,7 +2,7 @@
 
 use koto_bytecode::{Chunk, CompilerSettings, Loader};
 use koto_runtime::{prelude::*, KValue::*, Ptr, PtrMut, Result};
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, ops::RangeBounds, rc::Rc};
 
 pub fn test_script(script: &str, expected_output: impl Into<KValue>) {
     let output = PtrMut::from(String::new());
@@ -115,6 +115,10 @@ where
 
 pub fn list(values: &[KValue]) -> KValue {
     KList::from_slice(values).into()
+}
+
+pub fn range(bounds: impl RangeBounds<i64>) -> KValue {
+    KRange::from(bounds).into()
 }
 
 pub fn tuple(values: &[KValue]) -> KValue {

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -767,6 +767,17 @@ match x
         }
 
         #[test]
+        fn match_string_subslice_at_start_with_id() {
+            let script = "
+match 'hello!'
+  ('h', 'x', ...) then 'nope'
+  ('h', 'e', rest...) then 'llo!'
+  else 'abc'
+";
+            test_script(script, "llo!");
+        }
+
+        #[test]
         fn match_on_multiple_expressions_with_alternatives_wildcard() {
             let script = "
 match 0, 1
@@ -2663,7 +2674,7 @@ m.'key$x'
         }
 
         #[test]
-        fn value_with_overloaded_display() {
+        fn value_with_overridden_display() {
             let script = "
 foo = {@display: || 'Foo'}
 '$foo'
@@ -2888,7 +2899,7 @@ catch _
         }
     }
 
-    mod operator_overloading {
+    mod overridden_operators {
         use super::*;
 
         #[test]
@@ -3009,7 +3020,7 @@ foo = |x|
         }
 
         #[test]
-        fn equality_of_list_containing_overloaded_value() {
+        fn equality_of_list_containing_overridden_value() {
             let script = "
 foo = |x|
   x: x
@@ -3025,7 +3036,7 @@ a == b # Should evaluate to true due to the inverted equality operator
         }
 
         #[test]
-        fn equality_of_map_containing_overloaded_value() {
+        fn equality_of_map_containing_overridden_value() {
             let script = "
 foo = |x|
   x: x
@@ -3041,7 +3052,7 @@ a == b # Should evaluate to true due to the inverted equality operator
         }
 
         #[test]
-        fn equality_of_tuple_containing_overloaded_value() {
+        fn equality_of_tuple_containing_overridden_value() {
             let script = "
 foo = |x|
   x: x
@@ -3057,7 +3068,7 @@ a == b # Should evaluate to true due to the inverted equality operator
         }
 
         #[test]
-        fn inequality_of_list_containing_overloaded_value() {
+        fn inequality_of_list_containing_overridden_value() {
             let script = "
 foo = |x|
   x: x
@@ -3073,7 +3084,7 @@ a != b # Should evaluate to true due to the inverted equality operator
         }
 
         #[test]
-        fn inequality_of_map_containing_overloaded_value() {
+        fn inequality_of_map_containing_overridden_value() {
             let script = "
 foo = |x|
   x: x
@@ -3089,7 +3100,7 @@ a != b # Should evaluate to true due to the inverted equality operator
         }
 
         #[test]
-        fn inequality_of_tuple_containing_overloaded_value() {
+        fn inequality_of_tuple_containing_overridden_value() {
             let script = "
 foo = |x|
   x: x
@@ -3119,7 +3130,7 @@ b >= a
         }
 
         #[test]
-        fn equality_of_functions_with_overloaded_captures() {
+        fn equality_of_functions_with_overridden_captures() {
             let script = "
 # Make two functions which capture a different foo
 foos = (0, 1)
@@ -3136,7 +3147,7 @@ foos[0] == foos[1]
         }
 
         #[test]
-        fn map_addition_with_overloaded_operators() {
+        fn map_addition_with_overridden_operators() {
             let script = "
 foo = |a, b|
   @meta a: a
@@ -3156,7 +3167,7 @@ c.get_a() + c.get_b()
         }
     }
 
-    mod overloaded_call {
+    mod overridden_call {
         use super::*;
 
         #[test]
@@ -3189,7 +3200,7 @@ x 10
         }
     }
 
-    mod overloaded_index {
+    mod overridden_index_and_size {
         use super::*;
 
         #[test]
@@ -3201,9 +3212,54 @@ x[1]
 ";
             test_script(script, 11);
         }
+
+        #[test]
+        fn size() {
+            let script = "
+foo = |n|
+  n: n
+  @size: || self.n
+x = foo 99
+size x
+";
+            test_script(script, 99);
+        }
+
+        #[test]
+        fn argument_unpacking() {
+            let script = "
+foo = |data|
+  data: data
+  @[]: |index| self.data[index]
+  @size: || size self.data
+
+f = |(a, b, others...)| a + b + size others
+x = foo (10, 11, 12, 13)
+f x # 10 + 11 + 2
+";
+            test_script(script, 23);
+        }
+
+        #[test]
+        fn match_unpacking() {
+            let script = "
+foo = |data|
+  data: data
+  @[]: |index| self.data[index]
+  @size: || size self.data
+
+match foo (10, 11, 12, 13)
+  (a) then 99
+  (a, b) then -1
+  (a, b, c, others...) then
+    # 10 + 11 + 12 + 1
+    a + b + c + size others
+";
+            test_script(script, 34);
+        }
     }
 
-    mod overloaded_iterator {
+    mod overridden_iterator {
         use super::*;
 
         #[test]
@@ -3220,7 +3276,7 @@ a, b, c
         }
     }
 
-    mod overloaded_next {
+    mod overridden_next {
         use super::*;
 
         #[test]

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -1130,7 +1130,7 @@ f (1, 2, 3, 4, 5)
             #[test]
             fn ellipsis_with_id_at_end() {
                 let script = "
-f = |(a, b, others...)| a + b + others.size()
+f = |(a, b, others...)| a + b + size others
 f (1, 2, 3, 4, 5)
 ";
                 test_script(script, 6);
@@ -1148,7 +1148,7 @@ f (1, 2, 3, 4, 5)
             #[test]
             fn ellipsis_with_id_at_start() {
                 let script = "
-f = |(others..., y, z)| y + z + others.size()
+f = |(others..., y, z)| y + z + size others
 f (1, 2, 3, 4, 5)
 ";
                 test_script(script, 12);
@@ -1167,7 +1167,7 @@ f {foo: 42, bar: 99}
             fn ellipsis_mixed() {
                 let script = "
 f = |(a, (tuple_others..., z), list_others...)|
-  a + list_others.sum() + tuple_others.size() + z
+  a + list_others.sum() + (size tuple_others) + z
 f [10, (1, 2, 3), 20, 30]
 ";
                 test_script(script, 65);
@@ -2226,7 +2226,7 @@ result = {}
   .each |x|
     result.insert(x, x * x)
   .consume()
-result.size()
+size result
 ";
             test_script(script, 5);
         }
@@ -2245,7 +2245,7 @@ equal
         #[test]
         fn range_in_call_args() {
             let script = "
-foo = |range, x| range.size() + x
+foo = |range, x| (size range) + x
 min, max = 0, 10
 foo min..max, 20
 ";
@@ -2585,7 +2585,7 @@ x = 100
         #[test]
         fn inline_map() {
             let script = "
-foo = |m| m.size()
+foo = |m| size m
 '${foo {bar: 42, baz: 99}}!'
 ";
             test_script(script, string("2!"));

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -188,16 +188,16 @@ a, b, c
 
         #[test]
         fn range() {
-            test_script("0..10", KRange::bounded(0, 10, false));
-            test_script("0..-10", KRange::bounded(0, -10, false));
-            test_script("1 + 1..2 + 2", KRange::bounded(2, 4, false));
+            test_script("0..10", KRange::from(0..10));
+            test_script("0..-10", KRange::from(0..-10));
+            test_script("1 + 1..2 + 2", KRange::from(2..4));
         }
 
         #[test]
         fn range_inclusive() {
-            test_script("10..=20", KRange::bounded(10, 20, true));
-            test_script("4..=0", KRange::bounded(4, 0, true));
-            test_script("2 * 2..=3 * 3", KRange::bounded(4, 9, true));
+            test_script("10..=20", KRange::from(10..=20));
+            test_script("4..=0", KRange::from(4..=0));
+            test_script("2 * 2..=3 * 3", KRange::from(4..=9));
         }
     }
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -2490,32 +2490,32 @@ gen().to_tuple()
 
         #[test]
         fn greater_or_equal() {
-            test_script(r#""héllö42" >= "héllö11""#, true);
+            test_script(r#""hello42" >= "hello11""#, true);
             test_script(r#""hello1" >= "hello42""#, false);
         }
 
         #[test]
         fn index_single_index() {
-            test_script("'héllö'[1]", string("é"));
+            test_script("'hello'[1]", string("e"));
         }
 
         #[test]
         fn index_start_and_end() {
-            test_script("'héllö'[1..2]", string("é"));
-            test_script("'héllö'[1..3]", string("él"));
-            test_script("'héllö'[3..5]", string("lö"));
+            test_script("'hello'[1..2]", string("e"));
+            test_script("'hello'[1..3]", string("el"));
+            test_script("'föo'[1..3]", string("ö"));
         }
 
         #[test]
         fn index_from_start() {
-            test_script("'héllö'[2..]", string("llö"));
-            test_script("'héllö'[3..]", string("lö"));
+            test_script("'hello'[2..]", string("llo"));
+            test_script("'hello'[3..]", string("lo"));
         }
 
         #[test]
         fn index_to_end() {
-            test_script("'héllö'[..1]", string("h"));
-            test_script("'héllö'[..=2]", string("hél"));
+            test_script("'hello'[..1]", string("h"));
+            test_script("'hello'[..=2]", string("hel"));
         }
 
         #[test]
@@ -2523,18 +2523,18 @@ gen().to_tuple()
             test_script("'x'[0..1]", string("x"));
             test_script("'x'[1..]", string(""));
             test_script("'x'[1..1]", string(""));
-            test_script("'héllö'[5..]", string(""));
+            test_script("'hello'[5..]", string(""));
         }
 
         #[test]
         fn index_whole_string() {
-            test_script("'héllö'[..]", string("héllö"));
+            test_script("'hello'[..]", string("hello"));
         }
 
         #[test]
         fn index_sub_string() {
-            test_script("'héllö'[3..][..]", string("lö"));
-            test_script("'héllö'[3..][1]", string("ö"));
+            test_script("'hello'[3..][..]", string("lo"));
+            test_script("'hello'[3..][1]", string("o"));
         }
 
         #[test]

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -1137,6 +1137,15 @@ f (1, 2, 3, 4, 5)
             }
 
             #[test]
+            fn ellipsis_at_end_with_no_extra_values() {
+                let script = "
+f = |(a, b, others...)| a + b + size others
+f (1, 2)
+";
+                test_script(script, 3);
+            }
+
+            #[test]
             fn ellipsis_at_start() {
                 let script = "
 f = |(..., y, z)| y + z
@@ -1146,12 +1155,30 @@ f (1, 2, 3, 4, 5)
             }
 
             #[test]
+            fn ellipsis_at_start_with_no_extra_values() {
+                let script = "
+f = |(..., y, z)| y + z
+f (1, 2)
+";
+                test_script(script, 3);
+            }
+
+            #[test]
             fn ellipsis_with_id_at_start() {
                 let script = "
 f = |(others..., y, z)| y + z + size others
 f (1, 2, 3, 4, 5)
 ";
                 test_script(script, 12);
+            }
+
+            #[test]
+            fn ellipsis_at_start_and_end_with_no_extra_values() {
+                let script = "
+f = |(..., y, z)| y + z
+f (1, 2)
+";
+                test_script(script, 3);
             }
 
             #[test]

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -695,7 +695,6 @@ match (1, (2, 3), 4)
         fn match_list() {
             let script = "
 match [1, [2, 3], [4, 5, 6]]
-  (1, (2, 3), (4, 5, 6)) then -1 # Tuples don't match against lists
   [1, [x, -1], [_, y, _]] then x + y
   [1, [x, 3], [_, 5, y]] then x + y
   else 123

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -695,8 +695,8 @@ match (1, (2, 3), 4)
         fn match_list() {
             let script = "
 match [1, [2, 3], [4, 5, 6]]
-  [1, [x, -1], [_, y, _]] then x + y
-  [1, [x, 3], [_, 5, y]] then x + y
+  (1, (x, -1), (_, y, _)) then x + y
+  (1, (x, 3), (_, 5, y)) then x + y
   else 123
 ";
             test_script(script, 8);
@@ -707,8 +707,8 @@ match [1, [2, 3], [4, 5, 6]]
             let script = "
 x = [0]
 match x
-  [0] or [1] then 123
-  [x, y] or [x, y, z] then 99
+  (0) or (1) then 123
+  (x, y) or (x, y, z) then 99
   else -1
 ";
             test_script(script, 123);
@@ -719,9 +719,9 @@ match x
             let script = "
 x = (1..=5).to_list()
 match x
-  [0, ...] then 0
-  [..., 1] then -1
-  [1, ...] then 1
+  (0, ...) then 0
+  (..., 1) then -1
+  (1, ...) then 1
   else 123
 ";
             test_script(script, 1);
@@ -732,9 +732,9 @@ match x
             let script = "
 x = (1..=5).to_list()
 match x
-  [0, rest...] then rest
-  [rest..., 3, 2, 1] then rest
-  [1, 2, rest...] then rest
+  (0, rest...) then rest
+  (rest..., 3, 2, 1) then rest
+  (1, 2, rest...) then rest
   else 123
 ";
             test_script(script, number_list(&[3, 4, 5]));
@@ -745,9 +745,9 @@ match x
             let script = "
 x = (1..=5).to_list()
 match x
-  [0, rest...] then rest
-  [rest..., 3, 4, 5] then rest
-  [1, 2, rest...] then rest
+  (0, rest...) then rest
+  (rest..., 3, 4, 5) then rest
+  (1, 2, rest...) then rest
   else 123
 ";
             test_script(script, number_list(&[1, 2]));
@@ -1079,7 +1079,7 @@ f 1, 2, 3
         }
 
         #[test]
-        fn arg_unpacking_tuple() {
+        fn arg_unpacking() {
             let script = "
 f = |a, (_, c), d| a + c + d
 f 1, (2, 3), 4
@@ -1088,7 +1088,7 @@ f 1, (2, 3), 4
         }
 
         #[test]
-        fn arg_unpacking_tuple_nested() {
+        fn arg_unpacking_nested() {
             let script = "
 f = |a, (_, (c, d), _), f| a + c + d + f
 f 1, (2, (3, 4), 5), 6
@@ -1097,18 +1097,9 @@ f 1, (2, (3, 4), 5), 6
         }
 
         #[test]
-        fn arg_unpacking_list() {
-            let script = "
-f = |a, [_, c], d| a + c + d
-f 1, [2, 3], 4
-";
-            test_script(script, 8);
-        }
-
-        #[test]
         fn arg_unpacking_mixed() {
             let script = "
-f = |a, (b, [_, d]), e| a + b + d + e
+f = |a, (b, (_, d)), e| a + b + d + e
 f 1, (2, [3, 4]), 5
 ";
             test_script(script, 12);
@@ -1163,7 +1154,7 @@ f (1, 2, 3, 4, 5)
         #[test]
         fn arg_unpacking_ellipsis_mixed() {
             let script = "
-f = |[a, (tuple_others..., z), list_others...]|
+f = |(a, (tuple_others..., z), list_others...)|
   a + list_others.sum() + tuple_others.size() + z
 f [10, (1, 2, 3), 20, 30]
 ";

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -1078,97 +1078,110 @@ f 1, 2, 3
             test_script(script, 3);
         }
 
-        #[test]
-        fn arg_unpacking() {
-            let script = "
+        mod arg_unpacking {
+            use super::*;
+
+            #[test]
+            fn unpack_second_arg() {
+                let script = "
 f = |a, (_, c), d| a + c + d
 f 1, (2, 3), 4
 ";
-            test_script(script, 8);
-        }
+                test_script(script, 8);
+            }
 
-        #[test]
-        fn arg_unpacking_nested() {
-            let script = "
+            #[test]
+            fn nested() {
+                let script = "
 f = |a, (_, (c, d), _), f| a + c + d + f
 f 1, (2, (3, 4), 5), 6
 ";
-            test_script(script, 14);
-        }
+                test_script(script, 14);
+            }
 
-        #[test]
-        fn arg_unpacking_mixed() {
-            let script = "
+            #[test]
+            fn mixed_containers() {
+                let script = "
 f = |a, (b, (_, d)), e| a + b + d + e
 f 1, (2, [3, 4]), 5
 ";
-            test_script(script, 12);
-        }
+                test_script(script, 12);
+            }
 
-        #[test]
-        fn arg_unpacking_with_capture() {
-            let script = "
+            #[test]
+            fn unpacking_with_capture() {
+                let script = "
 x = 10
 f = |a, (b, c)| a + b + c + x
 f 1, (2, 3)
 ";
-            test_script(script, 16);
-        }
+                test_script(script, 16);
+            }
 
-        #[test]
-        fn arg_unpacking_ellipsis_at_end() {
-            let script = "
+            #[test]
+            fn ellipsis_at_end() {
+                let script = "
 f = |(a, b, ...)| a + b
 f (1, 2, 3, 4, 5)
 ";
-            test_script(script, 3);
-        }
+                test_script(script, 3);
+            }
 
-        #[test]
-        fn arg_unpacking_ellipsis_with_id_at_end() {
-            let script = "
+            #[test]
+            fn ellipsis_with_id_at_end() {
+                let script = "
 f = |(a, b, others...)| a + b + others.size()
 f (1, 2, 3, 4, 5)
 ";
-            test_script(script, 6);
-        }
+                test_script(script, 6);
+            }
 
-        #[test]
-        fn arg_unpacking_ellipsis_at_start() {
-            let script = "
+            #[test]
+            fn ellipsis_at_start() {
+                let script = "
 f = |(..., y, z)| y + z
 f (1, 2, 3, 4, 5)
 ";
-            test_script(script, 9);
-        }
+                test_script(script, 9);
+            }
 
-        #[test]
-        fn arg_unpacking_ellipsis_with_id_at_start() {
-            let script = "
+            #[test]
+            fn ellipsis_with_id_at_start() {
+                let script = "
 f = |(others..., y, z)| y + z + others.size()
 f (1, 2, 3, 4, 5)
 ";
-            test_script(script, 12);
-        }
+                test_script(script, 12);
+            }
 
-        #[test]
-        fn arg_unpacking_ellipsis_mixed() {
-            let script = "
+            #[test]
+            fn unpacking_a_map() {
+                let script = "
+f = |((_, a), (_, b))| a + b
+f {foo: 42, bar: 99}
+";
+                test_script(script, 141);
+            }
+
+            #[test]
+            fn ellipsis_mixed() {
+                let script = "
 f = |(a, (tuple_others..., z), list_others...)|
   a + list_others.sum() + tuple_others.size() + z
 f [10, (1, 2, 3), 20, 30]
 ";
-            test_script(script, 65);
-        }
+                test_script(script, 65);
+            }
 
-        #[test]
-        fn arg_unpacking_temporary_tuple() {
-            let script = "
+            #[test]
+            fn unpacking_a_temporary_tuple() {
+                let script = "
 {foo: 1, bar: 2, baz: 3}
   .keep |(key, _)| key.starts_with 'b'
   .count()
 ";
-            test_script(script, 2);
+                test_script(script, 2);
+            }
         }
 
         #[test]

--- a/docs/core_lib/iterator.md
+++ b/docs/core_lib/iterator.md
@@ -911,7 +911,7 @@ print! ('a', 'b', 'c').to_map()
 check! {a: null, b: null, c: null}
 
 print! ('a', 'bbb', 'cc')
-  .each |x| x, x.size()
+  .each |x| x, size x
   .to_map()
 check! {a: 1, bbb: 3, cc: 2}
 ```

--- a/docs/core_lib/koto.md
+++ b/docs/core_lib/koto.md
@@ -272,10 +272,6 @@ check! (10, 11, 20)
 
 Returns the type of the input Value as a String.
 
-Note that a map value can override the value returned from `type` by defining
-the `@type` meta value, for more information see
-[the reference for map](map.md#meta-maps-and-overloaded-operations).
-
 ### Example
 
 ```koto

--- a/docs/core_lib/koto.md
+++ b/docs/core_lib/koto.md
@@ -17,7 +17,7 @@ If no arguments were provided then the list is empty.
 
 ```koto
 # Assuming that the script was run with `koto script.koto -- 1 2 "hello"`
-koto.args.size()
+size koto.args
 # 3
 koto.args.first()
 # 1
@@ -228,6 +228,41 @@ String or Null
 
 If a script is being executed then `script_path` provides the path of the
 current script as a String, otherwise `script_path` is Null.
+
+## size
+
+```kototype
+|Value| -> Integer
+```
+
+Returns the _size_ of a value.
+
+The size of a value is typically defined as the number of elements in a
+container, with some notable exceptions:
+
+- For strings, the size is number of bytes in the string data.
+- For ranges, the size is the number of integers in the range. 
+  - For non-inclusive ranges, this is equivalent to 
+    `range.end() - range.start()`.
+  - For inclusive ranges, this is equivalent to 
+    `range.end() + 1 - range.start()`.
+  - If the range is unbounded then an error will be thrown.
+- An error will be thrown if the value doesn't have a defined size.
+
+### Example
+
+```koto
+from koto import size
+print! (size [1, 2, 3]), (size (,))
+check! (3, 0)
+
+print! (size 'hello'), (size 'héllø'), (size '')
+check! (5, 7, 0)
+
+print! (size 10..20), (size 10..=20), (size 20..0)
+check! (10, 11, 20)
+```
+
 
 ## type
 

--- a/docs/core_lib/list.md
+++ b/docs/core_lib/list.md
@@ -371,25 +371,6 @@ print! x
 check! ['world', 99, -1, 'hello']
 ```
 
-## size
-
-```kototype
-|List| -> Number
-```
-
-Returns the number of values contained in the list.
-
-### Example
-
-```koto
-x = (1..=100).to_list()
-print! x.size()
-check! 100
-
-print! [].size()
-check! 0
-```
-
 ## sort
 
 ```kototype
@@ -416,7 +397,7 @@ print! x
 check! [-1, 1, 42, 99]
 
 x = ['bb', 'ccc', 'a']
-print! x.sort string.size
+print! x.sort size
 check! ['a', 'bb', 'ccc']
 print! x
 check! ['a', 'bb', 'ccc']
@@ -478,7 +459,7 @@ provided function, and then returns the list.
 
 ```koto
 x = ['aaa', 'bb', 'c']
-print! x.transform string.size
+print! x.transform size
 check! [3, 2, 1]
 print! x
 check! [3, 2, 1]

--- a/docs/core_lib/map.md
+++ b/docs/core_lib/map.md
@@ -308,28 +308,6 @@ check! true
 
 - [`map.insert`](#insert)
 
-## size
-
-```kototype
-|Map| -> Number
-```
-
-Returns the number of entries contained in the map.
-
-### Example
-
-```koto
-print! {}.size()
-check! 0
-
-print! {a: 0, b: 1}.size()
-check! 2
-```
-
-### See also
-
-- [`map.is_empty`](#is-empty)
-
 ## sort
 
 ```kototype
@@ -367,7 +345,7 @@ print! x
 check! {bye: -1, tschüss: 99, hello: 123}
 
 # Sort the map by reversed key length
-x.sort |key, _| -key.size() 
+x.sort |key, _| -(size key)
 print! x
 check! {tschüss: 99, hello: 123, bye: -1}
 ```

--- a/docs/core_lib/range.md
+++ b/docs/core_lib/range.md
@@ -132,29 +132,6 @@ print! (100..).is_inclusive()
 check! false
 ```
 
-## size
-
-```kototype
-|Range| -> Int
-```
-
-Returns the size of the range.
-For non-inclusive ranges, this is equivalent to `range.end() - range.start()`.
-For inclusive ranges, this is equivalent to `range.end() + 1 - range.start()`.
-
-### Example
-
-```koto
-print! (10..20).size()
-check! 10
-
-print! (100..=200).size()
-check! 101
-
-print! (20..0).size()
-check! 20
-```
-
 ## start
 
 ```kototype

--- a/docs/core_lib/string.md
+++ b/docs/core_lib/string.md
@@ -267,31 +267,6 @@ print! '10101'.replace '0', 'x'
 check! 1x1x1
 ```
 
-## size
-
-```kototype
-|String| -> Number
-```
-
-Returns the number of graphemes in the string.
-
-### Note
-
-Equivalent to calling `.chars().count()`.
-
-### Example
-
-```koto
-print! ''.size()
-check! 0
-
-print! 'abcdef'.size()
-check! 6
-
-print! '🥳👋😁'.size()
-check! 3
-```
-
 ## split
 
 ```kototype

--- a/docs/core_lib/string.md
+++ b/docs/core_lib/string.md
@@ -6,7 +6,7 @@
 |String| -> Iterator
 ```
 
-Returns an iterator that yields a series of Numbers representing the bytes
+Returns an iterator that yields a series of integers representing the bytes
 contained in the string data.
 
 ### Example
@@ -28,15 +28,13 @@ check! (72, 195, 171, 121, 33)
 
 Returns an iterator that yields the string's characters as strings.
 
-### Note
-
-A 'character' in Koto is defined as a grapheme, so `.chars()` iterates over the
-string's grapheme clusters.
+A 'character' in Koto is defined as being a 
+[unicode grapheme cluster][grapheme-cluster].
 
 ### Note
 
 Note that this is the default iteration behaviour for a string, so calling
-`.chars()` on a string is equivalent to calling `iterator.iter()`.
+`'hello'.chars()` is equivalent to calling `iterator.iter('hello')`.
 
 ### Example
 
@@ -412,3 +410,5 @@ check! x
 print! '     >'.trim()
 check! >
 ```
+
+[grapheme-cluster]: https://www.unicode.org/glossary/#grapheme_cluster

--- a/docs/core_lib/string.md
+++ b/docs/core_lib/string.md
@@ -43,6 +43,33 @@ print! 'Héllø! 👋'.chars().to_tuple()
 check! ('H', 'é', 'l', 'l', 'ø', '!', ' ', '👋')
 ```
 
+### See Also
+
+- [`string.char-indices`](#char-indices)
+
+## char_indices
+
+```kototype
+|String| -> Iterator
+```
+
+Returns an iterator that yields the indices of each 
+[grapheme cluster][grapheme-cluster] in the string.
+
+Each cluster is represented as a range, which can then be used to extract the
+cluster from the string via indexing.
+
+### Example
+
+```koto
+print! 'Hi 👋'.char_indices().to_tuple()
+check! (0..1, 1..2, 2..3, 3..7)
+```
+
+### See Also
+
+- [`string.chars`](#chars)
+
 ## contains
 
 ```kototype

--- a/docs/core_lib/tuple.md
+++ b/docs/core_lib/tuple.md
@@ -20,8 +20,6 @@ print! ("goodbye", 123).contains "hello"
 check! false
 ```
 
-## deep_copy
-
 ## first
 
 ```kototype
@@ -86,22 +84,6 @@ check! 42
 
 print! (,).last()
 check! null
-```
-
-## size
-
-```kototype
-|Tuple| -> Number
-```
-
-Returns the number of values contained in the tuple.
-
-### Example
-
-```koto
-x = (10, 20, 30, 40, 50)
-print! x.size()
-check! 5
 ```
 
 ## sort_copy

--- a/docs/language/conditional_expressions.md
+++ b/docs/language/conditional_expressions.md
@@ -106,7 +106,7 @@ print! match ['a', 'b', 'c'].extend [1, 2, 3]
   (1, ...) then "Starts with '1'"
   (..., 'y', last) then "Ends with 'y' followed by '$last'"
   ('a', x, others...) then
-    "Starts with 'a', followed by '$x', then ${others.size()} others"
+    "Starts with 'a', followed by '$x', then ${size others} others"
   unmatched then "other: $unmatched"
 check! Starts with 'a', followed by 'b', then 4 others
 ```

--- a/docs/language/conditional_expressions.md
+++ b/docs/language/conditional_expressions.md
@@ -97,15 +97,15 @@ print! (10, 11, 12, 13, 14, 15)
 check! ('Buzz', 11, 'Fizz', 13, 14, 'Fizz Buzz')
 ```
 
-List and tuple entries can be matched against, 
+List and tuple entries can be matched against by using parentheses, 
 with `...` available for capturing the rest of the sequence.
 
 ```koto
 print! match ['a', 'b', 'c'].extend [1, 2, 3]
-  ['a', 'b'] then "A list containing 'a' and 'b'"
-  [1, ...] then "Starts with '1'"
-  [..., 'y', last] then "Ends with 'y' followed by '$last'"
-  ['a', x, others...] then
+  ('a', 'b') then "A list containing 'a' and 'b'"
+  (1, ...) then "Starts with '1'"
+  (..., 'y', last) then "Ends with 'y' followed by '$last'"
+  ('a', x, others...) then
     "Starts with 'a', followed by '$x', then ${others.size()} others"
   unmatched then "other: $unmatched"
 check! Starts with 'a', followed by 'b', then 4 others

--- a/docs/language/core_library.md
+++ b/docs/language/core_library.md
@@ -5,8 +5,8 @@ and values for working with the Koto language, organized within _modules_.
 
 ```koto
 # Get the size of a string
-print! string.size 'hello'
-check! 5
+print! string.to_lowercase 'HELLO'
+check! hello
 
 # Return the first element of the list
 print! list.first [99, -1, 3]
@@ -17,8 +17,8 @@ Values in Koto automatically have access to their corresponding core modules
 via `.` access.
 
 ```koto
-print! 'xyz'.size()
-check! 3
+print! 'xyz'.to_uppercase()
+check! XYZ
 
 print! ['abc', 123].first()
 check! abc

--- a/docs/language/functions_advanced.md
+++ b/docs/language/functions_advanced.md
@@ -113,27 +113,26 @@ check! a: 1, b: 2, others: (3, 4, 5)
 
 ## Argument Unpacking
 
-Functions that expect list or tuple arguments can _unpack_ their values 
-directly in the argument declaration.
+Functions that expect containers as arguments can _unpack_ their contained
+  values directly in the argument declaration by using parentheses.
 
 ```koto
-# A function that sums a List of three values
-f = |[a, b, c]| a + b + c
+# A function that sums a container with three contained values
+f = |(a, b, c)| a + b + c
 
 x = [100, 10, 1]
 print! f x
 check! 111
 ```
 
-In the above example, if anything other than a List with three values is used as
-an argument, then an error will be thrown. 
+Any value that supports indexing operations containing a matching number of
+elements will be unpacked, otherwise an error will be thrown.
 
 Unpacked values can contain nested unpacked values.
 
 ```koto
-# A function that takes a Tuple of Lists
-# and sums their entries
-f = |([a, b], [c, d, e])| 
+# A function that sums elements from nested containers
+f = |((a, b), (c, d, e))| 
   a + b + c + d + e
 x = ([1, 2], [3, 4, 5])
 print! f x
@@ -141,7 +140,7 @@ check! 15
 ```
 
 Ellipses can be used to unpack any number of elements at the start or end of a 
-list or tuple. 
+container.
 
 ```koto
 f = |(..., last)| last * last
@@ -159,19 +158,13 @@ print! f x
 check! 60
 ```
 
-As a performance consideration, when assigning elements this way from a list, 
-a new list will be created with copies of the elements. 
-Unpacking elements from a Tuple is cheaper because the underlying data is shared 
-between sub-tuples.
-
 ## Ignoring Arguments
 
 The wildcard `_` can be used to ignore function arguments.
 
 ```koto
-# A function that takes a List,
-# and sums its first and third values 
-f = |[a, _, c]| a + c
+# A function that sums the first and third elements of a container
+f = |(a, _, c)| a + c
 
 print! f [100, 10, 1]
 check! 101

--- a/docs/language/functions_advanced.md
+++ b/docs/language/functions_advanced.md
@@ -113,8 +113,8 @@ check! a: 1, b: 2, others: (3, 4, 5)
 
 ## Argument Unpacking
 
-Functions that expect containers as arguments can _unpack_ their contained
-  values directly in the argument declaration by using parentheses.
+Functions that expect containers as arguments can _unpack_ the contained
+elements directly in the argument declaration by using parentheses.
 
 ```koto
 # A function that sums a container with three contained values
@@ -125,10 +125,11 @@ print! f x
 check! 111
 ```
 
-Any value that supports indexing operations containing a matching number of
-elements will be unpacked, otherwise an error will be thrown.
+Any container that supports indexing operations (like lists and tuples) 
+with a matching number of elements will be unpacked, 
+otherwise an error will be thrown.
 
-Unpacked values can contain nested unpacked values.
+Unpacked arguments can also be nested.
 
 ```koto
 # A function that sums elements from nested containers

--- a/docs/language/meta_maps.md
+++ b/docs/language/meta_maps.md
@@ -16,17 +16,17 @@ a custom `Foo` object:
 foo = |n|
   data: n
 
-  # Overloading the addition operator
+  # Overriding the addition operator
   @+: |other|
     # A new Foo is made using the result 
     # of adding the two data values together
     foo self.data + other.data
 
-  # Overloading the subtraction operator
+  # Overriding the subtraction operator
   @-: |other|
     foo self.data - other.data
 
-  # Overloading the multiply-assignment operator
+  # Overriding the multiply-assignment operator
   @*=: |other|
     self.data *= other.data
     self
@@ -81,9 +81,14 @@ check! false
 
 The `@size` metakey defines how the object should report its size,
 while the `@[]` metakey defines what values should be returned when indexing is
-performed on the object.
+performed on the object. 
 
-Argument unpacking and pattern matching make use of both of these metakeys.
+If `@size` is implemented, then `@[]` should also be implemented.
+
+The `@[]` implementation can support indexing by any input values that make 
+sense for your object type, but for argument unpacking to work correctly the
+runtime expects that indexing by both single indices and ranges should be 
+supported.
 
 ```koto
 foo = |data|
@@ -101,6 +106,11 @@ check! 200
 multiply_first_two = |(a, b, ...)| a * b
 print! multiply_first_two x
 check! 20000
+
+# Inspect the first element in the object
+print! match x
+  (first, others...) then 'first: $first, remaining: ${size others}'
+check! first: 100, remaining: 2
 ```
 
 

--- a/docs/language/meta_maps.md
+++ b/docs/language/meta_maps.md
@@ -77,18 +77,32 @@ print! not (foo 10)
 check! false
 ```
 
-### `@[]`
+### `@size` and `@[]`
 
-The `@[]` metakey defines how indexing the object with `[]` should behave.
+The `@size` metakey defines how the object should report its size,
+while the `@[]` metakey defines what values should be returned when indexing is
+performed on the object.
+
+Argument unpacking and pattern matching make use of both of these metakeys.
 
 ```koto
-foo = |n|
-  data: n
-  @[]: |index| self.data + index
+foo = |data|
+  data: data
+  @size: || size self.data
+  @[]: |index| self.data[index]
 
-print! (foo 10)[7]
-check! 17
+x = foo (100, 200, 300)
+print! size x
+check! 3
+print! x[1]
+check! 200
+
+# Unpack the first two elements in the argument and multiply them
+multiply_first_two = |(a, b, ...)| a * b
+print! multiply_first_two x
+check! 20000
 ```
+
 
 ### `@||`
 

--- a/docs/language/modules.md
+++ b/docs/language/modules.md
@@ -22,25 +22,25 @@ check! 42
 Multiple items from a single module can be imported at the same time.
 
 ```koto
-from tuple import first, last, size
+from tuple import contains, first, last
 
 x = 'a', 'b', 'c'
 print! first x
 check! a
 print! last x
 check! c
-print! size x
-check! 3
+print! contains x, 'b'
+check! true
 ```
 
 Imported items can be renamed using `as` for clarity or to avoid conflicts.
 
 ```koto
-from list import size as list_size
-from tuple import size as tuple_size
-print! list_size [1, 2]
-check! 2
-print! tuple_size (3, 2, 1)
+from list import first as list_first
+from tuple import first as tuple_first
+print! list_first [1, 2]
+check! 1
+print! tuple_first (3, 2, 1)
 check! 3
 ```
 

--- a/docs/language/prelude.md
+++ b/docs/language/prelude.md
@@ -7,6 +7,7 @@ The modules that make up the core library are all included in the
 prelude, along with the following core library functions.
 
 - [`io.print`](../core_lib/io#print)
+- [`koto.size`](../core_lib/koto#size)
 - [`koto.type`](../core_lib/koto#type)
 - [`test.assert`](../core_lib/test#assert)
 - [`test.assert_eq`](../core_lib/test#assert-eq)

--- a/docs/language/ranges.md
+++ b/docs/language/ranges.md
@@ -99,11 +99,11 @@ If the end of the range is ommitted, then the slice includes all remaining
 elements in the container.
 
 ```koto
-z = 'Hëllø'
+z = 'Hëllø'.to_tuple()
 print! z[..2]
-check! Hë
+check! ('H', 'ë')
 print! z[2..]
-check! llø
+check! ('l', 'l', 'ø')
 ```
 
 [iterator]: ../core_lib/iterator

--- a/docs/language/strings.md
+++ b/docs/language/strings.md
@@ -1,6 +1,7 @@
 # Strings
 
-Strings can be declared using `'` or `"` quotes. 
+Strings in Koto contain a sequence of [UTF-8][utf-8] encoded characters, 
+and can be declared using `'` or `"` quotes. 
 
 ```koto
 print! 'Hello, World!'
@@ -28,16 +29,20 @@ print! 'a' + 'Bc' + 'Def'
 check! aBcDef
 ```
 
-Individual elements of a string can be accessed via indexing with `[]` braces.
+Individual _bytes_ of a string can be accessed via indexing with `[]` braces.
 
 ```koto
 print! 'abcdef'[3]
 check! d
-print! '👋🥳😆'[0]
-check! 👋
 print! 'xyz'[1..]
 check! yz
 ```
+
+Care must be taken when using indexing with strings that could contain
+non-[ASCII][ascii] data. 
+If the indexed bytes would produce invalid UTF-8 data then an 
+error will be thrown. To access unicode characters see [`string.chars`][chars].
+
 
 ## String Interpolation
 
@@ -125,3 +130,7 @@ check! This string contains "both" 'quote' types.
 print r##'This string also includes a '#' symbol.'##
 check! This string also includes a '#' symbol.
 ```
+
+[ascii]: https://en.wikipedia.org/wiki/ASCII
+[chars]: ../core_lib/string#chars
+[utf-8]: https://en.wikipedia.org/wiki/UTF-8

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -107,7 +107,7 @@ offset_momentum = |bodies, nbody|
 
 run_nbody = |n|
   init_bodies()
-  nbody = bodies.size()
+  nbody = size bodies
   offset_momentum bodies, nbody
   initial_energy = get_energy bodies, nbody
   for _ in 0..n

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -13,7 +13,7 @@ A = |i, j|
   1.0 / (ij * (ij - 1) * 0.5 + i)
 
 Av = |x, y, n|
-  for i in 0..y.size()
+  for i in 0..(size y)
     i2 = i + 1
     y[i] = x
       .enumerate()
@@ -21,7 +21,7 @@ Av = |x, y, n|
       .sum()
 
 Atv = |x, y, n|
-  for i in 0..y.size()
+  for i in 0..(size y)
     i2 = i + 1
     y[i] = x
       .enumerate()

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -84,11 +84,11 @@
 
     a = match z
       # ... matches against any number of elements
-      [3, 4, ...] then "starts with 3, 4"
+      (3, 4, ...) then "starts with 3, 4"
       # A name can be given to capture the matched elements
-      [start..., y, 10] then
+      (start..., y, 10) then
         "starts with ${start.size()} elements and ends with [...$y, 10]"
-      # Matched lists and tuples can be nested
-      [a, b, (3, 4), (c, [6, rest...])] then
+      # Matched containers can be nested
+      (a, b, (3, 4), (c, (6, rest...))) then
         a + b + c + rest.size()
     assert_eq a, 10

--- a/koto/tests/control_flow.koto
+++ b/koto/tests/control_flow.koto
@@ -87,8 +87,8 @@
       (3, 4, ...) then "starts with 3, 4"
       # A name can be given to capture the matched elements
       (start..., y, 10) then
-        "starts with ${start.size()} elements and ends with [...$y, 10]"
+        "starts with ${size start} elements and ends with [...$y, 10]"
       # Matched containers can be nested
       (a, b, (3, 4), (c, (6, rest...))) then
-        a + b + c + rest.size()
+        a + b + c + size rest
     assert_eq a, 10

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -27,20 +27,15 @@
     foo = |a, _, c, _ignored| a + c
     assert_eq (foo 1, 0, 3, 99), 4
 
-  @test list_unpacking: ||
-    foo = |a, [b, [c, d]], e|
-      a * b * c * d * e
-    assert_eq (foo 1, [2, [3, 4]], 5), 120
-
   @test unpacking_with_ellipses: ||
-    foo = |[others_a..., last], (first, others_b...)|
+    foo = |(others_a..., last), (first, others_b...)|
       others_a.sum() * last + first * others_b.sum()
     assert_eq (foo [1, 2, 3, 10], (100, 1, 2, 3)), 660
 
-  @test tuple_unpacking: ||
+  @test nested_unpacking: ||
     foo = |a, (b, (c, d)), e|
       a + b + c + d + e
-    assert_eq (foo 1, (2, (3, 4)), 5), 15
+    assert_eq (foo 1, [2, (3, 4)], 5), 15
 
   @test missing_args_set_to_empty: ||
     foo = |a, b|

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -237,7 +237,7 @@ make_foo = |x|
     # An initial value can be provided to override the default initial value of 1
     assert_eq (2, 3, 4).product(10), 240
 
-  @test product_with_overloaded_multiply_operator: ||
+  @test product_with_overridden_multiply_operator: ||
     foo = |x|
       x: x
       @*: |other| foo self.x * other.x
@@ -275,7 +275,7 @@ make_foo = |x|
     # An initial value can be provided to override the default initial value of 0
     assert_eq (1, 2, 3).sum(100), 106
 
-  @test sum_with_overloaded_add_operator: ||
+  @test sum_with_overridden_add_operator: ||
     foo = |x|
       x: x
       @+: |other| foo self.x + other.x

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -188,7 +188,7 @@ make_foo = |x|
     assert_eq x.max(|(key, value)| value), ("bar", 99)
 
     x = [[1], [2, 3], [4, 5, 6]]
-    assert_eq x.max(list.size), [4, 5, 6]
+    assert_eq x.max(size), [4, 5, 6]
 
   @test min: ||
     assert_eq (2, -1, 9).min(), -1
@@ -200,7 +200,7 @@ make_foo = |x|
     assert_eq x.min(|(key, value)| value), ("foo", 42)
 
     x = [[1], [2, 3], [4, 5, 6]]
-    assert_eq x.min(list.size), [1]
+    assert_eq x.min(size), [1]
 
   @test min_max: ||
     assert_eq (2, -1, 9).min_max(), (-1, 9)
@@ -212,7 +212,7 @@ make_foo = |x|
     assert_eq x.min_max(|(key, value)| value), (("baz", -1), ("bar", 99))
 
     x = [[1], [2, 3], [4, 5, 6]]
-    assert_eq x.min_max(list.size), ([1], [4, 5, 6])
+    assert_eq x.min_max(size), ([1], [4, 5, 6])
 
   @test peekable: ||
     i = 'abcde'.peekable()

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -15,7 +15,7 @@ make_foo = |x|
     assert x.contains 5
     assert not x.contains 15
 
-  @test contains_with_overloaded_equality_op: ||
+  @test contains_with_overridden_equality_op: ||
     bar = |x|
       x: x
       @==: |other| self.x != other.x # This inverts the usual behaviour of ==
@@ -112,7 +112,7 @@ make_foo = |x|
     z.retain |n| n % 2 == 0
     assert_eq z, [0, 2, 4, 6, 8]
 
-  @test retain_with_overloaded_equality_op: ||
+  @test retain_with_overridden_equality_op: ||
     bar = |x|
       x: x
       @==: |other| self.x != other.x # This inverts the usual behaviour of ==
@@ -141,7 +141,7 @@ make_foo = |x|
     z.sort size
     assert_eq z, [[1], [2, 3], [4, 5, 6]]
 
-    # values with overloaded operators
+    # values with overridden operators
     a = [make_foo(1), make_foo(2), make_foo(2), make_foo(3)]
     z = [a[3], a[1], a[0], a[2]] # 3, 2, 1, 2
     z.sort()

--- a/koto/tests/list_ops.koto
+++ b/koto/tests/list_ops.koto
@@ -119,16 +119,12 @@ make_foo = |x|
 
     z = [bar(0), bar(1), bar(1), bar(1), bar(2)]
     z.retain bar(1) # The inverted == operator causes the 'bar 1's to be dropped
-    assert_eq z.size(), 2
+    assert_eq (size z), 2
 
   @test reverse: ||
     a = [1, 2, 3]
     a.reverse()
     assert_eq a, [3, 2, 1]
-
-  @test size: ||
-    assert_eq [].size(), 0
-    assert_eq [1, 2, 3].size(), 3
 
   @test sort: ||
     z = [3, 2, 1]
@@ -142,7 +138,7 @@ make_foo = |x|
 
     # Sorting with a core op
     z = [[4, 5, 6], [1], [2, 3]]
-    z.sort list.size
+    z.sort size
     assert_eq z, [[1], [2, 3], [4, 5, 6]]
 
     # values with overloaded operators
@@ -155,8 +151,8 @@ make_foo = |x|
     z = [a[3], a[1], a[0], a[2]] # 3, 2, 1, 2
     z.sort |n| -n.x # reverse sorting
 
-    a_last = a.size() - 1
-    for n in 0..z.size()
+    a_last = (size a) - 1
+    for n in 0..(size z)
       assert_eq z[n].x, a[a_last - n].x
 
   @test swap: ||

--- a/koto/tests/map_ops.koto
+++ b/koto/tests/map_ops.koto
@@ -87,10 +87,6 @@ make_foo = |x|
     assert_eq (m.remove "bar"), 99
     assert_eq (m.remove "foo"), null
 
-  @test size: ||
-    assert_eq {}.size(), 0
-    assert_eq {foo: 42}.size(), 1
-
   @test sort: ||
     m = {foo: 42, bar: 99}
     assert_eq m.keys().to_tuple(), ("foo", "bar")

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -5,7 +5,7 @@ foo = |x|
   # Make a map that contains x, and return its data with the meta map from foo_meta
   {x}.with_meta globals.foo_meta
 
-# Declaring the overloaded operators once and then cloning the meta map into the foo
+# Declaring the overridden operators once and then cloning the meta map into the foo
 # instance is more efficient than declaring them each time foo is called.
 globals.foo_meta =
   # Arithmetic operators
@@ -144,7 +144,7 @@ globals.foo_meta =
       y: y
       @==: |other|
         # Maps already have equality comparison that compare each member,
-        # so to show the effect of overloading, ignore y
+        # so to show the effect of overriding, ignore y
         self.x == other.x
     assert bar(21, -1) == bar(21, -2)
     assert not (bar(21, -1) == bar(22, -1))

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -50,7 +50,11 @@ globals.foo_meta =
   @||: || self.x
 
   # Indexing
-  @[]: |index| self.x + index
+  @[]: |index|
+    if not (0..self.x).contains index
+      throw 'invalid index'
+    index
+  @size: || self.x
 
   # Custom iteration
   # @iterator must be a function that returns an iterable value,
@@ -158,8 +162,12 @@ globals.foo_meta =
     assert_eq not foo(0), true
 
   @test index: ||
-    assert_eq foo(10)[5], 15
-    assert_eq foo(100)[-1], 99
+    assert_eq foo(10)[5], 5
+    assert_eq foo(100)[99], 99
+
+  @test size: ||
+    assert_eq (size foo(10)), 10
+    assert_eq (size foo(99)), 99
 
   @test call: ||
     assert_eq foo(99)(), 99

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -179,7 +179,6 @@ globals.foo_meta =
 
     # Map operations aren't inherited by the Foo meta map, so the map module has to be used directly
     assert_eq map.keys(f).to_list(), ["x"]
-    assert_eq map.size(f), 1
 
     assert_eq f.hello, "Hello"
     assert_eq f.say_hello("you"), "Hello, you!"

--- a/koto/tests/ranges.koto
+++ b/koto/tests/ranges.koto
@@ -18,7 +18,7 @@
   @test evaluated_boundaries: ||
     z = |n| n
     x = ((z 10)..=(z 20)).to_tuple()
-    y = x[1 + 1..x.size() / 2]
+    y = x[1 + 1..(size x) / 2]
     assert_eq y[0], 12
 
   @test from_and_to_ranges: ||
@@ -65,8 +65,8 @@
     assert_eq x.expanded(-5), 5..5
 
   @test range_size: ||
-    assert_eq (0..10).size(), 10
-    assert_eq (0..=10).size(), 11
+    assert_eq size(0..10), 10
+    assert_eq size(0..=10), 11
 
   @test range_start_end: ||
     x = 10..20

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -27,16 +27,6 @@
     x = x + "_" + "^"
     assert_eq x, "^_^"
 
-  @test indexing: ||
-    assert_eq "Héllö"[4], "ö"
-    x = "Tschüss"
-    assert_eq x[0..3], "Tsc"
-    assert_eq x[2..=4], "chü"
-    assert_eq x[4..7], "üss"
-    assert_eq x[..=3], "Tsch"
-    assert_eq x[5..], "ss"
-    assert_eq "👋🥳😆"[1], "🥳"
-
   @test escape_codes: ||
     # Ascii characters
     assert_eq '\x4f\x5f\x6f', 'O_o'

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -72,7 +72,7 @@
     for c in hello
       hello_chars.push c
     assert_eq hello_chars, hello.to_list()
-    assert_eq hello_chars.size(), 5
+    assert_eq (size hello_chars), 5
 
   @test contains: ||
     assert "O_o".contains("_")
@@ -121,14 +121,6 @@ zzz
     assert_eq ''.replace('foo', 'bar'), ''
     assert_eq ' '.replace(' ', ''), ''
     assert_eq 'hëllø'.replace('ë', 'éé'), 'hééllø'
-
-  @test size: ||
-    # size returns the number of unicode graphemes in the string,
-    # rather than the number of bytes
-    assert_eq "".size(), 0
-    assert_eq "ø".size(), 1
-    assert_eq "abcdef".size(), 6
-    assert_eq "äbcdéf".size(), 6
 
   @test split: ||
     assert_eq "a,b,c".split(",").to_tuple(), ("a", "b", "c")

--- a/koto/tests/tests.koto
+++ b/koto/tests/tests.koto
@@ -12,10 +12,10 @@
   # Functions with that are tagged with @test will be automatically run as tests
   @test size: ||
     # assert_eq checks that its two arguments are equal
-    assert_eq self.test_data.size(), 3
+    assert_eq (size self.test_data), 3
 
     # assert_ne checks that its two arguments are not equal
-    assert_ne self.test_data.size(), 1
+    assert_ne (size self.test_data), 1
 
   # Test functions don't have to be instance functions
   @test extra: ||

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -17,7 +17,7 @@ make_foo = |x|
     assert (x.contains 2)
     assert not (x.contains 99)
 
-  @test contains_with_overloaded_equality_op: ||
+  @test contains_with_overridden_equality_op: ||
     bar = |x|
       x: x
       @==: |other| self.x != other.x # This inverts the usual behaviour of ==

--- a/koto/tests/tuples.koto
+++ b/koto/tests/tuples.koto
@@ -69,11 +69,6 @@ make_foo = |x|
     assert_eq (1, 2, 3).last(), 3
     assert_eq [].to_tuple().last(), null
 
-  @test size: ||
-    assert_eq (1, 2).size(), 2
-    assert_eq (1, 2, 3).size(), 3
-    assert_eq ((1, 2), (3, 4)).size(), 2
-
   @test sort_copy: ||
     assert_eq (3, 1, 2).sort_copy(), (1, 2, 3)
     assert_eq ("tuple", "sort", "copy").sort_copy(), ("copy", "sort", "tuple")

--- a/libs/regex/src/lib.rs
+++ b/libs/regex/src/lib.rs
@@ -174,7 +174,7 @@ impl Match {
 
         Self {
             text,
-            bounds: KRange::bounded(start as i64, end as i64, false),
+            bounds: KRange::from(start as i64..end as i64),
         }
         .into()
     }


### PR DESCRIPTION
This PR covers quite a lot of ground with the goal of allowing objects to work with the argument unpacking
and pattern matching features.

- A `@size` metakey has been added, along with `KObject::size`.
- A generic `koto.size` function has been added which replaces the various `.size()` core lib functions, and has been added to the prelude.
- Strings are now indexed over bytes instead of grapheme clusters to avoid performance footguns.
  - `string.char_indices` has been added to allow valid cluster indices to be retrieved.
- Unpacked slices will now match against zero elements.
