### PR TITLE
string interpolation followups

### DIFF
--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -375,15 +375,15 @@ impl FunctionFlags {
     }
 }
 
-/// TODO
+/// Format flags used by the [StringPush][crate::Op::StringPush] op
 pub struct StringFormatFlags {
-    /// TODO
+    /// The alignment of the string
     pub alignment: StringAlignment,
-    /// TODO
+    /// True if a min width value is specified
     pub min_width: bool,
-    /// TODO
+    /// True if a precision value is specified
     pub precision: bool,
-    /// TODO
+    /// True if a fill character is specified
     pub fill_character: bool,
 }
 
@@ -395,7 +395,7 @@ impl StringFormatFlags {
     /// Set to true when fill_character is defined
     pub const FILL_CHARACTER: u8 = 1 << 4;
 
-    /// TODO
+    /// Decodes a byte into format flags
     pub fn from_byte(byte: u8) -> Self {
         use StringAlignment::*;
         let alignment_bits = byte & 0b11;

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -148,7 +148,7 @@ pub enum Op {
     ///
     /// See [StringFormatFlags](crate::StringFormatFlags) for a description of the the format flags.
     ///
-    /// `[*value, format_flags, ?min_width, ?precision, ?@fill_character]`
+    /// `[*value, format_flags, ?@min_width, ?@precision, ?@fill_character]`
     StringPush,
 
     /// Places the finished string in the target register

--- a/crates/parser/src/string_format_options.rs
+++ b/crates/parser/src/string_format_options.rs
@@ -30,27 +30,38 @@ impl StringFormatOptions {
         let mut result = Self::default();
         let mut chars = format_string.chars().peekable();
 
-        while let Some(next) = chars.peek() {
-            match (next, position) {
-                ('0'..='9', Start | MinWidth) => {
-                    result.min_width = Some(consume_u32(&mut chars)?);
-                    position = Precision;
-                }
-                ('.', Start | MinWidth | Precision) => {
-                    chars.next();
-                    result.precision = Some(consume_u32(&mut chars)?);
-                    position = End;
-                }
-                ('<' | '^' | '>', Start | Alignment) => {
-                    result.alignment = match chars.next().unwrap() {
-                        '<' => StringAlignment::Left,
-                        '^' => StringAlignment::Center,
-                        '>' => StringAlignment::Right,
-                        _ => unreachable!(),
-                    };
+        let char_to_alignment = |c: char| match c {
+            '<' => StringAlignment::Left,
+            '^' => StringAlignment::Center,
+            '>' => StringAlignment::Right,
+            _ => unreachable!(),
+        };
+
+        while let Some(next) = chars.next() {
+            match (next, chars.peek(), position) {
+                // Check for single-char fill character at the start of the string
+                (_, Some('<' | '^' | '>'), Start) => {
+                    let fill_constant = constants
+                        .add_string(&format_string[0..1])
+                        .map_err(|_| StringFormatError::InternalError)?;
+                    result.fill_character = Some(fill_constant);
+                    result.alignment = char_to_alignment(chars.next().unwrap());
                     position = MinWidth;
                 }
-                (_, Start) => {
+                ('<' | '^' | '>', _, Start | Alignment) => {
+                    result.alignment = char_to_alignment(next);
+                    position = MinWidth;
+                }
+                ('0'..='9', _, Start | MinWidth) => {
+                    result.min_width = Some(consume_u32(next, &mut chars)?);
+                    position = Precision;
+                }
+                ('.', Some(_), Start | MinWidth | Precision) => {
+                    let first_digit = chars.next().unwrap();
+                    result.precision = Some(consume_u32(first_digit, &mut chars)?);
+                    position = End;
+                }
+                (_, _, Start) => {
                     // Unwrapping here is fine, format_string is valid UTF-8
                     let fill = format_string.graphemes(true).next().unwrap();
                     // The fill grapheme cluster can only appear at the start of the format string
@@ -61,8 +72,8 @@ impl StringFormatOptions {
                     result.fill_character = Some(fill_constant);
                     position = Alignment;
                 }
-                (other, _) => {
-                    return Err(StringFormatError::UnexpectedToken(*other));
+                (other, _, _) => {
+                    return Err(StringFormatError::UnexpectedToken(other));
                 }
             }
         }
@@ -81,27 +92,26 @@ enum FormatParsePosition {
     End,
 }
 
-fn consume_u32(chars: &mut Peekable<Chars>) -> Result<u32, StringFormatError> {
-    match chars.next() {
-        Some(n @ '0'..='9') => {
-            let mut n = n.to_digit(10).unwrap() as u64;
-            let index_max = u32::MAX as u64;
+fn consume_u32(first: char, chars: &mut Peekable<Chars>) -> Result<u32, StringFormatError> {
+    let mut n = first
+        .to_digit(10)
+        .ok_or(StringFormatError::ExpectedNumber(first))? as u64;
+    let index_max = u32::MAX as u64;
 
-            while let Some(n_next @ '0'..='9') = chars.peek().cloned() {
-                chars.next();
+    while let Some(n_next @ '0'..='9') = chars.peek().cloned() {
+        chars.next();
 
-                n *= 10;
-                n += n_next.to_digit(10).unwrap() as u64;
+        n *= 10;
+        n += n_next
+            .to_digit(10)
+            .ok_or(StringFormatError::ExpectedNumber(first))? as u64;
 
-                if n > index_max {
-                    return Err(StringFormatError::FormatNumberIsTooLarge(n));
-                }
-            }
-
-            Ok(n as u32)
+        if n > index_max {
+            return Err(StringFormatError::FormatNumberIsTooLarge(n));
         }
-        _ => Err(StringFormatError::ExpectedNumber),
     }
+
+    Ok(n as u32)
 }
 
 /// Alignment options for formatted strings
@@ -121,14 +131,14 @@ pub enum StringAlignment {
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
 pub enum StringFormatError {
-    #[error("An unexpected internal error occurred")]
-    InternalError,
-    #[error("Expected a number")]
-    ExpectedNumber,
-    #[error("Unexpected token '{0}'")]
-    UnexpectedToken(char),
+    #[error("Expected a number '{0}'")]
+    ExpectedNumber(char),
     #[error("{0} is larger than the maximum of {}", u32::MAX)]
     FormatNumberIsTooLarge(u64),
+    #[error("An unexpected internal error occurred")]
+    InternalError,
+    #[error("Unexpected token '{0}'")]
+    UnexpectedToken(char),
 }
 
 #[cfg(test)]
@@ -208,6 +218,15 @@ mod tests {
                     alignment: StringAlignment::Right,
                     fill_character: Some(0),
                     min_width: Some(2),
+                    ..Default::default()
+                },
+            ),
+            (
+                "8^4",
+                StringFormatOptions {
+                    alignment: StringAlignment::Center,
+                    fill_character: Some(0),
+                    min_width: Some(4),
                     ..Default::default()
                 },
             ),

--- a/crates/parser/src/string_format_options.rs
+++ b/crates/parser/src/string_format_options.rs
@@ -19,8 +19,7 @@ pub struct StringFormatOptions {
 }
 
 impl StringFormatOptions {
-    /// TODO
-    #[allow(unused)]
+    /// Parses a format string
     pub(crate) fn parse(
         format_string: &str,
         constants: &mut ConstantPoolBuilder,

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -2731,6 +2731,7 @@ x = ('foo', 'bar')
         use test_case::test_case;
 
         #[test_case("'{42:10}'", "        42"; "min width with integer")]
+        #[test_case("'{42:1<4}'", "4211"; "min width with integer fill")]
         #[test_case("'{42:-<10}'", "42--------"; "min width with left-aligned integer")]
         #[test_case("'{1/3:_^11.3}'", "___0.333___"; "fill with centered float")]
         #[test_case("'{'hello':.2}'", "he"; "precision with string")]

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -2731,6 +2731,7 @@ x = ('foo', 'bar')
         use test_case::test_case;
 
         #[test_case("'{42:10}'", "        42"; "min width with integer")]
+        #[test_case("'{42:06}'", "000042"; "min width with zero-prefixed integer")]
         #[test_case("'{42:1<4}'", "4211"; "min width with integer fill")]
         #[test_case("'{42:-<10}'", "42--------"; "min width with left-aligned integer")]
         #[test_case("'{1/3:_^11.3}'", "___0.333___"; "fill with centered float")]

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -374,6 +374,15 @@ print! '_{x:~<8}_'
 check! _1.2~~~~~_
 ```
 
+For numbers, the minimum width can be prefixed with `0`, which will pad the
+number to the specified width with zeroes.
+
+```koto
+x = 1.2
+print! '{x:06}'
+check! 0001.2
+```
+
 #### Maximum Width / Precision 
 
 A maximum width for the interpolated expression can be specified following a 


### PR DESCRIPTION
- **Allow numbers to be used as the fill character in format strings**
- **Add support for zero-prefixing the min width in format strings**
- **Clean up some remaining loose ends**
