### PR TITLE
`iterator.repeat` improvements and `string.repeat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The Koto project adheres to
 
 #### Core Library
 
+- `string.repeat` has been added.
 - `tuple.sort_copy` now supports sorting with a key function, like `list.sort`.
 
 #### API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "circular-buffer"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659bc3241f5e098a83ef22f74dc6d35403a2a0538a3372027d763ada53649261"
+
+[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +660,7 @@ dependencies = [
 name = "koto_bytecode"
 version = "0.15.0"
 dependencies = [
+ "circular-buffer",
  "derive-name",
  "dunce",
  "koto_memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ resolver = "2"
 anyhow = "1.0.75"
 # Date and time library for Rust
 chrono = "0.4.31"
+# Efficient, fixed-size, overwriting circular buffer
+circular-buffer = "0.1.8"
 # Statistics-driven micro-benchmarking library
 criterion = "0.5.1"
 # A crossplatform terminal library for manipulating terminals.

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -18,6 +18,7 @@ rc = ["koto_memory/rc"]
 koto_memory = { path = "../memory", version = "^0.15.0", default-features = false }
 koto_parser = { path = "../parser", version = "^0.15.0", default-features = false }
 
+circular-buffer = { workspace = true }
 derive-name = { workspace = true }
 dunce = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/bytecode/src/chunk.rs
+++ b/crates/bytecode/src/chunk.rs
@@ -134,7 +134,7 @@ impl Chunk {
                     .start
                     .line
                     .clamp(0, source_lines.len() as u32 - 1) as usize;
-                writeln!(result, "|{line}| {}", source_lines[line]).ok();
+                writeln!(result, "|{}| {}", line + 1, source_lines[line]).ok();
                 span = Some(instruction_span);
             }
 

--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -224,6 +224,13 @@ pub enum Instruction {
         frame_base: u8,
         arg_count: u8,
     },
+    CallInstance {
+        result: u8,
+        function: u8,
+        instance: u8,
+        frame_base: u8,
+        arg_count: u8,
+    },
     Return {
         register: u8,
     },
@@ -627,6 +634,17 @@ impl fmt::Debug for Instruction {
                 f,
                 "Call\t\tresult: {result}\tfunction: {function}\t\
                  frame base: {frame_base}\targs: {arg_count}",
+            ),
+            CallInstance {
+                result,
+                function,
+                instance,
+                frame_base,
+                arg_count,
+            } => write!(
+                f,
+                "CallInstance\tresult: {result}\tfunction: {function}\t\
+                 instance: {instance}\tframe base: {frame_base}\targs: {arg_count}",
             ),
             Return { register } => write!(f, "Return\t\tresult: {register}"),
             Yield { register } => write!(f, "Yield\t\tresult: {register}"),

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -322,6 +322,13 @@ impl Iterator for InstructionReader {
                 frame_base: get_u8!(),
                 arg_count: get_u8!(),
             }),
+            Op::CallInstance => Some(CallInstance {
+                result: get_u8!(),
+                function: get_u8!(),
+                instance: get_u8!(),
+                frame_base: get_u8!(),
+                arg_count: get_u8!(),
+            }),
             Op::Return => Some(Return {
                 register: get_u8!(),
             }),

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -313,10 +313,26 @@ pub enum Op {
     /// `[*condition, offset[2]]`
     JumpIfFalse,
 
-    /// Calls a function
+    /// Calls a standalone function
+    ///
+    /// The frame base register (which contains the instance during a method call) will be set to
+    /// Null by the runtime before the function is called.
+    ///
+    /// If the result can be ignored then it will be placed in the frame base at the end of the
+    /// call, which will result in it being discarded.
     ///
     /// `[*result, *function, *frame base, arg count]`
     Call,
+
+    /// Calls an instance function
+    ///
+    /// The instance will be copied into the frame base register by the runtime if necessary.
+    ///
+    /// If the result can be ignored then it will be placed in the frame base at the end of the
+    /// call, which will result in it being discarded.
+    ///
+    /// `[*result, *function, *instance, *frame base, arg count]`
+    CallInstance,
 
     /// Returns from the current frame with the given result
     ///
@@ -506,7 +522,6 @@ pub enum Op {
     CheckType,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused84,
     Unused85,
     Unused86,
     Unused87,

--- a/crates/cli/docs/core_lib/iterator.md
+++ b/crates/cli/docs/core_lib/iterator.md
@@ -191,8 +191,8 @@ check! [1, 2, 3, 1, 2, 3, 1, 2, 3, 1]
 |Iterable, function: |Any| -> Any| -> Iterator
 ```
 
-Takes an `Iterable` and a `Function`, and returns a new iterator that provides
-the result of calling the function with each value in the iterable.
+Creates a new iterator that yields the result of calling the provided `function` 
+with each value from the input iterator.
 
 ### Example
 
@@ -209,7 +209,7 @@ check! [4, 6, 8]
 |Iterable| -> Iterator
 ```
 
-Returns an iterator that provides each value along with an associated index.
+Creates an iterator that yields each value along with an associated index.
 
 ### Example
 
@@ -313,15 +313,17 @@ check! ['a', '-', 'b', '-', 'c', '-']
 |generator: || -> Any| -> Iterator
 ```
 
-Provides an iterator that yields the result of repeatedly calling the `generator`
-function. Note that this version of `generate` won't terminate and will iterate
-endlessly.
+Creates an iterator that yields the result of repeatedly calling the `generator`
+function. 
+
+_Warning_: This version of `generate` will iterate endlessly, so consider using 
+an adaptor like [`iterator.take`](#take) to produce an iterator that has an end.
 
 ```kototype
 |n: Number, generator: || -> Any| -> Any
 ```
 
-Provides an iterator that yields the result of calling the `generator`
+Creates an iterator that yields the result of calling the `generator`
 function `n` times.
 
 ### Example
@@ -757,24 +759,30 @@ check! my_type(60)
 ## repeat
 
 ```kototype
-|Any| -> Iterator
-```
-```kototype
-|Any, repeats: Number| -> Iterator
+|value: Any| -> Iterator
 ```
 
-Provides an iterator that repeats the provided value. 
-A number of repeats can be optionally provided as the second argument.
+Creates an iterator that endlessly yields the provided `value`.
+
+_Warning_: This version of `repeat` will iterate endlessly, so consider using 
+an adaptor like [`iterator.take`](#take) to produce an iterator with an end.
+
+```kototype
+|value: Any, n: Number| -> Iterator
+```
+
+Creates an iterator that yields `n` repeats of the provided `value`.
+
 
 ### Example
 
 ```koto
-print! iterator.repeat(42)
-  .take(5)
-  .to_list()
+from iterator import repeat
+
+print! repeat(42).take(5).to_list()
 check! [42, 42, 42, 42, 42]
 
-print! iterator.repeat('x', 3).to_tuple()
+print! repeat('x', 3).to_tuple()
 check! ('x', 'x', 'x')
 ```
 
@@ -890,14 +898,14 @@ check! my_type(103)
 |Iterable, count: Number| -> Iterator
 ```
 
-Provides an iterator that yields a number of values from the input before
+Creates an iterator that yields a number of values from the input before
 finishing.
 
 ```kototype
 |Iterable, test: |Any| -> Bool| -> Iterator
 ```
 
-Provides an iterator that yields values from the input while they pass a
+Creates an iterator that yields values from the input while they pass a
 test function.
 
 The test function should return `true` if the iterator should continue to yield
@@ -1044,7 +1052,7 @@ check! [(1, 2, 3), (2, 3, 4), (3, 4, 5)]
 |first: Iterable, second: Iterable| -> Iterator
 ```
 
-Combines the values in two iterables into an iterator that provides
+Combines the values in two iterables into an iterator that yields
 corresponding pairs of values, one at a time from each input iterable.
 
 ### Example

--- a/crates/cli/docs/core_lib/string.md
+++ b/crates/cli/docs/core_lib/string.md
@@ -195,6 +195,22 @@ print! '\n\n\n'.lines().to_tuple()
 check! ('', '', '')
 ```
 
+## repeat
+
+```kototype
+|String, n: Number| -> String
+```
+
+Creates a new string by repeating the input `n` times.
+
+
+### Example
+
+```koto
+print! 'abc'.repeat 3
+check! abcabcabc
+```
+
 ## replace
 
 ```kototype

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -123,6 +123,22 @@ pub fn make_module() -> KMap {
         }
     });
 
+    result.add_fn("repeat", |ctx| {
+        let expected_error = "|String, Number|";
+
+        match ctx.instance_and_args(is_string, expected_error)? {
+            (KValue::Str(input), [KValue::Number(n)]) => {
+                if *n >= 0.0 {
+                    let result = input.as_str().repeat(usize::from(n));
+                    Ok(result.into())
+                } else {
+                    runtime_error!("expected a non-negative number")
+                }
+            }
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
+        }
+    });
+
     result.add_fn("replace", |ctx| {
         let expected_error = "|String, String, String|";
 

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -325,6 +325,26 @@ result
         }
     }
 
+    mod repeat {
+        use super::*;
+
+        #[test]
+        fn repeat_used_as_imported_function() {
+            //  Call iterator.repeat several times.
+            //  iterator.repeat checks the instance register (aka 'frame base') to ensure that it's
+            //  being used as a standalone function. The runtime now clears the frame base for
+            //  non-instance functions, but previously this test would fail due to a temporary value
+            //  being left around in the frame base.
+            let script = "
+from iterator import repeat
+repeat(1, 4).to_tuple()
+repeat(2, 3).to_tuple()
+repeat(3, 2).to_tuple()
+";
+            check_script_output(script, number_tuple(&[3, 3]));
+        }
+    }
+
     mod skip {
         use super::*;
 

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -1,6 +1,6 @@
 mod runtime {
     use koto_bytecode::{CompilerSettings, Loader};
-    use koto_lexer::Span;
+    use koto_lexer::{Position, Span};
     use koto_runtime::{ErrorFrame, KotoVm};
     use koto_test_utils::script_instructions;
 
@@ -73,8 +73,6 @@ mod runtime {
         }
 
         mod type_checks {
-            use koto_lexer::Position;
-
             use super::*;
 
             #[test]
@@ -407,22 +405,48 @@ x
 
             #[test]
             fn iterator_consume_should_propagate_error() {
-                let script = "
+                let script = "\
 (1..5)
   .each |_| assert false
+#           ^^^^^^^^^^^^
   .consume()
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position {
+                            line: 1,
+                            column: 12,
+                        },
+                        end: Position {
+                            line: 1,
+                            column: 24,
+                        },
+                    },
+                );
             }
 
             #[test]
             fn iterator_count_should_propagate_error() {
-                let script = "
+                let script = "\
 (1..5)
   .each |_| assert false
+#           ^^^^^^^^^^^^
   .count()
 ";
-                check_script_fails(script);
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position {
+                            line: 1,
+                            column: 12,
+                        },
+                        end: Position {
+                            line: 1,
+                            column: 24,
+                        },
+                    },
+                );
             }
 
             #[test]

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -450,6 +450,22 @@ x
             }
 
             #[test]
+            fn iterator_generate_used_as_instance_function() {
+                let script = "
+[].generate(|| true).take(3).to_list()
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn iterator_repeat_used_as_instance_function() {
+                let script = "
+[1, 2, 3].repeat(3).to_list()
+";
+                check_script_fails(script);
+            }
+
+            #[test]
             fn unbounded_range_used_as_iterator() {
                 let script = "
 (1..).count()


### PR DESCRIPTION
This PR prevents a case where `iterator.repeat` could be easily misused.

For example:

```coffee
[1, 2].repeat(3).to_list()
```

It would be reasonable to expect a result here of `[[1, 2], [1, 2], [1, 2]]`, but instead it causes an infinite loop. 

- The runtime falls back to the `iterator` module when a matching item can't be found in `list`.
- The list `[1, 2]` is passed to `iterator.repeat` as the instance for the call.
- `iterator.repeat` is intended to be used as a standalone function and ignores the instance.
- `3` is then treated as the value to repeat, without a count, producing an endless iterator.

The solution here is to have `iterator.repeat` check that it's being used as a standalone function. `iterator.generate` is less prone to misuse, but is now similarly restricted. The check is a bit hacky, it checks that the instance is either `null` or the `iterator` module, which means that `repeat` won't work if it's added to another module and then called there. A more flexible solution would involve reworking the module system, which isn't a problem for today.

The PR also adds a specialized version of `repeat` for strings, which seems useful enough to treat as a special case, e.g. 

```coffee
'abc'.repeat 3
# -> abcabcabc
```

Additionally, checking for standalone use of `repeat` exposed a flaw where temporary values were left around and ending up in the instance register for standalone calls, so some work has gone into improving the use of temporary registers in lookup chains, and in ensuring that the instance register is cleared when necessary.