### PR TITLE
Add a Callable type hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The Koto project adheres to
 - `export` can be used with multi-assignment expressions.
   - e.g. expressions like `export a, b, c = foo()` are now allowed.
 - Maps now support `[]` indexing, returning the Nth entry as a tuple.
+- Objects that implement `KotoObject::call` can now be used in operations that
+  expect functions.
+  - `KotoObject::is_callable` has been added to support this, and needs to be
+    implemented for the runtime to accept the object as a function.
 
 #### Core Library
 

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1444,6 +1444,17 @@ print! let x: Any = 'hello'
 check! hello
 ```
 
+#### `Callable`
+
+The `Callable` type hint will accept functions, or any value that can behave
+like a function.
+
+```koto
+let say_hello: Callable = || 'hello'
+print! say_hello()
+check! hello
+```
+
 #### `Indexable` 
 
 The `Indexable` type hint will accept any value that supports `[]` indexing.

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -144,7 +144,17 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
         None
     }
 
+    /// Declares to the runtime whether or not the object is callable
+    ///
+    /// The `Callable` type hint defers to the function, expecting `true` to be returned for objects
+    /// that implement [KotoObject::call].
+    fn is_callable(&self) -> bool {
+        false
+    }
+
     /// Allows the object to behave as a function
+    ///
+    /// Objects that implement `call` should return `true` from [KotoObject::call].
     fn call(&mut self, _ctx: &mut CallContext) -> Result<KValue> {
         unimplemented_error("@||", self.type_string())
     }

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -101,6 +101,7 @@ impl KValue {
             CaptureFunction(f) if f.info.generator => false,
             Function(_) | CaptureFunction(_) | NativeFunction(_) => true,
             Map(m) => m.contains_meta_key(&MetaKey::Call),
+            Object(o) => o.try_borrow().map_or(false, |o| o.is_callable()),
             _ => false,
         }
     }

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -2834,6 +2834,7 @@ impl KotoVm {
         let value = self.get_register(value_register);
         match self.get_constant_str(type_index) {
             "Any" => true,
+            "Callable" => value.is_callable(),
             "Indexable" => value.is_indexable(),
             "Iterable" => value.is_iterable(),
             expected_type => {

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -144,6 +144,10 @@ mod objects {
             Some(self.x.unsigned_abs() as usize)
         }
 
+        fn is_callable(&self) -> bool {
+            true
+        }
+
         fn call(&mut self, _ctx: &mut CallContext) -> Result<KValue> {
             Ok(self.x.into())
         }
@@ -588,6 +592,15 @@ x.as_number()
             let script = "
 let x: TestObject = make_object 256
 x.as_number()
+";
+            test_object_script(script, 256);
+        }
+
+        #[test]
+        fn callable() {
+            let script = "
+let x: Callable = make_object 256
+x()
 ";
             test_object_script(script, 256);
         }

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -114,6 +114,21 @@ let x: String, y: Bool = 'abc', 123
             }
 
             #[test]
+            fn expected_callable() {
+                let script = "\
+let foo: Callable = 99
+#   ^^^
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 4 },
+                        end: Position { line: 0, column: 7 },
+                    },
+                );
+            }
+
+            #[test]
             fn expected_indexable() {
                 let script = "\
 let foo: Indexable = null

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -556,6 +556,15 @@ true
         }
 
         #[test]
+        fn callable_matches_functions() {
+            let script = "
+let x: Callable = || true
+x()
+";
+            check_script_output(script, true);
+        }
+
+        #[test]
         fn indexable_matches_indexable_values() {
             let script = "
 let w: Indexable, x: Indexable, y: Indexable, z: Indexable = {}, (1, 2, 3), [], 'foo'


### PR DESCRIPTION
This PR adds a `Callable` type that can be used in type checks, and adds support for objects that implement `KotoObject::call` to be used in core library operations that expect a function.
