### PR TITLE
Better Argument Error Message For String Module

### DIFF
--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -3,7 +3,7 @@
 pub mod iterators;
 
 use super::iterator::collect_pair;
-use crate::prelude::*;
+use crate::{error::redundant_argument_error, prelude::*};
 
 /// Initializes the `string` core library module
 pub fn make_module() -> KMap {
@@ -17,7 +17,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::Bytes::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -26,7 +26,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(KValue::Iterator(KIterator::with_string(s.clone()))),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -38,7 +38,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::CharIndices::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -47,7 +47,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s1), [KValue::Str(s2)]) => Ok(s1.contains(s2.as_str()).into()),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -58,7 +58,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().ends_with(pattern.as_str()).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -67,7 +67,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.escape_default().to_string().into()),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -104,7 +104,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.is_empty().into()),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -116,7 +116,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::Lines::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -127,7 +127,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(input), [KValue::Str(pattern), KValue::Str(replace)]) => {
                 Ok(input.replace(pattern.as_str(), replace).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -148,7 +148,7 @@ pub fn make_module() -> KMap {
                     );
                     KIterator::new(result)
                 }
-                (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+                (_, unexpected) => return redundant_argument_error(expected_error, unexpected),
             }
         };
 
@@ -162,7 +162,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().starts_with(pattern.as_str()).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -174,7 +174,7 @@ pub fn make_module() -> KMap {
                 let result = s.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -213,7 +213,7 @@ pub fn make_module() -> KMap {
                     Ok(KValue::Null)
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -225,7 +225,7 @@ pub fn make_module() -> KMap {
                 let result = s.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 
@@ -244,7 +244,7 @@ pub fn make_module() -> KMap {
 
                 Ok(result.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
         }
     });
 

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -195,16 +195,6 @@ pub fn type_error_with_slice<T>(expected_str: &str, unexpected: &[KValue]) -> Re
     })
 }
 
-/// Creates an error that describes there are arguments while no arguments needed
-pub fn unexpected_argument_error<T>(unexpected: &[KValue]) -> Result<T> {
-    runtime_error!({
-        format!(
-            "Unexpected {} while no arguments needed",
-            get_value_types(unexpected),
-        )
-    })
-}
-
 /// Creates an error that describes there are redundant arguments
 /// First argument, arity means how many argument can be used in calling
 pub fn redundant_argument_error<T>(expected_str: &str, unexpected: &[KValue]) -> Result<T> {

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -195,6 +195,28 @@ pub fn type_error_with_slice<T>(expected_str: &str, unexpected: &[KValue]) -> Re
     })
 }
 
+/// Creates an error that describes there are arguments while no arguments needed
+pub fn unexpected_argument_error<T>(unexpected: &[KValue]) -> Result<T> {
+    runtime_error!({
+        format!(
+            "Unexpected {} while no arguments needed",
+            get_value_types(unexpected),
+        )
+    })
+}
+
+/// Creates an error that describes there are redundant arguments
+/// First argument, arity means how many argument can be used in calling
+pub fn redundant_argument_error<T>(expected_str: &str, unexpected: &[KValue]) -> Result<T> {
+    runtime_error!({
+        format!(
+            "Unexpected {} while no arguments needed other than {}",
+            get_value_types(unexpected),
+            expected_str
+        )
+    })
+}
+
 fn get_value_types(values: &[KValue]) -> String {
     match values {
         [] => "no args".to_string(),


### PR DESCRIPTION
Currently, the argument error message in the string module is kind of confusing.

![image](https://github.com/koto-lang/koto/assets/40325625/9d535730-db0e-4306-9547-42fc8725e447)

With this PR, the message will be much clearer like this:
![image](https://github.com/koto-lang/koto/assets/40325625/c856ea08-3d35-4988-abeb-518507e3c29c)
