### PR TITLE
Tweaks and Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The Koto project adheres to
 - `export` can be used with multi-assignment expressions.
   - e.g. expressions like `export a, b, c = foo()` are now allowed.
 
+#### Core Library
+
+- `tuple.sort_copy` now supports sorting with a key function, like `list.sort`.
+
 ### Changed
 
 #### Language

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -1187,8 +1187,8 @@ impl Compiler {
                 } else {
                     self.push_span(type_node, ctx.ast);
                     self.push_op(Op::CheckType, &[value_register]);
-                    let jump_placeholder = self.push_offset_placeholder();
                     self.push_var_u32((*type_index).into());
+                    let jump_placeholder = self.push_offset_placeholder();
                     self.pop_span();
                     Ok(Some(jump_placeholder))
                 }
@@ -3683,6 +3683,8 @@ impl Compiler {
         self.push_bytes(&(offset as u16).to_le_bytes());
     }
 
+    // For offset placeholders to work correctly,
+    // ensure that they're the last value in the instruction.
     fn push_offset_placeholder(&mut self) -> usize {
         let offset_ip = self.bytes.len();
         self.push_bytes(&[0, 0]);

--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -326,8 +326,8 @@ pub enum Instruction {
     },
     CheckType {
         value: u8,
-        jump_offset: u16,
         type_string: ConstantIndex,
+        jump_offset: u16,
     },
     StringStart {
         size_hint: u32,
@@ -756,7 +756,7 @@ impl fmt::Debug for Instruction {
             } => {
                 write!(
                     f,
-                    "CheckType\tvalue: {value}\toffset: {jump_offset}\ttype: {type_string}"
+                    "CheckType\tvalue: {value}\ttype: {type_string}\toffset: {jump_offset}"
                 )
             }
             StringStart { size_hint } => {

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -487,8 +487,8 @@ impl Iterator for InstructionReader {
             }),
             Op::CheckType => Some(CheckType {
                 value: get_u8!(),
-                jump_offset: get_u16!(),
                 type_string: get_var_u32!().into(),
+                jump_offset: get_u16!(),
             }),
             Op::StringStart => Some(StringStart {
                 size_hint: get_var_u32!(),

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -495,7 +495,7 @@ pub enum Op {
     /// If the value doesn't match the type then the instruction pointer will be jumped forward to
     /// the location referred to by the jump offset.
     ///
-    /// `[*value, jump_offset[2], @type constant]`
+    /// `[*value, @type constant, jump_offset[2]]`
     CheckType,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.

--- a/crates/cli/docs/core_lib/list.md
+++ b/crates/cli/docs/core_lib/list.md
@@ -388,9 +388,10 @@ Sorts the list in place, and returns the list.
 |List, key: |Any| -> Any| -> List
 ```
 
-Sorts the list in place, based on the output of calling a 'key' function for
-each value, and returns the list. The function result is cached, so it's only
-called once per value.
+Sorts the list in place, based on the output of calling a `key` function for
+each of the list's elements, and returns the list. 
+
+The key function's result is cached, so it's only called once per element.
 
 ### Example
 
@@ -408,6 +409,7 @@ print! x
 check! ['a', 'bb', 'ccc']
 
 x = [2, 1, 3]
+# Sort in reverse order by using a key function
 print! x.sort |n| -n
 check! [3, 2, 1]
 print! x

--- a/crates/cli/docs/core_lib/range.md
+++ b/crates/cli/docs/core_lib/range.md
@@ -12,7 +12,7 @@ Returns true if the provided number is within the range, and false otherwise.
 |Range, Range| -> Bool
 ```
 
-Returns true if the provided range is entirely containd within the range, 
+Returns true if the provided range is entirely contained within the range,
 and false otherwise.
 
 ### Example
@@ -96,7 +96,7 @@ check! -5..5
 |Range, Range| -> Range
 ```
 
-Returns a range representing the intersection region of the two input ranges.
+Returns a range representing the intersecting region of the two input ranges.
 
 If there is no intersecting region then `null` is returned.
 

--- a/crates/cli/docs/core_lib/tuple.md
+++ b/crates/cli/docs/core_lib/tuple.md
@@ -94,6 +94,15 @@ check! null
 
 Returns a sorted copy of the tuple.
 
+```kototype
+|List, key: |Any| -> Any| -> List
+```
+
+Returns a sorted copy of the tuple, based on the output of calling a `key` 
+function for each of the tuple's elements. 
+
+The key function's result is cached, so it's only called once per value.
+
 ### Example
 
 ```koto
@@ -104,6 +113,10 @@ check! (-1, 1, 42, 99)
 
 print! x # x remains untouched
 check! (1, -1, 99, 42)
+
+# Sort in reverse order by using a key function
+print! x.sort_copy |n| -n
+check! (99, 42, 1, -1)
 ```
 
 ## to_list

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -333,7 +333,9 @@ impl<'source> Parser<'source> {
             };
 
             let Some(expression) = self.parse_line(&line_context)? else {
-                break;
+                // At this point we've peeked to check that the line is either the start of the
+                // block, or a continuation with the same indentation as the block.
+                return self.consume_token_and_error(SyntaxError::UnexpectedToken);
             };
 
             block.push(expression);

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -162,6 +162,20 @@ x .foo
             }
         }
 
+        mod piped_calls {
+            use super::*;
+
+            #[test]
+            fn pipe_without_indentation_in_function() {
+                let source = "
+x = ||
+  foo 42
+  -> bar
+";
+                check_parsing_fails(source);
+            }
+        }
+
         mod maps {
             use super::*;
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -885,7 +885,7 @@ f()
         }
 
         #[test]
-        fn match_with_type_hints() {
+        fn match_with_first_type_hint_in_arm() {
             let script = r#"
 match 42
   x: String or x: List then -1
@@ -893,6 +893,28 @@ match 42
   else -2
 "#;
             check_script_output(script, 42);
+        }
+
+        #[test]
+        fn match_with_second_type_hint_in_arm() {
+            let script = r#"
+match true
+  x: String or x: List then -1
+  x: Number or x: Bool then x
+  else -2
+"#;
+            check_script_output(script, true);
+        }
+
+        #[test]
+        fn match_with_no_matching_type_hints() {
+            let script = r#"
+match 42
+  x: String or x: List then -1
+  x: Tuple or x: Bool then -2
+  else 99
+"#;
+            check_script_output(script, 99);
         }
 
         #[test]


### PR DESCRIPTION
- **Fix typos in the docs**
- **Fix matching with type hints so that else branches are executed**
- **Block incorrect piped call indentation in the parser**
- **Add a key function overload to tuple.sort_copy**
