### PR TITLE
Remove the @not metakey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ The Koto project adheres to
 
 ### Removed
 
+#### Language
+
+- The `@not` metakey has been removed.
+
 #### API
 
 - `Koto::run_exported_function` has been removed. Functions can be accessed via

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1673,19 +1673,6 @@ print! x.data
 check! -100
 ```
 
-#### `@not`
-
-The `@not` metakey overrides the `not` operator.
-
-```koto
-foo = |n|
-  data: n
-  @not: || self.data == 0
-
-print! not (foo 10)
-check! false
-```
-
 #### `@size` and `@[]`
 
 The `@size` metakey defines how the object should report its size,

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -587,8 +587,6 @@ pub enum MetaKeyId {
     NextBack,
     /// @negate
     Negate,
-    /// @not
-    Not,
     /// @size
     Size,
     /// @type

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1954,7 +1954,6 @@ impl<'source> Parser<'source> {
             Some(Token::GreaterOrEqual) => MetaKeyId::GreaterOrEqual,
             Some(Token::Equal) => MetaKeyId::Equal,
             Some(Token::NotEqual) => MetaKeyId::NotEqual,
-            Some(Token::Not) => MetaKeyId::Not,
             Some(Token::Id) => match self.current_token.slice(self.source) {
                 "display" => MetaKeyId::Display,
                 "iterator" => MetaKeyId::Iterator,

--- a/crates/runtime/src/types/meta_map.rs
+++ b/crates/runtime/src/types/meta_map.rs
@@ -205,8 +205,6 @@ pub enum UnaryOp {
     NextBack,
     /// `@negate`
     Negate,
-    /// `@not`
-    Not,
     /// `@size`
     Size,
 }
@@ -238,7 +236,6 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<KString>) -> Result<MetaKey> {
         MetaKeyId::Next => MetaKey::UnaryOp(Next),
         MetaKeyId::NextBack => MetaKey::UnaryOp(NextBack),
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
-        MetaKeyId::Not => MetaKey::UnaryOp(Not),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),
         MetaKeyId::Size => MetaKey::UnaryOp(Size),
         MetaKeyId::Call => MetaKey::Call,

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -422,7 +422,6 @@ impl KotoVm {
         match op {
             Display => self.run_display(result_register, value_register)?,
             Negate => self.run_negate(result_register, value_register)?,
-            Not => self.run_not(result_register, value_register)?,
             Iterator => self.run_make_iterator(result_register, value_register, false)?,
             Next => self.run_iterator_next(Some(result_register), value_register, 0, false)?,
             NextBack => match self.clone_register(value_register) {
@@ -1398,18 +1397,13 @@ impl KotoVm {
 
     fn run_not(&mut self, result: u8, value: u8) -> Result<()> {
         use KValue::*;
-        use UnaryOp::Not;
 
-        let result_value = match &self.get_register(value) {
-            Null => Bool(true),
-            Bool(b) if !b => Bool(true),
-            Map(m) if m.contains_meta_key(&Not.into()) => {
-                let op = m.get_meta_value(&Not.into()).unwrap();
-                return self.call_overridden_unary_op(result, value, op);
-            }
-            _ => Bool(false), // All other values coerce to true, so return false
+        let result_bool = match &self.get_register(value) {
+            Null => true,
+            Bool(b) if !b => true,
+            _ => false, // All other values coerce to true, so return false
         };
-        self.set_register(result, result_value);
+        self.set_register(result, result_bool.into());
 
         Ok(())
     }

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -43,9 +43,6 @@ globals.foo_meta =
   # Negation (e.g. -foo)
   @negate: || foo -self.x
 
-  # Not (e.g. !foo)
-  @not: || if self.x == 0 then true else false
-
   # Function call
   @||: || self.x
 
@@ -156,10 +153,6 @@ globals.foo_meta =
 
   @test negate: ||
     assert_eq -foo(1), foo(-1)
-
-  @test test_not: ||
-    assert_eq not foo(1), false
-    assert_eq not foo(0), true
 
   @test index: ||
     assert_eq foo(10)[5], 5


### PR DESCRIPTION
This was a relic from before the updated truthiness rules that were introduced
in 0.11, and should have been removed then.