### PR TITLE
More link fixing in the docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           components: rustfmt, clippy
       - uses: taiki-e/install-action@v2
         with:
-          tool: just@1.5.0
+          tool: just@1.5.0,mlc@0.16.3
 
       - name: Check formatting
         run: just fmt
@@ -63,6 +63,9 @@ jobs:
 
       - name: Docs
         run: just doc
+
+      - name: Check links
+        run: just check_links
 
   wasm:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ language for [Rust][rust] applications, or as a standalone scripting language.
 - [Online Playground][playground]
 - [Example Rust application with Koto bindings](crates/koto/examples/poetry/)
 
+## Development
+
+The top-level [justfile](./justfile) contains some useful commands for working
+with the repo, for example `just checks` which runs all available checks and 
+tests.
+
+After installing [just][just], you can run `just setup` to install additional
+dependencies for working with the `justfile` commands.
+
 ## MSRV
 
 Koto is under active development, and tested against the latest stable release
@@ -29,6 +38,7 @@ of Rust.
 [discord]: https://discord.gg/JeV8RuK4CT
 [core-lib]: https://koto.dev/docs/next/core
 [crates]: https://crates.io/crates/koto
+[just]: https://just.systems/man/en/
 [playground]: https://koto.dev/play
 [rust]: https://rust-lang.org
 [rust-docs]: https://docs.rs/koto

--- a/crates/cli/docs/api.md
+++ b/crates/cli/docs/api.md
@@ -1,8 +1,8 @@
 A rendered version of this document can be found
 [here](https://koto.dev/docs/next/api).
 
-The Rust code examples are included from the [Koto examples
-dir](/crates/koto/examples).
+The Rust code examples are included from the 
+[Koto examples dir](../../koto/examples).
 
 ---
 

--- a/crates/cli/docs/cli.md
+++ b/crates/cli/docs/cli.md
@@ -51,8 +51,8 @@ Welcome to Koto
 ```
 
 [cli]: https://en.wikipedia.org/wiki/Command-line_interface
-[core]: ../core_lib
-[guide]: language_guide.md
+[core]: ./core_lib/
+[guide]: ./language_guide.md
 [repl]: https://en.wikipedia.org/wiki/Read–eval–print_loop
 [rust]: https://rust-lang.org 
 [rustup]: https://rustup.sh

--- a/crates/cli/docs/libs/geometry.md
+++ b/crates/cli/docs/libs/geometry.md
@@ -2,8 +2,8 @@
 
 Utilities for working with geometry in Koto.
 
-The module contains the [`Vec2`](vec2), [`Vec3`](vec3), and
-[`Rect`](rect) types.
+The module contains the [`Vec2`](#vec2-1), [`Vec3`](#vec3-1), and
+[`Rect`](#rect-1) types.
 
 ## rect
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-checks: fmt clippy clippy_rc test test_rc doc wasm
+checks: fmt clippy clippy_rc test test_rc check_links doc wasm
 
 check_links:
   mlc --offline README.md

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 checks: fmt clippy clippy_rc test test_rc doc wasm
 
+check_links:
+  mlc --offline README.md
+  mlc --offline docs
+
 clippy:
   cargo clippy --workspace -- -D warnings
 
@@ -11,6 +15,9 @@ doc:
 
 fmt:
   cargo fmt --all -- --check
+
+setup:
+  cargo install cargo-watch mlc wasm-pack
 
 temp *args:
   cargo run {{args}} -- --tests -i temp.koto


### PR DESCRIPTION
Following on from #308, this PR adds a `just check_links` command to make sure we don't end up with broken links again.
