### PR TITLE
Ensure that libs can be used with the rc build variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,34 @@ jobs:
       - name: Test with optimizations
         run: just test_release --verbose
 
+  build_and_test_rc:
+    # We don't need to test rc builds on all platforms for now
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.5.0
+
+      - name: Test the rc build variant
+        run: just test_rc --verbose
+
+  build_and_test_release_rc:
+    # We don't need to test rc builds on all platforms for now
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.5.0
+
+      - name: Test the rc build variant
+        run: just test_rc --release --verbose
+
   code_checks:
     runs-on: ubuntu-latest
 

--- a/justfile
+++ b/justfile
@@ -57,7 +57,6 @@ test_parser:
 
 test_release *args:
   just test --release {{args}}
-  just test_rc --release {{args}}
 
 test_runtime:
   cargo test --package koto_runtime

--- a/justfile
+++ b/justfile
@@ -26,7 +26,10 @@ test *args:
   cargo test {{args}}
 
 test_rc *args:
-  cargo test -p koto_runtime --no-default-features --features rc {{args}}
+  cargo test  --no-default-features --features rc \
+    -p koto_runtime \
+    -p lib_tests \
+    {{args}}
 
 test_benches:
   cargo test --benches

--- a/libs/json/Cargo.toml
+++ b/libs/json/Cargo.toml
@@ -15,11 +15,15 @@ arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 
 [dependencies]
-koto_serialize = { path = "../../crates/serialize", version = "^0.15.0" }
 serde_json = { workspace = true }
 
 [dependencies.koto_runtime]
 path = "../../crates/runtime"
+version = "^0.15.0"
+default-features = false
+
+[dependencies.koto_serialize]
+path = "../../crates/serialize"
 version = "^0.15.0"
 default-features = false
 

--- a/libs/lib_tests/Cargo.toml
+++ b/libs/lib_tests/Cargo.toml
@@ -9,13 +9,18 @@ description = "A test runner for the standard Koto libraries"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["arc"]
+arc = ["koto/arc"]
+rc = ["koto/rc"]
+
 [dev-dependencies]
-koto = { path = "../../crates/koto", version = "^0.15.0" }
-koto_color = { path = "../color", version = "^0.15.0" }
-koto_geometry = { path = "../geometry", version = "^0.15.0" }
-koto_json = { path = "../json", version = "^0.15.0" }
-koto_random = { path = "../random", version = "^0.15.0" }
-koto_regex = { path = "../regex", version = "^0.15.0" }
-koto_tempfile = { path = "../tempfile", version = "^0.15.0" }
-koto_toml = { path = "../toml", version = "^0.15.0" }
-koto_yaml = { path = "../yaml", version = "^0.15.0" }
+koto = { path = "../../crates/koto", version = "^0.15.0", default-features = false }
+koto_color = { path = "../color", version = "^0.15.0", default-features = false }
+koto_geometry = { path = "../geometry", version = "^0.15.0", default-features = false }
+koto_json = { path = "../json", version = "^0.15.0", default-features = false }
+koto_random = { path = "../random", version = "^0.15.0", default-features = false }
+koto_regex = { path = "../regex", version = "^0.15.0", default-features = false }
+koto_tempfile = { path = "../tempfile", version = "^0.15.0", default-features = false }
+koto_toml = { path = "../toml", version = "^0.15.0", default-features = false }
+koto_yaml = { path = "../yaml", version = "^0.15.0", default-features = false }

--- a/libs/toml/Cargo.toml
+++ b/libs/toml/Cargo.toml
@@ -15,11 +15,15 @@ arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 
 [dependencies]
-koto_serialize = { path = "../../crates/serialize", version = "^0.15.0" }
 toml = { workspace = true }
 
 [dependencies.koto_runtime]
 path = "../../crates/runtime"
+version = "^0.15.0"
+default-features = false
+
+[dependencies.koto_serialize]
+path = "../../crates/serialize"
 version = "^0.15.0"
 default-features = false
 

--- a/libs/yaml/Cargo.toml
+++ b/libs/yaml/Cargo.toml
@@ -15,11 +15,15 @@ arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 
 [dependencies]
-koto_serialize = { path = "../../crates/serialize", version = "^0.15.0" }
 serde_yaml = { workspace = true }
 
 [dependencies.koto_runtime]
 path = "../../crates/runtime"
+version = "^0.15.0"
+default-features = false
+
+[dependencies.koto_serialize]
+path = "../../crates/serialize"
 version = "^0.15.0"
 default-features = false
 


### PR DESCRIPTION
Fixes #339.

The libs that depend on `koto_serialize` need to disable default features,
otherwise its default `arc` feature creeps in to the build.
