### PR TITLE
Add support for adding type hints to functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The Koto project adheres to
 #### Language
 
 - `await`, `const`, and `let` have been reserved as keywords for future use.
+- The type of a number is now always `Number`, rather than distinguishing
+  between `Int` and `Float`.
 
 #### API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The Koto project adheres to
 - `await`, `const`, and `let` have been reserved as keywords for future use.
 - The type of a number is now always `Number`, rather than distinguishing
   between `Int` and `Float`.
+- The `>>` pipe operator has been replaced with `->`.
+  - This aligns it with the `->` function output type syntax, which avoids 
+    having two different special-case operators related to function output.
 
 #### API
 

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -52,8 +52,6 @@ enum ErrorKind {
     MissingValueForMapEntry,
     #[error("only one ellipsis is allowed in a match arm")]
     MultipleMatchEllipses,
-    #[error("nested type declarations are currently unsupported")]
-    NestedTypeDeclaration,
     #[error("the compiled expression has no output")]
     NoResultInExpressionOutput,
     #[error("child chain node out of position")]
@@ -1098,11 +1096,7 @@ impl Compiler {
         self.push_span(type_node, ctx.ast);
 
         match &type_node.node {
-            Node::Type(type_index, nested) => {
-                if !nested.is_empty() {
-                    return self.error(ErrorKind::NestedTypeDeclaration);
-                }
-
+            Node::Type(type_index) => {
                 if self.settings.enable_type_checks {
                     self.push_op(Op::CheckType, &[value_register]);
                     self.push_var_u32((*type_index).into());

--- a/crates/bytecode/src/frame.rs
+++ b/crates/bytecode/src/frame.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use koto_parser::{ConstantIndex, Span};
+use koto_parser::{AstIndex, ConstantIndex, Span};
 use thiserror::Error;
 
 /// The different error types that can be thrown while compiling a [Frame]
@@ -80,10 +80,17 @@ pub(crate) struct Frame {
     // This is a coarse check, e.g. we currently don't check if the last expression
     // returns in all branches, but it'll do for now as an optimization for simple cases.
     pub last_node_was_return: bool,
+    // An optional output type hint that should cause type checks to be emitted on each exit path.
+    pub output_type: Option<AstIndex>,
 }
 
 impl Frame {
-    pub fn new(local_count: u8, args: &[Arg], captures: &[ConstantIndex]) -> Self {
+    pub fn new(
+        local_count: u8,
+        args: &[Arg],
+        captures: &[ConstantIndex],
+        output_type: Option<AstIndex>,
+    ) -> Self {
         let temporary_base =
             // register 0 is always self
             1
@@ -121,6 +128,7 @@ impl Frame {
             register_stack: Vec::with_capacity(temporary_base as usize),
             local_registers,
             temporary_base,
+            output_type,
             ..Default::default()
         }
     }

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -281,7 +281,7 @@ check! Bool
 
 x = 42
 print! koto.type x
-check! Int
+check! Number
 
 foo =
   @type: "Foo"

--- a/crates/cli/docs/core_lib/number.md
+++ b/crates/cli/docs/core_lib/number.md
@@ -21,7 +21,7 @@ check! 1
 ## acos
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the arc cosine of the number. `acos` is the inverse function of `cos`.
@@ -38,7 +38,7 @@ assert_eq 1.acos(), 0
 ## acosh
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the inverse hyperbolic cosine of the number.
@@ -54,11 +54,17 @@ assert_near 2.acosh(), 1.3169578969248166
 ## and
 
 ```kototype
-|Integer, Integer| -> Integer
+|Number, Number| -> Number
 ```
 
-Returns the bitwise combination of two integers, where a `1` in both input
-positions produces a `1` in corresponding output positions.
+Returns the bitwise combination of the binary representations of two numbers, 
+where a `1` in both of the inputs produces a `1` in the corresponding output 
+position.
+
+### Note
+
+If either input is a float then its integer part will be used.
+
 
 ### Example
 
@@ -71,7 +77,7 @@ check! 8
 ## asin
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the arc sine of the number. `asin` is the inverse function of `sin`.
@@ -88,7 +94,7 @@ assert_near 1.asin(), pi / 2
 ## asinh
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the inverse hyperbolic sine of the number.
@@ -103,7 +109,7 @@ assert_near 1.asinh(), 0.8813735870195429
 ## atan
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the arc tangent of the number. `atan` is the inverse function of `tan`.
@@ -120,7 +126,7 @@ assert_near 1.atan(), pi / 4
 ## atanh
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the inverse hyperbolic tangent of the number.
@@ -141,7 +147,7 @@ check! inf
 ## atan2
 
 ```kototype
-|Number, Number| -> Float
+|Number, Number| -> Number
 ```
 
 Returns the arc tangent of `y` and `x` in radians, using the signs of `y` and
@@ -161,7 +167,7 @@ assert_near y.atan2(-x), pi - pi / 4
 ## ceil
 
 ```kototype
-|Number| -> Integer
+|Number| -> Number
 ```
 
 Returns the integer that's greater than or equal to the input.
@@ -210,7 +216,7 @@ check! 2
 ## cos
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the cosine of the number.
@@ -228,7 +234,7 @@ check! -1.0
 ## cosh
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the hyperbolic cosine of the number.
@@ -243,7 +249,7 @@ assert_near 1.cosh(), 1.5430806348152437
 ## degrees
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Converts radians into degrees.
@@ -263,7 +269,7 @@ check! 360.0
 ## e
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `e` constant.
@@ -271,7 +277,7 @@ Provides the `e` constant.
 ## exp
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the result of applying the exponential function,
@@ -287,7 +293,7 @@ assert_eq 1.exp(), number.e
 ## exp2
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the result of applying the base-2 exponential function,
@@ -306,7 +312,7 @@ check! 8.0
 ## flip_bits
 
 ```kototype
-|Integer| -> Integer
+|Number| -> Number
 ```
 
 Returns the input with its bits 'flipped', i.e. `1` => `0`, and `0` => `1`.
@@ -321,7 +327,7 @@ check! -2
 ## floor
 
 ```kototype
-|Number| -> Integer
+|Number| -> Number
 ```
 
 Returns the integer that's less than or equal to the input.
@@ -348,7 +354,7 @@ check! -1
 ## infinity
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `∞` constant.
@@ -374,7 +380,7 @@ check! true
 ## lerp
 
 ```kototype
-|a: Number, b: Number, t: Number| -> Float
+|a: Number, b: Number, t: Number| -> Number
 ```
 
 Linearly interpolates between `a` and `b` using the interpolation factor `t`.
@@ -409,7 +415,7 @@ check! 2.5
 ## ln
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the natural logarithm of the number.
@@ -427,7 +433,7 @@ check! 1.0
 ## log2
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the base-2 logarithm of the number.
@@ -445,7 +451,7 @@ check! 2.0
 ## log10
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the base-10 logarithm of the number.
@@ -499,7 +505,7 @@ check! 3
 ## nan
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `NaN` (Not a Number) constant.
@@ -507,7 +513,7 @@ Provides the `NaN` (Not a Number) constant.
 ## negative_infinity
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `-∞` constant.
@@ -515,11 +521,16 @@ Provides the `-∞` constant.
 ## or
 
 ```kototype
-|Integer, Integer| -> Integer
+|Number, Number| -> Number
 ```
 
-Returns the bitwise combination of two integers, where a `1` in either input
-positions produces a `1` in corresponding output positions.
+Returns the bitwise combination of the binary representations of two numbers, 
+where a `1` in either of the inputs produces a `1` in the corresponding output 
+position.
+
+### Note
+
+If either input is a float then its integer part will be used.
 
 ### Example
 
@@ -532,7 +543,7 @@ check! 14
 ## pi
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `π` constant.
@@ -540,7 +551,7 @@ Provides the `π` constant.
 ## pi_2
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `π` constant divided by `2`.
@@ -548,7 +559,7 @@ Provides the `π` constant divided by `2`.
 ## pi_4
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `π` constant divided by `4`.
@@ -571,7 +582,7 @@ check! 8
 ## radians
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Converts degrees into radians.
@@ -588,7 +599,7 @@ assert_near 360.radians(), pi * 2
 ## recip
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the reciprocal of the number, i.e. `1 / x`.
@@ -603,7 +614,7 @@ check! 0.5
 ## round
 
 ```kototype
-|Number| -> Integer
+|Number| -> Number
 ```
 
 Returns the nearest integer to the input number.
@@ -631,11 +642,15 @@ check! -1
 ## shift_left
 
 ```kototype
-|Integer, Integer| -> Integer
+|Number, Number| -> Number
 ```
 
 Returns the result of shifting the bits of the first number to the left by the
 amount specified by the second number.
+
+### Note
+
+If either input is a float then its integer part will be used.
 
 ### Note
 
@@ -652,11 +667,15 @@ check! 40
 ## shift_right
 
 ```kototype
-|Integer, Integer| -> Integer
+|Number, Number| -> Number
 ```
 
 Returns the result of shifting the bits of the first number to the right by the
 amount specified by the second number.
+
+### Note
+
+If either input is a float then its integer part will be used.
 
 ### Note
 
@@ -673,7 +692,7 @@ check! 2
 ## sin
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the sine of the number.
@@ -693,7 +712,7 @@ check! -1.0
 ## sinh
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the hyperbolic sine of the number.
@@ -708,7 +727,7 @@ assert_near 1.sinh(), 1.1752011936438014
 ## sqrt
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the square root of the number.
@@ -723,7 +742,7 @@ check! 8.0
 ## tan
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the tangent of the number.
@@ -738,7 +757,7 @@ assert_near 1.tan(), 1.557407724654902
 ## tanh
 
 ```kototype
-|Number| -> Float
+|Number| -> Number
 ```
 
 Returns the hyperbolic tangent of the number.
@@ -752,33 +771,18 @@ assert_near 1.tanh(), 1.sinh() / 1.cosh()
 ## tau
 
 ```kototype
-Float
+Number
 ```
 
 Provides the `τ` constant, equivalent to `2π`.
 
-## to_float
-
-```kototype
-|Number| -> Float
-```
-
-Returns the number as a `Float`.
-
-### Example
-
-```koto
-print! 1.to_float()
-check! 1.0
-```
-
 ## to_int
 
 ```kototype
-|Number| -> Integer
+|Number| -> Number
 ```
 
-Converts a Number into an integer by removing its fractional part.
+Returns the integer part of the input number.
 
 This is often called `trunc` in other languages.
 
@@ -807,12 +811,16 @@ check! -1
 ## xor
 
 ```kototype
-|Integer, Integer| -> Integer
+|Number, Number| -> Number
 ```
 
-Returns the bitwise combination of two integers,
+Returns the bitwise combination of the binary representations of two numbers,
 where a `1` in one (and only one) of the input positions
-produces a `1` in corresponding output positions.
+produces a `1` in the corresponding output position.
+
+### Note
+
+If either input is a float then its integer part will be used.
 
 ### Example
 

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -554,7 +554,7 @@ check! null
 
 ### Function Piping
 
-The pipe operator (`>>`) can be used to pass the result of one function to 
+The arrow operator (`->`) can be used to pass the result of one function to 
 another, working from left to right. This is known as _function piping_, 
 and can aid readability when working with a long chain of function calls.
 
@@ -572,13 +572,13 @@ print! x = multiply(2, square(add(1, 3)))
 check! 32
 
 # Piping allows for a left-to-right flow of results.
-print! x = add(1, 3) >> square >> multiply 2
+print! x = add(1, 3) -> square -> multiply 2
 check! 32
 
 # Call chains can also be broken across lines.
 print! x = add 1, 3
-  >> square 
-  >> multiply 2
+  -> square 
+  -> multiply 2
 check! 32
 ```
 

--- a/crates/koto/examples/poetry/scripts/guide.koto
+++ b/crates/koto/examples/poetry/scripts/guide.koto
@@ -1,7 +1,7 @@
 @main = ||
   input_file =
     io.extend_path koto.script_dir, '..', 'README.md'
-    >> io.read_to_string
+    -> io.read_to_string
   generator = poetry.new input_file
 
   separator = '==================================================='

--- a/crates/koto/examples/poetry/scripts/readme.koto
+++ b/crates/koto/examples/poetry/scripts/readme.koto
@@ -1,7 +1,7 @@
 @main = ||
   input_file =
     io.extend_path koto.script_dir, '..', '..', '..', '..', '..', 'docs', 'language_guide.md'
-    >> io.read_to_string
+    -> io.read_to_string
   generator = poetry.new input_file
 
   separator = '==================================================='

--- a/crates/lexer/src/lexer.rs
+++ b/crates/lexer/src/lexer.rs
@@ -58,7 +58,6 @@ pub enum Token {
     Less,
     LessOrEqual,
 
-    // Pipe is detected by the parser instead of the lexer
     Pipe,
 
     // Keywords
@@ -711,6 +710,8 @@ impl<'a> TokenLexer<'a> {
         check_symbol!("..=", RangeInclusive);
         check_symbol!("..", Range);
 
+        check_symbol!(">>", Pipe);
+
         check_symbol!("==", Equal);
         check_symbol!("!=", NotEqual);
         check_symbol!(">=", GreaterOrEqual);
@@ -1320,13 +1321,14 @@ r#''bar''#
 
         #[test]
         fn operators() {
-            let input = "> >= < <=";
+            let input = "> >= >> < <=";
 
             check_lexer_output(
                 input,
                 &[
                     (Greater, None, 0),
                     (GreaterOrEqual, None, 0),
+                    (Pipe, None, 0),
                     (Less, None, 0),
                     (LessOrEqual, None, 0),
                 ],
@@ -1433,22 +1435,7 @@ c *= 3";
         }
 
         #[test]
-        fn varible_declaration() {
-            let input = "let my_var = 42";
-
-            check_lexer_output(
-                input,
-                &[
-                    (Let, None, 0),
-                    (Id, Some("my_var"), 0),
-                    (Assign, None, 0),
-                    (Number, Some("42"), 0),
-                ],
-            )
-        }
-
-        #[test]
-        fn variable_declaration_with_type_hint() {
+        fn let_expression() {
             let input = "let my_var: Number = 42";
 
             check_lexer_output(
@@ -1460,65 +1447,6 @@ c *= 3";
                     (Id, Some("Number"), 0),
                     (Assign, None, 0),
                     (Number, Some("42"), 0),
-                ],
-            )
-        }
-
-        #[test]
-        fn variable_declaration_with_generic_type_hint() {
-            let input = "let my_var: List<Number> = [42, 43]";
-
-            check_lexer_output(
-                input,
-                &[
-                    (Let, None, 0),
-                    (Id, Some("my_var"), 0),
-                    (Colon, None, 0),
-                    (Id, Some("List"), 0),
-                    (Less, None, 0),
-                    (Id, Some("Number"), 0),
-                    (Greater, None, 0),
-                    (Assign, None, 0),
-                    (SquareOpen, None, 0),
-                    (Number, Some("42"), 0),
-                    (Comma, None, 0),
-                    (Number, Some("43"), 0),
-                    (SquareClose, None, 0),
-                ],
-            )
-        }
-
-        #[test]
-        fn variable_declaration_with_nested_generic_type_hint() {
-            let input = "let my_var: List<List<Number>> = [[42, 43], [97, 13]]";
-
-            check_lexer_output(
-                input,
-                &[
-                    (Let, None, 0),
-                    (Id, Some("my_var"), 0),
-                    (Colon, None, 0),
-                    (Id, Some("List"), 0),
-                    (Less, None, 0),
-                    (Id, Some("List"), 0),
-                    (Less, None, 0),
-                    (Id, Some("Number"), 0),
-                    (Greater, None, 0),
-                    (Greater, None, 0),
-                    (Assign, None, 0),
-                    (SquareOpen, None, 0),
-                    (SquareOpen, None, 0),
-                    (Number, Some("42"), 0),
-                    (Comma, None, 0),
-                    (Number, Some("43"), 0),
-                    (SquareClose, None, 0),
-                    (Comma, None, 0),
-                    (SquareOpen, None, 0),
-                    (Number, Some("97"), 0),
-                    (Comma, None, 0),
-                    (Number, Some("13"), 0),
-                    (SquareClose, None, 0),
-                    (SquareClose, None, 0),
                 ],
             )
         }

--- a/crates/lexer/src/lexer.rs
+++ b/crates/lexer/src/lexer.rs
@@ -58,7 +58,7 @@ pub enum Token {
     Less,
     LessOrEqual,
 
-    Pipe,
+    Arrow,
 
     // Keywords
     As,
@@ -710,7 +710,7 @@ impl<'a> TokenLexer<'a> {
         check_symbol!("..=", RangeInclusive);
         check_symbol!("..", Range);
 
-        check_symbol!(">>", Pipe);
+        check_symbol!("->", Arrow);
 
         check_symbol!("==", Equal);
         check_symbol!("!=", NotEqual);
@@ -1321,14 +1321,14 @@ r#''bar''#
 
         #[test]
         fn operators() {
-            let input = "> >= >> < <=";
+            let input = "> >= -> < <=";
 
             check_lexer_output(
                 input,
                 &[
                     (Greater, None, 0),
                     (GreaterOrEqual, None, 0),
-                    (Pipe, None, 0),
+                    (Arrow, None, 0),
                     (Less, None, 0),
                     (LessOrEqual, None, 0),
                 ],

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -159,8 +159,8 @@ pub enum SyntaxError {
     ExpectedUntilCondition,
     #[error("Expected condition in while loop")]
     ExpectedWhileCondition,
-    #[error("Expected type hint")]
-    ExpectedTypeHint,
+    #[error("Expected a type after ':'")]
+    ExpectedType,
     #[error(transparent)]
     FormatStringError(StringFormatError),
     #[error("Non-inline if expression isn't allowed in this context")]
@@ -171,6 +171,8 @@ pub enum SyntaxError {
     MatchEllipsisOutsideOfNestedPatterns,
     #[error("'else' can only be used in the last arm in a match expression")]
     MatchElseNotInLastArm,
+    #[error("Nested types aren't currently supported")]
+    NestedTypesArentSupported,
     #[error("Keyword reserved for future use")]
     ReservedKeyword,
     #[error("'self' doesn't need to be declared as an argument")]

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -260,7 +260,7 @@ pub enum Node {
     ///
     /// e.g. `let x: Number = 0`
     ///            ^~~ This is the beginning of the type hint
-    Type(ConstantIndex, Vec<AstIndex>),
+    Type(ConstantIndex),
 }
 
 /// A function definition

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -432,9 +432,9 @@ pub enum ChainNode {
         /// This is not cosmetic, as parentheses represent a 'closed call', which has an impact on
         /// function piping:
         /// e.g.
-        ///   `99 >> foo.bar 42` is equivalent to `foo.bar(42, 99)`
+        ///   `99 -> foo.bar 42` is equivalent to `foo.bar(42, 99)`
         /// but:
-        ///   `99 >> foo.bar(42)` is equivalent to `foo.bar(42)(99)`.
+        ///   `99 -> foo.bar(42)` is equivalent to `foo.bar(42)(99)`.
         with_parens: bool,
     },
 }

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -286,6 +286,8 @@ pub struct Function {
     ///
     /// The presence of a `yield` expression in the function body will set this to true.
     pub is_generator: bool,
+    /// The optional output type of the function
+    pub output_type: Option<AstIndex>,
 }
 
 /// A string definition

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -543,24 +543,9 @@ impl<'source> Parser<'source> {
         {
             return Ok(Some(assignment_expression));
         } else if let Some(next) = self.peek_token_with_context(context) {
-            let maybe_pipe = match next.token {
-                Token::Greater => {
-                    if matches!(self.peek_token_n(next.peek_count + 1), Some(Token::Greater)) {
-                        Some(Token::Pipe)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            };
-            if let Some((left_priority, right_priority)) =
-                operator_precedence(maybe_pipe.unwrap_or(next.token))
-            {
+            if let Some((left_priority, right_priority)) = operator_precedence(next.token) {
                 if left_priority >= min_precedence {
                     let (op, _) = self.consume_token_with_context(context).unwrap();
-                    if maybe_pipe.is_some() {
-                        self.consume_token();
-                    }
                     let op_span = self.current_span();
 
                     // Move on to the token after the operator
@@ -617,7 +602,7 @@ impl<'source> Parser<'source> {
                         Equal => AstBinaryOp::Equal,
                         NotEqual => AstBinaryOp::NotEqual,
 
-                        Greater if maybe_pipe.is_none() => AstBinaryOp::Greater,
+                        Greater => AstBinaryOp::Greater,
                         GreaterOrEqual => AstBinaryOp::GreaterOrEqual,
                         Less => AstBinaryOp::Less,
                         LessOrEqual => AstBinaryOp::LessOrEqual,
@@ -625,7 +610,7 @@ impl<'source> Parser<'source> {
                         And => AstBinaryOp::And,
                         Or => AstBinaryOp::Or,
 
-                        Greater if maybe_pipe.is_some() => AstBinaryOp::Pipe,
+                        Pipe => AstBinaryOp::Pipe,
 
                         _ => unreachable!(), // The list of tokens here matches the operators in
                                              // operator_precedence()

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -610,7 +610,7 @@ impl<'source> Parser<'source> {
                         And => AstBinaryOp::And,
                         Or => AstBinaryOp::Or,
 
-                        Pipe => AstBinaryOp::Pipe,
+                        Arrow => AstBinaryOp::Pipe,
 
                         _ => unreachable!(), // The list of tokens here matches the operators in
                                              // operator_precedence()
@@ -3278,7 +3278,7 @@ const MIN_PRECEDENCE_AFTER_PIPE: u8 = 3;
 fn operator_precedence(op: Token) -> Option<(u8, u8)> {
     use Token::*;
     let priority = match op {
-        Pipe => (1, 2),
+        Arrow => (1, 2),
         AddAssign | SubtractAssign | MultiplyAssign | DivideAssign | RemainderAssign => {
             (4, MIN_PRECEDENCE_AFTER_PIPE)
         }

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -2680,8 +2680,8 @@ f x";
         }
 
         #[test]
-        fn call_with_pipe() {
-            let source = "f x >> g >> h";
+        fn piped_call_chain() {
+            let source = "f x -> g -> h";
             check_ast(
                 source,
                 &[
@@ -2711,8 +2711,8 @@ f x";
         fn indented_piped_calls_after_chain() {
             let source = "
 foo.bar x
-  >> y
-  >> z
+  -> y
+  -> z
 ";
             check_ast(
                 source,

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -61,8 +61,8 @@ mod parser {
         Node::Id(constant.into(), Some(type_hint.into()))
     }
 
-    fn type_hint(constant: u32, inner: &[u32]) -> Node {
-        Node::Type(constant.into(), inner.iter().map(|i| i.into()).collect())
+    fn type_hint(constant: u32) -> Node {
+        Node::Type(constant.into())
     }
 
     fn int(constant: u32) -> Node {
@@ -1366,7 +1366,7 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    type_hint(1, &[]),       // Int
+                    type_hint(1),            // Int
                     id_with_type_hint(0, 0), // a
                     SmallInt(1),
                     Assign {
@@ -1383,77 +1383,15 @@ x %= 4";
         }
 
         #[test]
-        fn list_with_type_hint() {
-            let source = "let foo: List<String> = bar";
-
-            check_ast(
-                source,
-                &[
-                    type_hint(2, &[]),       // String
-                    type_hint(1, &[0]),      // List
-                    id_with_type_hint(0, 1), // foo
-                    id(3),                   // bar
-                    Assign {
-                        target: 2.into(),
-                        expression: 3.into(),
-                    },
-                    MainBlock {
-                        body: vec![4.into()],
-                        local_count: 1,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("foo"),
-                    Constant::Str("List"),
-                    Constant::Str("String"),
-                    Constant::Str("bar"),
-                ]),
-            )
-        }
-
-        #[test]
-        fn map_with_type_hint() {
-            let source = "let foo: Map<String, List<Int>> = bar";
-
-            check_ast(
-                source,
-                &[
-                    type_hint(2, &[]),       // String
-                    type_hint(4, &[]),       // Int
-                    type_hint(3, &[1]),      // List
-                    type_hint(1, &[0, 2]),   // Map
-                    id_with_type_hint(0, 3), // foo
-                    id(5),                   // bar - 5
-                    Assign {
-                        target: 4.into(),
-                        expression: 5.into(),
-                    },
-                    MainBlock {
-                        body: vec![6.into()],
-                        local_count: 1,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("foo"),
-                    Constant::Str("Map"),
-                    Constant::Str("String"),
-                    Constant::Str("List"),
-                    Constant::Str("Int"),
-                    Constant::Str("bar"),
-                ]),
-            )
-        }
-
-        #[test]
         fn multiple_targets() {
             let source = "let foo: String, bar: Int = baz";
 
             check_ast(
                 source,
                 &[
-                    type_hint(1, &[]),       // String
+                    type_hint(1),            // String
                     id_with_type_hint(0, 0), // foo
-                    type_hint(3, &[]),       // Int
+                    type_hint(3),            // Int
                     id_with_type_hint(2, 2), // bar
                     id(4),                   // baz
                     MultiAssign {
@@ -1482,7 +1420,7 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    type_hint(0, &[]),
+                    type_hint(0),
                     Wildcard(None, Some(0.into())),
                     SmallInt(1),
                     Assign {
@@ -1505,7 +1443,7 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    type_hint(1, &[]),
+                    type_hint(1),
                     Wildcard(Some(0.into()), Some(0.into())),
                     SmallInt(1),
                     Assign {
@@ -1527,11 +1465,11 @@ x %= 4";
             check_ast(
                 source,
                 &[
-                    type_hint(1, &[]),
+                    type_hint(1),
                     id_with_type_hint(0, 0),
-                    type_hint(1, &[]),
+                    type_hint(1),
                     Wildcard(None, Some(2.into())),
-                    type_hint(1, &[]),
+                    type_hint(1),
                     Wildcard(Some(2.into()), Some(4.into())),
                     id(3),
                     Chain((

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1994,6 +1994,7 @@ a",
                         body: 4.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }), // 5
                     MainBlock {
                         body: expressions(&[5]),
@@ -2182,6 +2183,7 @@ a()";
                         body: 1.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(0, 2),
                     id(0),
@@ -2230,6 +2232,7 @@ a()";
                         body: 4.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }), // 5
                     MainBlock {
                         body: expressions(&[5]),
@@ -2270,6 +2273,7 @@ a()";
                         body: 6.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[7]),
@@ -2282,6 +2286,47 @@ a()";
                     Constant::Str("y"),
                     Constant::Str("Number"),
                 ]),
+            )
+        }
+
+        #[test]
+        fn output_type_hint() {
+            let sources = [
+                "
+|x: String| -> String x
+",
+                "
+|x: String| -> String
+  x
+",
+                "
+|x: String
+| -> String
+  x
+",
+            ];
+            check_ast_for_equivalent_sources(
+                &sources,
+                &[
+                    type_hint(1),            // String
+                    id_with_type_hint(0, 0), // x
+                    type_hint(1),            // String
+                    id(0),                   // x
+                    Function(koto_parser::Function {
+                        args: expressions(&[1]),
+                        local_count: 1,
+                        accessed_non_locals: vec![],
+                        body: 3.into(),
+                        is_variadic: false,
+                        is_generator: false,
+                        output_type: Some(2.into()),
+                    }),
+                    MainBlock {
+                        body: expressions(&[4]),
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("x"), Constant::Str("String")]),
             )
         }
 
@@ -2312,6 +2357,7 @@ a()";
                         body: 7.into(),
                         is_variadic: true,
                         is_generator: false,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[8]),
@@ -2350,6 +2396,7 @@ f 42";
                         body: 6.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(0, 7),
                     id(0),        // f
@@ -2388,6 +2435,7 @@ f = |x|
                         body: 4.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(2, 5),
                     id(2), // y
@@ -2402,6 +2450,7 @@ f = |x|
                         body: 11.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }), // 10
                     assign(0, 12),
                     MainBlock {
@@ -2561,6 +2610,7 @@ foo
                         body: 3.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     chain_call(&[1, 4], false, None), // 5
                     chain_root(0, Some(5)),
@@ -2618,6 +2668,7 @@ f x";
                         body: 5.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(0, 6),
                     MainBlock {
@@ -2649,6 +2700,7 @@ f x";
                         body: 6.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     Nested(7.into()),
                     id(2), // x
@@ -2663,6 +2715,7 @@ f x";
                         body: 13.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     Nested(14.into()), // 15
                     TempTuple(expressions(&[8, 15])),
@@ -2769,6 +2822,7 @@ foo.bar x
                         body: 8.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     map_inline(&[(0, Some(1)), (2, Some(9))]), // 10
                     MainBlock {
@@ -2807,6 +2861,7 @@ f = ||
                         body: 5.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(0, 6),
                     MainBlock {
@@ -2849,6 +2904,7 @@ f = ||
                         body: 7.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(0, 8),
                     MainBlock {
@@ -2893,6 +2949,7 @@ f()";
                         body: 9.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }), // 10
                     map_block(&[(1, 2), (3, 10)]),
                     Function(koto_parser::Function {
@@ -2902,6 +2959,7 @@ f()";
                         body: 11.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(0, 12),
                     id(0), // f
@@ -2971,6 +3029,7 @@ f = |n|
                         body: 14.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }), // ast 15
                     assign(2, 15),
                     id(2),
@@ -2982,6 +3041,7 @@ f = |n|
                         body: 18.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     assign(0, 19), // ast 20
                     MainBlock {
@@ -3022,6 +3082,7 @@ f = |n|
                         body: 6.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[7]),
@@ -3056,6 +3117,7 @@ f = |n|
                         body: 7.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[8]),
@@ -3084,6 +3146,7 @@ f = |n|
                         body: 2.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[3]),
@@ -3119,6 +3182,7 @@ z = y [0..20], |x| x > 1
                         body: 9.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }), // 10
                     chain_call(&[5, 10], false, None),
                     chain_root(1, Some(11)),
@@ -3147,6 +3211,7 @@ z = y [0..20], |x| x > 1
                         body: 1.into(),
                         is_variadic: false,
                         is_generator: true,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[2]),
@@ -3174,6 +3239,7 @@ z = y [0..20], |x| x > 1
                         body: 3.into(),
                         is_variadic: false,
                         is_generator: true,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[4]),
@@ -3205,6 +3271,7 @@ z = y [0..20], |x| x > 1
                         body: 3.into(),
                         is_variadic: false,
                         is_generator: true,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[4]),
@@ -3251,6 +3318,7 @@ z = y [0..20], |x| x > 1
                         body: 8.into(),
                         is_variadic: false,
                         is_generator: false,
+                        output_type: None,
                     }),
                     MainBlock {
                         body: expressions(&[9]),

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -2241,6 +2241,51 @@ a()";
         }
 
         #[test]
+        fn two_args_with_type_hints() {
+            let sources = [
+                "
+|x: String, y: Number| x + y
+",
+                "
+| x: String,
+  y: Number,
+|
+  x + y
+",
+            ];
+            check_ast_for_equivalent_sources(
+                &sources,
+                &[
+                    type_hint(1),            // String
+                    id_with_type_hint(0, 0), // x
+                    type_hint(3),            // Number
+                    id_with_type_hint(2, 2), // y
+                    id(0),                   // x
+                    id(2),                   // y - 5
+                    binary_op(AstBinaryOp::Add, 4, 5),
+                    Function(koto_parser::Function {
+                        args: expressions(&[1, 3]),
+                        local_count: 2,
+                        accessed_non_locals: vec![],
+                        body: 6.into(),
+                        is_variadic: false,
+                        is_generator: false,
+                    }),
+                    MainBlock {
+                        body: expressions(&[7]),
+                        local_count: 0,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("x"),
+                    Constant::Str("String"),
+                    Constant::Str("y"),
+                    Constant::Str("Number"),
+                ]),
+            )
+        }
+
+        #[test]
         fn inline_var_args() {
             let source = "|x, y...| x + y.size()";
             check_ast(

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -77,7 +77,7 @@ mod parser {
         Node::Str(simple_string(literal_index, quotation_mark))
     }
 
-    fn expressions(ast_indices: &[u32]) -> Vec<AstIndex> {
+    fn nodes(ast_indices: &[u32]) -> Vec<AstIndex> {
         ast_indices.iter().map(|i| AstIndex::from(*i)).collect()
     }
 
@@ -175,7 +175,7 @@ null"#;
                     id(3),
                     Null,
                     MainBlock {
-                        body: expressions(&[0, 1, 2, 3, 4, 5, 6, 7]),
+                        body: nodes(&[0, 1, 2, 3, 4, 5, 6, 7]),
                         local_count: 0,
                     },
                 ],
@@ -212,7 +212,7 @@ null"#;
                     SmallInt(1),
                     SmallInt(4),
                     MainBlock {
-                        body: expressions(&[0, 1, 2, 3, 4, 5, 6, 7]),
+                        body: nodes(&[0, 1, 2, 3, 4, 5, 6, 7]),
                         local_count: 0,
                     },
                 ],
@@ -236,7 +236,7 @@ null"#;
                     string_literal(0, StringQuote::Double),
                     string_literal(1, StringQuote::Double),
                     MainBlock {
-                        body: expressions(&[0, 1]),
+                        body: nodes(&[0, 1]),
                         local_count: 0,
                     },
                 ],
@@ -259,7 +259,7 @@ null"#;
                     string_literal(0, StringQuote::Double),
                     string_literal(1, StringQuote::Single),
                     MainBlock {
-                        body: expressions(&[0, 1]),
+                        body: nodes(&[0, 1]),
                         local_count: 0,
                     },
                 ],
@@ -314,7 +314,7 @@ null"#;
                         ]),
                     }),
                     MainBlock {
-                        body: expressions(&[1, 3, 6]),
+                        body: nodes(&[1, 3, 6]),
                         local_count: 0,
                     },
                 ],
@@ -352,7 +352,7 @@ null"#;
                         ]),
                     }),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -386,7 +386,7 @@ null"#;
                         ]),
                     }),
                     MainBlock {
-                        body: expressions(&[1]),
+                        body: nodes(&[1]),
                         local_count: 0,
                     },
                 ],
@@ -434,7 +434,7 @@ r##'#$bar'##
                         },
                     }),
                     MainBlock {
-                        body: expressions(&[0, 1, 2, 3]),
+                        body: nodes(&[0, 1, 2, 3]),
                         local_count: 0,
                     },
                 ],
@@ -471,7 +471,7 @@ r##'#$bar'##
                     Nested(10.into()),
                     unary_op(AstUnaryOp::Negate, 11),
                     MainBlock {
-                        body: expressions(&[0, 2, 7, 12]),
+                        body: nodes(&[0, 2, 7, 12]),
                         local_count: 0,
                     },
                 ],
@@ -497,10 +497,10 @@ r##'#$bar'##
                     string_literal(1, StringQuote::Double),
                     id(0),
                     SmallInt(-1),
-                    List(expressions(&[0, 1, 2, 3, 4])),
-                    List(expressions(&[])),
+                    List(nodes(&[0, 1, 2, 3, 4])),
+                    List(nodes(&[])),
                     MainBlock {
-                        body: expressions(&[5, 6]),
+                        body: nodes(&[5, 6]),
                         local_count: 0,
                     },
                 ],
@@ -519,11 +519,11 @@ r##'#$bar'##
                     SmallInt(0),
                     SmallInt(1),
                     SmallInt(-1),
-                    List(expressions(&[1, 2])),
+                    List(nodes(&[1, 2])),
                     SmallInt(2),
-                    List(expressions(&[0, 3, 4])), // 5
+                    List(nodes(&[0, 3, 4])), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -576,10 +576,10 @@ x = [
                     SmallInt(0),
                     SmallInt(1),
                     SmallInt(0), // 5
-                    List(expressions(&[1, 2, 3, 4, 5])),
+                    List(nodes(&[1, 2, 3, 4, 5])),
                     assign(0, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -630,7 +630,7 @@ x =
                     map_inline(&[(2, Some(3)), (4, None), (5, Some(6)), (7, Some(8))]),
                     assign(1, 9), // 10
                     MainBlock {
-                        body: expressions(&[0, 10]),
+                        body: nodes(&[0, 10]),
                         local_count: 1,
                     },
                 ],
@@ -669,7 +669,7 @@ x"#;
                     assign(0, 9), //10
                     id(0),
                     MainBlock {
-                        body: expressions(&[10, 11]),
+                        body: nodes(&[10, 11]),
                         local_count: 1,
                     },
                 ],
@@ -696,7 +696,7 @@ x =
                     map_block(&[(1, 2)]),
                     assign(0, 3),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 1,
                     },
                 ],
@@ -722,7 +722,7 @@ x =
                     map_block(&[(1, 4)]), // 5
                     assign(0, 5),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 1,
                     },
                 ],
@@ -761,11 +761,11 @@ x =
                     SmallInt(10),
                     SmallInt(20),
                     SmallInt(30),
-                    Tuple(expressions(&[2, 3, 4])), //5
+                    Tuple(nodes(&[2, 3, 4])), //5
                     map_block(&[(1, 5)]),
                     assign(0, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -808,7 +808,7 @@ x =
                     map_block(&[(1, 2), (3, 7)]),
                     assign(0, 8),
                     MainBlock {
-                        body: expressions(&[9]),
+                        body: nodes(&[9]),
                         local_count: 1,
                     },
                 ],
@@ -842,7 +842,7 @@ x =
                     map_block(&[(1, 2), (3, 4), (5, 6)]),
                     assign(0, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 1,
                     },
                 ],
@@ -872,7 +872,7 @@ x =
                     assign(0, 7),
                     Export(8.into()),
                     MainBlock {
-                        body: expressions(&[9]),
+                        body: nodes(&[9]),
                         local_count: 0,
                     },
                 ],
@@ -899,7 +899,7 @@ x =
                     SmallInt(1),
                     range(3, 4, true), // 5
                     MainBlock {
-                        body: expressions(&[2, 5]),
+                        body: nodes(&[2, 5]),
                         local_count: 0,
                     },
                 ],
@@ -921,7 +921,7 @@ x =
                     binary_op(AstBinaryOp::Add, 3, 4), // 5
                     range(2, 5, false),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -949,7 +949,7 @@ min..max
                     id(1),
                     range(6, 7, false),
                     MainBlock {
-                        body: expressions(&[2, 5, 8]),
+                        body: nodes(&[2, 5, 8]),
                         local_count: 2,
                     },
                 ],
@@ -971,7 +971,7 @@ min..max
                     chain_root(3, Some(4)), // 5
                     range(2, 5, false),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -994,16 +994,16 @@ min..max
                     SmallInt(0),
                     SmallInt(1),
                     range(0, 1, false),
-                    List(expressions(&[2])),
+                    List(nodes(&[2])),
                     SmallInt(0),
                     SmallInt(10), // 5
                     range(4, 5, false),
                     SmallInt(10),
                     SmallInt(0),
                     range(7, 8, true),
-                    List(expressions(&[6, 9])),
+                    List(nodes(&[6, 9])),
                     MainBlock {
-                        body: expressions(&[3, 10]),
+                        body: nodes(&[3, 10]),
                         local_count: 0,
                     },
                 ],
@@ -1024,9 +1024,9 @@ min..max
                     SmallInt(0),
                     SmallInt(1),
                     SmallInt(0),
-                    Tuple(expressions(&[0, 1, 2])),
+                    Tuple(nodes(&[0, 1, 2])),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -1040,9 +1040,9 @@ min..max
             check_ast(
                 source,
                 &[
-                    Tuple(expressions(&[])),
+                    Tuple(nodes(&[])),
                     MainBlock {
-                        body: expressions(&[0]),
+                        body: nodes(&[0]),
                         local_count: 0,
                     },
                 ],
@@ -1058,7 +1058,7 @@ min..max
                 &[
                     Null,
                     MainBlock {
-                        body: expressions(&[0]),
+                        body: nodes(&[0]),
                         local_count: 0,
                     },
                 ],
@@ -1090,9 +1090,9 @@ min..max
                     SmallInt(0),
                     SmallInt(1),
                     SmallInt(0),
-                    Tuple(expressions(&[0, 1, 2])),
+                    Tuple(nodes(&[0, 1, 2])),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -1107,9 +1107,9 @@ min..max
                 source,
                 &[
                     SmallInt(1),
-                    Tuple(expressions(&[0])),
+                    Tuple(nodes(&[0])),
                     MainBlock {
-                        body: expressions(&[1]),
+                        body: nodes(&[1]),
                         local_count: 0,
                     },
                 ],
@@ -1131,7 +1131,7 @@ min..max
                     SmallInt(1),
                     assign(0, 1),
                     MainBlock {
-                        body: expressions(&[2]),
+                        body: nodes(&[2]),
                         local_count: 1,
                     },
                 ],
@@ -1148,10 +1148,10 @@ min..max
                     id(0),
                     SmallInt(1),
                     SmallInt(0),
-                    Tuple(expressions(&[1, 2])),
+                    Tuple(nodes(&[1, 2])),
                     assign(0, 3),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 1,
                     },
                 ],
@@ -1168,14 +1168,14 @@ min..max
                     id(0),
                     SmallInt(0),
                     SmallInt(1),
-                    Tuple(expressions(&[1, 2])),
+                    Tuple(nodes(&[1, 2])),
                     SmallInt(2),
                     SmallInt(3), // 5
-                    Tuple(expressions(&[4, 5])),
-                    Tuple(expressions(&[3, 6])),
+                    Tuple(nodes(&[4, 5])),
+                    Tuple(nodes(&[3, 6])),
                     assign(0, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 1,
                     },
                 ],
@@ -1196,13 +1196,13 @@ min..max
                     chain_root(1, Some(3)),
                     SmallInt(1), // 5
                     SmallInt(0),
-                    TempTuple(expressions(&[5, 6])),
+                    TempTuple(nodes(&[5, 6])),
                     MultiAssign {
-                        targets: expressions(&[0, 4]),
+                        targets: nodes(&[0, 4]),
                         expression: 7.into(),
                     },
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 1, // y is assumed to be non-local
                     },
                 ],
@@ -1224,14 +1224,14 @@ x";
                     id(1),
                     SmallInt(1),
                     SmallInt(0),
-                    TempTuple(expressions(&[2, 3])),
+                    TempTuple(nodes(&[2, 3])),
                     MultiAssign {
-                        targets: expressions(&[0, 1]),
+                        targets: nodes(&[0, 1]),
                         expression: 4.into(),
                     }, // 5
                     id(0),
                     MainBlock {
-                        body: expressions(&[5, 6]),
+                        body: nodes(&[5, 6]),
                         local_count: 2,
                     },
                 ],
@@ -1251,18 +1251,18 @@ x";
                     id(2),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
                     )),
                     chain_root(3, Some(4)), // 5
                     MultiAssign {
-                        targets: expressions(&[0, 1, 2]),
+                        targets: nodes(&[0, 1, 2]),
                         expression: 5.into(),
                     },
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 1,
                     },
                 ],
@@ -1297,7 +1297,7 @@ x %= 4";
                     SmallInt(4),
                     binary_op(AstBinaryOp::RemainderAssign, 12, 13),
                     MainBlock {
-                        body: expressions(&[2, 5, 8, 11, 14]),
+                        body: nodes(&[2, 5, 8, 11, 14]),
                         local_count: 0,
                     }, // 15
                 ],
@@ -1316,16 +1316,16 @@ x %= 4";
                     id(0),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
                     )),
                     chain_id(1, Some(1)),
                     chain_root(0, Some(2)),
-                    List(expressions(&[3])),
+                    List(nodes(&[3])),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -1395,7 +1395,7 @@ x %= 4";
                     id_with_type_hint(2, 2), // bar
                     id(4),                   // baz
                     MultiAssign {
-                        targets: expressions(&[1, 3]),
+                        targets: nodes(&[1, 3]),
                         expression: 4.into(),
                     }, // 5
                     MainBlock {
@@ -1474,18 +1474,18 @@ x %= 4";
                     id(3),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
                     )),
                     chain_root(6, Some(7)), // 5
                     MultiAssign {
-                        targets: expressions(&[1, 3, 5]),
+                        targets: nodes(&[1, 3, 5]),
                         expression: 8.into(),
                     },
                     MainBlock {
-                        body: expressions(&[9]),
+                        body: nodes(&[9]),
                         local_count: 1,
                     },
                 ],
@@ -1524,7 +1524,7 @@ export a =
                     assign(0, 3),
                     Export(4.into()), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 1,
                     },
                 ],
@@ -1550,7 +1550,7 @@ export
                     map_block(&[(0, 1), (2, 3)]),
                     Export(4.into()), //  5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -1587,7 +1587,7 @@ export
                     SmallInt(1),
                     binary_op(AstBinaryOp::Add, 2, 3),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -1609,7 +1609,7 @@ export
                     SmallInt(0), // 5
                     binary_op(AstBinaryOp::Add, 4, 5),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -1633,7 +1633,7 @@ export
                     Nested(6.into()),
                     binary_op(AstBinaryOp::Multiply, 3, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -1653,7 +1653,7 @@ export
                     SmallInt(4),
                     binary_op(AstBinaryOp::Remainder, 2, 3),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -1671,7 +1671,7 @@ export
                     id(1),
                     binary_op(AstBinaryOp::Add, 0, 1),
                     MainBlock {
-                        body: expressions(&[2]),
+                        body: nodes(&[2]),
                         local_count: 0,
                     },
                 ],
@@ -1694,7 +1694,7 @@ export
                     binary_op(AstBinaryOp::Add, 1, 5),
                     assign(0, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -1739,7 +1739,7 @@ a =
                     binary_op(AstBinaryOp::Add, 1, 4), // 5
                     assign(0, 5),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 1,
                     },
                 ],
@@ -1782,7 +1782,7 @@ a = (1
                     binary_op(AstBinaryOp::Multiply, 4, 5),
                     assign(0, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -1810,7 +1810,7 @@ a = (1
                     BoolTrue,
                     binary_op(AstBinaryOp::Or, 6, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -1830,7 +1830,7 @@ a = (1
                     binary_op(AstBinaryOp::LessOrEqual, 1, 2),
                     binary_op(AstBinaryOp::Less, 0, 3),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -1860,7 +1860,7 @@ a = (1
                     }),
                     binary_op(AstBinaryOp::Add, 0, 4),
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -1923,7 +1923,7 @@ a",
                     assign(0, 8),
                     id(0),
                     MainBlock {
-                        body: expressions(&[9, 10]),
+                        body: nodes(&[9, 10]),
                         local_count: 1,
                     }, // 10
                 ],
@@ -1942,10 +1942,10 @@ a",
                     BoolTrue,
                     SmallInt(0),
                     SmallInt(1),
-                    Tuple(expressions(&[3, 4])), // 5
+                    Tuple(nodes(&[3, 4])), // 5
                     SmallInt(1),
                     SmallInt(0),
-                    Tuple(expressions(&[6, 7])),
+                    Tuple(nodes(&[6, 7])),
                     If(AstIf {
                         condition: 2.into(),
                         then_node: 5.into(),
@@ -1953,11 +1953,11 @@ a",
                         else_node: Some(8.into()),
                     }),
                     MultiAssign {
-                        targets: expressions(&[0, 1]),
+                        targets: nodes(&[0, 1]),
                         expression: 9.into(),
                     }, // 10
                     MainBlock {
-                        body: expressions(&[10]),
+                        body: nodes(&[10]),
                         local_count: 2,
                     },
                 ],
@@ -1986,9 +1986,9 @@ a",
                         else_node: None,
                     }),
                     id(0),
-                    Block(expressions(&[2, 3])),
+                    Block(nodes(&[2, 3])),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![0.into()],
                         body: 4.into(),
@@ -1997,7 +1997,7 @@ a",
                         output_type: None,
                     }), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -2024,12 +2024,12 @@ for x, _, _y, z in foo
                     id(3),                          // foo
                     id(0),                          // x - 5
                     For(AstFor {
-                        args: expressions(&[0, 1, 2, 3]),
+                        args: nodes(&[0, 1, 2, 3]),
                         iterable: 4.into(),
                         body: 5.into(),
                     }),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 2, // x, z
                     },
                 ],
@@ -2059,7 +2059,7 @@ while x > y
                         body: 3.into(),
                     },
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -2084,7 +2084,7 @@ until x < y
                         body: 3.into(),
                     },
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -2103,17 +2103,17 @@ for x in y
             check_ast(
                 source,
                 &[
-                    List(expressions(&[])),
+                    List(nodes(&[])),
                     id(0), // x
                     id(1), // y
                     id(0), // x
                     For(AstFor {
-                        args: expressions(&[1]),
+                        args: nodes(&[1]),
                         iterable: 2.into(),
                         body: 3.into(),
                     }),
                     MainBlock {
-                        body: expressions(&[0, 4]),
+                        body: nodes(&[0, 4]),
                         local_count: 1,
                     },
                 ],
@@ -2135,7 +2135,7 @@ for a in x.zip y
                     id(3), // y
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[2]),
+                            args: nodes(&[2]),
                             with_parens: false,
                         },
                         None,
@@ -2144,12 +2144,12 @@ for a in x.zip y
                     chain_root(1, Some(4)), // ast 5
                     id(0),                  // a
                     For(AstFor {
-                        args: expressions(&[0]),
+                        args: nodes(&[0]),
                         iterable: 5.into(),
                         body: 6.into(),
                     }),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -2177,7 +2177,7 @@ a()";
                     id(0),
                     SmallInt(42),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 1.into(),
@@ -2189,14 +2189,14 @@ a()";
                     id(0),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
                     )), // 5
                     chain_root(4, Some(5)),
                     MainBlock {
-                        body: expressions(&[3, 6]),
+                        body: nodes(&[3, 6]),
                         local_count: 1,
                     },
                 ],
@@ -2226,7 +2226,7 @@ a()";
                     id(1),
                     binary_op(AstBinaryOp::Add, 2, 3),
                     Function(koto_parser::Function {
-                        args: expressions(&[0, 1]),
+                        args: nodes(&[0, 1]),
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 4.into(),
@@ -2235,7 +2235,7 @@ a()";
                         output_type: None,
                     }), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -2267,7 +2267,7 @@ a()";
                     id(2),                   // y - 5
                     binary_op(AstBinaryOp::Add, 4, 5),
                     Function(koto_parser::Function {
-                        args: expressions(&[1, 3]),
+                        args: nodes(&[1, 3]),
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 6.into(),
@@ -2276,7 +2276,7 @@ a()";
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 0,
                     },
                 ],
@@ -2313,7 +2313,7 @@ a()";
                     type_hint(1),            // String
                     id(0),                   // x
                     Function(koto_parser::Function {
-                        args: expressions(&[1]),
+                        args: nodes(&[1]),
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 3.into(),
@@ -2322,7 +2322,7 @@ a()";
                         output_type: Some(2.into()),
                     }),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -2342,7 +2342,7 @@ a()";
                     id(1),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -2351,7 +2351,7 @@ a()";
                     chain_root(3, Some(5)),
                     binary_op(AstBinaryOp::Add, 2, 6),
                     Function(koto_parser::Function {
-                        args: expressions(&[0, 1]),
+                        args: nodes(&[0, 1]),
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 7.into(),
@@ -2360,7 +2360,7 @@ a()";
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -2388,9 +2388,9 @@ f 42";
                     id(1), // x
                     assign(2, 3),
                     id(2), // 5
-                    Block(expressions(&[4, 5])),
+                    Block(nodes(&[4, 5])),
                     Function(koto_parser::Function {
-                        args: expressions(&[1]),
+                        args: nodes(&[1]),
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 6.into(),
@@ -2404,7 +2404,7 @@ f 42";
                     chain_call(&[10], false, None),
                     chain_root(9, Some(11)),
                     MainBlock {
-                        body: expressions(&[8, 12]),
+                        body: nodes(&[8, 12]),
                         local_count: 1,
                     },
                 ],
@@ -2429,7 +2429,7 @@ f = |x|
                     id(3), // z
                     id(3), // z
                     Function(koto_parser::Function {
-                        args: expressions(&[3]),
+                        args: nodes(&[3]),
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 4.into(),
@@ -2442,9 +2442,9 @@ f = |x|
                     id(1), // x
                     chain_call(&[8], false, None),
                     chain_root(7, Some(9)), // 10
-                    Block(expressions(&[6, 10])),
+                    Block(nodes(&[6, 10])),
                     Function(koto_parser::Function {
-                        args: expressions(&[1]),
+                        args: nodes(&[1]),
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 11.into(),
@@ -2454,7 +2454,7 @@ f = |x|
                     }), // 10
                     assign(0, 12),
                     MainBlock {
-                        body: expressions(&[13]),
+                        body: nodes(&[13]),
                         local_count: 1,
                     },
                 ],
@@ -2480,7 +2480,7 @@ f = |x|
                     chain_call(&[1, 3], false, None),
                     chain_root(0, Some(4)), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -2501,7 +2501,7 @@ f = |x|
                     chain_call(&[3], false, None),
                     chain_root(0, Some(4)), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -2538,14 +2538,14 @@ f(x,
                     unary_op(AstUnaryOp::Negate, 2),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[1, 3]),
+                            args: nodes(&[1, 3]),
                             with_parens: true,
                         },
                         None,
                     )),
                     chain_root(0, Some(4)),
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -2582,7 +2582,7 @@ foo x,
                     chain_call(&[1, 2], false, None),
                     chain_root(0, Some(3)),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -2604,7 +2604,7 @@ foo
                     id(2), // y
                     id(2), // y
                     Function(koto_parser::Function {
-                        args: expressions(&[2]),
+                        args: nodes(&[2]),
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 3.into(),
@@ -2615,7 +2615,7 @@ foo
                     chain_call(&[1, 4], false, None), // 5
                     chain_root(0, Some(5)),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -2641,7 +2641,7 @@ f x";
                     chain_call(&[5], false, None),
                     chain_root(4, Some(6)),
                     MainBlock {
-                        body: expressions(&[3, 7]),
+                        body: nodes(&[3, 7]),
                         local_count: 0,
                     },
                 ],
@@ -2662,7 +2662,7 @@ f x";
                     chain_call(&[3], false, None),
                     chain_root(2, Some(4)), // 5
                     Function(koto_parser::Function {
-                        args: expressions(&[1]),
+                        args: nodes(&[1]),
                         local_count: 1,
                         accessed_non_locals: vec![0.into()],
                         body: 5.into(),
@@ -2672,7 +2672,7 @@ f x";
                     }),
                     assign(0, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -2694,7 +2694,7 @@ f x";
                     chain_call(&[4], false, None), // 5
                     chain_root(3, Some(5)),
                     Function(koto_parser::Function {
-                        args: expressions(&[2]),
+                        args: nodes(&[2]),
                         local_count: 1,
                         accessed_non_locals: vec![0.into()],
                         body: 6.into(),
@@ -2709,7 +2709,7 @@ f x";
                     chain_call(&[11], false, None),
                     chain_root(10, Some(12)),
                     Function(koto_parser::Function {
-                        args: expressions(&[9]),
+                        args: nodes(&[9]),
                         local_count: 1,
                         accessed_non_locals: vec![1.into()],
                         body: 13.into(),
@@ -2718,13 +2718,13 @@ f x";
                         output_type: None,
                     }),
                     Nested(14.into()), // 15
-                    TempTuple(expressions(&[8, 15])),
+                    TempTuple(nodes(&[8, 15])),
                     MultiAssign {
-                        targets: expressions(&[0, 1]),
+                        targets: nodes(&[0, 1]),
                         expression: 16.into(),
                     },
                     MainBlock {
-                        body: expressions(&[17]),
+                        body: nodes(&[17]),
                         local_count: 2,
                     },
                 ],
@@ -2747,7 +2747,7 @@ f x";
                     id(3),                              // h
                     binary_op(AstBinaryOp::Pipe, 5, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 0,
                     },
                 ],
@@ -2774,7 +2774,7 @@ foo.bar x
                     id(2), // x
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[1]),
+                            args: nodes(&[1]),
                             with_parens: false,
                         },
                         None,
@@ -2786,7 +2786,7 @@ foo.bar x
                     id(4), // z
                     binary_op(AstBinaryOp::Pipe, 6, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -2816,7 +2816,7 @@ foo.bar x
                     id(2),
                     assign(6, 7),
                     Function(koto_parser::Function {
-                        args: expressions(&[3]),
+                        args: nodes(&[3]),
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 8.into(),
@@ -2826,7 +2826,7 @@ foo.bar x
                     }),
                     map_inline(&[(0, Some(1)), (2, Some(9))]), // 10
                     MainBlock {
-                        body: expressions(&[10]),
+                        body: nodes(&[10]),
                         local_count: 0,
                     },
                 ],
@@ -2855,7 +2855,7 @@ f = ||
                     SmallInt(0),
                     map_block(&[(1, 2), (3, 4)]), // 5
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![2.into()],
                         body: 5.into(),
@@ -2865,7 +2865,7 @@ f = ||
                     }),
                     assign(0, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -2898,7 +2898,7 @@ f = ||
                     SmallInt(0),
                     map_block(&[(1, 4), (5, 6)]),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![3.into()],
                         body: 7.into(),
@@ -2908,7 +2908,7 @@ f = ||
                     }),
                     assign(0, 8),
                     MainBlock {
-                        body: expressions(&[9]),
+                        body: nodes(&[9]),
                         local_count: 1,
                     },
                 ],
@@ -2943,7 +2943,7 @@ f()";
                     id(3), // x
                     assign(7, 8),
                     Function(koto_parser::Function {
-                        args: expressions(&[4]),
+                        args: nodes(&[4]),
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 9.into(),
@@ -2953,7 +2953,7 @@ f()";
                     }), // 10
                     map_block(&[(1, 2), (3, 10)]),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 11.into(),
@@ -2965,14 +2965,14 @@ f()";
                     id(0), // f
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
                     )), // 15
                     chain_root(14, Some(15)),
                     MainBlock {
-                        body: expressions(&[13, 16]),
+                        body: nodes(&[13, 16]),
                         local_count: 1,
                     },
                 ],
@@ -3018,12 +3018,12 @@ f = |n|
                         else_node: None,
                     }),
                     For(AstFor {
-                        args: expressions(&[4]),
+                        args: nodes(&[4]),
                         iterable: 7.into(),
                         body: 13.into(),
                     }),
                     Function(koto_parser::Function {
-                        args: expressions(&[3]),
+                        args: nodes(&[3]),
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 14.into(),
@@ -3033,9 +3033,9 @@ f = |n|
                     }), // ast 15
                     assign(2, 15),
                     id(2),
-                    Block(expressions(&[16, 17])),
+                    Block(nodes(&[16, 17])),
                     Function(koto_parser::Function {
-                        args: expressions(&[1]),
+                        args: nodes(&[1]),
                         local_count: 2,
                         accessed_non_locals: vec![],
                         body: 18.into(),
@@ -3045,7 +3045,7 @@ f = |n|
                     }),
                     assign(0, 19), // ast 20
                     MainBlock {
-                        body: expressions(&[20]),
+                        body: nodes(&[20]),
                         local_count: 1,
                     },
                 ],
@@ -3074,9 +3074,9 @@ f = |n|
                     binary_op(AstBinaryOp::Add, 1, 2),
                     assign(0, 3),
                     id(0), // 5
-                    Block(expressions(&[4, 5])),
+                    Block(nodes(&[4, 5])),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 1,
                         accessed_non_locals: vec![0.into()], // initial read of x via capture
                         body: 6.into(),
@@ -3085,7 +3085,7 @@ f = |n|
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 0,
                     },
                 ],
@@ -3108,10 +3108,10 @@ f = |n|
                     assign(1, 2),
                     Nested(3.into()),
                     id(1), // 5
-                    Tuple(expressions(&[4, 5])),
+                    Tuple(nodes(&[4, 5])),
                     assign(0, 6),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 2,
                         accessed_non_locals: vec![], // b is locally assigned when accessed
                         body: 7.into(),
@@ -3120,7 +3120,7 @@ f = |n|
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -3140,7 +3140,7 @@ f = |n|
                     SmallInt(1),
                     binary_op(AstBinaryOp::AddAssign, 0, 1),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![0.into()], // initial read of x via capture
                         body: 2.into(),
@@ -3149,7 +3149,7 @@ f = |n|
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -3170,13 +3170,13 @@ z = y [0..20], |x| x > 1
                     SmallInt(0),
                     SmallInt(20),
                     range(2, 3, false),
-                    List(expressions(&[4])), // 5
-                    id(2),                   // x
-                    id(2),                   // x
+                    List(nodes(&[4])), // 5
+                    id(2),             // x
+                    id(2),             // x
                     SmallInt(1),
                     binary_op(AstBinaryOp::Greater, 7, 8),
                     Function(koto_parser::Function {
-                        args: expressions(&[6]),
+                        args: nodes(&[6]),
                         local_count: 1,
                         accessed_non_locals: vec![],
                         body: 9.into(),
@@ -3188,7 +3188,7 @@ z = y [0..20], |x| x > 1
                     chain_root(1, Some(11)),
                     assign(0, 12),
                     MainBlock {
-                        body: expressions(&[13]),
+                        body: nodes(&[13]),
                         local_count: 1,
                     },
                 ],
@@ -3205,7 +3205,7 @@ z = y [0..20], |x| x > 1
                     SmallInt(1),
                     Yield(0.into()),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 1.into(),
@@ -3214,7 +3214,7 @@ z = y [0..20], |x| x > 1
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[2]),
+                        body: nodes(&[2]),
                         local_count: 0,
                     },
                 ],
@@ -3230,10 +3230,10 @@ z = y [0..20], |x| x > 1
                 &[
                     SmallInt(1),
                     SmallInt(0),
-                    Tuple(expressions(&[0, 1])),
+                    Tuple(nodes(&[0, 1])),
                     Yield(2.into()),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 3.into(),
@@ -3242,7 +3242,7 @@ z = y [0..20], |x| x > 1
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -3265,7 +3265,7 @@ z = y [0..20], |x| x > 1
                     map_block(&[(0, 1)]),
                     Yield(2.into()),
                     Function(koto_parser::Function {
-                        args: expressions(&[]),
+                        args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: vec![],
                         body: 3.into(),
@@ -3274,7 +3274,7 @@ z = y [0..20], |x| x > 1
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -3307,12 +3307,12 @@ z = y [0..20], |x| x > 1
                     Ellipsis(Some(1.into())),       // others
                     id(2),                          // c
                     Wildcard(Some(3.into()), None), // d
-                    Tuple(expressions(&[2, 3, 4])), // ast index 5
-                    Tuple(expressions(&[1, 5])),
+                    Tuple(nodes(&[2, 3, 4])),       // ast index 5
+                    Tuple(nodes(&[1, 5])),
                     Wildcard(Some(4.into()), None), // e
                     id(0),
                     Function(koto_parser::Function {
-                        args: expressions(&[0, 6, 7]),
+                        args: nodes(&[0, 6, 7]),
                         local_count: 3,
                         accessed_non_locals: vec![],
                         body: 8.into(),
@@ -3321,7 +3321,7 @@ z = y [0..20], |x| x > 1
                         output_type: None,
                     }),
                     MainBlock {
-                        body: expressions(&[9]),
+                        body: nodes(&[9]),
                         local_count: 0,
                     },
                 ],
@@ -3356,7 +3356,7 @@ z = y [0..20], |x| x > 1
                     chain_root(4, Some(6)),
                     assign(3, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -3375,7 +3375,7 @@ z = y [0..20], |x| x > 1
                     chain_index(1, None),
                     chain_root(0, Some(2)),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -3398,7 +3398,7 @@ z = y [0..20], |x| x > 1
                     chain_index(2, None),
                     chain_root(0, Some(3)),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -3420,7 +3420,7 @@ z = y [0..20], |x| x > 1
                     chain_index(2, Some(4)), // 5
                     chain_root(0, Some(5)),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -3438,7 +3438,7 @@ z = y [0..20], |x| x > 1
                     chain_id(1, None),
                     chain_root(0, Some(1)),
                     MainBlock {
-                        body: expressions(&[2]),
+                        body: nodes(&[2]),
                         local_count: 0,
                     },
                 ],
@@ -3455,7 +3455,7 @@ z = y [0..20], |x| x > 1
                     id(0),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -3463,7 +3463,7 @@ z = y [0..20], |x| x > 1
                     chain_id(1, Some(1)),
                     chain_root(0, Some(2)),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -3480,7 +3480,7 @@ z = y [0..20], |x| x > 1
                     id(0),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -3490,7 +3490,7 @@ z = y [0..20], |x| x > 1
                     SmallInt(1),
                     binary_op(AstBinaryOp::Subtract, 3, 4), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -3516,7 +3516,7 @@ x.bar()."baz" = 1
                     )),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         Some(1.into()),
@@ -3526,7 +3526,7 @@ x.bar()."baz" = 1
                     SmallInt(1), // 5
                     assign(4, 5),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -3548,7 +3548,7 @@ x.bar()."baz" = 1
                     SmallInt(42),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[1]),
+                            args: nodes(&[1]),
                             with_parens: false,
                         },
                         None,
@@ -3556,7 +3556,7 @@ x.bar()."baz" = 1
                     chain_id(1, Some(2)),
                     chain_root(0, Some(3)),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -3577,7 +3577,7 @@ x.foo
                     SmallInt(42),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[1]),
+                            args: nodes(&[1]),
                             with_parens: false,
                         },
                         None,
@@ -3585,7 +3585,7 @@ x.foo
                     chain_id(1, Some(2)),
                     chain_root(0, Some(3)),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -3608,7 +3608,7 @@ x.takes_a_map
                     map_block(&[(1, 2)]),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[3]),
+                            args: nodes(&[3]),
                             with_parens: false,
                         },
                         None,
@@ -3616,7 +3616,7 @@ x.takes_a_map
                     chain_id(1, Some(4)), // 5 - takes_a_map
                     chain_root(0, Some(5)),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -3657,9 +3657,9 @@ x.takes_a_map
                     id(0),
                     chain_id(2, None),
                     chain_root(3, Some(4)), // 5
-                    List(expressions(&[2, 5])),
+                    List(nodes(&[2, 5])),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -3685,7 +3685,7 @@ x.takes_a_map
                     chain_id(2, None), // 5
                     chain_root(4, Some(5)),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -3708,7 +3708,7 @@ x.takes_a_map
                     chain_index(5, None),
                     chain_root(4, Some(6)),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 0,
                     },
                 ],
@@ -3731,7 +3731,7 @@ x.takes_a_map
                     chain_call(&[5], true, None),
                     chain_root(4, Some(6)),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 0,
                     },
                 ],
@@ -3748,7 +3748,7 @@ x.takes_a_map
                     SmallInt(1),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -3756,7 +3756,7 @@ x.takes_a_map
                     chain_id(0, Some(1)),
                     chain_root(0, Some(2)),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -3774,7 +3774,7 @@ x.takes_a_map
                     string_literal(2, StringQuote::Single),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[1]),
+                            args: nodes(&[1]),
                             with_parens: false,
                         },
                         None,
@@ -3782,7 +3782,7 @@ x.takes_a_map
                     chain_id(1, Some(2)),
                     chain_root(0, Some(3)),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],
@@ -3816,11 +3816,11 @@ x = ( 0
                     id(0),
                     SmallInt(0),
                     SmallInt(1),
-                    Tuple(expressions(&[1, 2])),
+                    Tuple(nodes(&[1, 2])),
                     id(2),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[4]),
+                            args: nodes(&[4]),
                             with_parens: false,
                         },
                         None,
@@ -3829,7 +3829,7 @@ x = ( 0
                     chain_root(3, Some(6)),
                     assign(0, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 1,
                     },
                 ],
@@ -3862,11 +3862,11 @@ x = [ 0
                     id(0),
                     SmallInt(0),
                     SmallInt(1),
-                    List(expressions(&[1, 2])),
+                    List(nodes(&[1, 2])),
                     id(2),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[4]),
+                            args: nodes(&[4]),
                             with_parens: false,
                         },
                         None,
@@ -3875,7 +3875,7 @@ x = [ 0
                     chain_root(3, Some(6)),
                     assign(0, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 1,
                     },
                 ],
@@ -3917,7 +3917,7 @@ x = { y
                     map_inline(&[(1, None), (2, None)]),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -3926,7 +3926,7 @@ x = { y
                     chain_root(3, Some(5)),
                     assign(0, 6),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -3951,7 +3951,7 @@ x = { y
                     Nested(2.into()),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -3959,7 +3959,7 @@ x = { y
                     chain_id(0, Some(4)), // 5
                     chain_root(3, Some(5)),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -3981,7 +3981,7 @@ x = { y
                     range(0, 1, false),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -3989,7 +3989,7 @@ x = { y
                     chain_id(0, Some(3)),
                     chain_root(2, Some(4)), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -4008,7 +4008,7 @@ x = { y
                     id(2),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[2]),
+                            args: nodes(&[2]),
                             with_parens: false,
                         },
                         None,
@@ -4017,7 +4017,7 @@ x = { y
                     chain_root(1, Some(4)), // 5
                     Nested(5.into()),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -4043,7 +4043,7 @@ x.iter()
                     SmallInt(1),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -4051,7 +4051,7 @@ x.iter()
                     chain_id(3, Some(2)),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[1]),
+                            args: nodes(&[1]),
                             with_parens: false,
                         },
                         Some(3.into()),
@@ -4059,7 +4059,7 @@ x.iter()
                     chain_id(2, Some(4)), // 5
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         Some(5.into()),
@@ -4067,7 +4067,7 @@ x.iter()
                     chain_id(1, Some(6)),
                     chain_root(0, Some(7)),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -4100,7 +4100,7 @@ foo.bar
                     BoolFalse,
                     binary_op(AstBinaryOp::Or, 6, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -4132,7 +4132,7 @@ return 1";
                     SmallInt(1),
                     Return(Some(3.into())),
                     MainBlock {
-                        body: expressions(&[0, 1, 2, 4]),
+                        body: nodes(&[0, 1, 2, 4]),
                         local_count: 0,
                     },
                 ],
@@ -4159,7 +4159,7 @@ debug x + x
                         expression: 4.into(),
                     }, // 5
                     MainBlock {
-                        body: expressions(&[1, 5]),
+                        body: nodes(&[1, 5]),
                         local_count: 0,
                     },
                 ],
@@ -4193,7 +4193,7 @@ debug x + x
                         items: import_items(&[0]),
                     },
                     MainBlock {
-                        body: expressions(&[1]),
+                        body: nodes(&[1]),
                         local_count: 1,
                     },
                 ],
@@ -4217,7 +4217,7 @@ debug x + x
                         }],
                     },
                     MainBlock {
-                        body: expressions(&[2]),
+                        body: nodes(&[2]),
                         local_count: 1,
                     },
                 ],
@@ -4238,7 +4238,7 @@ debug x + x
                         items: import_items(&[1]),
                     },
                     MainBlock {
-                        body: expressions(&[2]),
+                        body: nodes(&[2]),
                         local_count: 1,
                     },
                 ],
@@ -4261,7 +4261,7 @@ debug x + x
                     },
                     assign(0, 3),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 2, // x and bar both assigned locally
                     },
                 ],
@@ -4300,7 +4300,7 @@ import foo,
                         items: import_items(&[0, 1, 2]),
                     },
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 2, // foo and baz, bar needs to be assigned
                     },
                 ],
@@ -4336,7 +4336,7 @@ from foo import bar,
                         items: import_items(&[1, 2]),
                     },
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 2,
                     },
                 ],
@@ -4363,7 +4363,7 @@ from foo import bar,
                         items: import_items(&[2, 3]),
                     },
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 2,
                     },
                 ],
@@ -4394,7 +4394,7 @@ catch e
                     id(0),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -4413,7 +4413,7 @@ catch e
                         finally_block: None,
                     }),
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 1,
                     },
                 ],
@@ -4442,7 +4442,7 @@ catch _
                         finally_block: None,
                     }),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -4471,7 +4471,7 @@ catch _error
                         finally_block: None,
                     }),
                     MainBlock {
-                        body: expressions(&[3]),
+                        body: nodes(&[3]),
                         local_count: 0,
                     },
                 ],
@@ -4499,7 +4499,7 @@ finally
                     id(0),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[]),
+                            args: nodes(&[]),
                             with_parens: true,
                         },
                         None,
@@ -4519,7 +4519,7 @@ finally
                         finally_block: Some(6.into()),
                     }),
                     MainBlock {
-                        body: expressions(&[7]),
+                        body: nodes(&[7]),
                         local_count: 1,
                     },
                 ],
@@ -4536,7 +4536,7 @@ finally
                     id(0),
                     Throw(0.into()),
                     MainBlock {
-                        body: expressions(&[1]),
+                        body: nodes(&[1]),
                         local_count: 0,
                     },
                 ],
@@ -4553,7 +4553,7 @@ finally
                     string_literal(0, StringQuote::Single),
                     Throw(0.into()),
                     MainBlock {
-                        body: expressions(&[1]),
+                        body: nodes(&[1]),
                         local_count: 0,
                     },
                 ],
@@ -4578,7 +4578,7 @@ throw
                     map_block(&[(0, 1), (2, 3)]),
                     Throw(4.into()), // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -4616,12 +4616,12 @@ x = match y
                         expression: 1.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[2, 3]),
+                                patterns: nodes(&[2, 3]),
                                 condition: None,
                                 expression: 4.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[5]),
+                                patterns: nodes(&[5]),
                                 condition: None,
                                 expression: 6.into(),
                             },
@@ -4629,7 +4629,7 @@ x = match y
                     },
                     assign(0, 7),
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 2,
                     },
                 ],
@@ -4657,19 +4657,19 @@ match x
                         expression: 0.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[1]),
+                                patterns: nodes(&[1]),
                                 condition: None,
                                 expression: 2.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[3, 4]),
+                                patterns: nodes(&[3, 4]),
                                 condition: None,
                                 expression: 5.into(),
                             },
                         ],
                     },
                     MainBlock {
-                        body: expressions(&[6]),
+                        body: nodes(&[6]),
                         local_count: 0,
                     },
                 ],
@@ -4695,36 +4695,36 @@ match (x, y, z)
                     id(0),
                     id(1),
                     id(2),
-                    Tuple(expressions(&[0, 1, 2])),
+                    Tuple(nodes(&[0, 1, 2])),
                     SmallInt(0),
                     id(3), // 5
                     Wildcard(None, None),
-                    Tuple(expressions(&[4, 5, 6])),
+                    Tuple(nodes(&[4, 5, 6])),
                     id(3),
                     Wildcard(None, None),
                     SmallInt(0), // 10
                     id(4),
-                    Tuple(expressions(&[10, 11])),
+                    Tuple(nodes(&[10, 11])),
                     Wildcard(Some(5.into()), None),
-                    Tuple(expressions(&[9, 12, 13])),
+                    Tuple(nodes(&[9, 12, 13])),
                     SmallInt(0), // 15
                     Match {
                         expression: 3.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[7]),
+                                patterns: nodes(&[7]),
                                 condition: None,
                                 expression: 8.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[14]),
+                                patterns: nodes(&[14]),
                                 condition: None,
                                 expression: 15.into(),
                             },
                         ],
                     },
                     MainBlock {
-                        body: expressions(&[16]),
+                        body: nodes(&[16]),
                         local_count: 2,
                     },
                 ],
@@ -4752,29 +4752,29 @@ match x
                     id(0),
                     Ellipsis(None),
                     SmallInt(0),
-                    Tuple(expressions(&[1, 2])),
+                    Tuple(nodes(&[1, 2])),
                     SmallInt(0),
                     SmallInt(1), // 5
                     Ellipsis(None),
-                    Tuple(expressions(&[5, 6])),
+                    Tuple(nodes(&[5, 6])),
                     SmallInt(1),
                     Match {
                         expression: 0.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[3]),
+                                patterns: nodes(&[3]),
                                 condition: None,
                                 expression: 4.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[7]),
+                                patterns: nodes(&[7]),
                                 condition: None,
                                 expression: 8.into(),
                             },
                         ],
                     },
                     MainBlock {
-                        body: expressions(&[9]),
+                        body: nodes(&[9]),
                         local_count: 0,
                     },
                 ],
@@ -4796,30 +4796,30 @@ match y
                     Ellipsis(Some(1.into())),
                     SmallInt(0),
                     SmallInt(1),
-                    Tuple(expressions(&[1, 2, 3])),
+                    Tuple(nodes(&[1, 2, 3])),
                     SmallInt(0), // 5
                     SmallInt(1),
                     SmallInt(0),
                     Ellipsis(Some(2.into())),
-                    Tuple(expressions(&[6, 7, 8])),
+                    Tuple(nodes(&[6, 7, 8])),
                     SmallInt(1), // 10
                     Match {
                         expression: 0.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[4]),
+                                patterns: nodes(&[4]),
                                 condition: None,
                                 expression: 5.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[9]),
+                                patterns: nodes(&[9]),
                                 condition: None,
                                 expression: 10.into(),
                             },
                         ],
                     },
                     MainBlock {
-                        body: expressions(&[11]),
+                        body: nodes(&[11]),
                         local_count: 2,
                     },
                 ],
@@ -4861,24 +4861,24 @@ match x
                         expression: 0.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[1]),
+                                patterns: nodes(&[1]),
                                 condition: Some(4.into()),
                                 expression: 5.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[6]),
+                                patterns: nodes(&[6]),
                                 condition: Some(9.into()),
                                 expression: 10.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[11]),
+                                patterns: nodes(&[11]),
                                 condition: None,
                                 expression: 12.into(),
                             },
                         ],
                     },
                     MainBlock {
-                        body: expressions(&[13]),
+                        body: nodes(&[13]),
                         local_count: 1,
                     },
                 ],
@@ -4900,42 +4900,42 @@ match x, y
                 &[
                     id(0),
                     id(1),
-                    TempTuple(expressions(&[0, 1])),
+                    TempTuple(nodes(&[0, 1])),
                     SmallInt(0),
                     SmallInt(1),
-                    TempTuple(expressions(&[3, 4])), // 5
+                    TempTuple(nodes(&[3, 4])), // 5
                     SmallInt(2),
                     SmallInt(3),
-                    TempTuple(expressions(&[6, 7])),
+                    TempTuple(nodes(&[6, 7])),
                     id(2),
                     SmallInt(0), // 10
                     id(3),
                     Null,
-                    TempTuple(expressions(&[11, 12])),
+                    TempTuple(nodes(&[11, 12])),
                     id(3),
                     SmallInt(0), // 15
                     Match {
                         expression: 2.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[5, 8]),
+                                patterns: nodes(&[5, 8]),
                                 condition: Some(9.into()),
                                 expression: 10.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[13]),
+                                patterns: nodes(&[13]),
                                 condition: None,
                                 expression: 14.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[]),
+                                patterns: nodes(&[]),
                                 condition: None,
                                 expression: 15.into(),
                             },
                         ],
                     },
                     MainBlock {
-                        body: expressions(&[16]),
+                        body: nodes(&[16]),
                         local_count: 1,
                     },
                 ],
@@ -4962,7 +4962,7 @@ match x.foo 42
                     SmallInt(42),
                     Chain((
                         ChainNode::Call {
-                            args: expressions(&[1]),
+                            args: nodes(&[1]),
                             with_parens: false,
                         },
                         None,
@@ -4976,19 +4976,19 @@ match x.foo 42
                         expression: 4.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[5]),
+                                patterns: nodes(&[5]),
                                 condition: None,
                                 expression: 6.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[]),
+                                patterns: nodes(&[]),
                                 condition: None,
                                 expression: 7.into(),
                             },
                         ],
                     },
                     MainBlock {
-                        body: expressions(&[8]),
+                        body: nodes(&[8]),
                         local_count: 0,
                     },
                 ],
@@ -5013,13 +5013,13 @@ match x
                     Match {
                         expression: 0.into(),
                         arms: vec![MatchArm {
-                            patterns: expressions(&[3]),
+                            patterns: nodes(&[3]),
                             condition: None,
                             expression: 4.into(),
                         }],
                     },
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -5046,19 +5046,19 @@ match x
                         expression: 0.into(),
                         arms: vec![
                             MatchArm {
-                                patterns: expressions(&[1]),
+                                patterns: nodes(&[1]),
                                 condition: None,
                                 expression: 2.into(),
                             },
                             MatchArm {
-                                patterns: expressions(&[]),
+                                patterns: nodes(&[]),
                                 condition: None,
                                 expression: 4.into(),
                             },
                         ],
                     }, // 5
                     MainBlock {
-                        body: expressions(&[5]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -5101,7 +5101,7 @@ switch
                         },
                     ]),
                     MainBlock {
-                        body: expressions(&[9]),
+                        body: nodes(&[9]),
                         local_count: 0,
                     },
                 ],
@@ -5137,7 +5137,7 @@ switch
                         },
                     ]),
                     MainBlock {
-                        body: expressions(&[4]),
+                        body: nodes(&[4]),
                         local_count: 0,
                     },
                 ],

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -145,8 +145,7 @@ impl KValue {
         match &self {
             Null => TYPE_NULL.with(|x| x.clone()),
             Bool(_) => TYPE_BOOL.with(|x| x.clone()),
-            Number(KNumber::F64(_)) => TYPE_FLOAT.with(|x| x.clone()),
-            Number(KNumber::I64(_)) => TYPE_INT.with(|x| x.clone()),
+            Number(_) => TYPE_NUMBER.with(|x| x.clone()),
             List(_) => TYPE_LIST.with(|x| x.clone()),
             Range { .. } => TYPE_RANGE.with(|x| x.clone()),
             Map(m) if m.meta_map().is_some() => match m.get_meta_value(&MetaKey::Type) {
@@ -202,8 +201,7 @@ impl KValue {
 thread_local! {
     static TYPE_NULL: KString = "Null".into();
     static TYPE_BOOL: KString = "Bool".into();
-    static TYPE_FLOAT: KString = "Float".into();
-    static TYPE_INT: KString = "Int".into();
+    static TYPE_NUMBER: KString = "Number".into();
     static TYPE_LIST: KString = "List".into();
     static TYPE_RANGE: KString = "Range".into();
     static TYPE_MAP: KString = "Map".into();

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -121,6 +121,15 @@ f ('hello',)
 ";
                 check_script_fails(script);
             }
+
+            #[test]
+            fn function_with_return_type() {
+                let script = "
+f = |x: Number| -> String x
+f 42
+";
+                check_script_fails(script);
+            }
         }
 
         mod missing_values {

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -85,6 +85,42 @@ let _x: String, y: Bool = 99, true
 ";
                 check_script_fails(script);
             }
+
+            #[test]
+            fn function_arg_with_type() {
+                let script = "
+f = |x: Number| x
+f 'hello'
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn nested_arg_with_type() {
+                let script = "
+f = |(x: Number)| x
+f ('hello',)
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn wildcard_arg_with_type() {
+                let script = "
+f = |_x: List| true
+f 'hello'
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn nested_wildcard_arg_with_type() {
+                let script = "
+f = |(_x: Bool)| true
+f ('hello',)
+";
+                check_script_fails(script);
+            }
         }
 
         mod missing_values {

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -522,7 +522,7 @@ x
         #[test]
         fn multi_assignment() {
             let script = "
-let x: String, y: Bool, z: Int = 'foo', true, 123
+let x: String, y: Bool, z: Number = 'foo', true, 123
 x, y, z
 ";
             check_script_output(script, tuple(&["foo".into(), true.into(), 123.into()]));

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -1555,8 +1555,8 @@ add = |a, b| a + b
 multiply = |a, b| a * b
 square = |x| x * x
 add 1, 2
-  >> square
-  >> multiply 10
+  -> square
+  -> multiply 10
 ";
                 check_script_output(script, 90);
             }
@@ -1570,9 +1570,9 @@ ops =
   square: |x| x * x
 
 2
-  >> ops.add 1
-  >> ops.square
-  >> ops.multiply 2
+  -> ops.add 1
+  -> ops.square
+  -> ops.multiply 2
 ";
                 check_script_output(script, 18);
             }
@@ -1587,10 +1587,10 @@ ops = [inc, dec]
 get_op = |i| ops[i]
 
 0
-  >> ops[0]     # 1
-  >> get_op(0)  # 2
-  >> (get_op 0) # 3
-  >> get_op(1)  # 2
+  -> ops[0]     # 1
+  -> get_op(0)  # 2
+  -> (get_op 0) # 3
+  -> get_op(1)  # 2
 ";
                 check_script_output(script, 2);
             }
@@ -1607,7 +1607,7 @@ g = |x|
   calls.push x
   f
 
-g(1)(100) >> g(2) >> g(3) >> g(4)
+g(1)(100) -> g(2) -> g(3) -> g(4)
 
 calls
 ";

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-checks: fmt clippy clippy_rc test test_rc check_links doc wasm
+checks: test test_rc clippy clippy_rc fmt check_links doc wasm
 
 check_links:
   mlc --offline README.md

--- a/koto/tests/functions.koto
+++ b/koto/tests/functions.koto
@@ -75,7 +75,7 @@
 
     # Piping can help with making long call chains more readable
     x = multiply 2, square add 1, 3
-    y = 3 >> add 1 >> square >> multiply 2
+    y = 3 -> add 1 -> square -> multiply 2
     assert_eq x, y
     assert_eq y, 32
 

--- a/koto/tests/number_ops.koto
+++ b/koto/tests/number_ops.koto
@@ -85,7 +85,6 @@ from number import e, infinity, negative_infinity, pi, pi_2, pi_4, tau
   @test floor: ||
     assert_eq 1.5.floor(), 1
     assert_eq -1.2.floor(), -2
-    assert_eq type(1.1.floor()), "Int"
 
   @test is_nan: ||
     assert not 0.is_nan()
@@ -137,7 +136,6 @@ from number import e, infinity, negative_infinity, pi, pi_2, pi_4, tau
     assert_eq 1.5.round(), 2
     assert_eq -1.2.round(), -1
     assert_eq -2.5.round(), -3
-    assert_eq type(1.1.round()), "Int"
 
   @test shift_left: ||
     assert_eq 0b10101.shift_left(1), 0b101010
@@ -168,18 +166,13 @@ from number import e, infinity, negative_infinity, pi, pi_2, pi_4, tau
     assert_eq 0.tanh(), 0
     assert_eq 1.tanh(), (1.sinh() / 1.cosh())
 
-  @test to_float: ||
-    x = 1
-    assert_eq type(x), "Int"
-    assert_eq type(x.to_float()), "Float"
-    assert_eq x.to_float(), x
-
   @test to_int: ||
     x = 1.0
-    assert_eq type(x), "Float"
-    assert_eq type(x.to_int()), "Int"
     assert_eq x.to_int(), x
+    assert_eq 1.1.to_int(), 1
+    assert_eq 1.9.to_int(), 1
 
   @test xor: ||
     assert_eq (0b10101.xor 0b01011), 0b11110
     assert_eq (-1.xor 1), -2
+    assert_eq (-1.5.xor 1.1), -2

--- a/koto/tests/strings.koto
+++ b/koto/tests/strings.koto
@@ -117,7 +117,7 @@ zzz
     check_int = |s, n|
       x = s.to_number()
       assert_eq x, n
-      assert_eq type(x), 'Int'
+      assert_eq type(x), 'Number'
 
     check_int '42', 42
     check_int '0xdeadbeef', 3735928559
@@ -126,7 +126,6 @@ zzz
 
     x = '-1.5'.to_number()
     assert_eq x, -1.5
-    assert_eq type(x), "Float"
 
   @test to_uppercase: ||
     assert_eq (string.to_uppercase "xyz 890"), "XYZ 890"

--- a/koto/tests/types.koto
+++ b/koto/tests/types.koto
@@ -4,13 +4,13 @@
     assert_eq (type |x| x * x), "Function"
     assert_eq (type [1, 2, 3]), "List"
     assert_eq (type {foo: 42}), "Map"
-    assert_eq (type 0), "Int"
-    assert_eq (type 0.0), "Float"
+    assert_eq (type 0), "Number"
+    assert_eq (type 0.0), "Number"
     assert_eq (type 0..10), "Range"
     assert_eq (type "foo"), "String"
 
     x = 1
-    assert_eq (type x), "Int"
+    assert_eq (type x), "Number"
 
     x = "bar"
     assert_eq (type x), "String"


### PR DESCRIPTION
This PR adds support for type hints on function arguments and on the function's return type.

The `>>` pipe operator has been replaced with `->` to match the function output type syntax, which avoids there being two unique syntax elements related to function output.

Additionally numbers now report their types as `Number` rather than `Int` or `Float`.
