### PR TITLE
Type hints for generators

### DIFF
--- a/crates/bytecode/src/frame.rs
+++ b/crates/bytecode/src/frame.rs
@@ -80,8 +80,14 @@ pub(crate) struct Frame {
     // This is a coarse check, e.g. we currently don't check if the last expression
     // returns in all branches, but it'll do for now as an optimization for simple cases.
     pub last_node_was_return: bool,
-    // An optional output type hint that should cause type checks to be emitted on each exit path.
+    // An optional output type hint that should cause type checks to be emitted when the frame is
+    // exited.
+    // If the frame is representing a generator, then yield expressions will be checked, otherwise
+    // the type check will be applied to any return paths.
     pub output_type: Option<AstIndex>,
+    // Used to decide if return types should be checked (output type hints only apply to yield
+    // expressions in genertors).
+    pub is_generator: bool,
 }
 
 impl Frame {
@@ -90,6 +96,7 @@ impl Frame {
         args: &[Arg],
         captures: &[ConstantIndex],
         output_type: Option<AstIndex>,
+        is_generator: bool,
     ) -> Self {
         let temporary_base =
             // register 0 is always self
@@ -129,6 +136,7 @@ impl Frame {
             local_registers,
             temporary_base,
             output_type,
+            is_generator,
             ..Default::default()
         }
     }

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1377,11 +1377,11 @@ Type hints can also be added to `for` loop arguments.
 The type will be checked on each iteration of the loop.
 
 ```koto
-for x: Number in (1, 2, 3)
-  print x
-check! 1
-check! 2
-check! 3
+for i: Number, s: String in 'abc'.enumerate()
+  print i, s
+check! (0, 'a')
+check! (1, 'b')
+check! (2, 'c')
 ```
 
 ### Functions

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1384,7 +1384,7 @@ check! 2
 check! 3
 ```
 
-### Function arguments
+### Functions
 
 Function arguments can also be given type hints, and the type of the 
 return value can be checked with the `->` operator.
@@ -1394,6 +1394,18 @@ f = |s: String| -> Tuple
   s.to_tuple()
 print! f 'abc'
 check! ('a', 'b', 'c')
+```
+
+For [generator functions](#generators), the `->` type hint is used to check
+the generator's `yield` expressions.
+
+```koto
+g = || -> Number 
+  yield 1
+  yield 2
+  yield 3
+print! g().to_tuple()
+check! (1, 2, 3)
 ```
 
 ### `match` patterns

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -155,12 +155,11 @@ where
 }
 
 /// A chunk and ip in a call stack where an error was thrown
-///
-/// See [RuntimeErrorTrace]
 #[derive(Clone, Debug)]
+#[allow(missing_docs)]
 pub struct ErrorFrame {
-    chunk: Ptr<Chunk>,
-    instruction: u32,
+    pub chunk: Ptr<Chunk>,
+    pub instruction: u32,
 }
 
 /// The Result type used by the Koto Runtime

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -14,7 +14,7 @@ mod send_sync;
 
 pub use crate::{
     display_context::DisplayContext,
-    error::{type_error, type_error_with_slice, Error, ErrorKind, Result},
+    error::{type_error, type_error_with_slice, Error, ErrorFrame, ErrorKind, Result},
     io::{BufferedFile, DefaultStderr, DefaultStdin, DefaultStdout, KotoFile, KotoRead, KotoWrite},
     send_sync::{KotoSend, KotoSync},
     types::{

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -139,6 +139,18 @@ for x: Number in (1, true, 2)
 ";
                 check_script_fails(script);
             }
+
+            #[test]
+            fn generator_with_type_hint() {
+                let script = "
+g = || -> Number
+  yield 1
+  yield 'abc'
+  42
+g().consume()
+";
+                check_script_fails(script);
+            }
         }
 
         mod missing_values {

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -277,6 +277,50 @@ for _foo: Number in (1, true, 2)
             }
 
             #[test]
+            fn for_loop_with_typed_unpacked_arg() {
+                let script = "\
+for i: Number, x: Bool in 'abc'.enumerate()
+#              ^
+  null
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position {
+                            line: 0,
+                            column: 15,
+                        },
+                        end: Position {
+                            line: 0,
+                            column: 16,
+                        },
+                    },
+                );
+            }
+
+            #[test]
+            fn for_loop_with_typed_unpacked_wildcard_arg() {
+                let script = "\
+for i: Number, _x: Bool in 'abc'.enumerate()
+#              ^^
+  null
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position {
+                            line: 0,
+                            column: 15,
+                        },
+                        end: Position {
+                            line: 0,
+                            column: 17,
+                        },
+                    },
+                );
+            }
+
+            #[test]
             fn generator_with_type_hint() {
                 let script = "\
 g = || -> Number

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -1,9 +1,18 @@
 mod runtime {
     use koto_bytecode::{CompilerSettings, Loader};
-    use koto_runtime::KotoVm;
+    use koto_lexer::Span;
+    use koto_runtime::{ErrorFrame, KotoVm};
     use koto_test_utils::script_instructions;
 
     fn check_script_fails(script: &str) {
+        check_that_script_fails(script, None);
+    }
+
+    fn check_script_fails_with_span(script: &str, span: Span) {
+        check_that_script_fails(script, Some(span))
+    }
+
+    fn check_that_script_fails(script: &str, span: Option<Span>) {
         let mut vm = KotoVm::default();
 
         let mut loader = Loader::default();
@@ -15,12 +24,24 @@ mod runtime {
             }
         };
 
-        if let Ok(result) = vm.run(chunk) {
-            println!("{}", script_instructions(script, vm.chunk()));
-            panic!(
-                "Script didn't fail as expected, result: {}",
-                vm.value_to_string(&result).unwrap()
-            )
+        match vm.run(chunk) {
+            Ok(result) => {
+                println!("{}", script_instructions(script, vm.chunk()));
+                panic!(
+                    "Script didn't fail as expected, result: {}",
+                    vm.value_to_string(&result).unwrap()
+                )
+            }
+            Err(e) => {
+                if let Some(expected_span) = span {
+                    let ErrorFrame { chunk, instruction } = e.trace.first().unwrap();
+                    let error_span = chunk.debug_info.get_source_span(*instruction).unwrap();
+                    if error_span != expected_span {
+                        println!("{}", script_instructions(script, vm.chunk()));
+                        assert_eq!(expected_span, error_span);
+                    }
+                }
+            }
         }
     }
 
@@ -52,104 +73,229 @@ mod runtime {
         }
 
         mod type_checks {
+            use koto_lexer::Position;
+
             use super::*;
 
             #[test]
             fn expected_string() {
-                let script = "
-let x: String = 123
+                let script = "\
+let foo: String = 123
+#   ^^^
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 4 },
+                        end: Position { line: 0, column: 7 },
+                    },
+                );
             }
 
             #[test]
             fn expected_bool_in_multi_assignment() {
-                let script = "
+                let script = "\
 let x: String, y: Bool = 'abc', 123
+#              ^
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position {
+                            line: 0,
+                            column: 15,
+                        },
+                        end: Position {
+                            line: 0,
+                            column: 16,
+                        },
+                    },
+                );
             }
 
             #[test]
             fn wildcard_expected_bool() {
-                let script = "
-let _x: Bool = 'abc'
+                let script = "\
+let _foo: Bool = 'abc'
+#   ^^^^
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 4 },
+                        end: Position { line: 0, column: 8 },
+                    },
+                );
             }
 
             #[test]
             fn wildcard_expected_string_in_multi_assignment() {
-                let script = "
+                let script = "\
 let _x: String, y: Bool = 99, true
+#   ^^
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 4 },
+                        end: Position { line: 0, column: 6 },
+                    },
+                );
             }
 
             #[test]
             fn function_arg_with_type() {
-                let script = "
+                let script = "\
 f = |x: Number| x
+#    ^
 f 'hello'
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 5 },
+                        end: Position { line: 0, column: 6 },
+                    },
+                );
             }
 
             #[test]
             fn nested_arg_with_type() {
-                let script = "
-f = |(x: Number)| x
+                let script = "\
+f = |(foo: Number)| foo
+#     ^^^
 f ('hello',)
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 6 },
+                        end: Position { line: 0, column: 9 },
+                    },
+                );
             }
 
             #[test]
             fn wildcard_arg_with_type() {
-                let script = "
+                let script = "\
 f = |_x: List| true
+#    ^^
 f 'hello'
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 5 },
+                        end: Position { line: 0, column: 7 },
+                    },
+                );
             }
 
             #[test]
             fn nested_wildcard_arg_with_type() {
-                let script = "
+                let script = "\
 f = |(_x: Bool)| true
+#     ^^
 f ('hello',)
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 6 },
+                        end: Position { line: 0, column: 8 },
+                    },
+                );
             }
 
             #[test]
-            fn function_with_return_type() {
-                let script = "
-f = |x: Number| -> String x
+            fn function_with_output_type_and_implicit_return() {
+                let script = "\
+f = |x: Number| -> String
+  x + x
+# ^^^^^
 f 42
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 1, column: 2 },
+                        end: Position { line: 1, column: 7 },
+                    },
+                );
+            }
+
+            #[test]
+            fn function_with_output_type_and_explicit_return() {
+                let script = "\
+f = |x: Number| -> String
+  return x + x
+# ^^^^^^^^^^^^
+f 42
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 1, column: 2 },
+                        end: Position {
+                            line: 1,
+                            column: 14,
+                        },
+                    },
+                );
             }
 
             #[test]
             fn for_loop_with_typed_arg() {
-                let script = "
-for x: Number in (1, true, 2)
-  x
+                let script = "\
+for foo: Number in (1, true, 2)
+#   ^^^
+  foo
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 4 },
+                        end: Position { line: 0, column: 7 },
+                    },
+                );
+            }
+
+            #[test]
+            fn for_loop_with_typed_wildcard_arg() {
+                let script = "\
+for _foo: Number in (1, true, 2)
+#   ^^^^
+  null
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 4 },
+                        end: Position { line: 0, column: 8 },
+                    },
+                );
             }
 
             #[test]
             fn generator_with_type_hint() {
-                let script = "
+                let script = "\
 g = || -> Number
   yield 1
   yield 'abc'
+# ^^^^^^^^^^^
   42
 g().consume()
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 2, column: 2 },
+                        end: Position {
+                            line: 2,
+                            column: 13,
+                        },
+                    },
+                );
             }
         }
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -2507,7 +2507,7 @@ gen().to_tuple()";
         #[test]
         fn generator_loop() {
             let script = "
-gen = ||
+gen = || -> Number
   x = 1
   while x <= 5
     yield x
@@ -2550,7 +2550,7 @@ gen(10, 1, 2, 3).to_tuple()";
         #[test]
         fn generator_returning_multiple_values() {
             let script = "
-gen = |xs|
+gen = |xs| -> Tuple
   for i, x in xs.enumerate()
     yield i, x
 z = gen(1..=5).to_tuple()


### PR DESCRIPTION
- **Make output type hints useful for generators**
- **Improve span placement for failed type checks**
- **Enable type checks on for loops with multiple arguments**
