### PR TITLE
Implement type checks for let expressions

### DIFF
--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -52,6 +52,8 @@ enum ErrorKind {
     MissingValueForMapEntry,
     #[error("only one ellipsis is allowed in a match arm")]
     MultipleMatchEllipses,
+    #[error("nested type declarations are currently unsupported")]
+    NestedTypeDeclaration,
     #[error("the compiled expression has no output")]
     NoResultInExpressionOutput,
     #[error("child chain node out of position")]
@@ -196,13 +198,27 @@ impl CompileNodeOutput {
 }
 
 /// The settings used by the [Compiler]
-#[derive(Default)]
 pub struct CompilerSettings {
     /// Causes all top level identifiers to be exported
+    ///
+    /// Disabled by default.
     ///
     /// This is used by the REPL to automatically export values so that they're available between
     /// chunks.
     pub export_top_level_ids: bool,
+    /// Causes the compiler to emit CheckType instructions when type hints are encountered.
+    ///
+    /// Enabled by default.
+    pub enable_type_checks: bool,
+}
+
+impl Default for CompilerSettings {
+    fn default() -> Self {
+        Self {
+            export_top_level_ids: false,
+            enable_type_checks: true,
+        }
+    }
 }
 
 /// The compiler used by the Koto language
@@ -574,7 +590,8 @@ impl Compiler {
                 unreachable!();
             }
             Node::Type(..) => {
-                unimplemented!()
+                // Type hints are only compiled in the context of typed identifiers.
+                unreachable!();
             }
         };
 
@@ -851,12 +868,16 @@ impl Compiler {
         self.push_span(target_node, ctx.ast);
 
         match &target_node.node {
-            Node::Id(id_index, ..) => {
+            Node::Id(id_index, type_hint) => {
                 if !value_result.is_temporary {
                     // To ensure that exported rhs ids with the same name as a local that's
                     // currently being assigned can be loaded correctly, only commit the
                     // reserved local as assigned after the rhs has been compiled.
                     self.commit_local_register(value_register)?;
+                }
+
+                if let Some(type_hint) = type_hint {
+                    self.compile_check_type(value_register, *type_hint, ctx)?;
                 }
 
                 if export_assignment || self.force_export_assignment() {
@@ -1051,6 +1072,38 @@ impl Compiler {
         };
 
         Ok(result)
+    }
+
+    fn compile_check_type(
+        &mut self,
+        value_register: u8,
+        type_hint: AstIndex,
+        ctx: CompileNodeContext,
+    ) -> Result<()> {
+        let type_node = ctx.node_with_span(type_hint);
+        self.push_span(type_node, ctx.ast);
+
+        match &type_node.node {
+            Node::Type(type_index, nested) => {
+                if !nested.is_empty() {
+                    return self.error(ErrorKind::NestedTypeDeclaration);
+                }
+
+                if self.settings.enable_type_checks {
+                    self.push_op(Op::CheckType, &[value_register]);
+                    self.push_var_u32((*type_index).into());
+                }
+            }
+            unexpected => {
+                return self.error(ErrorKind::UnexpectedNode {
+                    expected: "Type".into(),
+                    unexpected: unexpected.clone(),
+                })
+            }
+        }
+
+        self.pop_span();
+        Ok(())
     }
 
     fn compile_value_export(&mut self, id: ConstantIndex, value_register: u8) -> Result<()> {

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -969,7 +969,7 @@ impl Compiler {
             targets.iter().zip(target_registers.iter()).enumerate()
         {
             match ctx.node(*target) {
-                Node::Id(id_index, ..) => {
+                Node::Id(id_index, type_hint) => {
                     let target_register =
                         target_register.expect("Missing target register for assignment");
                     if rhs_is_temp_tuple {
@@ -980,6 +980,10 @@ impl Compiler {
                     // The register was reserved before the RHS was compiled, and now it
                     // needs to be committed.
                     self.commit_local_register(target_register)?;
+
+                    if let Some(type_hint) = type_hint {
+                        self.compile_check_type(target_register, *type_hint, ctx)?;
+                    }
 
                     // Multi-assignments typically aren't exported, but exporting
                     // assignments might be forced, e.g. in REPL mode.

--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -320,6 +320,10 @@ pub enum Instruction {
         register: u8,
         size: usize,
     },
+    CheckType {
+        value: u8,
+        type_string: ConstantIndex,
+    },
     StringStart {
         size_hint: u32,
     },
@@ -736,6 +740,9 @@ impl fmt::Debug for Instruction {
             }
             CheckSizeMin { register, size } => {
                 write!(f, "CheckSizeMin\tvalue: {register}\tsize: {size}")
+            }
+            CheckType { value, type_string } => {
+                write!(f, "CheckType\tvalue: {value}\ttype: {type_string}")
             }
             StringStart { size_hint } => {
                 write!(f, "StringStart\tsize hint: {size_hint}")

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -481,6 +481,10 @@ impl Iterator for InstructionReader {
                 register: get_u8!(),
                 size: get_u8!() as usize,
             }),
+            Op::CheckType => Some(CheckType {
+                value: get_u8!(),
+                type_string: get_var_u32!().into(),
+            }),
             Op::StringStart => Some(StringStart {
                 size_hint: get_var_u32!(),
             }),

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -485,8 +485,12 @@ pub enum Op {
     /// `[*value, size]`
     CheckSizeMin,
 
+    /// Throws an error if the value doesn't match the provided type
+    ///
+    /// `[*value, @type constant]`
+    CheckType,
+
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused82,
     Unused83,
     Unused84,
     Unused85,

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -33,6 +33,7 @@ pub struct Koto {
     runtime: KotoVm,
     run_tests: bool,
     export_top_level_ids: bool,
+    enable_type_checks: bool,
     script_path: Option<PathBuf>,
     chunk: Option<Ptr<Chunk>>,
 }
@@ -55,6 +56,7 @@ impl Koto {
             runtime: KotoVm::with_settings(settings.vm_settings),
             run_tests: settings.run_tests,
             export_top_level_ids: settings.export_top_level_ids,
+            enable_type_checks: settings.enable_type_checks,
             chunk: None,
             script_path: None,
         }
@@ -84,6 +86,7 @@ impl Koto {
             self.script_path.as_deref(),
             CompilerSettings {
                 export_top_level_ids: self.export_top_level_ids,
+                enable_type_checks: self.enable_type_checks,
             },
         )?;
 
@@ -243,6 +246,11 @@ pub struct KotoSettings {
     /// This is used by the REPL, allowing for incremental compilation and execution of expressions
     /// that need to share declared values.
     pub export_top_level_ids: bool,
+    /// When enabled, the compiler will emit type check instructions when type hints are encountered
+    /// that will be performed at runtime.
+    ///
+    /// Enabled by default.
+    pub enable_type_checks: bool,
     /// Settings that apply to the runtime
     pub vm_settings: KotoVmSettings,
 }
@@ -317,6 +325,7 @@ impl Default for KotoSettings {
         Self {
             run_tests: true,
             export_top_level_ids: false,
+            enable_type_checks: true,
             vm_settings: KotoVmSettings::default(),
         }
     }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -863,7 +863,7 @@ impl<'source> Parser<'source> {
             Token::From | Token::Import => self.consume_import(context),
             Token::Export => self.consume_export(context),
             Token::Try => self.consume_try_expression(context),
-            Token::Let => self.consume_variable_declaration(context),
+            Token::Let => self.consume_let_expression(context),
             // Reserved keywords
             Token::Await => self.consume_token_and_error(SyntaxError::ReservedKeyword),
             Token::Const => self.consume_token_and_error(SyntaxError::ReservedKeyword),
@@ -2750,7 +2750,7 @@ impl<'source> Parser<'source> {
         )
     }
 
-    fn consume_variable_declaration(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
+    fn consume_let_expression(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::Let
 
         let mut targets = vec![];

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1443,6 +1443,37 @@ x %= 4";
                 ]),
             )
         }
+
+        #[test]
+        fn multiple_targets() {
+            let source = "let foo: String, bar: Number = baz";
+
+            check_ast(
+                source,
+                &[
+                    type_hint(1, &[]),       // String
+                    id_with_type_hint(0, 0), // foo
+                    type_hint(3, &[]),       // Number
+                    id_with_type_hint(2, 2), // bar
+                    id(4),                   // baz
+                    MultiAssign {
+                        targets: expressions(&[1, 3]),
+                        expression: 4.into(),
+                    }, // 5
+                    MainBlock {
+                        body: vec![5.into()],
+                        local_count: 2,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("foo"),
+                    Constant::Str("String"),
+                    Constant::Str("bar"),
+                    Constant::Str("Number"),
+                    Constant::Str("baz"),
+                ]),
+            )
+        }
     }
 
     mod export {

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1334,17 +1334,17 @@ x %= 4";
         }
     }
 
-    mod variable_declaration {
+    mod let_expression {
         use super::*;
 
         #[test]
-        fn single() {
+        fn number() {
             let source = "let a = 1";
 
             check_ast(
                 source,
                 &[
-                    id(0),
+                    id(0), // a
                     SmallInt(1),
                     Assign {
                         target: 0.into(),
@@ -1360,14 +1360,14 @@ x %= 4";
         }
 
         #[test]
-        fn single_with_type_hint() {
+        fn number_with_type_hint() {
             let source = "let a: Number = 1";
 
             check_ast(
                 source,
                 &[
-                    type_hint(1, &[]),
-                    id_with_type_hint(0, 0),
+                    type_hint(1, &[]),       // Number
+                    id_with_type_hint(0, 0), // a
                     SmallInt(1),
                     Assign {
                         target: 1.into(),
@@ -1379,6 +1379,68 @@ x %= 4";
                     },
                 ],
                 Some(&[Constant::Str("a"), Constant::Str("Number")]),
+            )
+        }
+
+        #[test]
+        fn list_with_type_hint() {
+            let source = "let foo: List<String> = bar";
+
+            check_ast(
+                source,
+                &[
+                    type_hint(2, &[]),       // String
+                    type_hint(1, &[0]),      // List
+                    id_with_type_hint(0, 1), // foo
+                    id(3),                   // bar
+                    Assign {
+                        target: 2.into(),
+                        expression: 3.into(),
+                    },
+                    MainBlock {
+                        body: vec![4.into()],
+                        local_count: 1,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("foo"),
+                    Constant::Str("List"),
+                    Constant::Str("String"),
+                    Constant::Str("bar"),
+                ]),
+            )
+        }
+
+        #[test]
+        fn map_with_type_hint() {
+            let source = "let foo: Map<String, List<Number>> = bar";
+
+            check_ast(
+                source,
+                &[
+                    type_hint(2, &[]),       // String
+                    type_hint(4, &[]),       // Number
+                    type_hint(3, &[1]),      // List
+                    type_hint(1, &[0, 2]),   // Map
+                    id_with_type_hint(0, 3), // foo
+                    id(5),                   // bar - 5
+                    Assign {
+                        target: 4.into(),
+                        expression: 5.into(),
+                    },
+                    MainBlock {
+                        body: vec![6.into()],
+                        local_count: 1,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("foo"),
+                    Constant::Str("Map"),
+                    Constant::Str("String"),
+                    Constant::Str("List"),
+                    Constant::Str("Number"),
+                    Constant::Str("bar"),
+                ]),
             )
         }
     }

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -23,7 +23,7 @@ pub enum ErrorKind {
     },
     #[error("Execution timed out (the limit of {} seconds was reached)", .0.as_secs_f64())]
     Timeout(Duration),
-    #[error("Expected {expected}, but found '{}'", get_value_types(unexpected))]
+    #[error("Expected '{expected}', but found '{}'", get_value_types(unexpected))]
     UnexpectedType {
         expected: String,
         unexpected: Vec<KValue>,

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -937,6 +937,7 @@ impl KotoVm {
             Debug { register, constant } => self.run_debug(register, constant)?,
             CheckSizeEqual { register, size } => self.run_check_size_equal(register, size)?,
             CheckSizeMin { register, size } => self.run_check_size_min(register, size)?,
+            CheckType { value, type_string } => self.run_check_type(value, type_string)?,
         }
 
         Ok(control_flow)
@@ -2798,6 +2799,16 @@ impl KotoVm {
             runtime_error!(
                 "The container has a size of '{size}', expected a minimum of  '{expected_size}'"
             )
+        }
+    }
+
+    fn run_check_type(&mut self, value_register: u8, type_index: ConstantIndex) -> Result<()> {
+        let value = self.get_register(value_register);
+        let expected_type = self.get_constant_str(type_index);
+        if value.type_as_string() == expected_type {
+            Ok(())
+        } else {
+            type_error(expected_type, self.get_register(value_register))
         }
     }
 

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -51,6 +51,18 @@ mod runtime {
             }
         }
 
+        mod type_checks {
+            use super::*;
+
+            #[test]
+            fn expected_string() {
+                let script = "
+let x: String = 123
+";
+                check_script_fails(script);
+            }
+        }
+
         mod missing_values {
             use super::*;
 
@@ -58,7 +70,7 @@ mod runtime {
             fn missing_identifier_before_last_expression() {
                 let script = "
 x = 123
-y
+y # y hasn't been declared, so should throw an error on access
 x
 ";
                 check_script_fails(script);

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -518,6 +518,15 @@ x
 ";
             check_script_output(script, "foo");
         }
+
+        #[test]
+        fn multi_assignment() {
+            let script = "
+let x: String, y: Bool, z: Int = 'foo', true, 123
+x, y, z
+";
+            check_script_output(script, tuple(&["foo".into(), true.into(), 123.into()]));
+        }
     }
 
     mod if_expressions {

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -507,6 +507,19 @@ c
         }
     }
 
+    mod type_checks {
+        use super::*;
+
+        #[test]
+        fn assigning_a_string() {
+            let script = "
+let x: String = 'foo'
+x
+";
+            check_script_output(script, "foo");
+        }
+    }
+
     mod if_expressions {
         use super::*;
 


### PR DESCRIPTION
Following on from #322, this PR adds a `CheckType` instruction that can
optionally be emmitted by the compiler when type hints are encountered in `let`
expressions.
