### PR TITLE
Implementing Better Error Messages for IO and Iterable modules

### DIFF
--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -1,6 +1,11 @@
 //! The `io` core library module
 
-use crate::{derive::*, prelude::*, BufferedFile, Error, Ptr, Result};
+use crate::{
+    derive::*,
+    error::{argument_error, no_argument_error},
+    prelude::*,
+    BufferedFile, Error, Ptr, Result,
+};
 use std::{
     fmt, fs,
     io::{self, BufRead, Read, Seek, SeekFrom, Write},
@@ -22,7 +27,7 @@ pub fn make_module() -> KMap {
                     Err(error) => runtime_error!("io.create: Error while creating file: {error}"),
                 }
             }
-            unexpected => type_error_with_slice("a path String as argument", unexpected),
+            unexpected => argument_error("a path String as argument", unexpected, false),
         }
     });
 
@@ -36,7 +41,7 @@ pub fn make_module() -> KMap {
 
     result.add_fn("exists", |ctx| match ctx.args() {
         [Str(path)] => Ok(Bool(fs::canonicalize(path.as_str()).is_ok())),
-        unexpected => type_error_with_slice("a path String as argument", unexpected),
+        unexpected => argument_error("a path String as argument", unexpected, false),
     });
 
     result.add_fn("extend_path", |ctx| match ctx.args() {
@@ -55,10 +60,9 @@ pub fn make_module() -> KMap {
             }
             Ok(path.to_string_lossy().to_string().into())
         }
-        unexpected => type_error_with_slice(
-            "a path String as argument, followed by some additional path nodes",
-            unexpected,
-        ),
+        _unexpected => {
+            no_argument_error("a path String as argument, followed by some additional path nodes")
+        }
     });
 
     result.add_fn("open", {
@@ -70,7 +74,7 @@ pub fn make_module() -> KMap {
                 },
                 Err(_) => runtime_error!("io.open: Failed to canonicalize path"),
             },
-            unexpected => type_error_with_slice("a path String as argument", unexpected),
+            unexpected => argument_error("a path String as argument", unexpected, false),
         }
     });
 
@@ -94,10 +98,9 @@ pub fn make_module() -> KMap {
                     unexpected => return type_error("string from @display", &unexpected),
                 }
             }
-            unexpected => {
-                return type_error_with_slice(
+            _unexpected => {
+                return no_argument_error(
                     "a String as argument, followed by optional additional Values",
-                    unexpected,
                 )
             }
         };
@@ -112,7 +115,7 @@ pub fn make_module() -> KMap {
                 runtime_error!("io.read_to_string: Unable to read file '{path}': {error}")
             }
         },
-        unexpected => type_error_with_slice("a path String as argument", unexpected),
+        unexpected => argument_error("a path String as argument", unexpected, false),
     });
 
     result.add_fn("remove_file", {
@@ -127,7 +130,7 @@ pub fn make_module() -> KMap {
                     ),
                 }
             }
-            unexpected => type_error_with_slice("a path String as argument", unexpected),
+            unexpected => argument_error("a path String as argument", unexpected, false),
         }
     });
 
@@ -207,9 +210,11 @@ impl File {
                 }
                 self.0.seek(n.into()).map(|_| KValue::Null)
             }
-            unexpected => {
-                type_error_with_slice("a non-negative Number as the seek position", unexpected)
-            }
+            unexpected => argument_error(
+                "a non-negative Number as the seek position",
+                unexpected,
+                true,
+            ),
         }
     }
 
@@ -224,7 +229,7 @@ impl File {
                     .write(display_context.result().as_bytes())
                     .map(|_| KValue::Null)
             }
-            unexpected => type_error_with_slice("a single argument", unexpected),
+            unexpected => argument_error("a single argument", unexpected, true),
         }
     }
 
@@ -234,7 +239,7 @@ impl File {
         match ctx.args {
             [] => {}
             [value] => value.display(&mut display_context)?,
-            unexpected => return type_error_with_slice("a single argument", unexpected),
+            unexpected => return argument_error("a single argument", unexpected, true),
         };
         display_context.append('\n');
         ctx.instance_mut()?

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -27,7 +27,7 @@ pub fn make_module() -> KMap {
                     Err(error) => runtime_error!("io.create: Error while creating file: {error}"),
                 }
             }
-            unexpected => argument_error("a path String as argument", unexpected, false),
+            unexpected => argument_error("a path String as argument", unexpected, None),
         }
     });
 
@@ -41,7 +41,7 @@ pub fn make_module() -> KMap {
 
     result.add_fn("exists", |ctx| match ctx.args() {
         [Str(path)] => Ok(Bool(fs::canonicalize(path.as_str()).is_ok())),
-        unexpected => argument_error("a path String as argument", unexpected, false),
+        unexpected => argument_error("a path String as argument", unexpected, None),
     });
 
     result.add_fn("extend_path", |ctx| match ctx.args() {
@@ -74,7 +74,7 @@ pub fn make_module() -> KMap {
                 },
                 Err(_) => runtime_error!("io.open: Failed to canonicalize path"),
             },
-            unexpected => argument_error("a path String as argument", unexpected, false),
+            unexpected => argument_error("a path String as argument", unexpected, None),
         }
     });
 
@@ -115,7 +115,7 @@ pub fn make_module() -> KMap {
                 runtime_error!("io.read_to_string: Unable to read file '{path}': {error}")
             }
         },
-        unexpected => argument_error("a path String as argument", unexpected, false),
+        unexpected => argument_error("a path String as argument", unexpected, None),
     });
 
     result.add_fn("remove_file", {
@@ -130,7 +130,7 @@ pub fn make_module() -> KMap {
                     ),
                 }
             }
-            unexpected => argument_error("a path String as argument", unexpected, false),
+            unexpected => argument_error("a path String as argument", unexpected, None),
         }
     });
 
@@ -213,7 +213,7 @@ impl File {
             unexpected => argument_error(
                 "a non-negative Number as the seek position",
                 unexpected,
-                true,
+                Some("File"),
             ),
         }
     }
@@ -229,7 +229,7 @@ impl File {
                     .write(display_context.result().as_bytes())
                     .map(|_| KValue::Null)
             }
-            unexpected => argument_error("a single argument", unexpected, true),
+            unexpected => argument_error("a single argument", unexpected, Some("File")),
         }
     }
 
@@ -239,7 +239,7 @@ impl File {
         match ctx.args {
             [] => {}
             [value] => value.display(&mut display_context)?,
-            unexpected => return argument_error("a single argument", unexpected, true),
+            unexpected => return argument_error("a single argument", unexpected, Some("File")),
         };
         display_context.append('\n');
         ctx.instance_mut()?

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -45,7 +45,7 @@ pub fn make_module() -> KMap {
 
                 Ok(true.into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -84,7 +84,7 @@ pub fn make_module() -> KMap {
 
                 Ok(false.into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -101,7 +101,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Iterator(result))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -117,7 +117,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.chunks: {}", e),
                 }
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -151,7 +151,7 @@ pub fn make_module() -> KMap {
                 }
                 Ok(KValue::Null)
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -170,7 +170,7 @@ pub fn make_module() -> KMap {
                 }
                 Ok(KValue::Number(result.into()))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -189,7 +189,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -203,7 +203,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -216,7 +216,7 @@ pub fn make_module() -> KMap {
                 let result = adaptors::Enumerate::new(ctx.vm.make_iterator(iterable)?);
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -253,7 +253,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Null)
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -270,7 +270,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -310,7 +310,7 @@ pub fn make_module() -> KMap {
                     _ => unreachable!(),
                 }
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -323,7 +323,7 @@ pub fn make_module() -> KMap {
             let result = generators::GenerateN::new(n.into(), f.clone(), ctx.vm.spawn_shared_vm());
             Ok(KIterator::new(result).into())
         }
-        unexpected => argument_error("(Function), or (Number, Function)", unexpected, false),
+        unexpected => argument_error("(Function), or (Number, Function)", unexpected, None),
     });
 
     result.add_fn("intersperse", |ctx| {
@@ -348,7 +348,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -360,7 +360,7 @@ pub fn make_module() -> KMap {
                 let iterable = iterable.clone();
                 Ok(KValue::Iterator(ctx.vm.make_iterator(iterable)?))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -378,7 +378,7 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -401,7 +401,7 @@ pub fn make_module() -> KMap {
 
                 Ok(result)
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -418,7 +418,7 @@ pub fn make_module() -> KMap {
                 let key_fn = key_fn.clone();
                 run_iterator_comparison_by_key(ctx.vm, iterable, key_fn, InvertResult::Yes)
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -435,7 +435,7 @@ pub fn make_module() -> KMap {
                 let key_fn = key_fn.clone();
                 run_iterator_comparison_by_key(ctx.vm, iterable, key_fn, InvertResult::No)
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -505,7 +505,7 @@ pub fn make_module() -> KMap {
                     KValue::Tuple(vec![min, max].into())
                 }))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -515,7 +515,7 @@ pub fn make_module() -> KMap {
         let mut iter = match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (KValue::Iterator(i), []) => i.clone(),
             (iterable, []) if iterable.is_iterable() => ctx.vm.make_iterator(iterable.clone())?,
-            (_, unexpected) => return argument_error(expected_error, unexpected, true),
+            (_, unexpected) => return argument_error(expected_error, unexpected, Some("Iterable")),
         };
 
         let output = match iter_output_to_result(iter.next())? {
@@ -532,7 +532,7 @@ pub fn make_module() -> KMap {
         let mut iter = match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (KValue::Iterator(i), []) => i.clone(),
             (iterable, []) if iterable.is_iterable() => ctx.vm.make_iterator(iterable.clone())?,
-            (_, unexpected) => return argument_error(expected_error, unexpected, true),
+            (_, unexpected) => return argument_error(expected_error, unexpected, Some("Iterable")),
         };
 
         let output = match iter_output_to_result(iter.next_back())? {
@@ -558,7 +558,7 @@ pub fn make_module() -> KMap {
                     ctx.vm.make_iterator(iterable)?,
                 ))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -597,7 +597,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Null)
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -608,7 +608,9 @@ pub fn make_module() -> KMap {
             match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
                 (iterable, []) => (iterable.clone(), KValue::Number(1.into())),
                 (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
-                (_, unexpected) => return argument_error(expected_error, unexpected, true),
+                (_, unexpected) => {
+                    return argument_error(expected_error, unexpected, Some("Iterable"))
+                }
             }
         };
 
@@ -624,7 +626,7 @@ pub fn make_module() -> KMap {
             let result = generators::RepeatN::new(value.clone(), n.into());
             Ok(KIterator::new(result).into())
         }
-        unexpected => argument_error("(Value), or (Number, Value)", unexpected, false),
+        unexpected => argument_error("(Value), or (Number, Value)", unexpected, None),
     });
 
     result.add_fn("reversed", |ctx| {
@@ -638,7 +640,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.reversed: {}", e),
                 }
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -659,7 +661,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Iterator(iter))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -675,7 +677,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.step: {}", e),
                 }
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -686,7 +688,9 @@ pub fn make_module() -> KMap {
             match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
                 (iterable, []) => (iterable.clone(), KValue::Number(0.into())),
                 (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
-                (_, unexpected) => return argument_error(expected_error, unexpected, true),
+                (_, unexpected) => {
+                    return argument_error(expected_error, unexpected, Some("Iterable"))
+                }
             }
         };
 
@@ -713,7 +717,7 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -737,7 +741,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::List(KList::with_data(result)))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -768,7 +772,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Map(KMap::with_data(result)))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -792,7 +796,7 @@ pub fn make_module() -> KMap {
 
                 Ok(display_context.result().into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -816,7 +820,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Tuple(result.into()))
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -832,7 +836,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.windows: {}", e),
                 }
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 
@@ -849,7 +853,7 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("Iterable")),
         }
     });
 

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -4,7 +4,7 @@ pub mod adaptors;
 pub mod generators;
 pub mod peekable;
 
-use crate::{derive::*, prelude::*, KIteratorOutput as Output, Result};
+use crate::{derive::*, error::argument_error, prelude::*, KIteratorOutput as Output, Result};
 
 /// Initializes the `iterator` core library module
 pub fn make_module() -> KMap {
@@ -45,7 +45,7 @@ pub fn make_module() -> KMap {
 
                 Ok(true.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -84,7 +84,7 @@ pub fn make_module() -> KMap {
 
                 Ok(false.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -101,7 +101,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Iterator(result))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -117,7 +117,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.chunks: {}", e),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -151,7 +151,7 @@ pub fn make_module() -> KMap {
                 }
                 Ok(KValue::Null)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -170,7 +170,7 @@ pub fn make_module() -> KMap {
                 }
                 Ok(KValue::Number(result.into()))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -189,7 +189,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -203,7 +203,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -216,7 +216,7 @@ pub fn make_module() -> KMap {
                 let result = adaptors::Enumerate::new(ctx.vm.make_iterator(iterable)?);
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -253,7 +253,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Null)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -270,7 +270,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -310,7 +310,7 @@ pub fn make_module() -> KMap {
                     _ => unreachable!(),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -323,7 +323,7 @@ pub fn make_module() -> KMap {
             let result = generators::GenerateN::new(n.into(), f.clone(), ctx.vm.spawn_shared_vm());
             Ok(KIterator::new(result).into())
         }
-        unexpected => type_error_with_slice("(Function), or (Number, Function)", unexpected),
+        unexpected => argument_error("(Function), or (Number, Function)", unexpected, false),
     });
 
     result.add_fn("intersperse", |ctx| {
@@ -348,7 +348,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -360,7 +360,7 @@ pub fn make_module() -> KMap {
                 let iterable = iterable.clone();
                 Ok(KValue::Iterator(ctx.vm.make_iterator(iterable)?))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -378,7 +378,7 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -401,7 +401,7 @@ pub fn make_module() -> KMap {
 
                 Ok(result)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -418,7 +418,7 @@ pub fn make_module() -> KMap {
                 let key_fn = key_fn.clone();
                 run_iterator_comparison_by_key(ctx.vm, iterable, key_fn, InvertResult::Yes)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -435,7 +435,7 @@ pub fn make_module() -> KMap {
                 let key_fn = key_fn.clone();
                 run_iterator_comparison_by_key(ctx.vm, iterable, key_fn, InvertResult::No)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -505,7 +505,7 @@ pub fn make_module() -> KMap {
                     KValue::Tuple(vec![min, max].into())
                 }))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -515,7 +515,7 @@ pub fn make_module() -> KMap {
         let mut iter = match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (KValue::Iterator(i), []) => i.clone(),
             (iterable, []) if iterable.is_iterable() => ctx.vm.make_iterator(iterable.clone())?,
-            (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => return argument_error(expected_error, unexpected, true),
         };
 
         let output = match iter_output_to_result(iter.next())? {
@@ -532,7 +532,7 @@ pub fn make_module() -> KMap {
         let mut iter = match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (KValue::Iterator(i), []) => i.clone(),
             (iterable, []) if iterable.is_iterable() => ctx.vm.make_iterator(iterable.clone())?,
-            (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => return argument_error(expected_error, unexpected, true),
         };
 
         let output = match iter_output_to_result(iter.next_back())? {
@@ -558,7 +558,7 @@ pub fn make_module() -> KMap {
                     ctx.vm.make_iterator(iterable)?,
                 ))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -597,7 +597,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Null)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -608,7 +608,7 @@ pub fn make_module() -> KMap {
             match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
                 (iterable, []) => (iterable.clone(), KValue::Number(1.into())),
                 (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
-                (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+                (_, unexpected) => return argument_error(expected_error, unexpected, true),
             }
         };
 
@@ -624,7 +624,7 @@ pub fn make_module() -> KMap {
             let result = generators::RepeatN::new(value.clone(), n.into());
             Ok(KIterator::new(result).into())
         }
-        unexpected => type_error_with_slice("(Value), or (Number, Value)", unexpected),
+        unexpected => argument_error("(Value), or (Number, Value)", unexpected, false),
     });
 
     result.add_fn("reversed", |ctx| {
@@ -638,7 +638,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.reversed: {}", e),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -659,7 +659,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Iterator(iter))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -675,7 +675,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.step: {}", e),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -686,7 +686,7 @@ pub fn make_module() -> KMap {
             match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
                 (iterable, []) => (iterable.clone(), KValue::Number(0.into())),
                 (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
-                (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+                (_, unexpected) => return argument_error(expected_error, unexpected, true),
             }
         };
 
@@ -713,7 +713,7 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -737,7 +737,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::List(KList::with_data(result)))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -768,7 +768,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Map(KMap::with_data(result)))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -792,7 +792,7 @@ pub fn make_module() -> KMap {
 
                 Ok(display_context.result().into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -816,7 +816,7 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Tuple(result.into()))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -832,7 +832,7 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.windows: {}", e),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -849,7 +849,7 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -20,7 +20,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::Bytes::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -29,7 +29,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(KValue::Iterator(KIterator::with_string(s.clone()))),
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -41,7 +41,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::CharIndices::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -50,7 +50,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s1), [KValue::Str(s2)]) => Ok(s1.contains(s2.as_str()).into()),
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -61,7 +61,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().ends_with(pattern.as_str()).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -70,7 +70,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.escape_default().to_string().into()),
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -107,7 +107,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.is_empty().into()),
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -119,7 +119,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::Lines::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -130,7 +130,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(input), [KValue::Str(pattern), KValue::Str(replace)]) => {
                 Ok(input.replace(pattern.as_str(), replace).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -151,7 +151,9 @@ pub fn make_module() -> KMap {
                     );
                     KIterator::new(result)
                 }
-                (_, unexpected) => return argument_error(expected_error, unexpected, true),
+                (_, unexpected) => {
+                    return argument_error(expected_error, unexpected, Some("String"))
+                }
             }
         };
 
@@ -165,7 +167,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().starts_with(pattern.as_str()).into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -177,7 +179,7 @@ pub fn make_module() -> KMap {
                 let result = s.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -216,7 +218,7 @@ pub fn make_module() -> KMap {
                     Ok(KValue::Null)
                 }
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -228,7 +230,7 @@ pub fn make_module() -> KMap {
                 let result = s.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 
@@ -247,7 +249,7 @@ pub fn make_module() -> KMap {
 
                 Ok(result.into())
             }
-            (_, unexpected) => argument_error(expected_error, unexpected, true),
+            (_, unexpected) => argument_error(expected_error, unexpected, Some("String")),
         }
     });
 

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -3,7 +3,10 @@
 pub mod iterators;
 
 use super::iterator::collect_pair;
-use crate::{error::redundant_argument_error, prelude::*};
+use crate::{
+    error::{argument_error, no_argument_error},
+    prelude::*,
+};
 
 /// Initializes the `string` core library module
 pub fn make_module() -> KMap {
@@ -17,7 +20,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::Bytes::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -26,7 +29,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(KValue::Iterator(KIterator::with_string(s.clone()))),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -38,7 +41,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::CharIndices::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -47,7 +50,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s1), [KValue::Str(s2)]) => Ok(s1.contains(s2.as_str()).into()),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -58,7 +61,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().ends_with(pattern.as_str()).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -67,7 +70,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.escape_default().to_string().into()),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -96,7 +99,7 @@ pub fn make_module() -> KMap {
                 Err(_) => runtime_error!("Input failed UTF-8 validation"),
             }
         }
-        unexpected => type_error_with_slice("an iterable", unexpected),
+        _unexpected => no_argument_error("an iterable"),
     });
 
     result.add_fn("is_empty", |ctx| {
@@ -104,7 +107,7 @@ pub fn make_module() -> KMap {
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.is_empty().into()),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -116,7 +119,7 @@ pub fn make_module() -> KMap {
                 let result = iterators::Lines::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -127,7 +130,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(input), [KValue::Str(pattern), KValue::Str(replace)]) => {
                 Ok(input.replace(pattern.as_str(), replace).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -148,7 +151,7 @@ pub fn make_module() -> KMap {
                     );
                     KIterator::new(result)
                 }
-                (_, unexpected) => return redundant_argument_error(expected_error, unexpected),
+                (_, unexpected) => return argument_error(expected_error, unexpected, true),
             }
         };
 
@@ -162,7 +165,7 @@ pub fn make_module() -> KMap {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().starts_with(pattern.as_str()).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -174,7 +177,7 @@ pub fn make_module() -> KMap {
                 let result = s.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -213,7 +216,7 @@ pub fn make_module() -> KMap {
                     Ok(KValue::Null)
                 }
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -225,7 +228,7 @@ pub fn make_module() -> KMap {
                 let result = s.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 
@@ -244,7 +247,7 @@ pub fn make_module() -> KMap {
 
                 Ok(result.into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (_, unexpected) => argument_error(expected_error, unexpected, true),
         }
     });
 

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -215,7 +215,11 @@ pub fn self_argument_error<T>(expected_str: &str, unexpected: &[KValue]) -> Resu
 Couldn't detect self from first argument.
 Detected self: {}
 Expected: {}"#,
-            humanize_value_types(&unexpected[..1]),
+            if unexpected.is_empty() {
+                String::from("no args")
+            } else {
+                humanize_value_types(&unexpected[..1])
+            },
             expected_str
         )
     })
@@ -223,7 +227,10 @@ Expected: {}"#,
 
 /// Creates an error that describes that there is no args while expected
 pub fn no_argument_error<T>(expected_str: &str) -> Result<T> {
-    runtime_error!(format!("No argument given while {} needed", expected_str))
+    runtime_error!(format!(
+        "Argument Error\nNo argument given while {} needed",
+        expected_str
+    ))
 }
 
 // An alternative to get_value_types
@@ -233,6 +240,10 @@ fn humanize_value_types(values: &[KValue]) -> String {
         .map(|value| value.type_as_string().to_string())
         .collect();
     let values_len = values.len();
+
+    if values_len == 0 {
+        return String::from("no args");
+    }
 
     // [XType] -> XType
     if values_len == 1 {
@@ -250,7 +261,7 @@ fn humanize_value_types(values: &[KValue]) -> String {
         result.push_str(value);
         result.push_str(", ");
     }
-    result.push_str(" and ");
+    result.push_str("and ");
     result.push_str(&values[values_len - 1]);
     result
 }

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -239,9 +239,9 @@ fn humanize_value_types(values: &[KValue]) -> String {
         return values.remove(0);
     }
 
-    // [XType, YType] -> XType and YType
+    // [XType, YType] -> XType, and YType
     if values_len == 2 {
-        return values.join(" and ");
+        return values.join(", and ");
     }
 
     // [XType, YType, ZType] -> XType, YType and ZType

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -196,33 +196,21 @@ pub fn type_error_with_slice<T>(expected_str: &str, unexpected: &[KValue]) -> Re
 }
 
 /// Creates an error that describes there are redundant arguments
-pub fn argument_error<T>(expected_str: &str, unexpected: &[KValue], has_self: bool) -> Result<T> {
-    runtime_error!({
-        format!(
-            "Argument Error.\nGiven: {}{}\nExpected: {}",
-            humanize_value_types(unexpected),
-            if has_self { " (with self)" } else { "" },
-            expected_str
-        )
-    })
-}
-
-/// Creates an error that describes self couldn't found
-pub fn self_argument_error<T>(expected_str: &str, unexpected: &[KValue]) -> Result<T> {
-    runtime_error!({
-        format!(
-            r#"
-Couldn't detect self from first argument.
-Detected self: {}
-Expected: {}"#,
-            if unexpected.is_empty() {
-                String::from("no args")
-            } else {
-                humanize_value_types(&unexpected[..1])
-            },
-            expected_str
-        )
-    })
+pub fn argument_error<T>(
+    expected_str: &str,
+    unexpected: &[KValue],
+    self_type: Option<&str>,
+) -> Result<T> {
+    let mut result = String::new();
+    result.push_str("Argument Error.\nExpected: ");
+    result.push_str(expected_str);
+    result.push('\n');
+    result.push_str("Given: ");
+    if let Some(self_type) = self_type {
+        result.push_str(&format!("({}), ", self_type))
+    }
+    result.push_str(&humanize_value_types(unexpected));
+    runtime_error!(result)
 }
 
 /// Creates an error that describes that there is no args while expected

--- a/crates/runtime/src/types/native_function.rs
+++ b/crates/runtime/src/types/native_function.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Ptr, Result};
+use crate::{error::self_argument_error, prelude::*, Ptr, Result};
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -112,7 +112,7 @@ impl<'a> CallContext<'a> {
         match (self.instance(), self.args()) {
             (instance, args) if instance_check(instance) => Ok((instance, args)),
             (_, [first, rest @ ..]) if instance_check(first) => Ok((first, rest)),
-            (_, unexpected_args) => type_error_with_slice(expected_args_message, unexpected_args),
+            (_, unexpected_args) => self_argument_error(expected_args_message, unexpected_args),
         }
     }
 }

--- a/crates/runtime/src/types/native_function.rs
+++ b/crates/runtime/src/types/native_function.rs
@@ -1,4 +1,4 @@
-use crate::{error::self_argument_error, prelude::*, Ptr, Result};
+use crate::{error::argument_error, prelude::*, Ptr, Result};
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -112,7 +112,7 @@ impl<'a> CallContext<'a> {
         match (self.instance(), self.args()) {
             (instance, args) if instance_check(instance) => Ok((instance, args)),
             (_, [first, rest @ ..]) if instance_check(first) => Ok((first, rest)),
-            (_, unexpected_args) => self_argument_error(expected_args_message, unexpected_args),
+            (_, unexpected_args) => argument_error(expected_args_message, unexpected_args, None),
         }
     }
 }


### PR DESCRIPTION
I was implemented better error messages for the String module
https://github.com/koto-lang/koto/pull/345

I wanted to make error messages betters, and want to make them less confusing. Then, I prepared a template for the argument errors.

When the "Self" is undecidable:
![image](https://github.com/koto-lang/koto/assets/40325625/40cdb2ab-3e95-47cf-972b-cb47e3396567)

When the number of arguments are just wrong:
![image](https://github.com/koto-lang/koto/assets/40325625/55320c4c-e288-477f-a847-cb3359c5ee77)

When the number of arguments are just wrong while the function targets a "self":
![image](https://github.com/koto-lang/koto/assets/40325625/fa57b853-1819-4e4d-938e-3c41138e91c4)

When no argument given:
![image](https://github.com/koto-lang/koto/assets/40325625/e1843925-7f33-4ef1-8b90-690be72d8cff)
