### PR TITLE
Implement `TryFrom<KValue>` for some `std` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The Koto project adheres to
   IDs are now represented as AST nodes.
 - `Node::NamedCall` has been removed, with all calls represented by expression
   chains.
+- `KNumber::as_i64` has been removed in favour of `i64::from`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The Koto project adheres to
   - The macros in `koto_derive` have been updated to support generics.
     - `KotoField` has been added to reduce boilerplate when using the derive
       macros.
+- `TryFrom<KValue>` has been implemented for some `core` and `std` types,
+  including `bool`, string, and number types.
 
 ### Changed
 
@@ -57,6 +59,8 @@ The Koto project adheres to
 - `type_error` has been renamed to `unexpected_type`.  
   - `type_error_with_slice` has been replaced by `unexpected_args` and
     `unexpected_args_after_instance`. 
+- `From` impls for `KNumber` now saturate integer values that are out of the
+  target type's bounds, instead of wrapping.
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "koto_parser",
  "koto_test_utils",
  "rustc-hash",
+ "saturating_cast",
  "smallvec",
  "test-case",
  "thiserror",
@@ -1428,6 +1429,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "saturating_cast"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4972f129a0ea378b69fa7c186d63255606e362ad00795f00b869dea5265eb"
 
 [[package]]
 name = "scoped-tls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ regex = "1.10.2"
 rustc-hash = "1.1.0"
 # Rustyline, a readline implementation
 rustyline = "13.0.0"
+# Library for saturating casts between integer primitives.
+saturating_cast = "0.1.0"
 # A generic serialization/deserialization framework
 serde = "1.0.0"
 # JSON support for serde

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -295,7 +295,7 @@ fn load_config(config_path: Option<&String>) -> Result<Config> {
                             None => {}
                         }
                         match repl_config.get("max_history") {
-                            Some(KValue::Number(value)) => match value.as_i64() {
+                            Some(KValue::Number(value)) => match i64::from(value) {
                                 value if value > 0 => config.max_history = value as usize,
                                 _ => bail!("expected positive number for max_history setting"),
                             },

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -24,6 +24,7 @@ koto_parser = { path = "../parser", version = "^0.15.0", default-features = fals
 downcast-rs = { workspace = true }
 indexmap = { workspace = true }
 rustc-hash = { workspace = true }
+saturating_cast = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 unicode-segmentation = { workspace = true }

--- a/crates/runtime/src/core_lib/list.rs
+++ b/crates/runtime/src/core_lib/list.rs
@@ -117,20 +117,25 @@ pub fn make_module() -> KMap {
 
     result.add_fn("get", |ctx| {
         let (list, index, default) = {
+            use KValue::{List, Null, Number};
             let expected_error = "|List, Number|, or |List, Number, Any|";
 
             match ctx.instance_and_args(is_list, expected_error)? {
-                (KValue::List(list), [KValue::Number(n)]) => (list, n, &KValue::Null),
-                (KValue::List(list), [KValue::Number(n), default]) => (list, n, default),
+                (List(list), [Number(n)]) => (list, n, Null),
+                (List(list), [Number(n), default]) => (list, n, default.clone()),
                 (instance, args) => {
                     return unexpected_args_after_instance(expected_error, instance, args)
                 }
             }
         };
 
-        match list.data().get::<usize>(index.into()) {
-            Some(value) => Ok(value.clone()),
-            None => Ok(default.clone()),
+        if *index >= 0 {
+            match list.data().get(usize::from(index)) {
+                Some(value) => Ok(value.clone()),
+                None => Ok(default),
+            }
+        } else {
+            Ok(default)
         }
     });
 

--- a/crates/runtime/src/core_lib/number.rs
+++ b/crates/runtime/src/core_lib/number.rs
@@ -118,7 +118,7 @@ pub fn make_module() -> KMap {
         let expected_error = "|Number|";
 
         match ctx.instance_and_args(is_number, expected_error)? {
-            (Number(n), []) => Ok((!n.as_i64()).into()),
+            (Number(n), []) => Ok((!n.to_bits()).into()),
             (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });

--- a/crates/runtime/src/core_lib/number.rs
+++ b/crates/runtime/src/core_lib/number.rs
@@ -118,7 +118,7 @@ pub fn make_module() -> KMap {
         let expected_error = "|Number|";
 
         match ctx.instance_and_args(is_number, expected_error)? {
-            (Number(n), []) => Ok((!n.to_bits()).into()),
+            (Number(n), []) => Ok((!n.to_bits() as i64).into()),
             (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
         }
     });

--- a/crates/runtime/src/core_lib/string.rs
+++ b/crates/runtime/src/core_lib/string.rs
@@ -84,7 +84,7 @@ pub fn make_module() -> KMap {
             for output in iterator.map(collect_pair) {
                 use KIteratorOutput as Output;
                 match output {
-                    Output::Value(KValue::Number(n)) => match u8::try_from(n.as_i64()) {
+                    Output::Value(KValue::Number(n)) => match u8::try_from(i64::from(n)) {
                         Ok(byte) => bytes.push(byte),
                         Err(_) => return runtime_error!("'{n}' is out of the valid byte range"),
                     },

--- a/crates/runtime/src/types/function.rs
+++ b/crates/runtime/src/types/function.rs
@@ -5,9 +5,9 @@ use koto_memory::Ptr;
 /// A Koto function
 ///
 /// See also:
-/// * [KCaptureFunction]
-/// * [KNativeFunction](crate::KNativeFunction)
-/// * [KValue::Function](crate::KValue::Function)
+/// * [`KCaptureFunction`]
+/// * [`KNativeFunction`](crate::KNativeFunction)
+/// * [`KValue::Function`](crate::KValue::Function)
 #[derive(Clone, Debug, PartialEq)]
 pub struct KFunction {
     /// The [Chunk] in which the function can be found.
@@ -26,16 +26,20 @@ pub struct KFunction {
     pub arg_is_unpacked_tuple: bool,
     /// If the function is a generator, then calling the function will yield an iterator that
     /// executes the function's body for each iteration step, pausing when a yield instruction is
-    /// encountered. See Vm::call_generator and Iterable::Generator.
+    /// encountered.
+    ///
+    // See also:
+    // - `Vm::call_generator`
+    // - `Iterable::Generator`
     pub generator: bool,
 }
 
 /// A Koto function with captured values
 ///
 /// See also:
-/// * [KFunction]
-/// * [KNativeFunction](crate::KNativeFunction)
-/// * [KValue::CaptureFunction](crate::KValue::CaptureFunction)
+/// * [`KFunction`]
+/// * [`KNativeFunction`](crate::KNativeFunction)
+/// * [`KValue::CaptureFunction`](crate::KValue::CaptureFunction)
 #[derive(Clone)]
 pub struct KCaptureFunction {
     /// The function's properties

--- a/crates/runtime/src/types/list.rs
+++ b/crates/runtime/src/types/list.rs
@@ -1,9 +1,9 @@
 use crate::{prelude::*, Borrow, BorrowMut, PtrMut, Result};
 
-/// The underlying Vec type used by [KList]
+/// The underlying `Vec` type used by [KList]
 pub type ValueVec = smallvec::SmallVec<[KValue; 4]>;
 
-/// The Koto runtime's List type
+/// The List type used by the Koto runtime
 #[derive(Clone, Default)]
 pub struct KList(PtrMut<ValueVec>);
 

--- a/crates/runtime/src/types/map.rs
+++ b/crates/runtime/src/types/map.rs
@@ -11,14 +11,14 @@ pub type KotoHasher = FxHasher;
 
 type ValueMapType = IndexMap<ValueKey, KValue, BuildHasherDefault<KotoHasher>>;
 
-/// The (ValueKey -> Value) 'data' hashmap used by the Koto runtime
+/// The (ValueKey -> Value) 'data' hash map used by the Koto runtime
 ///
 /// See also: [KMap]
 #[derive(Clone, Default)]
 pub struct ValueMap(ValueMapType);
 
 impl ValueMap {
-    /// Creates a new DataMap with the given capacity
+    /// Creates a new map with the given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self(ValueMapType::with_capacity_and_hasher(
             capacity,
@@ -26,7 +26,7 @@ impl ValueMap {
         ))
     }
 
-    /// Makes a new ValueMap containing a slice of the map's elements
+    /// Creates a new map containing a slice of the map's elements
     pub fn make_data_slice(&self, range: impl RangeBounds<usize>) -> Option<Self> {
         self.get_range(range).map(|entries| {
             Self::from_iter(
@@ -58,7 +58,7 @@ impl FromIterator<(ValueKey, KValue)> for ValueMap {
     }
 }
 
-/// The core hashmap value type used in Koto, containing a [ValueMap] and a [MetaMap]
+/// The core hash map value type used in Koto, containing a [ValueMap] and a [MetaMap]
 #[derive(Clone, Default)]
 pub struct KMap {
     data: PtrMut<ValueMap>,

--- a/crates/runtime/src/types/meta_map.rs
+++ b/crates/runtime/src/types/meta_map.rs
@@ -12,7 +12,7 @@ type MetaMapType = IndexMap<MetaKey, KValue, BuildHasherDefault<KotoHasher>>;
 /// The meta map used by [KMap](crate::KMap)
 ///
 /// Each KMap contains a metamap, which allows for customized value behaviour by implementing
-/// [MetaKeys](crate::MetaKey).
+/// [`MetaKeys`](crate::MetaKey).
 #[derive(Clone, Default)]
 pub struct MetaMap(MetaMapType);
 
@@ -43,7 +43,7 @@ impl DerefMut for MetaMap {
     }
 }
 
-/// The key type used by [MetaMaps](crate::MetaMap)
+/// The key type used by [`MetaMaps`](crate::MetaMap)
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub enum MetaKey {
     /// A binary operation
@@ -62,7 +62,7 @@ pub enum MetaKey {
     ///
     /// e.g. `@meta my_named_key`
     ///
-    /// Named entries are used in [KMaps][crate::KMap], so that shared named items can be
+    /// Named entries are used in [`KMaps`][crate::KMap], so that shared named items can be
     /// made available without them being inserted into the map's contents.
     Named(KString),
     /// A test function
@@ -255,7 +255,7 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<KString>) -> Result<MetaKey> {
     Ok(result)
 }
 
-// Support efficient map accesses with &str
+/// Support efficient map accesses with `&str`
 impl Equivalent<MetaKey> for str {
     fn equivalent(&self, other: &MetaKey) -> bool {
         match &other {

--- a/crates/runtime/src/types/native_function.rs
+++ b/crates/runtime/src/types/native_function.rs
@@ -17,7 +17,7 @@ impl<T> KotoFunction for T where
 
 /// An function that's defined outside of the Koto runtime
 ///
-/// See [KValue::NativeFunction]
+/// See [`KValue::NativeFunction`]
 pub struct KNativeFunction {
     /// The function implementation that should be called when calling the external function
     //

--- a/crates/runtime/src/types/number.rs
+++ b/crates/runtime/src/types/number.rs
@@ -38,7 +38,10 @@ impl KNumber {
     /// Returns the largest integer less than or equal to the number
     #[must_use]
     pub fn floor(self) -> Self {
-        Self::I64(self.as_i64())
+        match self {
+            Self::F64(n) => Self::I64(n.floor() as i64),
+            Self::I64(n) => Self::I64(n),
+        }
     }
 
     /// Returns the integer closest to the number
@@ -108,14 +111,6 @@ impl KNumber {
         match self {
             Self::F64(n) => n.to_bits(),
             Self::I64(n) => n as u64,
-        }
-    }
-
-    /// Returns the number as an `i64`, calling `floor` if the number is an `f64`
-    pub fn as_i64(self) -> i64 {
-        match self {
-            Self::F64(n) => n.floor() as i64,
-            Self::I64(n) => n,
         }
     }
 }

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -58,8 +58,8 @@ pub trait KotoEntries {
 
 /// A trait for implementing objects that can be added to the Koto runtime
 ///
-/// [KotoObject]s are added to the Koto runtime by the [KObject] type, and stored as
-/// [KValue::Object]s.
+/// [`KotoObject`]s are added to the Koto runtime by the [KObject] type, and stored as
+/// [`KValue::Object`]s.
 ///
 /// ## Example
 ///
@@ -116,7 +116,7 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     ///
     /// By default, the object's type is used as the display string.
     ///
-    /// The [DisplayContext] is used to append strings to the result, and also provides context
+    /// The [`DisplayContext`] is used to append strings to the result, and also provides context
     /// about any parent containers.
     fn display(&self, ctx: &mut DisplayContext) -> Result<()> {
         ctx.append(self.type_string());
@@ -132,14 +132,15 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
 
     /// Called when checking for the number of elements contained in the object
     ///
-    /// The size should represent the maximum valid index that can be passed to [KotoObject::index].
+    /// The size should represent the maximum valid index that can be passed to
+    /// [`KotoObject::index`].
     ///
     /// The runtime defers to this function when the 'size' of an object is needed,
     /// e.g. when `koto.size` is called, or when unpacking function arguments.
     ///
     /// The `Indexable` type hint will pass for objects with a defined size.
     ///
-    /// See also: [KotoObject::index]
+    /// See also: [`KotoObject::index`]
     fn size(&self) -> Option<usize> {
         None
     }
@@ -147,14 +148,14 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     /// Declares to the runtime whether or not the object is callable
     ///
     /// The `Callable` type hint defers to the function, expecting `true` to be returned for objects
-    /// that implement [KotoObject::call].
+    /// that implement [`KotoObject::call`].
     fn is_callable(&self) -> bool {
         false
     }
 
     /// Allows the object to behave as a function
     ///
-    /// Objects that implement `call` should return `true` from [KotoObject::call].
+    /// Objects that implement `call` should return `true` from [`KotoObject::call`].
     fn call(&mut self, _ctx: &mut CallContext) -> Result<KValue> {
         unimplemented_error("@||", self.type_string())
     }
@@ -254,30 +255,30 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
 
     /// Returns an iterator that iterates over the objects contents
     ///
-    /// If [IsIterable::Iterable] is returned from [is_iterable](Self::is_iterable),
+    /// If [`IsIterable::Iterable`] is returned from [`is_iterable`](Self::is_iterable),
     /// then the runtime will call this function when the object is used in iterable contexts,
-    /// expecting a [KIterator] to be returned.
+    /// expecting a [`KIterator`] to be returned.
     fn make_iterator(&self, _vm: &mut KotoVm) -> Result<KIterator> {
         unimplemented_error("@iterator", self.type_string())
     }
 
     /// Gets the object's next value in an iteration
     ///
-    /// If either [ForwardIterator][IsIterable::ForwardIterator] or
-    /// [BidirectionalIterator][IsIterable::BidirectionalIterator] is returned from
-    /// [is_iterable](Self::is_iterable), then the object will be wrapped in a [KIterator]
+    /// If either [`ForwardIterator`][IsIterable::ForwardIterator] or
+    /// [`BidirectionalIterator`][IsIterable::BidirectionalIterator] is returned from
+    /// [is_iterable](Self::is_iterable), then the object will be wrapped in a [`KIterator`]
     /// whenever it's used in an iterable context. This function will then be called each time
-    /// [KIterator::next] is invoked.
+    /// [`KIterator::next`] is invoked.
     fn iterator_next(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
         None
     }
 
     /// Gets the object's next value from the end of an iteration
     ///
-    /// If [BidirectionalIterator][IsIterable::BidirectionalIterator] is returned from
-    /// [is_iterable](Self::is_iterable), then the object will be wrapped in a [KIterator]
+    /// If [`BidirectionalIterator`][IsIterable::BidirectionalIterator] is returned from
+    /// [`is_iterable`](Self::is_iterable), then the object will be wrapped in a [`KIterator`]
     /// whenever it's used in an iterable context. This function will then be called each time
-    /// [KIterator::next_back] is invoked.
+    /// [`KIterator::next_back`] is invoked.
     fn iterator_next_back(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
         None
     }
@@ -285,7 +286,7 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
 
 impl_downcast!(KotoObject);
 
-/// A wrapper for [KotoObject]s used in the Koto runtime
+/// A [`KotoObject`] wrapper used in the Koto runtime
 #[derive(Clone)]
 pub struct KObject {
     object: PtrMut<dyn KotoObject>,
@@ -367,10 +368,10 @@ impl fmt::Debug for KObject {
     }
 }
 
-/// A trait that represents the basic requirements of fields in a type that implements [KotoObject]
+/// A trait that represents the basic requirements of fields in a type that implements [`KotoObject`]
 ///
 /// This is useful for reducing repetitive duplication in bounds when implementing a generic
-/// [KotoObject] type .
+/// [KotoObject] type.
 pub trait KotoField: Clone + KotoSend + KotoSync + 'static {}
 impl<T> KotoField for T where T: Clone + KotoSend + KotoSync + 'static {}
 
@@ -390,7 +391,7 @@ pub struct MethodContext<'a, T> {
     //    reference from the VM, disallowing a mutable reference.
     pub vm: &'a KotoVm,
     // The instance of the object for the method call,
-    // accessable via the context's `instance`/`instance_mut` functions
+    // accessible via the context's `instance`/`instance_mut` functions
     object: &'a KObject,
     // We want to be able to cast to `T`.
     _phantom: PhantomData<T>,
@@ -431,7 +432,7 @@ fn unimplemented_error<T>(fn_name: &'static str, object_type: KString) -> Result
     })
 }
 
-/// An enum that indicates to the runtime if a [KotoObject] is iterable
+/// An enum that indicates to the runtime if a [`KotoObject`] is iterable
 pub enum IsIterable {
     /// The object is not iterable
     NotIterable,

--- a/crates/runtime/src/types/range.rs
+++ b/crates/runtime/src/types/range.rs
@@ -8,7 +8,7 @@ use std::{
 
 /// The integer range type used by the Koto runtime
 ///
-/// See [KValue::Range]
+/// See [`KValue::Range`]
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct KRange(Inner);
 

--- a/crates/runtime/src/types/string.rs
+++ b/crates/runtime/src/types/string.rs
@@ -12,7 +12,7 @@ use unicode_segmentation::UnicodeSegmentation;
 /// The underlying string data is shared between instances, with internal bounds allowing for shared
 /// subslices.
 ///
-/// [`AsRef`](std::convert::AsRef) is implemented for &str, which automatically resolves to the
+/// [`AsRef`](std::convert::AsRef) is implemented for `&str`, which automatically resolves to the
 /// correct slice of the string data.
 #[derive(Clone)]
 pub struct KString(Inner);
@@ -56,7 +56,7 @@ impl KString {
 
     /// Returns a new KString with shared data and bounds defined by the grapheme indices
     ///
-    /// This allows for subslicing by index, with the index referring to unicode graphemes.
+    /// This allows for subslicing by index, with the index referring to Unicode graphemes.
     ///
     /// If the provided indices are out of bounds then an empty string will be returned.
     pub fn with_grapheme_indices(&self, indices: Range<usize>) -> Self {

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -43,7 +43,7 @@ pub enum KValue {
     /// The iterator type used in Koto
     Iterator(KIterator),
 
-    /// An object with behaviour defined via the [KotoObject] trait
+    /// An object with behaviour defined via the [`KotoObject`] trait
     Object(KObject),
 
     /// A tuple of values that are packed into a contiguous series of registers
@@ -58,7 +58,7 @@ pub enum KValue {
 impl KValue {
     /// Returns a recursive 'deep copy' of a Value
     ///
-    /// This is used by koto.deep_copy.
+    /// This is used by `koto.deep_copy`.
     pub fn deep_copy(&self) -> Result<KValue> {
         let result = match &self {
             KValue::List(l) => {
@@ -321,7 +321,7 @@ where
     }
 }
 
-/// A slice of a VM's registers
+/// A slice of a VM's register stack
 ///
 /// See [Value::TemporaryTuple]
 #[allow(missing_docs)]

--- a/justfile
+++ b/justfile
@@ -10,8 +10,8 @@ clippy:
 clippy_rc:
   cargo clippy -p koto_memory --no-default-features --features rc -- -D warnings
 
-doc:
-  RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude koto_cli
+doc *args:
+  RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude koto_cli {{args}}
 
 fmt:
   cargo fmt --all -- --check

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -120,7 +120,7 @@ impl ChaChaRng {
             input => match vm.run_unary_op(UnaryOp::Size, input.clone())? {
                 Number(size) => {
                     if size > 0 {
-                        let index = self.0.gen_range(0..(size.as_i64() as usize));
+                        let index = self.0.gen_range(0..usize::from(size));
                         vm.run_binary_op(BinaryOp::Index, input.clone(), index.into())
                     } else {
                         Ok(Null)


### PR DESCRIPTION
- **Improve a few doc comments**
- **Allow args to be passed to `just doc`**
- **Remove KNumber::as_i64 in favour of From<KNumber> for i64**
- **Start adding TryFrom<KValue> impls for std types**
- **Extend From implementations for KNumber, and use saturating conversions**
- **Add TryFrom impls for standard number types**
