### PR TITLE
Flexible map syntax followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ The Koto project adheres to
   incorrect arguments.
 - `await` and `const` have been reserved as keywords for future use.
 - `@||` has been renamed to `@call`, and `@[]` has been renamed to `@index`.
+- `:` placement following keys in maps is now more flexible.
+  ([#368](https://github.com/koto-lang/koto/issues/368))
 
 #### API
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -305,7 +305,7 @@ impl<'source> Parser<'source> {
         Ok(result)
     }
 
-    // Attempts to parse an indented block after the current positon
+    // Attempts to parse an indented block after the current position
     //
     // e.g.
     //   my_function = |x, y| # <- Here at entry
@@ -737,7 +737,9 @@ impl<'source> Parser<'source> {
                 let string = self.parse_string(context)?.unwrap();
                 let string_node = self.push_node_with_span(Str(string.string), string.span)?;
 
-                if self.peek_token() == Some(Token::Colon) && string.context.allow_map_block {
+                if string.context.allow_map_block
+                    && self.peek_next_token_on_same_line() == Some(Token::Colon)
+                {
                     self.consume_map_block(string_node, start_span, &string.context)
                 } else {
                     self.check_for_chain_after_node(string_node, &string.context)
@@ -1240,7 +1242,7 @@ impl<'source> Parser<'source> {
         let id_node = self.push_node(Node::Id(constant_index, None))?;
         let id_span = self.current_span();
 
-        if self.peek_token() == Some(Token::Colon) && id_context.allow_map_block {
+        if id_context.allow_map_block && self.peek_next_token_on_same_line() == Some(Token::Colon) {
             // The ID is the start of a map block
             self.consume_map_block(id_node, id_span, &id_context)
         } else {
@@ -1863,7 +1865,7 @@ impl<'source> Parser<'source> {
 
         let start_indent = self.current_indent();
 
-        if self.consume_token() != Some(Token::Colon) {
+        if self.consume_next_token_on_same_line() != Some(Token::Colon) {
             return self.error(InternalError::ExpectedMapColon);
         }
 

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -665,15 +665,27 @@ x =
 
         #[test]
         fn map_block_syntax() {
-            let source = r#"
+            let sources = [
+                r#"
 x =
   foo: 42
   "baz":
     foo: 0
   @-: -1
-x"#;
-            check_ast(
-                source,
+x
+"#,
+                r#"
+x   =
+    foo: 42
+    "baz" :
+          foo   : 0
+    @-  : -1
+x
+"#,
+            ];
+
+            check_ast_for_equivalent_sources(
+                &sources,
                 &[
                     id(0), // x
                     id(1), // foo

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -611,7 +611,7 @@ x = {'foo': 42, bar, baz: 'hello', @+: 99}",
 }
 x = { 'foo': 42
   , bar
-  , baz: 'hello'
+  , baz   : 'hello'
   , @+: 99
 }
 ",
@@ -620,7 +620,7 @@ x = { 'foo': 42
 x =
   { 'foo': 42, bar
     , baz: 'hello'
-    , @+: 99
+    , @+  : 99
     }
 ",
                 "
@@ -628,7 +628,7 @@ x =
   }
 
 x =
-  { 'foo': 42, bar,
+  { 'foo' : 42, bar,
      baz: 'hello'
   , @+: 99
 }


### PR DESCRIPTION
- **Test that `:` can be placed flexibly in inline maps**
- **Relax `:` placement in map blocks**

Following on from #369, see issue #368.
