### PR TITLE
Inline strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The Koto project adheres to
 - Type hints with runtime type checks have been added ([#298](https://github.com/koto-lang/koto/issues/298)).
   - Thanks to [@Tarbetu](https://github.com/Tarbetu) for the contributions.
 - `export` can be used with multi-assignment expressions.
-  - e.g. expressions like `export a, b, c = foo()` are now allowed.
+  - E.g. expressions like `export a, b, c = foo()` are now allowed.
 - Maps now support `[]` indexing, returning the Nth entry as a tuple.
 - Objects that implement `KotoObject::call` can now be used in operations that
   expect functions.
@@ -61,6 +61,7 @@ The Koto project adheres to
     `unexpected_args_after_instance`. 
 - `From` impls for `KNumber` now saturate integer values that are out of the
   target type's bounds, instead of wrapping.
+- `KString` will now inline short strings to reduce allocations.
 
 ### Removed
 

--- a/crates/derive/src/koto_impl.rs
+++ b/crates/derive/src/koto_impl.rs
@@ -1,4 +1,3 @@
-use crate::PREFIX_FUNCTION;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
@@ -6,6 +5,8 @@ use syn::{
     Generics, Ident, ImplItem, ImplItemFn, ItemImpl, LitStr, Meta, Path, ReturnType, Signature,
     Type, TypePath,
 };
+
+const PREFIX_FUNCTION: &str = "__koto_";
 
 struct KotoImplParser {
     runtime_path: Path,

--- a/crates/derive/src/koto_type.rs
+++ b/crates/derive/src/koto_type.rs
@@ -1,6 +1,6 @@
-use crate::{attributes::koto_derive_attributes, PREFIX_STATIC};
+use crate::attributes::koto_derive_attributes;
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 pub fn derive_koto_type(input: TokenStream) -> TokenStream {
@@ -14,23 +14,37 @@ pub fn derive_koto_type(input: TokenStream) -> TokenStream {
         .type_name
         .unwrap_or_else(|| quote!(#name).to_string());
 
-    let type_string_name = format_ident!("{PREFIX_STATIC}TYPE_STRING_{}", type_name.to_uppercase());
+    // Short type names don't need to be cached, 22 is the `MAX_INLINE_STRING_LEN` constant
+    let result = if type_name.len() <= 22 {
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics KotoType for #name #ty_generics #where_clause {
+                fn type_static() -> &'static str {
+                    #type_name
+                }
 
-    let result = quote! {
-        #[automatically_derived]
-        impl #impl_generics KotoType for #name #ty_generics #where_clause {
-            fn type_static() -> &'static str {
-                #type_name
-            }
-
-            fn type_string(&self) -> KString {
-                #type_string_name.with(KString::clone)
+                fn type_string(&self) -> KString {
+                    #type_name.into()
+                }
             }
         }
+    } else {
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics KotoType for #name #ty_generics #where_clause {
+                fn type_static() -> &'static str {
+                    #type_name
+                }
 
-        #[automatically_derived]
-        thread_local! {
-            static #type_string_name: KString = #type_name.into();
+                fn type_string(&self) -> KString {
+                    thread_local! {
+                        static TYPE_NAME: KString = #type_name.into();
+                    }
+
+                    TYPE_NAME.with(KString::clone)
+                }
+            }
+
         }
     };
 

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -142,6 +142,3 @@ pub fn koto_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn koto_method(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
-
-const PREFIX_STATIC: &str = "__KOTO_";
-const PREFIX_FUNCTION: &str = "__koto_";

--- a/crates/parser/src/constant_pool.rs
+++ b/crates/parser/src/constant_pool.rs
@@ -52,7 +52,7 @@ enum ConstantEntry {
     F64(f64),
     // An i64 constant
     I64(i64),
-    // The range in bytes in the ConstantPool's string data for a string constant
+    // The range in bytes in the `ConstantPool`'s string data for a string constant
     Str(Range<usize>),
 }
 
@@ -327,7 +327,7 @@ mod tests {
         assert_eq!(ConstantIndex(0), builder.add_string(s1).unwrap());
         assert_eq!(ConstantIndex(1), builder.add_string(s2).unwrap());
 
-        // don't duplicate string_data
+        // Don't duplicate string_data
         assert_eq!(ConstantIndex(0), builder.add_string(s1).unwrap());
         assert_eq!(ConstantIndex(1), builder.add_string(s2).unwrap());
 
@@ -349,7 +349,7 @@ mod tests {
         assert_eq!(ConstantIndex(0), builder.add_i64(n1).unwrap());
         assert_eq!(ConstantIndex(1), builder.add_f64(n2).unwrap());
 
-        // don't duplicate numbers
+        // Don't duplicate numbers
         assert_eq!(ConstantIndex(0), builder.add_i64(n1).unwrap());
         assert_eq!(ConstantIndex(1), builder.add_f64(n2).unwrap());
 

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -203,7 +203,7 @@ pub enum SyntaxError {
     UnterminatedString,
 }
 
-/// See [ParserError]
+/// See [`ParserError`]
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
 pub enum ErrorKind {

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -2,19 +2,19 @@ use crate::{ast::AstIndex, constant_pool::ConstantIndex, StringFormatOptions, St
 use smallvec::SmallVec;
 use std::fmt;
 
-/// The vec type used in the AST
+/// The Vec type used in the AST
 //
-//  Q. Why 4 elements in the small vec?
+//  Q. Why 4 elements in the small Vec?
 //  A. It's the maximum number of elements that can be used in [Node] without increasing its overall
 //     size.
 pub type AstVec<T> = SmallVec<[T; 4]>;
 
-/// A convenience macro for initializing [AstVec]s
+/// A convenience macro for initializing an [`AstVec`]
 pub use smallvec::smallvec as astvec;
 
 /// A parsed node that can be included in the [AST](crate::Ast).
 ///
-/// Nodes refer to each other via [AstIndex]s, see [AstNode](crate::AstNode).
+/// Nodes refer to each other via [`AstIndex`], see [`AstNode`](crate::AstNode).
 #[derive(Clone, Debug, Default, PartialEq, Eq, derive_name::VariantName)]
 pub enum Node {
     /// The `null` keyword
@@ -24,14 +24,14 @@ pub enum Node {
     /// A single expression wrapped in parentheses
     Nested(AstIndex),
 
-    /// An identifer, and optionally the type hint node
+    /// An identifier, and optionally the type hint node
     Id(ConstantIndex, Option<AstIndex>),
 
     /// A meta identifier, e.g. `@display` or `@test my_test`
     Meta(MetaKeyId, Option<ConstantIndex>),
 
     /// A chained expression, and optionally the node that follows it in the chain
-    Chain((ChainNode, Option<AstIndex>)), // chain node, next node
+    Chain((ChainNode, Option<AstIndex>)), // Chain node, next node
 
     /// The `true` keyword
     BoolTrue,
@@ -53,12 +53,12 @@ pub enum Node {
 
     /// A list literal
     ///
-    /// e.g. `[foo, bar, 42]`
+    /// E.g. `[foo, bar, 42]`
     List(AstVec<AstIndex>),
 
     /// A tuple literal
     ///
-    /// e.g. `(foo, bar, 42)`
+    /// E.g. `(foo, bar, 42)`
     ///
     /// Note that this is also used for implicit tuples, e.g. in `x = 1, 2, 3`
     Tuple(AstVec<AstIndex>),
@@ -78,8 +78,8 @@ pub enum Node {
         end: AstIndex,
         /// Whether or not the end of the range includes the end value itself
         ///
-        /// e.g. `1..10` - a range from 1 up to but not including 10
-        /// e.g. `1..=10` - a range from 1 up to and including 10
+        /// E.g. `1..10` - a range from 1 up to but not including 10
+        /// E.g. `1..=10` - a range from 1 up to and including 10
         inclusive: bool,
     },
 
@@ -128,7 +128,7 @@ pub enum Node {
     /// A block node
     ///
     /// Used for indented blocks that share the context of the frame they're in,
-    /// e.g. if expressions, arms in match or switch experssions, loop bodies
+    /// e.g. if expressions, arms in match or switch expressions, loop bodies.
     Block(AstVec<AstIndex>),
 
     /// A function node
@@ -136,7 +136,7 @@ pub enum Node {
 
     /// An import expression
     ///
-    /// e.g. `from foo.bar import baz, 'qux'
+    /// E.g. `from foo.bar import baz, 'qux'`
     Import {
         /// Where the items should be imported from
         ///
@@ -163,7 +163,7 @@ pub enum Node {
 
     /// A multiple-assignment expression
     ///
-    /// e.g. `x, y = foo()`, or `foo, bar, baz = 1, 2, 3`
+    /// E.g. `x, y = foo()`, or `foo, bar, baz = 1, 2, 3`
     MultiAssign {
         /// The targets of the assignment
         targets: AstVec<AstIndex>,
@@ -269,7 +269,7 @@ pub enum Node {
 
     /// A type hint
     ///
-    /// e.g. `let x: Number = 0`
+    /// E.g. `let x: Number = 0`
     ///            ^~~ This is the beginning of the type hint
     Type(ConstantIndex),
 }

--- a/crates/parser/src/string_slice.rs
+++ b/crates/parser/src/string_slice.rs
@@ -1,5 +1,5 @@
 use koto_memory::Ptr;
-use std::ops::Range;
+use std::ops::{Deref, Range};
 
 /// String data with bounds
 ///
@@ -98,9 +98,17 @@ impl From<String> for StringSlice {
     }
 }
 
+impl Deref for StringSlice {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl AsRef<str> for StringSlice {
     fn as_ref(&self) -> &str {
-        self.as_str()
+        self.deref()
     }
 }
 

--- a/crates/parser/src/string_slice.rs
+++ b/crates/parser/src/string_slice.rs
@@ -11,7 +11,7 @@ pub struct StringSlice {
 }
 
 impl StringSlice {
-    /// Initalizes a string slice with the given string data and bounds
+    /// Initializes a string slice with the given string data and bounds
     ///
     /// If the bounds aren't valid for the given string data then None is returned.
     pub fn new(string: Ptr<str>, bounds: Range<usize>) -> Option<Self> {
@@ -25,11 +25,11 @@ impl StringSlice {
         }
     }
 
-    /// Initalizes a string slice with the given string data and bounds
+    /// Initializes a string slice with the given string data and bounds
     ///
     /// # Safety
     /// Care must be taken to ensure that the bounds are valid within the provided string,
-    /// i.e. string.get(bounds).is_some() must be true.
+    /// i.e. `string.get(bounds).is_some()` must be true.
     pub unsafe fn new_unchecked(string: Ptr<str>, bounds: Range<usize>) -> Self {
         Self {
             data: string,

--- a/crates/runtime/src/io/stdio.rs
+++ b/crates/runtime/src/io/stdio.rs
@@ -7,7 +7,7 @@ pub struct DefaultStdin {}
 
 impl KotoFile for DefaultStdin {
     fn id(&self) -> KString {
-        STDIN_ID.with(|id| id.clone())
+        "_stdin_".into()
     }
 }
 
@@ -35,7 +35,7 @@ pub struct DefaultStdout {}
 
 impl KotoFile for DefaultStdout {
     fn id(&self) -> KString {
-        STDOUT_ID.with(|id| id.clone())
+        "_stdout_".into()
     }
 }
 
@@ -63,7 +63,7 @@ pub struct DefaultStderr {}
 
 impl KotoFile for DefaultStderr {
     fn id(&self) -> KString {
-        STDERR_ID.with(|id| id.clone())
+        "_stderr_".into()
     }
 }
 
@@ -83,10 +83,4 @@ impl KotoWrite for DefaultStderr {
     fn flush(&self) -> Result<(), Error> {
         io::stdout().flush().map_err(map_io_err)
     }
-}
-
-thread_local! {
-    static STDIN_ID: KString = "_stdin_".into();
-    static STDOUT_ID: KString = "_stdout_".into();
-    static STDERR_ID: KString = "_stderr_".into();
 }

--- a/crates/runtime/src/types/string.rs
+++ b/crates/runtime/src/types/string.rs
@@ -19,7 +19,7 @@ pub struct KString(Inner);
 
 // Either the full string, or a slice
 //
-// By heap-allocating slice bounds we can keep KString's size down to 16 bytes; otherwise it
+// By heap-allocating slice bounds we can keep `KString`s size down to 16 bytes; otherwise it
 // would have a size of 32 bytes.
 #[derive(Clone)]
 enum Inner {
@@ -75,7 +75,7 @@ impl KString {
                 // By checking against start - 1 (rather than waiting until the next iteration),
                 // we can allow for indexing from 'one past the end' to get to an empty string,
                 // which can be useful when consuming characters from a string.
-                // e.g.
+                // E.g.
                 //   x = get_string()
                 //   do_something_with_first_char x[0]
                 //   do_something_with_remaining_string x[1..]
@@ -85,7 +85,7 @@ impl KString {
             if i == end - 1 {
                 // Checking against end - 1 in the same way as for result_start,
                 // allowing for indexing one-past-the-end.
-                // e.g. assert_eq 'xyz'[1..3], 'yz'
+                // E.g. `assert_eq 'xyz'[1..3], 'yz'`
                 result_end = Some(grapheme_start + grapheme.len());
                 break;
             }
@@ -101,6 +101,10 @@ impl KString {
     }
 
     /// Removes and returns the first grapheme from the string
+    ///
+    /// Although strings are treated as immutable in Koto scripts, there are cases where it's useful
+    /// to be able to mutate the string data in place. For example, iterators can hold on to a string
+    /// and pop characters without introducing extra allocations.
     pub fn pop_front(&mut self) -> Option<Self> {
         match self.clone().graphemes(true).next() {
             Some(grapheme) => match &mut self.0 {
@@ -122,6 +126,10 @@ impl KString {
     }
 
     /// Removes and returns the last grapheme from the string
+    ///
+    /// Although strings are treated as immutable in Koto scripts, there are cases where it's useful
+    /// to be able to mutate the string data in place. For example, iterators can hold on to a string
+    /// and pop characters without introducing extra allocations.
     pub fn pop_back(&mut self) -> Option<Self> {
         match self.clone().graphemes(true).next_back() {
             Some(grapheme) => match &mut self.0 {

--- a/crates/runtime/src/types/string.rs
+++ b/crates/runtime/src/types/string.rs
@@ -35,13 +35,6 @@ impl KString {
         Self::from(EMPTY_STRING.with(|s| s.clone()))
     }
 
-    /// Initializes a new KString with the provided data and bounds
-    ///
-    /// If the bounds aren't valid for the data then `None` is returned.
-    pub fn new_with_bounds(string: Ptr<str>, bounds: Range<usize>) -> Option<Self> {
-        StringSlice::new(string, bounds).map(Self::from)
-    }
-
     /// Returns a new KString with shared data and new bounds
     ///
     /// If the bounds aren't valid for the string then `None` is returned.

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -156,34 +156,33 @@ impl KValue {
     /// Returns the value's type as a [KString]
     pub fn type_as_string(&self) -> KString {
         use KValue::*;
+
         match &self {
-            Null => TYPE_NULL.with(|x| x.clone()),
-            Bool(_) => TYPE_BOOL.with(|x| x.clone()),
-            Number(_) => TYPE_NUMBER.with(|x| x.clone()),
-            List(_) => TYPE_LIST.with(|x| x.clone()),
-            Range { .. } => TYPE_RANGE.with(|x| x.clone()),
+            Null => "Null".into(),
+            Bool(_) => "Bool".into(),
+            Number(_) => "Number".into(),
+            List(_) => "List".into(),
+            Range { .. } => "Range".into(),
             Map(m) if m.meta_map().is_some() => match m.get_meta_value(&MetaKey::Type) {
                 Some(Str(s)) => s,
                 Some(_) => "Error: expected string as result of @type".into(),
                 None => match m.get_meta_value(&MetaKey::Base) {
                     Some(base @ Map(_)) => base.type_as_string(),
-                    _ => TYPE_OBJECT.with(|x| x.clone()),
+                    _ => "Object".into(),
                 },
             },
-            Map(_) => TYPE_MAP.with(|x| x.clone()),
-            Str(_) => TYPE_STRING.with(|x| x.clone()),
-            Tuple(_) => TYPE_TUPLE.with(|x| x.clone()),
-            Function(f) if f.generator => TYPE_GENERATOR.with(|x| x.clone()),
-            CaptureFunction(f) if f.info.generator => TYPE_GENERATOR.with(|x| x.clone()),
-            Function(_) | CaptureFunction(_) | NativeFunction(_) => {
-                TYPE_FUNCTION.with(|x| x.clone())
-            }
+            Map(_) => "Map".into(),
+            Str(_) => "String".into(),
+            Tuple(_) => "Tuple".into(),
+            Function(f) if f.generator => "Generator".into(),
+            CaptureFunction(f) if f.info.generator => "Generator".into(),
+            Function(_) | CaptureFunction(_) | NativeFunction(_) => "Function".into(),
             Object(o) => o.try_borrow().map_or_else(
                 |_| "Error: object already borrowed".into(),
                 |o| o.type_string(),
             ),
-            Iterator(_) => TYPE_ITERATOR.with(|x| x.clone()),
-            TemporaryTuple { .. } => TYPE_TEMPORARY_TUPLE.with(|x| x.clone()),
+            Iterator(_) => "Iterator".into(),
+            TemporaryTuple { .. } => "Temporary_tuple".into(),
         }
     }
 
@@ -213,22 +212,6 @@ impl KValue {
             runtime_error!("Failed to write to string")
         }
     }
-}
-
-thread_local! {
-    static TYPE_NULL: KString = "Null".into();
-    static TYPE_BOOL: KString = "Bool".into();
-    static TYPE_NUMBER: KString = "Number".into();
-    static TYPE_LIST: KString = "List".into();
-    static TYPE_RANGE: KString = "Range".into();
-    static TYPE_MAP: KString = "Map".into();
-    static TYPE_OBJECT: KString = "Object".into();
-    static TYPE_STRING: KString = "String".into();
-    static TYPE_TUPLE: KString = "Tuple".into();
-    static TYPE_FUNCTION: KString = "Function".into();
-    static TYPE_GENERATOR: KString = "Generator".into();
-    static TYPE_ITERATOR: KString = "Iterator".into();
-    static TYPE_TEMPORARY_TUPLE: KString = "TemporaryTuple".into();
 }
 
 impl fmt::Debug for KValue {

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -88,13 +88,13 @@ pub struct KotoVmSettings {
     /// reload the script when one of its dependencies has changed.
     pub module_imported_callback: Option<Box<dyn ModuleImportedCallback>>,
 
-    /// The runtime's stdin
+    /// The runtime's `stdin`
     pub stdin: Ptr<dyn KotoFile>,
 
-    /// The runtime's stdout
+    /// The runtime's `stdout`
     pub stdout: Ptr<dyn KotoFile>,
 
-    /// The runtime's stderr
+    /// The runtime's `stderr`
     pub stderr: Ptr<dyn KotoFile>,
 }
 
@@ -169,7 +169,7 @@ impl KotoVm {
 
     /// Spawn a VM that shares the same execution context
     ///
-    /// e.g.
+    /// E.g.
     ///   - An iterator spawns a shared VM that can be used to execute functors
     ///   - A generator function spawns a shared VM to yield incremental results
     ///   - Thrown errors spawn a shared VM to display an error from a custom error type
@@ -211,17 +211,17 @@ impl KotoVm {
         &mut self.exports
     }
 
-    /// The stdin wrapper used by the VM
+    /// The `stdin` wrapper used by the VM
     pub fn stdin(&self) -> &Ptr<dyn KotoFile> {
         &self.context.settings.stdin
     }
 
-    /// The stdout wrapper used by the VM
+    /// The `stdout` wrapper used by the VM
     pub fn stdout(&self) -> &Ptr<dyn KotoFile> {
         &self.context.settings.stdout
     }
 
-    /// The stderr wrapper used by the VM
+    /// The `stderr` wrapper used by the VM
     pub fn stderr(&self) -> &Ptr<dyn KotoFile> {
         &self.context.settings.stderr
     }
@@ -231,8 +231,8 @@ impl KotoVm {
         // Set up an execution frame to run the chunk in
         let result_register = self.next_register();
         let frame_base = result_register + 1;
-        self.registers.push(KValue::Null); // result register
-        self.registers.push(KValue::Null); // instance register
+        self.registers.push(KValue::Null); // Result register
+        self.registers.push(KValue::Null); // Instance register
         self.push_frame(chunk, 0, frame_base, result_register);
 
         // Ensure that execution stops here if an error is thrown
@@ -299,8 +299,8 @@ impl KotoVm {
         let result_register = self.next_register();
         let frame_base = result_register + 1;
 
-        self.registers.push(KValue::Null); // result register
-        self.registers.push(instance.unwrap_or_default()); // frame base
+        self.registers.push(KValue::Null); // Result register
+        self.registers.push(instance.unwrap_or_default()); // Frame base
         let (arg_count, temp_tuple_values) = match args {
             CallArgs::Single(arg) => {
                 self.registers.push(arg);
@@ -327,8 +327,8 @@ impl KotoVm {
                 match &function {
                     KValue::Function(f) if f.arg_is_unpacked_tuple => {
                         let temp_tuple = KValue::TemporaryTuple(RegisterSlice {
-                            // The unpacked tuple contents go into the registers after the
-                            // the temp tuple and instance registers.
+                            // The unpacked tuple's contents go into the registers after the
+                            // temp tuple and instance registers.
                             start: 2,
                             count: args.len() as u8,
                         });
@@ -404,8 +404,8 @@ impl KotoVm {
         let result_register = self.next_register();
         let value_register = result_register + 1;
 
-        self.registers.push(KValue::Null); // result_register
-        self.registers.push(value); // value_register
+        self.registers.push(KValue::Null); // `result_register`
+        self.registers.push(value); // `value_register`
 
         match op {
             Display => self.run_display(result_register, value_register)?,
@@ -454,7 +454,7 @@ impl KotoVm {
         let lhs_register = result_register + 1;
         let rhs_register = result_register + 2;
 
-        self.registers.push(KValue::Null); // result register
+        self.registers.push(KValue::Null); // Result register
         self.registers.push(lhs);
         self.registers.push(rhs);
 
@@ -566,7 +566,7 @@ impl KotoVm {
         use KValue::{Map, Null};
 
         // It's important throughout this function to make sure we don't hang on to any references
-        // to the internal test map data while calling the test functions, otherwise we'll end up in
+        // to the internal test map data while calling the test functions. Otherwise we'll end up in
         // deadlocks when the map needs to be modified (e.g. in pre or post test functions).
 
         let (pre_test, post_test, meta_entry_count) = match tests.meta_map() {
@@ -1026,7 +1026,7 @@ impl KotoVm {
     // This function is distinct from the public `make_iterator`, which will defer to this function
     // when the input value implements @iterator.
     //
-    // temp_iterator is used for temporary unpacking operations.
+    // `temp_iterator` is used for temporary unpacking operations.
     fn run_make_iterator(
         &mut self,
         result_register: u8,
@@ -1383,7 +1383,7 @@ impl KotoVm {
 
     fn run_capture_value(&mut self, function: u8, capture_index: u8, value: u8) -> Result<()> {
         let Some(function) = self.get_register_safe(function) else {
-            // e.g. x = (1..10).find |n| n == x
+            // E.g. `x = (1..10).find |n| n == x`
             // The function was temporary and has been removed from the value stack,
             // but the capture of `x` is still attempted. It would be cleaner for the compiler to
             // detect this case but for now a runtime error will have to do.
@@ -2018,8 +2018,8 @@ impl KotoVm {
 
         // Set up the call registers at the end of the stack
         let frame_base = self.new_frame_base()?;
-        self.registers.push(self.clone_register(lhs_register)); // frame_base
-        self.registers.push(rhs); // arg
+        self.registers.push(self.clone_register(lhs_register)); // Frame base
+        self.registers.push(rhs); // The rhs goes in the first arg register
         self.call_callable(
             &CallInfo {
                 result_register,
@@ -2144,11 +2144,11 @@ impl KotoVm {
             _ => {}
         }
 
-        // The module needs to be loaded, which involves the following steps:
-        //   - Execute the module's script
-        //   - If the module contains @tests, run them
-        //   - If the module contains a @main function, run it
-        //   - If the steps above are successful, then cache the resulting exports map
+        // The module needs to be loaded, which involves the following steps.
+        //   - Execute the module's script.
+        //   - If the module contains @tests, run them.
+        //   - If the module contains a @main function, run it.
+        //   - If the steps above are successful, then cache the resulting exports map.
 
         // Insert a placeholder for the new module, preventing recursive imports
         self.context
@@ -2302,7 +2302,7 @@ impl KotoVm {
             (Tuple(t), Range(range)) => {
                 let indices = range.indices(t.len());
                 let Some(result) = t.make_sub_tuple(indices) else {
-                    // range.indices is guaranteed to return valid indices for the tuple
+                    // `range.indices` is guaranteed to return valid indices for the tuple
                     unreachable!();
                 };
                 Tuple(result)


### PR DESCRIPTION
This PR introduces an `Inline` variant to `KString` which stores small strings
in an internal buffer, reducing the number of heap allocations when working with
strings (aka small string optimization).

This doesn't affect string literals in scripts given that they're already
interned in the constant pool, but this will be beneficial for strings coming
from outside the script, or when building `KMap`s from Rust code, where keys are
nearly always a `KString`.
