### PR TITLE
Prevent exhausted generators causing a panic

### DIFF
--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -272,6 +272,10 @@ impl KotoVm {
     /// This is currently used to support generators, which yield incremental results and then
     /// leave the VM in a suspended state.
     pub fn continue_running(&mut self) -> Result<ReturnOrYield> {
+        if self.call_stack.is_empty() {
+            return Ok(ReturnOrYield::Return(KValue::Null));
+        }
+
         let result = self.execute_instructions()?;
 
         match self.execution_state {

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -347,3 +347,11 @@ make_foo = |x|
     assert_eq
       (10..15).each(|x| '{x}').every_other().to_tuple(),
       ('10', '12', '14')
+
+  @test exhausted_generator: ||
+    gen = || yield 42
+    foo = gen()
+
+    assert_eq foo.next().get(), 42
+    assert_eq foo.next(), null
+    assert_eq foo.next(), null


### PR DESCRIPTION
Calling `next()` on a generator with no more values to yield should always return `null`, in line with what happens for normal iterators.

Prior to this patch, attempting to consume a value from an exhausted generator (that is, one for which `next()` has already returned `null`) would result in [a runtime panic](https://koto.dev/play-0.14/?gist=e21c46a1dcde2fa5942bfab1279aeace) due to the call stack being empty when invoking `execute_instructions()` from within `continue_running()`.