### PR TITLE
Add multi-assignment-support to `export`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The Koto project adheres to
 
 - Type hints with runtime type checks have been added ([#298](https://github.com/koto-lang/koto/issues/298)).
   - Thanks to [@Tarbetu](https://github.com/Tarbetu) for the contributions.
+- `export` can be used with multi-assignment expressions.
+  - e.g. expressions like `export a, b, c = foo()` are now allowed.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "derive-name"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19af109a7f1118ab96e1fd2a0c87310787f791680fa71b4bbfa5dffbc358b08"
+dependencies = [
+ "derive-name-macros",
+]
+
+[[package]]
+name = "derive-name-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa60999fb9292247d7c7eec5dada22b4ba337394612b0d935616bf49964c8bfd"
+dependencies = [
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +655,7 @@ dependencies = [
 name = "koto_bytecode"
 version = "0.15.0"
 dependencies = [
+ "derive-name",
  "dunce",
  "koto_memory",
  "koto_parser",
@@ -726,6 +746,7 @@ dependencies = [
 name = "koto_parser"
 version = "0.15.0"
 dependencies = [
+ "derive-name",
  "koto_lexer",
  "koto_memory",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ chrono = "0.4.31"
 criterion = "0.5.1"
 # A crossplatform terminal library for manipulating terminals.
 crossterm = "0.27.0"
+# Derive macro to get the name of a struct, enum or enum variant
+derive-name = "1.1.0"
 # Trait object downcasting support using only safe Rust.
 downcast-rs = "1.1.1"
 # Normalize Windows paths to the most compatible format

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -18,6 +18,7 @@ rc = ["koto_memory/rc"]
 koto_memory = { path = "../memory", version = "^0.15.0", default-features = false }
 koto_parser = { path = "../parser", version = "^0.15.0", default-features = false }
 
+derive-name = { workspace = true }
 dunce = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -2,6 +2,7 @@ use crate::{
     frame::{Arg, AssignedOrReserved, Frame, FrameError},
     DebugInfo, FunctionFlags, Op, StringFormatFlags,
 };
+use derive_name::VariantName;
 use koto_parser::{
     Ast, AstBinaryOp, AstFor, AstIf, AstIndex, AstNode, AstTry, AstUnaryOp, ChainNode,
     ConstantIndex, Function, ImportItem, MatchArm, MetaKeyId, Node, Span, StringContents,
@@ -14,7 +15,7 @@ use thiserror::Error;
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
 enum ErrorKind {
-    #[error("expected {expected}, found {unexpected:?}")]
+    #[error("expected {expected}, found '{}'", unexpected.variant_name())]
     UnexpectedNode { expected: String, unexpected: Node },
     #[error("attempting to assign to a temporary value")]
     AssigningToATemporaryValue,
@@ -1435,7 +1436,7 @@ impl Compiler {
             }
             Node::Map(entries) => self.compile_make_map(entries, true, ctx),
             unexpected => self.error(ErrorKind::UnexpectedNode {
-                expected: "ID for export".into(),
+                expected: "an assignment or a Map to export".into(),
                 unexpected: unexpected.clone(),
             }),
         }

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -2190,25 +2190,29 @@ check! 3
 
 `export` is used to add values to the current module's _exports map_.
 
-Single values can be assigned to and exported at the same time:
+Values can be assigned to and exported at the same time:
 
 ```koto,skip_run
 ##################
 # my_module.koto #
 ##################
 
-export say_hello = |name| 'Hello, {name}!'
+export hello, goodbye = 'Hello', 'Goodbye'
+export say_hello = |name| '{hello}, {name}!'
 
 ##################
+#   other.koto   #
 ##################
 
-from my_module import say_hello
+from my_module import say_hello, goodbye
 
 say_hello 'Koto'
 check! 'Hello, Koto!' 
+print! goodbye
+check! Goodbye
 ```
 
-When exporting multiple values, it can be convenient to use map syntax:
+When exporting a lot of values, it can be convenient to use map syntax:
 
 ```koto,skip_run
 ##################
@@ -2255,6 +2259,7 @@ export say_hello = |name| 'Hello, {name}!'
     assert_eq (say_hello 'World'), 'Hello, World!'
 
 ##################
+#   other.koto   #
 ##################
 
 from my_module import say_hello

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -2212,6 +2212,12 @@ print! goodbye
 check! Goodbye
 ```
 
+To add a [type check](#type_checks) to an exported value, use a `let` expression:
+
+```koto,skip_run
+export let foo: Number = -1
+```
+
 When exporting a lot of values, it can be convenient to use map syntax:
 
 ```koto,skip_run

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -21,5 +21,6 @@ panic_on_parser_error = []
 koto_lexer = { path = "../lexer", version = "^0.15.0" }
 koto_memory = { path = "../memory", version = "^0.15.0", default-features = false }
 
+derive-name = { workspace = true }
 thiserror = { workspace = true }
 unicode-segmentation = { workspace = true }

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -4,7 +4,7 @@ use std::fmt;
 /// A parsed node that can be included in the [AST](crate::Ast).
 ///
 /// Nodes refer to each other via [AstIndex]s, see [AstNode](crate::AstNode).
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, derive_name::VariantName)]
 pub enum Node {
     /// The `null` keyword
     #[default]

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -401,10 +401,11 @@ impl<'source> Parser<'source> {
             if !encountered_linebreak && self.current_line > start_line {
                 // e.g.
                 //   x, y =
-                //     1, # <- We're here, and want following values to have matching indentation
-                //     0
+                //     1, # <- We're here,
+                //        #    following values should have at least this level of indentation.
+                //     0,
                 expression_context = expression_context
-                    .with_expected_indentation(Indentation::Equal(self.current_indent()));
+                    .with_expected_indentation(Indentation::GreaterOrEqual(self.current_indent()));
                 encountered_linebreak = true;
             }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1620,9 +1620,11 @@ impl<'source> Parser<'source> {
 
     fn consume_export(&mut self, context: &ExpressionContext) -> Result<AstIndex> {
         self.consume_token_with_context(context); // Token::Export
-
         let start_span = self.current_span();
-        if let Some(expression) = self.parse_expression(&ExpressionContext::permissive())? {
+
+        if let Some(expression) =
+            self.parse_expressions(&ExpressionContext::permissive(), TempResult::No)?
+        {
             self.push_node_with_start_span(Node::Export(expression), start_span)
         } else {
             self.consume_token_and_error(SyntaxError::ExpectedExpression)

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1557,6 +1557,44 @@ export a =
         }
 
         #[test]
+        fn export_multi_assignment() {
+            let sources = [
+                "export a, b, c = foo",
+                "
+export a, b, c
+  = foo",
+                "
+export a, b, c =
+  foo",
+            ];
+
+            check_ast_for_equivalent_sources(
+                &sources,
+                &[
+                    id(0),
+                    id(1),
+                    id(2),
+                    id(3),
+                    MultiAssign {
+                        targets: nodes(&[0, 1, 2]),
+                        expression: 3.into(),
+                    },
+                    Export(4.into()), // 5
+                    MainBlock {
+                        body: nodes(&[5]),
+                        local_count: 3,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("a"),
+                    Constant::Str("b"),
+                    Constant::Str("c"),
+                    Constant::Str("foo"),
+                ]),
+            )
+        }
+
+        #[test]
         fn export_map_block() {
             let source = "
 export 

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1536,6 +1536,10 @@ export a
                 "
 export a =
   1 + 1",
+                "
+export 
+  a =
+    1 + 1",
             ];
 
             check_ast_for_equivalent_sources(
@@ -1566,6 +1570,13 @@ export a, b, c
                 "
 export a, b, c =
   foo",
+                "
+export 
+  a, b, c = foo",
+                "
+export 
+  a, b, c 
+    = foo",
             ];
 
             check_ast_for_equivalent_sources(

--- a/koto/tests/test_module/baz.koto
+++ b/koto/tests/test_module/baz.koto
@@ -1,5 +1,6 @@
 # This file is imported by ./main.koto
 
+# Testing that import works within a submodule
 from number import pi
 assert_eq pi, pi
 
@@ -7,7 +8,7 @@ local_value = 999
 qux = null
 
 # Export using inline map syntax
-export { qux }
+export { qux, @type: 'Baz' }
 
 @main = ||
   # Redefine qux to check that main has been called

--- a/koto/tests/test_module/baz.koto
+++ b/koto/tests/test_module/baz.koto
@@ -6,6 +6,7 @@ assert_eq pi, pi
 local_value = 999
 qux = null
 
+# Export using inline map syntax
 export { qux }
 
 @main = ||

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -2,9 +2,11 @@
 
 local_value = 123
 
+# Export with multi-assignment
+export foo, bar = 42, -1
+
+# Export with a map block
 export
-  foo: 42
-  bar: -1
   square: |x| x * x
   baz: import baz # Re-export the neighbouring baz module
 

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -5,9 +5,13 @@ local_value = 123
 # Export with multi-assignment
 export foo, bar = 42, -1
 
+# Export with let
+export let square: Function = |x| x * x
+
 # Export with a map block
 export
-  square: |x| x * x
+  @type: 'test_module'
+
   baz: import baz # Re-export the neighbouring baz module
 
   tests_were_run: false
@@ -18,5 +22,3 @@ export
 
     @test local_value_unmodified_by_import: ||
       assert_eq local_value, 123
-
-  @type: 'test_module'


### PR DESCRIPTION
This PR adds support for multi-assignment to `export`, allowing expressions like:

```js
export a, b, c = 'a-b-c'.split '-'
```
