### PR TITLE
Various tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ The Koto project adheres to
 - `Node::NamedCall` has been removed, with all calls represented by expression
   chains.
 
+### Fixed
+
+#### Language
+
+- Calling `.next()` on an exhausted generator no longer causes a panic.
+  - Thanks to [@edenbynever](https://github.com/edenbynever) for the fix.
+
 ## [0.14.0] 2024.04.17
 
 ### Added 

--- a/crates/cli/docs/core_lib/iterator.md
+++ b/crates/cli/docs/core_lib/iterator.md
@@ -958,8 +958,8 @@ Consumes all values coming from the iterator and places them in a tuple.
 ### Example
 
 ```koto
-print! ('a', 42, (-1, -2)).to_list()
-check! ['a', 42, (-1, -2)]
+print! ('a', 42, (-1, -2)).to_tuple()
+check! ('a', 42, (-1, -2))
 ```
 
 ### See also

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -2332,7 +2332,7 @@ impl KotoVm {
         let key = ValueKey::try_from(self.clone_register(key_register))?;
         let value = self.clone_register(value_register);
 
-        match self.get_register_mut(map_register) {
+        match self.get_register(map_register) {
             KValue::Map(map) => {
                 map.data_mut().insert(key, value);
                 Ok(())

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -3070,18 +3070,22 @@ impl KotoVm {
         self.registers[index] = value;
     }
 
+    #[track_caller]
     fn clone_register(&self, register: u8) -> KValue {
         self.get_register(register).clone()
     }
 
+    #[track_caller]
     pub(crate) fn get_register(&self, register: u8) -> &KValue {
         let index = self.register_index(register);
         match self.registers.get(index) {
             Some(value) => value,
             None => {
                 panic!(
-                    "Out of bounds access, index: {}, register: {}, ip: {}",
-                    index, register, self.instruction_ip
+                    "Out of bounds access, index: {index}, register: {register}, ip: {}
+  Caller: {}",
+                    self.instruction_ip,
+                    std::panic::Location::caller()
                 );
             }
         }

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -2516,6 +2516,21 @@ gen().to_tuple()
 ";
             check_script_output(script, tuple(&[1.into(), KValue::Null, 3.into()]));
         }
+
+        #[test]
+        fn exhausted_generator_returns_null() {
+            let script = "
+gen = || yield 1
+x = gen()
+
+x.next() # -> IteratorOutput(1)
+x.next() # -> null
+
+# The generator is now exhausted, calling .next() again should return null
+x.next()
+";
+            check_script_output(script, KValue::Null);
+        }
     }
 
     mod strings {

--- a/koto/tests/iterators.koto
+++ b/koto/tests/iterators.koto
@@ -347,11 +347,3 @@ make_foo = |x|
     assert_eq
       (10..15).each(|x| '{x}').every_other().to_tuple(),
       ('10', '12', '14')
-
-  @test exhausted_generator: ||
-    gen = || yield 42
-    foo = gen()
-
-    assert_eq foo.next().get(), 42
-    assert_eq foo.next(), null
-    assert_eq foo.next(), null


### PR DESCRIPTION
- **Add #[track_caller] to KotoVm::get_register**
- **Avoid unnecessary use of get_register_mut**
- **Update the changelog**
- **Move the exhausted_generator test to vm_tests.rs**
- **Tidy up execution_state in execute_instructions()**
- **Fix to_tuple doc example**
