### PR TITLE
Improve errors for calls with unexpected arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The Koto project adheres to
 - The `>>` pipe operator has been replaced with `->`.
   - This aligns it with the `->` function output type syntax, which avoids 
     having two different special-case operators related to function output.
+- Error messages have been improved when calling core library functions with
+  incorrect arguments.
 
 #### API
 
@@ -40,6 +42,9 @@ The Koto project adheres to
 - `AstIndex` and `ConstantIndex` are now newtypes that wrap `u32`.
 - `Node::Lookup` has been renamed to `Node::Chain`, and `LookupNode` is now 
   `ChainNode`.
+- `type_error` has been renamed to `unexpected_type`.  
+  - `type_error_with_slice` has been replaced by `unexpected_args` and
+    `unexpected_args_after_instance`. 
 
 ### Removed
 

--- a/crates/cli/docs/core_lib/iterator.md
+++ b/crates/cli/docs/core_lib/iterator.md
@@ -310,18 +310,18 @@ check! ['a', '-', 'b', '-', 'c', '-']
 ## generate
 
 ```kototype
-|Function| -> Iterator
+|generator: || -> Any| -> Iterator
 ```
 
-Provides an iterator that yields the result of repeatedly calling the provided
+Provides an iterator that yields the result of repeatedly calling the `generator`
 function. Note that this version of `generate` won't terminate and will iterate
 endlessly.
 
 ```kototype
-|n: Number, Function| -> Any
+|n: Number, generator: || -> Any| -> Any
 ```
 
-Provides an iterator that yields the result of repeatedly calling the provided
+Provides an iterator that yields the result of calling the `generator`
 function `n` times.
 
 ### Example
@@ -865,7 +865,7 @@ Provides an iterator that yields a number of values from the input before
 finishing.
 
 ```kototype
-|Iterable, test: Callable| -> Iterator
+|Iterable, test: |Any| -> Bool| -> Iterator
 ```
 
 Provides an iterator that yields values from the input while they pass a

--- a/crates/cli/docs/libs/random.md
+++ b/crates/cli/docs/libs/random.md
@@ -80,7 +80,7 @@ check! 0.168
 ## pick
 
 ```kototype
-|Any| -> Any
+|Indexable| -> Any
 ```
 
 Selects a random value from the input using the current thread's generator.

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -106,9 +106,9 @@ pub fn derive_koto_copy(input: TokenStream) -> TokenStream {
 ///     #[koto_method]
 ///     fn reset(&mut self, args: &[KValue]) -> Result<KValue> {
 ///         let reset_value = match args {
-///             [KValue::Number(reset_value)] => reset_value.into(),
 ///             [] => 0.0,
-///             unexpected => return type_error_with_slice("an optional Number", unexpected),
+///             [KValue::Number(reset_value)] => reset_value.into(),
+///             unexpected => return unexpected_args("||, or |Number|", unexpected),
 ///         };
 ///         self.x = reset_value;
 ///         Ok(())
@@ -122,7 +122,7 @@ pub fn derive_koto_copy(input: TokenStream) -> TokenStream {
 ///                 // Return a clone of the instance that's being modified
 ///                 ctx.instance_result()
 ///             }
-///             unexpected => type_error_with_slice("a Number", unexpected),
+///             unexpected => unexpected_args("|Number|", unexpected),
 ///         }
 ///     }
 /// }

--- a/crates/koto/examples/module.rs
+++ b/crates/koto/examples/module.rs
@@ -18,12 +18,12 @@ fn make_module() -> KMap {
 
     module.add_fn("echo", |ctx| match ctx.args() {
         [KValue::Str(s)] => Ok(format!("{s}!").into()),
-        unexpected => type_error_with_slice("a string", unexpected),
+        unexpected => unexpected_args("|String|", unexpected),
     });
 
     module.add_fn("square", |ctx| match ctx.args() {
         [KValue::Number(n)] => Ok((n * n).into()),
-        unexpected => type_error_with_slice("a number", unexpected),
+        unexpected => unexpected_args("|Number|", unexpected),
     });
 
     module

--- a/crates/koto/examples/poetry/src/koto_bindings.rs
+++ b/crates/koto/examples/poetry/src/koto_bindings.rs
@@ -11,7 +11,7 @@ pub fn make_module() -> KMap {
                 poetry.add_source_material(text);
                 Ok(KObject::from(KotoPoetry(poetry)).into())
             }
-            unexpected => type_error_with_slice("a String", unexpected),
+            unexpected => unexpected_args("|String|", unexpected),
         }
     });
 

--- a/crates/koto/examples/rust_function.rs
+++ b/crates/koto/examples/rust_function.rs
@@ -15,7 +15,7 @@ print plus 10, 20
     // The add_fn helper avoids the need for type annotations
     prelude.add_fn("plus", |ctx| match ctx.args() {
         [KValue::Number(a), KValue::Number(b)] => Ok((a + b).into()),
-        unexpected => type_error_with_slice("two numbers", unexpected),
+        unexpected => unexpected_args("|Number, Number|", unexpected),
     });
 
     koto.compile_and_run(script).unwrap();
@@ -25,7 +25,7 @@ fn say_hello(ctx: &mut CallContext) -> koto::Result<KValue> {
     match ctx.args() {
         [] => println!("Hello?"),
         [KValue::Str(name)] => println!("Hello, {name}"),
-        unexpected => return type_error_with_slice("an optional string", unexpected),
+        unexpected => return unexpected_args("||, or |String|", unexpected),
     }
 
     Ok(KValue::Null)

--- a/crates/koto/examples/rust_object.rs
+++ b/crates/koto/examples/rust_object.rs
@@ -11,7 +11,7 @@ print my_type.set 99
     koto.prelude()
         .add_fn("make_my_type", |ctx| match ctx.args() {
             [KValue::Number(n)] => Ok(MyType::make_koto_object(*n).into()),
-            unexpected => type_error_with_slice("a number", unexpected),
+            unexpected => unexpected_args("|Number|", unexpected),
         });
 
     koto.compile_and_run(script).unwrap();
@@ -48,7 +48,7 @@ impl MyType {
                 ctx.instance_mut()?.0 = n.into();
                 ctx.instance_result()
             }
-            unexpected => type_error_with_slice("a Number", unexpected),
+            unexpected => unexpected_args("|Number|", unexpected),
         }
     }
 }

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -219,7 +219,7 @@ impl Koto {
                     self.runtime.run_tests(tests)?;
                 }
                 Some(other) => {
-                    return type_error("test map", &other);
+                    return unexpected_type("test map", &other);
                 }
                 None => {}
             }

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -81,7 +81,7 @@ pub fn make_module() -> KMap {
                 let value = value.clone();
                 match ctx.vm.run_unary_op(crate::UnaryOp::Display, value)? {
                     Str(s) => ctx.vm.stdout().write_line(s.as_str()),
-                    unexpected => return type_error("String from @display", &unexpected),
+                    unexpected => return unexpected_type("String from @display", &unexpected),
                 }
             }
             values @ [_, ..] => {
@@ -91,7 +91,7 @@ pub fn make_module() -> KMap {
                     .run_unary_op(crate::UnaryOp::Display, KValue::Tuple(tuple_data.into()))?
                 {
                     Str(s) => ctx.vm.stdout().write_line(s.as_str()),
-                    unexpected => return type_error("String from @display", &unexpected),
+                    unexpected => return unexpected_type("String from @display", &unexpected),
                 }
             }
             unexpected => return unexpected_args("|Any|, or |Any, Any...|", unexpected),

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -34,7 +34,7 @@ pub fn make_module() -> KMap {
                             }
                         }
                         Ok(unexpected) => {
-                            return type_error(
+                            return unexpected_type(
                                 "a Bool to be returned from the predicate",
                                 &unexpected,
                             )
@@ -73,7 +73,7 @@ pub fn make_module() -> KMap {
                             }
                         }
                         Ok(unexpected) => {
-                            return type_error(
+                            return unexpected_type(
                                 "a Bool to be returned from the predicate",
                                 &unexpected,
                             )
@@ -239,7 +239,7 @@ pub fn make_module() -> KMap {
                                     }
                                 }
                                 Ok(unexpected) => {
-                                    return type_error(
+                                    return unexpected_type(
                                         "a Bool to be returned from the predicate",
                                         &unexpected,
                                     )
@@ -594,7 +594,7 @@ pub fn make_module() -> KMap {
                             }
                         }
                         Ok(unexpected) => {
-                            return type_error(
+                            return unexpected_type(
                                 "a Bool to be returned from the predicate",
                                 &unexpected,
                             )

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -11,7 +11,7 @@ pub fn make_module() -> KMap {
     let result = KMap::with_type("core.iterator");
 
     result.add_fn("all", |ctx| {
-        let expected_error = "an iterable and predicate function";
+        let expected_error = "|Iterable, |Any| -> Bool|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
@@ -45,12 +45,12 @@ pub fn make_module() -> KMap {
 
                 Ok(true.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("any", |ctx| {
-        let expected_error = "an iterable and predicate function";
+        let expected_error = "|Iterable, |Any| -> Bool|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
@@ -84,12 +84,13 @@ pub fn make_module() -> KMap {
 
                 Ok(false.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("chain", |ctx| {
-        let expected_error = "two iterable values";
+        let expected_error = "|Iterable, Iterable|";
+
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable_a, [iterable_b]) if iterable_b.is_iterable() => {
                 let iterable_a = iterable_a.clone();
@@ -101,12 +102,12 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Iterator(result))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("chunks", |ctx| {
-        let expected_error = "an iterable and a chunk size greater than zero";
+        let expected_error = "|Iterable, Number|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [KValue::Number(n)]) => {
@@ -117,12 +118,12 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.chunks: {}", e),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("consume", |ctx| {
-        let expected_error = "an iterable value (and optional consumer function)";
+        let expected_error = "|Iterable|, or |Iterable, |Any| -> Any|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -151,12 +152,12 @@ pub fn make_module() -> KMap {
                 }
                 Ok(KValue::Null)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("count", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -170,12 +171,26 @@ pub fn make_module() -> KMap {
                 }
                 Ok(KValue::Number(result.into()))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
+        }
+    });
+
+    result.add_fn("cycle", |ctx| {
+        let expected_error = "|Iterable|";
+
+        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
+            (iterable, []) => {
+                let iterable = iterable.clone();
+                let result = adaptors::Cycle::new(ctx.vm.make_iterator(iterable)?);
+
+                Ok(KIterator::new(result).into())
+            }
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("each", |ctx| {
-        let expected_error = "an iterable and function";
+        let expected_error = "|Iterable, |Any| -> Any|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [f]) if f.is_callable() => {
@@ -189,26 +204,12 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
-        }
-    });
-
-    result.add_fn("cycle", |ctx| {
-        let expected_error = "an iterable";
-
-        match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
-            (iterable, []) => {
-                let iterable = iterable.clone();
-                let result = adaptors::Cycle::new(ctx.vm.make_iterator(iterable)?);
-
-                Ok(KIterator::new(result).into())
-            }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("enumerate", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -216,12 +217,12 @@ pub fn make_module() -> KMap {
                 let result = adaptors::Enumerate::new(ctx.vm.make_iterator(iterable)?);
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("find", |ctx| {
-        let expected_error = "an iterable and a predicate function";
+        let expected_error = "|Iterable, |Any| -> Bool|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
@@ -253,12 +254,12 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Null)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("flatten", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -270,12 +271,12 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("fold", |ctx| {
-        let expected_error = "an iterable, initial value, and folding function";
+        let expected_error = "|Iterable, Any, |Any, Any| -> Any|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [result, f]) if f.is_callable() => {
@@ -310,7 +311,7 @@ pub fn make_module() -> KMap {
                     _ => unreachable!(),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
@@ -323,11 +324,14 @@ pub fn make_module() -> KMap {
             let result = generators::GenerateN::new(n.into(), f.clone(), ctx.vm.spawn_shared_vm());
             Ok(KIterator::new(result).into())
         }
-        unexpected => type_error_with_slice("(Function), or (Number, Function)", unexpected),
+        unexpected => unexpected_args(
+            "|generator: || -> Any|, or |n: Number, generator: || -> Any|",
+            unexpected,
+        ),
     });
 
     result.add_fn("intersperse", |ctx| {
-        let expected_error = "an iterable and a separator";
+        let expected_error = "|Iterable, Value|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [separator_fn]) if separator_fn.is_callable() => {
@@ -348,24 +352,24 @@ pub fn make_module() -> KMap {
 
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("iter", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
                 let iterable = iterable.clone();
                 Ok(KValue::Iterator(ctx.vm.make_iterator(iterable)?))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("keep", |ctx| {
-        let expected_error = "an iterable and a predicate function";
+        let expected_error = "|Iterable, |Any| -> Bool|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
@@ -378,12 +382,12 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("last", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -401,12 +405,12 @@ pub fn make_module() -> KMap {
 
                 Ok(result)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("max", |ctx| {
-        let expected_error = "an iterable and an optional key function";
+        let expected_error = "|Iterable|, or |Iterable, |Any| -> Any|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -418,12 +422,12 @@ pub fn make_module() -> KMap {
                 let key_fn = key_fn.clone();
                 run_iterator_comparison_by_key(ctx.vm, iterable, key_fn, InvertResult::Yes)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("min", |ctx| {
-        let expected_error = "an iterable and an optional key function";
+        let expected_error = "|Iterable|, or |Iterable, |Any| -> Any|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -435,12 +439,12 @@ pub fn make_module() -> KMap {
                 let key_fn = key_fn.clone();
                 run_iterator_comparison_by_key(ctx.vm, iterable, key_fn, InvertResult::No)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("min_max", |ctx| {
-        let expected_error = "an iterable and an optional key function";
+        let expected_error = "|Iterable|, or |Iterable, |Any| -> Any|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -505,17 +509,19 @@ pub fn make_module() -> KMap {
                     KValue::Tuple(vec![min, max].into())
                 }))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("next", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         let mut iter = match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (KValue::Iterator(i), []) => i.clone(),
             (iterable, []) if iterable.is_iterable() => ctx.vm.make_iterator(iterable.clone())?,
-            (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+            (instance, args) => {
+                return unexpected_args_after_instance(expected_error, instance, args)
+            }
         };
 
         let output = match iter_output_to_result(iter.next())? {
@@ -527,12 +533,14 @@ pub fn make_module() -> KMap {
     });
 
     result.add_fn("next_back", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         let mut iter = match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (KValue::Iterator(i), []) => i.clone(),
             (iterable, []) if iterable.is_iterable() => ctx.vm.make_iterator(iterable.clone())?,
-            (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+            (instance, args) => {
+                return unexpected_args_after_instance(expected_error, instance, args)
+            }
         };
 
         let output = match iter_output_to_result(iter.next_back())? {
@@ -545,11 +553,11 @@ pub fn make_module() -> KMap {
 
     result.add_fn("once", |ctx| match ctx.args() {
         [value] => Ok(KIterator::new(generators::Once::new(value.clone())).into()),
-        unexpected => type_error_with_slice("a single value", unexpected),
+        unexpected => unexpected_args("|Any|", unexpected),
     });
 
     result.add_fn("peekable", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -558,12 +566,12 @@ pub fn make_module() -> KMap {
                     ctx.vm.make_iterator(iterable)?,
                 ))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("position", |ctx| {
-        let expected_error = "an iterable and a predicate function";
+        let expected_error = "|Iterable, |Any| -> Bool|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [predicate]) if predicate.is_callable() => {
@@ -586,9 +594,9 @@ pub fn make_module() -> KMap {
                             }
                         }
                         Ok(unexpected) => {
-                            return type_error_with_slice(
+                            return type_error(
                                 "a Bool to be returned from the predicate",
-                                &[unexpected],
+                                &unexpected,
                             )
                         }
                         Err(error) => return Err(error),
@@ -597,18 +605,20 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Null)
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("product", |ctx| {
         let (iterable, initial_value) = {
-            let expected_error = "an iterable and optional initial value";
+            let expected_error = "|Iterable|";
 
             match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
                 (iterable, []) => (iterable.clone(), KValue::Number(1.into())),
-                (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
-                (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+                (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()), // TODO - remove?
+                (instance, args) => {
+                    return unexpected_args_after_instance(expected_error, instance, args)
+                }
             }
         };
 
@@ -624,11 +634,11 @@ pub fn make_module() -> KMap {
             let result = generators::RepeatN::new(value.clone(), n.into());
             Ok(KIterator::new(result).into())
         }
-        unexpected => type_error_with_slice("(Value), or (Number, Value)", unexpected),
+        unexpected => unexpected_args("|Any|, or |Number, Any|", unexpected),
     });
 
     result.add_fn("reversed", |ctx| {
-        let expected_error = "an iterable and non-negative number";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -638,55 +648,65 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.reversed: {}", e),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("skip", |ctx| {
-        let expected_error = "an iterable and non-negative number";
+        let expected_error = "|Iterable, Number|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
-            (iterable, [KValue::Number(n)]) if *n >= 0.0 => {
-                let iterable = iterable.clone();
-                let n = *n;
-                let mut iter = ctx.vm.make_iterator(iterable)?;
+            (iterable, [KValue::Number(n)]) => {
+                if *n >= 0.0 {
+                    let iterable = iterable.clone();
+                    let n = *n;
+                    let mut iter = ctx.vm.make_iterator(iterable)?;
 
-                for _ in 0..n.into() {
-                    if let Some(Output::Error(error)) = iter.next() {
-                        return Err(error);
+                    for _ in 0..n.into() {
+                        if let Some(Output::Error(error)) = iter.next() {
+                            return Err(error);
+                        }
                     }
-                }
 
-                Ok(KValue::Iterator(iter))
+                    Ok(KValue::Iterator(iter))
+                } else {
+                    runtime_error!("expected a non-negative number")
+                }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("step", |ctx| {
-        let expected_error = "an iterable and positive step size";
+        let expected_error = "|Iterable, Number|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
-            (iterable, [KValue::Number(n)]) if *n > 0 => {
-                let iterable = iterable.clone();
-                let step_size = n.into();
-                match adaptors::Step::new(ctx.vm.make_iterator(iterable)?, step_size) {
-                    Ok(result) => Ok(KIterator::new(result).into()),
-                    Err(e) => runtime_error!("iterator.step: {}", e),
+            (iterable, [KValue::Number(n)]) => {
+                if *n > 0 {
+                    let iterable = iterable.clone();
+                    let step_size = n.into();
+                    match adaptors::Step::new(ctx.vm.make_iterator(iterable)?, step_size) {
+                        Ok(result) => Ok(KIterator::new(result).into()),
+                        Err(e) => runtime_error!("iterator.step: {}", e),
+                    }
+                } else {
+                    runtime_error!("expected a non-negative number")
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("sum", |ctx| {
         let (iterable, initial_value) = {
-            let expected_error = "an iterable and optional initial value";
+            let expected_error = "|Iterable|";
 
             match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
                 (iterable, []) => (iterable.clone(), KValue::Number(0.into())),
                 (iterable, [initial_value]) => (iterable.clone(), initial_value.clone()),
-                (_, unexpected) => return type_error_with_slice(expected_error, unexpected),
+                (instance, args) => {
+                    return unexpected_args_after_instance(expected_error, instance, args)
+                }
             }
         };
 
@@ -694,7 +714,7 @@ pub fn make_module() -> KMap {
     });
 
     result.add_fn("take", |ctx| {
-        let expected_error = "an iterable and a count or predicate";
+        let expected_error = "|Iterable, Number|, or |Iterable, |Any| -> Bool|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [KValue::Number(n)]) if *n >= 0.0 => {
@@ -713,12 +733,12 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("to_list", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -737,12 +757,12 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::List(KList::with_data(result)))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("to_map", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -768,12 +788,12 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Map(KMap::with_data(result)))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("to_string", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -792,12 +812,12 @@ pub fn make_module() -> KMap {
 
                 Ok(display_context.result().into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("to_tuple", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, []) => {
@@ -816,12 +836,12 @@ pub fn make_module() -> KMap {
 
                 Ok(KValue::Tuple(result.into()))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("windows", |ctx| {
-        let expected_error = "an iterable and a chunnk size greater than zero";
+        let expected_error = "|Iterable, Number|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable, [KValue::Number(n)]) => {
@@ -832,12 +852,12 @@ pub fn make_module() -> KMap {
                     Err(e) => runtime_error!("iterator.windows: {}", e),
                 }
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("zip", |ctx| {
-        let expected_error = "an iterable";
+        let expected_error = "|Iterable|";
 
         match ctx.instance_and_args(KValue::is_iterable, expected_error)? {
             (iterable_a, [iterable_b]) if iterable_b.is_iterable() => {
@@ -849,7 +869,7 @@ pub fn make_module() -> KMap {
                 );
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 

--- a/crates/runtime/src/core_lib/list.rs
+++ b/crates/runtime/src/core_lib/list.rs
@@ -283,7 +283,7 @@ pub fn make_module() -> KMap {
                                 }
                             }
                             Ok(unexpected) => {
-                                return type_error(
+                                return unexpected_type(
                                     "a Bool to returned from the predicate",
                                     &unexpected,
                                 );
@@ -310,7 +310,7 @@ pub fn make_module() -> KMap {
                             Ok(KValue::Bool(true)) => true,
                             Ok(KValue::Bool(false)) => false,
                             Ok(unexpected) => {
-                                error = Some(type_error(
+                                error = Some(unexpected_type(
                                     "a Bool from the equality comparison",
                                     &unexpected,
                                 ));

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -10,9 +10,15 @@ pub fn make_module() -> KMap {
 
     let result = KMap::with_type("core.os");
 
-    result.add_fn("name", |_| Ok(std::env::consts::OS.into()));
+    result.add_fn("name", |ctx| match ctx.args() {
+        [] => Ok(std::env::consts::OS.into()),
+        unexpected => unexpected_args("||", unexpected),
+    });
 
-    result.add_fn("start_timer", |_| Ok(Timer::now()));
+    result.add_fn("start_timer", |ctx| match ctx.args() {
+        [] => Ok(Timer::now()),
+        unexpected => unexpected_args("||", unexpected),
+    });
 
     result.add_fn("time", |ctx| match ctx.args() {
         [] => Ok(DateTime::now()),
@@ -20,10 +26,7 @@ pub fn make_module() -> KMap {
         [Number(seconds), Number(offset)] => {
             DateTime::from_seconds(seconds.into(), Some(offset.into()))
         }
-        unexpected => type_error_with_slice(
-            "no args, or a timestamp in seconds, with optional timezone offset in seconds",
-            unexpected,
-        ),
+        unexpected => unexpected_args("||, or |Number|, or |Number, Number|", unexpected),
     });
 
     result

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -165,7 +165,7 @@ impl KotoObject for Timer {
 
                 Ok(result.into())
             }
-            unexpected => type_error(Self::type_static(), unexpected),
+            unexpected => unexpected_type(Self::type_static(), unexpected),
         }
     }
 }

--- a/crates/runtime/src/core_lib/range.rs
+++ b/crates/runtime/src/core_lib/range.rs
@@ -7,7 +7,7 @@ pub fn make_module() -> KMap {
     let result = KMap::with_type("core.range");
 
     result.add_fn("contains", |ctx| {
-        let expected_error = "a Range, and a Number or another Range";
+        let expected_error = "|Range, Number|, or |Range, Range|";
 
         match ctx.instance_and_args(is_range, expected_error)? {
             (KValue::Range(r), [KValue::Number(n)]) => Ok(r.contains(*n).into()),
@@ -17,23 +17,23 @@ pub fn make_module() -> KMap {
                 let result = r_b.start >= r_a.start && r_b.end <= r_a.end;
                 Ok(result.into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("end", |ctx| {
-        let expected_error = "a Range";
+        let expected_error = "|Range|";
 
         match ctx.instance_and_args(is_range, expected_error)? {
             (KValue::Range(r), []) => {
                 Ok(r.end().map_or(KValue::Null, |(end, _inclusive)| end.into()))
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("expanded", |ctx| {
-        let expected_error = "a Range and Number";
+        let expected_error = "|Range, Number|";
 
         match ctx.instance_and_args(is_range, expected_error)? {
             (KValue::Range(r), [KValue::Number(n)]) => match (r.start(), r.end()) {
@@ -48,43 +48,43 @@ pub fn make_module() -> KMap {
                 }
                 _ => runtime_error!("range.expanded can't be used with '{r}'"),
             },
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("intersection", |ctx| {
-        let expected_error = "two Ranges";
+        let expected_error = "|Range, Range|";
 
         match ctx.instance_and_args(is_range, expected_error)? {
             (KValue::Range(a), [KValue::Range(b)]) => Ok(a
                 .intersection(b)
                 .map_or(KValue::Null, |result| result.into())),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("is_inclusive", |ctx| {
-        let expected_error = "a Range";
+        let expected_error = "|Range|";
 
         match ctx.instance_and_args(is_range, expected_error)? {
             (KValue::Range(r), []) => {
                 Ok(r.end().map_or(false, |(_end, inclusive)| inclusive).into())
             }
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("start", |ctx| {
-        let expected_error = "a Range";
+        let expected_error = "|Range|";
 
         match ctx.instance_and_args(is_range, expected_error)? {
             (KValue::Range(r), []) => Ok(r.start().map_or(KValue::Null, KValue::from)),
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("union", |ctx| {
-        let expected_error = "a Range, and a Number or another Range";
+        let expected_error = "|Range, Number|, or |Range, Range|";
 
         match ctx.instance_and_args(is_range, expected_error)? {
             (KValue::Range(r), [KValue::Number(n)]) => {
@@ -119,7 +119,7 @@ pub fn make_module() -> KMap {
                 }
                 _ => runtime_error!("range.union can't be used with '{a}' and '{b}'"),
             },
-            (_, unexpected) => type_error_with_slice(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -88,7 +88,7 @@ pub fn make_module() -> KMap {
                         Ok(byte) => bytes.push(byte),
                         Err(_) => return runtime_error!("'{n}' is out of the valid byte range"),
                     },
-                    Output::Value(unexpected) => return type_error("Number", &unexpected),
+                    Output::Value(unexpected) => return unexpected_type("Number", &unexpected),
                     Output::Error(error) => return Err(error),
                     _ => unreachable!(),
                 }

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -3,71 +3,74 @@
 pub mod iterators;
 
 use super::iterator::collect_pair;
-use crate::{error::redundant_argument_error, prelude::*};
+use crate::{
+    error::{unexpected_args, unexpected_args_after_instance},
+    prelude::*,
+};
 
 /// Initializes the `string` core library module
 pub fn make_module() -> KMap {
     let result = KMap::with_type("core.string");
 
     result.add_fn("bytes", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => {
                 let result = iterators::Bytes::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("chars", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(KValue::Iterator(KIterator::with_string(s.clone()))),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("char_indices", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => {
                 let result = iterators::CharIndices::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("contains", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s1), [KValue::Str(s2)]) => Ok(s1.contains(s2.as_str()).into()),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("ends_with", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().ends_with(pattern.as_str()).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("escape", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.escape_default().to_string().into()),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
@@ -85,7 +88,7 @@ pub fn make_module() -> KMap {
                         Ok(byte) => bytes.push(byte),
                         Err(_) => return runtime_error!("'{n}' is out of the valid byte range"),
                     },
-                    Output::Value(unexpected) => return type_error("a number", &unexpected),
+                    Output::Value(unexpected) => return type_error("Number", &unexpected),
                     Output::Error(error) => return Err(error),
                     _ => unreachable!(),
                 }
@@ -96,44 +99,44 @@ pub fn make_module() -> KMap {
                 Err(_) => runtime_error!("Input failed UTF-8 validation"),
             }
         }
-        unexpected => type_error_with_slice("an iterable", unexpected),
+        unexpected => unexpected_args("|Iterable|", unexpected),
     });
 
     result.add_fn("is_empty", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => Ok(s.is_empty().into()),
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("lines", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => {
                 let result = iterators::Lines::new(s.clone());
                 Ok(KIterator::new(result).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("replace", |ctx| {
-        let expected_error = "a String, followed by pattern and replacement Strings";
+        let expected_error = "|String, String, String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(input), [KValue::Str(pattern), KValue::Str(replace)]) => {
                 Ok(input.replace(pattern.as_str(), replace).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("split", |ctx| {
         let iterator = {
-            let expected_error = "a String, and either a String or a predicate function";
+            let expected_error = "|String, String|, or |String, |String| -> Bool|";
 
             match ctx.instance_and_args(is_string, expected_error)? {
                 (KValue::Str(input), [KValue::Str(pattern)]) => {
@@ -148,7 +151,9 @@ pub fn make_module() -> KMap {
                     );
                     KIterator::new(result)
                 }
-                (_, unexpected) => return redundant_argument_error(expected_error, unexpected),
+                (instance, args) => {
+                    return unexpected_args_after_instance(expected_error, instance, args)
+                }
             }
         };
 
@@ -156,30 +161,30 @@ pub fn make_module() -> KMap {
     });
 
     result.add_fn("starts_with", |ctx| {
-        let expected_error = "two Strings";
+        let expected_error = "|String, String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), [KValue::Str(pattern)]) => {
                 Ok(s.as_str().starts_with(pattern.as_str()).into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("to_lowercase", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => {
                 let result = s.chars().flat_map(|c| c.to_lowercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("to_number", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => {
@@ -213,24 +218,24 @@ pub fn make_module() -> KMap {
                     Ok(KValue::Null)
                 }
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("to_uppercase", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => {
                 let result = s.chars().flat_map(|c| c.to_uppercase()).collect::<String>();
                 Ok(result.into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 
     result.add_fn("trim", |ctx| {
-        let expected_error = "a String";
+        let expected_error = "|String|";
 
         match ctx.instance_and_args(is_string, expected_error)? {
             (KValue::Str(s), []) => {
@@ -244,7 +249,7 @@ pub fn make_module() -> KMap {
 
                 Ok(result.into())
             }
-            (_, unexpected) => redundant_argument_error(expected_error, unexpected),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });
 

--- a/crates/runtime/src/core_lib/test.rs
+++ b/crates/runtime/src/core_lib/test.rs
@@ -14,7 +14,7 @@ pub fn make_module() -> KMap {
                         return runtime_error!("Assertion failed");
                     }
                 }
-                unexpected => return type_error("Bool as argument", unexpected),
+                unexpected => return type_error("Bool", unexpected),
             }
         }
         Ok(KValue::Null)
@@ -38,7 +38,7 @@ pub fn make_module() -> KMap {
                 Err(e) => Err(e),
             }
         }
-        unexpected => type_error_with_slice("two Values", unexpected),
+        unexpected => unexpected_args("|Any, Any|", unexpected),
     });
 
     result.add_fn("assert_ne", |ctx| match ctx.args() {
@@ -61,7 +61,7 @@ pub fn make_module() -> KMap {
                 Err(e) => Err(e),
             }
         }
-        unexpected => type_error_with_slice("two Values", unexpected),
+        unexpected => unexpected_args("|Any, Any|", unexpected),
     });
 
     result.add_fn("assert_near", |ctx| match ctx.args() {
@@ -69,11 +69,7 @@ pub fn make_module() -> KMap {
         [KValue::Number(a), KValue::Number(b), KValue::Number(allowed_diff)] => {
             number_near(*a, *b, allowed_diff.into())
         }
-        unexpected => type_error_with_slice(
-            "two Numbers as arguments, \
-             followed by an optional Number that specifies the allowed difference",
-            unexpected,
-        ),
+        unexpected => unexpected_args("|Number, Number, Number|", unexpected),
     });
 
     result.add_fn("run_tests", |ctx| match ctx.args() {
@@ -81,7 +77,7 @@ pub fn make_module() -> KMap {
             let tests = tests.clone();
             ctx.vm.run_tests(tests)
         }
-        unexpected => type_error_with_slice("a Map as argument", unexpected),
+        unexpected => unexpected_args("|Map|", unexpected),
     });
 
     result

--- a/crates/runtime/src/core_lib/test.rs
+++ b/crates/runtime/src/core_lib/test.rs
@@ -14,7 +14,7 @@ pub fn make_module() -> KMap {
                         return runtime_error!("Assertion failed");
                     }
                 }
-                unexpected => return type_error("Bool", unexpected),
+                unexpected => return unexpected_type("Bool", unexpected),
             }
         }
         Ok(KValue::Null)
@@ -34,7 +34,7 @@ pub fn make_module() -> KMap {
                         ctx.vm.value_to_string(&b)?,
                     )
                 }
-                Ok(unexpected) => type_error("Bool from equality comparison", &unexpected),
+                Ok(unexpected) => unexpected_type("Bool from equality comparison", &unexpected),
                 Err(e) => Err(e),
             }
         }
@@ -57,7 +57,7 @@ pub fn make_module() -> KMap {
                         ctx.vm.value_to_string(&b)?
                     )
                 }
-                Ok(unexpected) => type_error("Bool from equality comparison", &unexpected),
+                Ok(unexpected) => unexpected_type("Bool from equality comparison", &unexpected),
                 Err(e) => Err(e),
             }
         }

--- a/crates/runtime/src/core_lib/tuple.rs
+++ b/crates/runtime/src/core_lib/tuple.rs
@@ -22,7 +22,10 @@ pub fn make_module() -> KMap {
                         Ok(KValue::Bool(false)) => {}
                         Ok(KValue::Bool(true)) => return Ok(true.into()),
                         Ok(unexpected) => {
-                            return type_error("a Bool from the equality comparison", &unexpected)
+                            return unexpected_type(
+                                "a Bool from the equality comparison",
+                                &unexpected,
+                            )
                         }
                         Err(e) => return Err(e),
                     }

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -50,6 +50,8 @@ pub enum ErrorKind {
     MissingSequenceBuilder,
     #[error("Missing string builder")]
     MissingStringBuilder,
+    #[error("An unexpected error occurred, please report this as a bug at https://github.com/koto-lang/koto/issues")]
+    UnexpectedError,
 }
 
 fn display_thrown_value(value: &KValue, vm: &KotoVm) -> String {

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -200,14 +200,6 @@ pub fn type_error<T>(expected_str: &str, unexpected: &KValue) -> Result<T> {
     })
 }
 
-/// Creates an error that describes a type mismatch with a slice of [KValue]s
-pub fn type_error_with_slice<T>(expected_str: &str, unexpected: &[KValue]) -> Result<T> {
-    runtime_error!(ErrorKind::UnexpectedArguments {
-        expected: expected_str.into(),
-        unexpected: unexpected.into(),
-    })
-}
-
 /// Creates an unexpected arguments error containg the provided arguments
 pub fn unexpected_args<T>(expected_str: &str, arguments: &[KValue]) -> Result<T> {
     runtime_error!(ErrorKind::UnexpectedArguments {

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -193,7 +193,7 @@ macro_rules! runtime_error {
 }
 
 /// Creates an error that describes a type mismatch
-pub fn type_error<T>(expected_str: &str, unexpected: &KValue) -> Result<T> {
+pub fn unexpected_type<T>(expected_str: &str, unexpected: &KValue) -> Result<T> {
     runtime_error!(ErrorKind::UnexpectedType {
         expected: expected_str.into(),
         unexpected: unexpected.clone(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,8 +15,8 @@ mod send_sync;
 pub use crate::{
     display_context::DisplayContext,
     error::{
-        type_error, unexpected_args, unexpected_args_after_instance, Error, ErrorFrame, ErrorKind,
-        Result,
+        unexpected_args, unexpected_args_after_instance, unexpected_type, Error, ErrorFrame,
+        ErrorKind, Result,
     },
     io::{BufferedFile, DefaultStderr, DefaultStdin, DefaultStdout, KotoFile, KotoRead, KotoWrite},
     send_sync::{KotoSend, KotoSync},

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -14,7 +14,10 @@ mod send_sync;
 
 pub use crate::{
     display_context::DisplayContext,
-    error::{type_error, type_error_with_slice, Error, ErrorFrame, ErrorKind, Result},
+    error::{
+        type_error, type_error_with_slice, unexpected_args, unexpected_args_after_instance, Error,
+        ErrorFrame, ErrorKind, Result,
+    },
     io::{BufferedFile, DefaultStderr, DefaultStdin, DefaultStdout, KotoFile, KotoRead, KotoWrite},
     send_sync::{KotoSend, KotoSync},
     types::{

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,8 +15,8 @@ mod send_sync;
 pub use crate::{
     display_context::DisplayContext,
     error::{
-        type_error, type_error_with_slice, unexpected_args, unexpected_args_after_instance, Error,
-        ErrorFrame, ErrorKind, Result,
+        type_error, unexpected_args, unexpected_args_after_instance, Error, ErrorFrame, ErrorKind,
+        Result,
     },
     io::{BufferedFile, DefaultStderr, DefaultStdin, DefaultStdout, KotoFile, KotoRead, KotoWrite},
     send_sync::{KotoSend, KotoSync},

--- a/crates/runtime/src/prelude.rs
+++ b/crates/runtime/src/prelude.rs
@@ -2,10 +2,10 @@
 
 #[doc(inline)]
 pub use crate::{
-    make_ptr, make_ptr_mut, runtime_error, type_error, type_error_with_slice, BinaryOp, CallArgs,
-    CallContext, DisplayContext, IsIterable, KCell, KIterator, KIteratorOutput, KList, KMap,
-    KNativeFunction, KNumber, KObject, KRange, KString, KTuple, KValue, KotoCopy, KotoEntries,
-    KotoFile, KotoFunction, KotoHasher, KotoIterator, KotoObject, KotoRead, KotoSend, KotoSync,
-    KotoType, KotoVm, KotoVmSettings, KotoWrite, MetaKey, MetaMap, MethodContext, UnaryOp,
-    ValueKey, ValueMap, ValueVec,
+    make_ptr, make_ptr_mut, runtime_error, type_error, type_error_with_slice, unexpected_args,
+    unexpected_args_after_instance, BinaryOp, CallArgs, CallContext, DisplayContext, IsIterable,
+    KCell, KIterator, KIteratorOutput, KList, KMap, KNativeFunction, KNumber, KObject, KRange,
+    KString, KTuple, KValue, KotoCopy, KotoEntries, KotoFile, KotoFunction, KotoHasher,
+    KotoIterator, KotoObject, KotoRead, KotoSend, KotoSync, KotoType, KotoVm, KotoVmSettings,
+    KotoWrite, MetaKey, MetaMap, MethodContext, UnaryOp, ValueKey, ValueMap, ValueVec,
 };

--- a/crates/runtime/src/prelude.rs
+++ b/crates/runtime/src/prelude.rs
@@ -2,7 +2,7 @@
 
 #[doc(inline)]
 pub use crate::{
-    make_ptr, make_ptr_mut, runtime_error, type_error, type_error_with_slice, unexpected_args,
+    make_ptr, make_ptr_mut, runtime_error, type_error, unexpected_args,
     unexpected_args_after_instance, BinaryOp, CallArgs, CallContext, DisplayContext, IsIterable,
     KCell, KIterator, KIteratorOutput, KList, KMap, KNativeFunction, KNumber, KObject, KRange,
     KString, KTuple, KValue, KotoCopy, KotoEntries, KotoFile, KotoFunction, KotoHasher,

--- a/crates/runtime/src/prelude.rs
+++ b/crates/runtime/src/prelude.rs
@@ -2,10 +2,10 @@
 
 #[doc(inline)]
 pub use crate::{
-    make_ptr, make_ptr_mut, runtime_error, type_error, unexpected_args,
-    unexpected_args_after_instance, BinaryOp, CallArgs, CallContext, DisplayContext, IsIterable,
-    KCell, KIterator, KIteratorOutput, KList, KMap, KNativeFunction, KNumber, KObject, KRange,
-    KString, KTuple, KValue, KotoCopy, KotoEntries, KotoFile, KotoFunction, KotoHasher,
-    KotoIterator, KotoObject, KotoRead, KotoSend, KotoSync, KotoType, KotoVm, KotoVmSettings,
-    KotoWrite, MetaKey, MetaMap, MethodContext, UnaryOp, ValueKey, ValueMap, ValueVec,
+    make_ptr, make_ptr_mut, runtime_error, unexpected_args, unexpected_args_after_instance,
+    unexpected_type, BinaryOp, CallArgs, CallContext, DisplayContext, IsIterable, KCell, KIterator,
+    KIteratorOutput, KList, KMap, KNativeFunction, KNumber, KObject, KRange, KString, KTuple,
+    KValue, KotoCopy, KotoEntries, KotoFile, KotoFunction, KotoHasher, KotoIterator, KotoObject,
+    KotoRead, KotoSend, KotoSync, KotoType, KotoVm, KotoVmSettings, KotoWrite, MetaKey, MetaMap,
+    MethodContext, UnaryOp, ValueKey, ValueMap, ValueVec,
 };

--- a/crates/runtime/src/types/iterator.rs
+++ b/crates/runtime/src/types/iterator.rs
@@ -416,13 +416,13 @@ impl MetaIterator {
 
         match m.get_meta_value(&UnaryOp::Next.into()) {
             Some(op) if op.is_callable() => {}
-            Some(op) => return type_error("Callable function from @next", &op),
+            Some(op) => return unexpected_type("Callable function from @next", &op),
             None => return runtime_error!("Expected implementation of @next"),
         };
 
         let is_bidirectional = match m.get_meta_value(&UnaryOp::NextBack.into()) {
             Some(op) if op.is_callable() => true,
-            Some(op) => return type_error("Callable function from @next_back", &op),
+            Some(op) => return unexpected_type("Callable function from @next_back", &op),
             None => false,
         };
 

--- a/crates/runtime/src/types/map.rs
+++ b/crates/runtime/src/types/map.rs
@@ -204,7 +204,7 @@ impl KMap {
                 KValue::Str(display_result) => {
                     ctx.append(display_result);
                 }
-                unexpected => return type_error("String as @display result", &unexpected),
+                unexpected => return unexpected_type("String as @display result", &unexpected),
             }
         } else {
             ctx.append('{');

--- a/crates/runtime/src/types/native_function.rs
+++ b/crates/runtime/src/types/native_function.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, Ptr, Result};
+use crate::{error::unexpected_args_after_instance, prelude::*, Ptr, Result};
 use std::{
     fmt,
     hash::{Hash, Hasher},
@@ -111,8 +111,14 @@ impl<'a> CallContext<'a> {
     ) -> Result<(&KValue, &[KValue])> {
         match (self.instance(), self.args()) {
             (instance, args) if instance_check(instance) => Ok((instance, args)),
-            (_, [first, rest @ ..]) if instance_check(first) => Ok((first, rest)),
-            (_, unexpected_args) => type_error_with_slice(expected_args_message, unexpected_args),
+            (_, [first, rest @ ..]) => {
+                if instance_check(first) {
+                    Ok((first, rest))
+                } else {
+                    unexpected_args_after_instance(expected_args_message, first, rest)
+                }
+            }
+            (_, []) => unexpected_args(expected_args_message, &[]),
         }
     }
 }

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -94,7 +94,7 @@ pub trait KotoEntries {
 ///     fn set_data(ctx: MethodContext<Self>) -> Result<KValue> {
 ///         match ctx.args {
 ///             [KValue::Number(n)] => ctx.instance_mut()?.data = n.into(),
-///             unexpected => return type_error_with_slice("a Number", unexpected),
+///             unexpected => return unexpected_args("|Number|", unexpected),
 ///         }
 ///
 ///         // Return the object instance as the result of the setter operation

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -44,7 +44,7 @@ mod objects {
                     ctx.instance_mut()?.x = b_x;
                     Ok(KValue::Null)
                 }
-                unexpected => type_error_with_slice("TestExternal", unexpected),
+                unexpected => unexpected_args("|TestExternal|", unexpected),
             }
         }
     }

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -30,7 +30,7 @@ mod objects {
             for arg in args.iter() {
                 match arg {
                     KValue::Number(n) => self.x += i64::from(n),
-                    other => return type_error("Number", other),
+                    other => return unexpected_type("Number", other),
                 }
             }
             Ok(KValue::Null)
@@ -62,7 +62,7 @@ mod objects {
                         Ok(Self::make_value($self.x $op i64::from(n)))
                     }
                     unexpected => {
-                        type_error(&format!("a {} or Number", Self::type_static()), unexpected)
+                        unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
                     }
                 }
             }
@@ -84,7 +84,7 @@ mod objects {
                         Ok(())
                     }
                     unexpected => {
-                        type_error(&format!("a {} or Number", Self::type_static()), unexpected)
+                        unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
                     }
                 }
             }
@@ -106,7 +106,7 @@ mod objects {
                         Ok($self.x $op i64::from(n))
                     }
                     unexpected => {
-                        type_error(&format!("a {} or Number", Self::type_static()), unexpected)
+                        unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
                     }
                 }
             }
@@ -136,7 +136,7 @@ mod objects {
                     }
                     _ => unimplemented!(),
                 },
-                unexpected => type_error("Number as index", unexpected),
+                unexpected => unexpected_type("Number as index", unexpected),
             }
         }
 

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -67,7 +67,7 @@ macro_rules! color_arithmetic_op {
                     Ok((*$self $op f32::from(n)).into())
                 }
                 unexpected => {
-                    type_error(&format!("a {} or Number", Self::type_static()), unexpected)
+                    unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
                 }
             }
         }
@@ -89,7 +89,7 @@ macro_rules! color_compound_assign_op {
                     Ok(())
                 }
                 unexpected => {
-                    type_error(&format!("a {} or Number", Self::type_static()), unexpected)
+                    unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
                 }
             }
         }
@@ -106,7 +106,7 @@ macro_rules! color_comparison_op {
                     Ok(*$self $op *rhs)
                 }
                 unexpected => {
-                    type_error(&format!("a {}", Self::type_static()), unexpected)
+                    unexpected_type(&format!("a {}", Self::type_static()), unexpected)
                 }
             }
         }
@@ -283,7 +283,7 @@ impl KotoObject for Color {
                 3 => Ok(self.alpha()),
                 other => runtime_error!("index out of range (got {other}, should be <= 3)"),
             },
-            unexpected => type_error("Number", unexpected),
+            unexpected => unexpected_type("Number", unexpected),
         }
     }
 

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -170,7 +170,7 @@ impl Color {
                 ctx.instance_mut()?.0.color.red = n.into();
                 ctx.instance_result()
             }
-            unexpected => type_error_with_slice("a Number", unexpected),
+            unexpected => unexpected_args("|Number|", unexpected),
         }
     }
 
@@ -181,7 +181,7 @@ impl Color {
                 ctx.instance_mut()?.0.color.green = n.into();
                 ctx.instance_result()
             }
-            unexpected => type_error_with_slice("a Number", unexpected),
+            unexpected => unexpected_args("|Number|", unexpected),
         }
     }
 
@@ -192,7 +192,7 @@ impl Color {
                 ctx.instance_mut()?.0.color.blue = n.into();
                 ctx.instance_result()
             }
-            unexpected => type_error_with_slice("a Number", unexpected),
+            unexpected => unexpected_args("|Number|", unexpected),
         }
     }
 
@@ -203,7 +203,7 @@ impl Color {
                 ctx.instance_mut()?.0.alpha = n.into();
                 ctx.instance_result()
             }
-            unexpected => type_error_with_slice("a Number", unexpected),
+            unexpected => unexpected_args("|Number|", unexpected),
         }
     }
 
@@ -223,7 +223,7 @@ impl Color {
 
                 Ok(Color::from(a.0.mix(b.0, n)).into())
             }
-            unexpected => type_error_with_slice("2 Colors and an optional mix amount", unexpected),
+            unexpected => unexpected_args("|Color|, or |Color, Number|", unexpected),
         }
     }
 }

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -117,7 +117,7 @@ macro_rules! color_comparison_op {
 #[koto(use_copy)]
 pub struct Color(Inner);
 
-#[koto_impl(runtime = crate)]
+#[koto_impl(runtime = koto_runtime)]
 impl Color {
     pub fn rgb(r: f32, g: f32, b: f32) -> Self {
         Self(Inner::new(r, g, b, 1.0))

--- a/libs/color/src/lib.rs
+++ b/libs/color/src/lib.rs
@@ -16,7 +16,7 @@ pub fn make_module() -> KMap {
             let hsv = Hsl::new(f32::from(h), f32::from(s), f32::from(l));
             Ok(Color::from(hsv).into())
         }
-        unexpected => type_error_with_slice("3 Numbers, with hue specified in degrees", unexpected),
+        unexpected => unexpected_args("|Number, Number, Number|", unexpected),
     });
 
     result.add_fn("hsv", |ctx| match ctx.args() {
@@ -24,22 +24,22 @@ pub fn make_module() -> KMap {
             let hsv = Hsv::new(f32::from(h), f32::from(s), f32::from(v));
             Ok(Color::from(hsv).into())
         }
-        unexpected => type_error_with_slice("3 Numbers, with hue specified in degrees", unexpected),
+        unexpected => unexpected_args("|Number, Number, Number|", unexpected),
     });
 
     result.add_fn("named", |ctx| match ctx.args() {
         [Str(s)] => named(s),
-        unexpected => type_error_with_slice("a String", unexpected),
+        unexpected => unexpected_args("|String|", unexpected),
     });
 
     result.add_fn("rgb", |ctx| match ctx.args() {
         [Number(r), Number(g), Number(b)] => rgb(r, g, b),
-        unexpected => type_error_with_slice("3 Numbers", unexpected),
+        unexpected => unexpected_args("|Number, Number, Number|", unexpected),
     });
 
     result.add_fn("rgba", |ctx| match ctx.args() {
         [Number(r), Number(g), Number(b), Number(a)] => rgba(r, g, b, a),
-        unexpected => type_error_with_slice("4 Numbers", unexpected),
+        unexpected => unexpected_args("|Number, Number, Number, Number|", unexpected),
     });
 
     let mut meta = MetaMap::default();
@@ -49,7 +49,10 @@ pub fn make_module() -> KMap {
         [Str(s)] => named(s),
         [Number(r), Number(g), Number(b)] => rgb(r, g, b),
         [Number(r), Number(g), Number(b), Number(a)] => rgba(r, g, b, a),
-        unexpected => type_error_with_slice("a color name, rgb, or rgba values", unexpected),
+        unexpected => unexpected_args(
+            "|String|, or |Number, Number, Number|, or |Number, Number, Number, Number|",
+            unexpected,
+        ),
     });
 
     result.set_meta_map(Some(meta.into()));

--- a/libs/geometry/src/lib.rs
+++ b/libs/geometry/src/lib.rs
@@ -28,7 +28,12 @@ pub fn make_module() -> KMap {
                 let size = size.cast::<Vec2>().unwrap().inner();
                 (xy.x, xy.y, size.x, size.y)
             }
-            unexpected => return type_error_with_slice("4 Numbers", unexpected),
+            unexpected => {
+                return unexpected_args(
+                    "||, or |Vec2, Vec2|, or |Number, Number, Number, Number|",
+                    unexpected,
+                )
+            }
         };
 
         Ok(Rect::from_x_y_w_h(x, y, width, height).into())
@@ -42,7 +47,12 @@ pub fn make_module() -> KMap {
             [Object(vec2)] if vec2.is_a::<Vec2>() => {
                 return Ok((*vec2.cast::<Vec2>().unwrap()).into())
             }
-            unexpected => return type_error_with_slice("up to 2 Numbers", unexpected),
+            unexpected => {
+                return unexpected_args(
+                    "||, or |Number|, or |Number, Number|, or |Vec2|",
+                    unexpected,
+                )
+            }
         };
 
         Ok(Vec2::new(x, y).into())
@@ -64,7 +74,11 @@ pub fn make_module() -> KMap {
             }
             [Object(v)] if v.is_a::<Vec3>() => return Ok((*v.cast::<Vec3>().unwrap()).into()),
             unexpected => {
-                return type_error_with_slice("up to 3 Numbers, a Vec2, or a Vec3", unexpected)
+                return unexpected_args(
+                    "||, or |Number|, or |Number, Number|, or |Number, Number, Number|,\
+                     or |Vec2|, or |Vec2, Number|, or |Vec3|",
+                    unexpected,
+                )
             }
         };
 

--- a/libs/geometry/src/macros.rs
+++ b/libs/geometry/src/macros.rs
@@ -72,7 +72,7 @@ macro_rules! geometry_arithmetic_op {
                     Ok((*$self $op f64::from(n)).into())
                 }
                 unexpected => {
-                    type_error(&format!("a {} or Number", Self::type_static()), unexpected)
+                    unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
                 }
             }
         }
@@ -94,7 +94,7 @@ macro_rules! geometry_compound_assign_op {
                     Ok(())
                 }
                 unexpected => {
-                    type_error(&format!("a {} or Number", Self::type_static()), unexpected)
+                    unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
                 }
             }
         }
@@ -111,7 +111,7 @@ macro_rules! geometry_comparison_op {
                     Ok(*$self $op *rhs)
                 }
                 unexpected => {
-                    type_error(&format!("a {}", Self::type_static()), unexpected)
+                    unexpected_type(&format!("a {}", Self::type_static()), unexpected)
                 }
             }
         }

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -67,7 +67,7 @@ impl Rect {
                 let result = self.0.contains(p.inner());
                 Ok(result.into())
             }
-            unexpected => type_error_with_slice("Vec2", unexpected),
+            unexpected => unexpected_args("|Vec2|", unexpected),
         }
     }
 
@@ -81,7 +81,7 @@ impl Rect {
                 let p = p.cast::<Vec2>().unwrap();
                 (p.inner().x, p.inner().y)
             }
-            unexpected => return type_error_with_slice("two Numbers or a Vec2", unexpected),
+            unexpected => return unexpected_args("|Vec2|, or |Number, Number|", unexpected),
         };
         let mut this = ctx.instance_mut()?;
         this.0 = Inner::from_x_y_w_h(x, y, this.0.w(), this.0.h());

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -95,7 +95,7 @@ impl KotoObject for Vec2 {
                 1 => Ok(self.y()),
                 other => runtime_error!("index out of range (got {other}, should be <= 1)"),
             },
-            unexpected => type_error("Number", unexpected),
+            unexpected => unexpected_type("Number", unexpected),
         }
     }
 

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -86,7 +86,7 @@ impl KotoObject for Vec3 {
                 2 => Ok(self.z()),
                 other => runtime_error!("index out of range (got {other}, should be <= 2)"),
             },
-            unexpected => type_error("Number", unexpected),
+            unexpected => unexpected_type("Number", unexpected),
         }
     }
 

--- a/libs/json/src/lib.rs
+++ b/libs/json/src/lib.rs
@@ -52,7 +52,7 @@ pub fn make_module() -> KMap {
                 e.to_string()
             ),
         },
-        unexpected => type_error_with_slice("a String as argument", unexpected),
+        unexpected => unexpected_args("|String|", unexpected),
     });
 
     result.add_fn("to_string", |ctx| match ctx.args() {
@@ -60,7 +60,7 @@ pub fn make_module() -> KMap {
             Ok(result) => Ok(result.into()),
             Err(e) => runtime_error!("json.to_string: {e}"),
         },
-        unexpected => type_error_with_slice("a Value as argument", unexpected),
+        unexpected => unexpected_args("|Any|", unexpected),
     });
 
     result

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -106,7 +106,7 @@ impl ChaChaRng {
                     let index = self.0.gen_range(0..(size.as_i64() as usize));
                     vm.run_binary_op(BinaryOp::Index, input.clone(), index.into())
                 }
-                unexpected => type_error("a Number from @size", &unexpected),
+                unexpected => unexpected_type("a Number from @size", &unexpected),
             },
         }
     }

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -8,7 +8,10 @@ use std::cell::RefCell;
 pub fn make_module() -> KMap {
     let result = KMap::with_type("random");
 
-    result.add_fn("bool", |_| THREAD_RNG.with_borrow_mut(|rng| rng.bool()));
+    result.add_fn("bool", |ctx| match ctx.args() {
+        [] => THREAD_RNG.with_borrow_mut(|rng| rng.bool()),
+        unexpected => unexpected_args("||", unexpected),
+    });
 
     result.add_fn("generator", |ctx| {
         let rng = match ctx.args() {
@@ -16,20 +19,21 @@ pub fn make_module() -> KMap {
             [] => ChaCha8Rng::from_entropy(),
             // RNG from seed
             [KValue::Number(n)] => ChaCha8Rng::seed_from_u64(n.to_bits()),
-            unexpected => {
-                return type_error_with_slice("an optional seed Number as argument", unexpected)
-            }
+            unexpected => return unexpected_args("||, or |Number|", unexpected),
         };
 
         Ok(ChaChaRng::make_value(rng))
     });
 
-    result.add_fn("number", |_| THREAD_RNG.with_borrow_mut(|rng| rng.number()));
+    result.add_fn("number", |ctx| match ctx.args() {
+        [] => THREAD_RNG.with_borrow_mut(|rng| rng.number()),
+        unexpected => unexpected_args("||", unexpected),
+    });
 
     result.add_fn("pick", |ctx| {
         THREAD_RNG.with_borrow_mut(|rng| match ctx.args() {
             [arg] => rng.pick_inner(arg.clone(), ctx.vm),
-            unexpected => type_error_with_slice("a single argument", unexpected),
+            unexpected => unexpected_args("|Indexable|", unexpected),
         })
     });
 
@@ -66,7 +70,7 @@ impl ChaChaRng {
             [arg] => ctx
                 .instance_mut()?
                 .pick_inner(arg.clone(), &mut ctx.vm.spawn_shared_vm()),
-            unexpected => type_error_with_slice("a single argument", unexpected),
+            unexpected => unexpected_args("|Indexable|", unexpected),
         }
     }
 
@@ -102,7 +106,7 @@ impl ChaChaRng {
                     let index = self.0.gen_range(0..(size.as_i64() as usize));
                     vm.run_binary_op(BinaryOp::Index, input.clone(), index.into())
                 }
-                unexpected => type_error("a number from @size", &unexpected),
+                unexpected => type_error("a Number from @size", &unexpected),
             },
         }
     }
@@ -115,7 +119,7 @@ impl ChaChaRng {
                 self.0 = ChaCha8Rng::seed_from_u64(n.to_bits());
                 Ok(Null)
             }
-            unexpected => type_error_with_slice("a Number as argument", unexpected),
+            unexpected => unexpected_args("|Number|", unexpected),
         }
     }
 }

--- a/libs/regex/src/lib.rs
+++ b/libs/regex/src/lib.rs
@@ -5,7 +5,7 @@ pub fn make_module() -> KMap {
 
     result.add_fn("new", |ctx| match ctx.args() {
         [KValue::Str(pattern)] => Ok(Regex::new(pattern)?.into()),
-        unexpected => type_error_with_slice("a regex pattern as string", unexpected),
+        unexpected => unexpected_args("|String|", unexpected),
     });
 
     result
@@ -27,7 +27,7 @@ impl Regex {
     fn is_match(&self, args: &[KValue]) -> Result<KValue> {
         match args {
             [KValue::Str(text)] => Ok(self.0.is_match(text).into()),
-            unexpected => type_error_with_slice("a string", unexpected),
+            unexpected => unexpected_args("|String|", unexpected),
         }
     }
 
@@ -41,7 +41,7 @@ impl Regex {
                     None => Ok(KValue::Null),
                 }
             }
-            unexpected => type_error_with_slice("a string", unexpected),
+            unexpected => unexpected_args("|String|", unexpected),
         }
     }
 
@@ -68,7 +68,7 @@ impl Regex {
 
                 Ok(result)
             }
-            unexpected => type_error_with_slice("a string", unexpected),
+            unexpected => unexpected_args("|String|", unexpected),
         }
     }
 
@@ -104,7 +104,7 @@ impl Regex {
                     None => Ok(KValue::Null),
                 }
             }
-            unexpected => type_error_with_slice("a string", unexpected),
+            unexpected => unexpected_args("|String|", unexpected),
         }
     }
 
@@ -115,7 +115,7 @@ impl Regex {
                 let result = self.0.replace_all(text, replacement.as_str());
                 Ok(result.to_string().into())
             }
-            unexpected => type_error_with_slice("two strings", unexpected),
+            unexpected => unexpected_args("|String, String|", unexpected),
         }
     }
 }

--- a/libs/tempfile/src/lib.rs
+++ b/libs/tempfile/src/lib.rs
@@ -2,7 +2,7 @@
 
 use koto_runtime::{
     core_lib::io::{map_io_err, File},
-    KMap,
+    unexpected_args, KMap,
 };
 use tempfile::NamedTempFile;
 
@@ -10,12 +10,15 @@ pub fn make_module() -> KMap {
     let result = KMap::with_type("temp_file");
 
     result.add_fn("temp_file", {
-        |_| match NamedTempFile::new().map_err(map_io_err) {
-            Ok(file) => {
-                let path = file.path().to_path_buf();
-                Ok(File::system_file(file, path))
-            }
-            Err(e) => Err(e),
+        |ctx| match ctx.args() {
+            [] => match NamedTempFile::new().map_err(map_io_err) {
+                Ok(file) => {
+                    let path = file.path().to_path_buf();
+                    Ok(File::system_file(file, path))
+                }
+                Err(e) => Err(e),
+            },
+            unexpected => unexpected_args("||", unexpected),
         }
     });
 

--- a/libs/toml/src/lib.rs
+++ b/libs/toml/src/lib.rs
@@ -38,7 +38,7 @@ pub fn make_module() -> KMap {
             },
             Err(e) => runtime_error!("Error while parsing input: {}", e.to_string()),
         },
-        unexpected => type_error_with_slice("a String as argument", unexpected),
+        unexpected => unexpected_args("|String|", unexpected),
     });
 
     result.add_fn("to_string", |ctx| match ctx.args() {
@@ -46,7 +46,7 @@ pub fn make_module() -> KMap {
             Ok(result) => Ok(result.into()),
             Err(e) => runtime_error!("toml.to_string: {e}"),
         },
-        unexpected => type_error_with_slice("a Value as argument", unexpected),
+        unexpected => unexpected_args("|Any|", unexpected),
     });
 
     result

--- a/libs/yaml/src/lib.rs
+++ b/libs/yaml/src/lib.rs
@@ -53,7 +53,7 @@ pub fn make_module() -> KMap {
             },
             Err(e) => runtime_error!("Error while parsing input: {}", e.to_string()),
         },
-        unexpected => type_error_with_slice("a String as argument", unexpected),
+        unexpected => unexpected_args("|String|", unexpected),
     });
 
     result.add_fn("to_string", |ctx| match ctx.args() {
@@ -61,7 +61,7 @@ pub fn make_module() -> KMap {
             Ok(result) => Ok(result.into()),
             Err(e) => runtime_error!("yaml.to_string: {}", e),
         },
-        unexpected => type_error_with_slice("a Value as argument", unexpected),
+        unexpected => unexpected_args("|Any|", unexpected),
     });
 
     result


### PR DESCRIPTION
Following on from #345 and #347, this PR improves error messages when Koto functions are called with unexpected arguments.

The aim here is to introduce a standard format for error messages that reduces ambiguity regardless of how the function was called (as an instance method or as a standalone function), or in how the arguments are incorrect (correct instance but missing args, superfluous args, etc).

For example, before:
```
» number.max 1
error: Expected 'two Numbers', but found 'no args'
--- 1:8
   |
 1 | number.max 1
   |        ^^^

» [1, 2, 3].reverse 'hello'
error: Expected 'a List', but found 'String'
--- 1:11
   |
 1 | [1, 2, 3].reverse 'hello'
   |           ^^^^^^^
```

...and after:
```
error: Unexpected arguments.
  Expected: |Number, Number|
  Provided: |Number|
--- 1:8
   |
 1 | number.max 1
   |        ^^^

» [1, 2, 3].reverse 'hello'
error: Unexpected arguments.
  Expected: |List|
  Provided: |List, String|
--- 1:11
   |
 1 | [1, 2, 3].reverse 'hello'
   |           ^^^^^^^
```


