### PR TITLE
docs: Fix readme for poetry example

### DIFF
--- a/crates/koto/examples/poetry/README.md
+++ b/crates/koto/examples/poetry/README.md
@@ -3,7 +3,7 @@
 An example of integrating Koto into a Rust application, in this case a simple
 Markov chain generator that produces generated 'poetry'.
 
-`cargo run --example poetry -- scripts/readme.koto`
+`cargo run --example poetry -- -s scripts/readme.koto`
 
 ## `poetry.rs`
 


### PR DESCRIPTION
This adds a lacking flag to the readme :)