### PR TITLE
`script_path` / `script_dir` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ The Koto project adheres to
 - `:` placement following keys in maps is now more flexible.
   ([#368](https://github.com/koto-lang/koto/issues/368))
 
+#### Core Library
+
+- `koto.script_path` and `script_dir` are now functions.
+
 #### API
 
 - The line and column numbers referred to in spans are now zero-based. 
@@ -80,6 +84,9 @@ The Koto project adheres to
 - `From` impls for `KNumber` now saturate integer values that are out of the
   target type's bounds, instead of wrapping.
 - `KString` will now inline short strings to reduce allocations.
+- `Koto::compile` and `compile_and_run` now take `CompileArgs` which include
+  compiler settings. The equivalent compiler settings have been removed from 
+  `KotoSettings`.
 
 #### Libs
 

--- a/crates/bytecode/src/chunk.rs
+++ b/crates/bytecode/src/chunk.rs
@@ -3,7 +3,7 @@ use koto_memory::Ptr;
 use koto_parser::{ConstantPool, Span};
 use std::{
     fmt::{self, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 /// Debug information for a Koto program
@@ -62,21 +62,6 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    /// Initializes a Chunk
-    pub fn new(
-        bytes: Box<[u8]>,
-        constants: ConstantPool,
-        source_path: Option<&Path>,
-        debug_info: DebugInfo,
-    ) -> Self {
-        Self {
-            bytes,
-            constants,
-            source_path: source_path.map(Path::to_path_buf),
-            debug_info,
-        }
-    }
-
     /// Returns a [String] displaying the instructions contained in the compiled [Chunk]
     pub fn bytes_as_string(chunk: &Chunk) -> String {
         let mut iter = chunk.bytes.iter();

--- a/crates/bytecode/src/chunk.rs
+++ b/crates/bytecode/src/chunk.rs
@@ -1,10 +1,7 @@
 use crate::InstructionReader;
 use koto_memory::Ptr;
-use koto_parser::{ConstantPool, Span};
-use std::{
-    fmt::{self, Write},
-    path::PathBuf,
-};
+use koto_parser::{ConstantPool, KString, Span};
+use std::fmt::{self, Write};
 
 /// Debug information for a Koto program
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -56,7 +53,7 @@ pub struct Chunk {
     /// The constant data associated with the chunk's bytecode
     pub constants: ConstantPool,
     /// The path of the program's source file
-    pub source_path: Option<PathBuf>,
+    pub source_path: Option<KString>,
     /// Debug information associated with the chunk's bytecode
     pub debug_info: DebugInfo,
 }

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -203,14 +203,16 @@ impl CompileNodeOutput {
 
 /// The settings used by the [Compiler]
 pub struct CompilerSettings {
-    /// Causes all top level identifiers to be exported
+    /// Whether or not top-level identifiers should be automatically exported
     ///
-    /// Disabled by default.
+    /// The default behaviour in Koto is that `export` expressions are required to make a value
+    /// available outside of the current module.
     ///
-    /// This is used by the REPL to automatically export values so that they're available between
-    /// chunks.
+    /// This is used by the REPL, allowing for incremental compilation and execution of expressions
+    /// that need to share declared values.
     pub export_top_level_ids: bool,
-    /// Causes the compiler to emit CheckType instructions when type hints are encountered.
+    /// When enabled, the compiler will emit type check instructions when type hints are encountered
+    /// that will be performed at runtime.
     ///
     /// Enabled by default.
     pub enable_type_checks: bool,

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -217,20 +217,18 @@ check! 10
 ## script_dir
 
 ```kototype
-String or Null
+|| -> String or Null
 ```
 
-If a script is being executed then `script_dir` provides the directory that the
-current script is contained in as a String, otherwise `script_dir` is Null.
+Returns the path of the directory containing the current script, if available.
 
 ## script_path
 
 ```kototype
-String or Null
+|| -> String or Null
 ```
 
-If a script is being executed then `script_path` provides the path of the
-current script as a String, otherwise `script_path` is Null.
+Returns the path of the file containing the current script, if available.
 
 ## size
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -166,7 +166,7 @@ fn main() -> Result<()> {
 
         match koto.compile(CompileArgs {
             script: &script,
-            script_path: script_path.map(PathBuf::from),
+            script_path: script_path.map(KString::from),
             compiler_settings: Default::default(),
         }) {
             Ok(chunk) => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,12 +6,7 @@ use crossterm::tty::IsTty;
 use koto::prelude::*;
 use repl::{Repl, ReplSettings};
 use rustyline::EditMode;
-use std::{
-    env,
-    error::Error,
-    fs, io,
-    path::{Path, PathBuf},
-};
+use std::{env, error::Error, fs, io, path::PathBuf};
 
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -139,7 +134,6 @@ fn main() -> Result<()> {
             run_import_tests: args.run_import_tests,
             ..Default::default()
         },
-        ..Default::default()
     };
 
     let mut stdin = io::stdin();
@@ -167,13 +161,14 @@ fn main() -> Result<()> {
 
     if let Some(script) = script {
         let mut koto = Koto::with_settings(koto_settings);
-        if let Err(error) = koto.set_script_path(script_path.as_deref().map(Path::new)) {
-            bail!("{error}");
-        }
 
         add_modules(&koto);
 
-        match koto.compile(&script) {
+        match koto.compile(CompileArgs {
+            script: &script,
+            script_path: script_path.map(PathBuf::from),
+            compiler_settings: Default::default(),
+        }) {
             Ok(chunk) => {
                 if args.show_bytecode {
                     println!("{}\n", &Chunk::bytes_as_string(&chunk));
@@ -266,10 +261,10 @@ fn load_config(config_path: Option<&String>) -> Result<Config> {
 
     // Load the config file if it exists
     if let Some(config_path) = config_path {
-        let script = fs::read_to_string(config_path).context("Failed to load the config file")?;
+        let script = fs::read_to_string(&config_path).context("Failed to load the config file")?;
 
         let mut koto = Koto::new();
-        match koto.compile_and_run(&script) {
+        match koto.compile_and_run(CompileArgs::with_path(&script, config_path)) {
             Ok(_) => {
                 let exports = koto.exports().data();
                 match exports.get("repl") {

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -66,12 +66,7 @@ fn history_path() -> Option<PathBuf> {
 }
 
 impl Repl {
-    pub fn with_settings(
-        repl_settings: ReplSettings,
-        mut koto_settings: KotoSettings,
-    ) -> Result<Self> {
-        koto_settings.export_top_level_ids = true;
-
+    pub fn with_settings(repl_settings: ReplSettings, koto_settings: KotoSettings) -> Result<Self> {
         let koto = Koto::with_settings(koto_settings);
         super::add_modules(&koto);
 

--- a/crates/koto/Cargo.toml
+++ b/crates/koto/Cargo.toml
@@ -19,7 +19,6 @@ koto_bytecode = { path = "../bytecode", version = "^0.15.0", default-features = 
 koto_parser = { path = "../parser", version = "^0.15.0", default-features = false }
 koto_runtime = { path = "../runtime", version = "^0.15.0", default-features = false }
 
-dunce = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -28,6 +27,7 @@ koto_test_utils = { path = "../test_utils" }
 
 anyhow = { workspace = true }
 criterion2 = { workspace = true }
+dunce = { workspace = true }
 mimalloc = { workspace = true }
 
 [[bench]]

--- a/crates/koto/examples/poetry/scripts/guide.koto
+++ b/crates/koto/examples/poetry/scripts/guide.koto
@@ -1,6 +1,6 @@
 @main = ||
   input_file =
-    io.extend_path koto.script_dir, '..', 'README.md'
+    io.extend_path koto.script_dir(), '..', 'README.md'
     -> io.read_to_string
   generator = poetry.new input_file
 

--- a/crates/koto/examples/poetry/scripts/readme.koto
+++ b/crates/koto/examples/poetry/scripts/readme.koto
@@ -1,6 +1,6 @@
 @main = ||
   input_file =
-    io.extend_path koto.script_dir, '..', '..', '..', '..', '..', 'docs', 'language_guide.md'
+    io.extend_path koto.script_dir(), '..', '..', '..', '..', '..', 'docs', 'language_guide.md'
     -> io.read_to_string
   generator = poetry.new input_file
 

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -1,7 +1,7 @@
 use crate::{prelude::*, Ptr, Result};
 use koto_bytecode::CompilerSettings;
 use koto_runtime::ModuleImportedCallback;
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 /// The main interface for the Koto language.
 ///
@@ -275,17 +275,17 @@ pub struct CompileArgs<'a> {
     ///
     /// The path provided here becomes accessible within the script via
     /// `koto.script_path`/`koto.script_dir`.
-    pub script_path: Option<PathBuf>,
+    pub script_path: Option<KString>,
     /// Settings used during compilation
     pub compiler_settings: CompilerSettings,
 }
 
 impl<'a> CompileArgs<'a> {
     /// A convenience initializer for when the script has been loaded from a path
-    pub fn with_path(script: &'a str, script_path: PathBuf) -> Self {
+    pub fn with_path(script: &'a str, script_path: impl Into<KString>) -> Self {
         Self {
             script,
-            script_path: Some(script_path),
+            script_path: Some(script_path.into()),
             compiler_settings: Default::default(),
         }
     }

--- a/crates/koto/src/lib.rs
+++ b/crates/koto/src/lib.rs
@@ -36,4 +36,4 @@ pub use koto_parser as parser;
 pub use koto_runtime as runtime;
 pub use koto_runtime::{derive, Borrow, BorrowMut, Error, ErrorKind, Ptr, PtrMut, Result};
 
-pub use crate::koto::{Koto, KotoSettings};
+pub use crate::koto::{CompileArgs, Koto, KotoSettings};

--- a/crates/koto/src/prelude.rs
+++ b/crates/koto/src/prelude.rs
@@ -1,5 +1,5 @@
 //! A collection of useful items to make it easier to work with `koto`
 
-pub use crate::{Koto, KotoSettings};
+pub use crate::{CompileArgs, Koto, KotoSettings};
 pub use koto_bytecode::{Chunk, Loader, LoaderError};
 pub use koto_runtime::prelude::*;

--- a/crates/koto/tests/koto_tests.rs
+++ b/crates/koto/tests/koto_tests.rs
@@ -24,7 +24,7 @@ fn run_script(script: &str, script_path: PathBuf, expected_module_paths: &[PathB
 
     if let Err(error) = koto.compile(CompileArgs {
         script,
-        script_path: Some(script_path),
+        script_path: Some(script_path.into()),
         compiler_settings: Default::default(),
     }) {
         panic!("{error}");

--- a/crates/koto/tests/koto_tests.rs
+++ b/crates/koto/tests/koto_tests.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-fn run_script(script: &str, script_path: &Path, expected_module_paths: &[PathBuf]) {
+fn run_script(script: &str, script_path: PathBuf, expected_module_paths: &[PathBuf]) {
     let loaded_module_paths = PtrMut::from(vec![]);
 
     let mut koto = Koto::with_settings(
@@ -21,9 +21,12 @@ fn run_script(script: &str, script_path: &Path, expected_module_paths: &[PathBuf
             move |path: &Path| loaded_module_paths.borrow_mut().push(path.to_path_buf())
         }),
     );
-    koto.set_script_path(Some(script_path)).unwrap();
 
-    if let Err(error) = koto.compile(script) {
+    if let Err(error) = koto.compile(CompileArgs {
+        script,
+        script_path: Some(script_path),
+        compiler_settings: Default::default(),
+    }) {
         panic!("{error}");
     }
     if let Err(error) = koto.run() {
@@ -57,7 +60,7 @@ fn load_and_run_script(script_file_name: &str, imported_modules: &[&str]) {
     test_folder.push("..");
     test_folder.push("koto");
     test_folder.push("tests");
-    test_folder = test_folder.canonicalize().unwrap();
+    test_folder = dunce::canonicalize(test_folder).unwrap();
 
     let mut script_path = test_folder.clone();
     script_path.push(script_file_name);
@@ -76,7 +79,7 @@ fn load_and_run_script(script_file_name: &str, imported_modules: &[&str]) {
         })
         .collect::<Vec<_>>();
 
-    run_script(&script, &script_path, &expected_module_paths);
+    run_script(&script, script_path, &expected_module_paths);
 }
 
 macro_rules! koto_test {

--- a/crates/koto/tests/repl_mode_tests.rs
+++ b/crates/koto/tests/repl_mode_tests.rs
@@ -6,27 +6,32 @@
 //! each subsequent chunk.
 
 use koto::{prelude::*, runtime::Result, PtrMut};
+use koto_bytecode::CompilerSettings;
 
 fn run_repl_mode_test(inputs_and_expected_outputs: &[(&str, &str)]) {
     let output = PtrMut::from(String::new());
 
     let mut koto = Koto::with_settings(
-        KotoSettings {
-            export_top_level_ids: true,
-            ..Default::default()
-        }
-        .with_stdout(OutputCapture {
-            output: output.clone(),
-        })
-        .with_stderr(OutputCapture {
-            output: output.clone(),
-        }),
+        KotoSettings::default()
+            .with_stdout(OutputCapture {
+                output: output.clone(),
+            })
+            .with_stderr(OutputCapture {
+                output: output.clone(),
+            }),
     );
 
     let mut chunks = Vec::with_capacity(inputs_and_expected_outputs.len());
 
     for (input, expected_output) in inputs_and_expected_outputs {
-        match koto.compile(input) {
+        match koto.compile(CompileArgs {
+            script: *input,
+            script_path: None,
+            compiler_settings: CompilerSettings {
+                export_top_level_ids: true,
+                ..Default::default()
+            },
+        }) {
             Ok(chunk) => chunks.push((input, chunk)),
             Err(error) => panic!("{}", error),
         }

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -1,5 +1,5 @@
 use koto_lexer::Span;
-use std::{fmt::Write, path::Path};
+use std::fmt::Write;
 use thiserror::Error;
 
 use crate::string_format_options::StringFormatError;
@@ -245,7 +245,7 @@ impl Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Renders the excerpt of the source corresponding to the given span
-pub fn format_source_excerpt(source: &str, span: &Span, source_path: Option<&Path>) -> String {
+pub fn format_source_excerpt(source: &str, span: &Span, source_path: Option<&str>) -> String {
     let Span { start, end } = span;
 
     let (excerpt, padding) = {
@@ -291,15 +291,10 @@ pub fn format_source_excerpt(source: &str, span: &Span, source_path: Option<&Pat
     };
 
     let position_info = if let Some(path) = source_path {
-        let display_path = if let Ok(current_dir) = std::env::current_dir() {
-            if let Ok(stripped) = path.strip_prefix(current_dir) {
-                stripped.display()
-            } else {
-                path.display()
-            }
-        } else {
-            path.display()
-        };
+        let display_path = std::env::current_dir()
+            .ok()
+            .and_then(|dir| dir.to_str().and_then(|dir_str| path.strip_prefix(dir_str)))
+            .unwrap_or(path);
 
         format!("{display_path} - {}:{}", start.line + 1, start.column + 1)
     } else {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -7,6 +7,7 @@ mod constant_pool;
 mod error;
 mod node;
 mod parser;
+mod string;
 mod string_format_options;
 mod string_slice;
 
@@ -16,6 +17,7 @@ pub use crate::{
     error::{format_source_excerpt, Error, Result},
     node::*,
     parser::Parser,
+    string::KString,
     string_format_options::{StringAlignment, StringFormatOptions},
     string_slice::StringSlice,
 };

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -703,7 +703,7 @@ impl<'source> Parser<'source> {
             };
             Ok(Some(self.push_node_with_span(node, assign_span)?))
         } else {
-            self.consume_token_on_same_line_and_error(ExpectedIndentation::AssignmentExpression)
+            self.error(ExpectedIndentation::AssignmentExpression)
         }
     }
 

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -42,19 +42,32 @@ mod parser {
     mod should_fail {
         use super::*;
 
-        #[test]
-        fn wildcard_as_map_id() {
-            check_parsing_fails("{_}");
+        mod arithmetic {
+            use super::*;
+
+            #[test]
+            fn missing_term_in_arithmetic() {
+                check_parsing_fails("1 + * 2");
+            }
         }
 
-        #[test]
-        fn missing_term_in_arithmetic() {
-            check_parsing_fails("1 + * 2");
-        }
+        mod assignment {
+            use super::*;
 
-        #[test]
-        fn missing_comma_in_import() {
-            check_parsing_fails("import foo bar");
+            #[test]
+            fn missing_assignment_rhs() {
+                let source = "\
+x =
+# ^
+";
+                check_parsing_fails_with_span(
+                    source,
+                    Span {
+                        start: Position { line: 0, column: 2 },
+                        end: Position { line: 0, column: 3 },
+                    },
+                )
+            }
         }
 
         mod indentation {
@@ -233,6 +246,11 @@ x = ||
 
         mod maps {
             use super::*;
+
+            #[test]
+            fn wildcard_as_map_id() {
+                check_parsing_fails("{_}");
+            }
 
             #[test]
             fn block_starting_on_same_line_as_assignment_single_entry() {
@@ -489,6 +507,11 @@ switch
 
         mod import {
             use super::*;
+
+            #[test]
+            fn missing_comma_in_import() {
+                check_parsing_fails("import foo bar");
+            }
 
             #[test]
             fn nested_import() {

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -50,8 +50,35 @@ pub fn make_module() -> KMap {
         unexpected => unexpected_args("|Any|", unexpected),
     });
 
-    result.insert("script_dir", KValue::Null);
-    result.insert("script_path", KValue::Null);
+    result.add_fn("script_dir", |ctx| {
+        let result = ctx
+            .vm
+            .chunk()
+            .source_path
+            .as_ref()
+            .and_then(|path| path.parent())
+            .map_or(KValue::Null, |path| {
+                KValue::from(path.to_string_lossy().to_string())
+            });
+        Ok(result)
+    });
+
+    result.add_fn("script_path", |ctx| {
+        let result = ctx
+            .vm
+            .chunk()
+            .source_path
+            .as_ref()
+            .map_or(KValue::Null, |path| {
+                KValue::from(path.to_string_lossy().to_string())
+            });
+        Ok(result)
+    });
+
+    result.add_fn("script_path", |ctx| match &ctx.vm.chunk().source_path {
+        Some(path) => Ok(path.to_string_lossy().to_string().into()),
+        None => Ok(KValue::Null),
+    });
 
     result.add_fn("size", |ctx| match ctx.args() {
         [value] => ctx.vm.run_unary_op(UnaryOp::Size, value.clone()),

--- a/crates/runtime/src/types/mod.rs
+++ b/crates/runtime/src/types/mod.rs
@@ -9,10 +9,11 @@ mod native_function;
 mod number;
 mod object;
 mod range;
-mod string;
 mod tuple;
 pub mod value;
 mod value_key;
+
+pub use koto_parser::KString;
 
 pub use self::{
     function::{KCaptureFunction, KFunction},
@@ -26,7 +27,6 @@ pub use self::{
         IsIterable, KObject, KotoCopy, KotoEntries, KotoField, KotoObject, KotoType, MethodContext,
     },
     range::KRange,
-    string::KString,
     tuple::KTuple,
     value::KValue,
     value_key::ValueKey,

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -189,28 +189,30 @@ impl KValue {
     /// Renders the value into the provided display context
     pub fn display(&self, ctx: &mut DisplayContext) -> Result<()> {
         use KValue::*;
-        let result = match self {
+        let _ = match self {
             Null => write!(ctx, "null"),
             Bool(b) => write!(ctx, "{b}"),
             Number(n) => write!(ctx, "{n}"),
             Range(r) => write!(ctx, "{r}"),
             Function(_) | CaptureFunction(_) => write!(ctx, "||"),
-            Iterator(_) => write!(ctx, "Iterator"),
             NativeFunction(_) => write!(ctx, "||"),
+            Iterator(_) => write!(ctx, "Iterator"),
             TemporaryTuple(RegisterSlice { start, count }) => {
                 write!(ctx, "TemporaryTuple [{start}..{}]", start + count)
             }
-            Str(s) => return s.display(ctx),
+            Str(s) => {
+                if ctx.is_contained() {
+                    write!(ctx, "\'{s}\'")
+                } else {
+                    write!(ctx, "{s}")
+                }
+            }
             List(l) => return l.display(ctx),
             Tuple(t) => return t.display(ctx),
             Map(m) => return m.display(ctx),
             Object(o) => return o.try_borrow()?.display(ctx),
         };
-        if result.is_ok() {
-            Ok(())
-        } else {
-            runtime_error!("Failed to write to string")
-        }
+        Ok(())
     }
 }
 

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -2119,15 +2119,11 @@ impl KotoVm {
         // Attempt to compile the imported module from disk,
         // using the current source path as the relative starting location
         let source_path = self.reader.chunk.source_path.clone();
-        let compile_result = match self
+        let compile_result = self
             .context
             .loader
             .borrow_mut()
-            .compile_module(&import_name, source_path.as_deref())
-        {
-            Ok(result) => result,
-            Err(error) => return runtime_error!("Failed to import '{import_name}': {error}"),
-        };
+            .compile_module(&import_name, source_path.as_deref())?;
 
         // Has the module been loaded previously?
         let maybe_in_cache = self

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -2853,9 +2853,9 @@ impl KotoVm {
                 .get_source_span(self.instruction_ip),
             self.reader.chunk.source_path.as_ref(),
         ) {
-            (Some(span), Some(path)) => format!("[{}: {}] ", path.display(), span.start.line + 1),
+            (Some(span), Some(path)) => format!("[{}: {}] ", path, span.start.line + 1),
             (Some(span), None) => format!("[{}] ", span.start.line + 1),
-            (None, Some(path)) => format!("[{}: #ERR] ", path.display()),
+            (None, Some(path)) => format!("[{}: #ERR] ", path),
             (None, None) => "[#ERR] ".to_string(),
         };
 

--- a/crates/test_utils/src/check_script_output.rs
+++ b/crates/test_utils/src/check_script_output.rs
@@ -5,7 +5,7 @@ use koto_runtime::{prelude::*, Result};
 pub fn check_script_output(script: &str, expected_output: impl Into<KValue>) {
     let (vm, output) = OutputCapture::make_vm_with_output_capture();
 
-    if let Err(e) = run_test_script(vm, script, Some(expected_output.into())) {
+    if let Err(e) = run_test_script(vm, script, None, Some(expected_output.into())) {
         let output = output.captured_output();
         if !output.is_empty() {
             println!("Stdout:\n-------\n\n{output}\n-------\n");
@@ -20,5 +20,5 @@ pub fn check_script_output_with_vm(
     script: &str,
     expected_output: impl Into<KValue>,
 ) -> Result<()> {
-    run_test_script(vm, script, Some(expected_output.into()))
+    run_test_script(vm, script, None, Some(expected_output.into()))
 }

--- a/crates/test_utils/src/run_test_script.rs
+++ b/crates/test_utils/src/run_test_script.rs
@@ -1,13 +1,12 @@
 use crate::script_instructions;
 use koto_bytecode::{CompilerSettings, Loader};
 use koto_runtime::{prelude::*, Result};
-use std::path::PathBuf;
 
 /// Runs a script using the provided Vm, optionally checking its output
 pub fn run_test_script(
     mut vm: KotoVm,
     script: &str,
-    script_path: Option<PathBuf>,
+    script_path: Option<KString>,
     expected_output: Option<KValue>,
 ) -> Result<()> {
     let mut loader = Loader::default();

--- a/crates/test_utils/src/run_test_script.rs
+++ b/crates/test_utils/src/run_test_script.rs
@@ -1,15 +1,17 @@
 use crate::script_instructions;
 use koto_bytecode::{CompilerSettings, Loader};
 use koto_runtime::{prelude::*, Result};
+use std::path::PathBuf;
 
 /// Runs a script using the provided Vm, optionally checking its output
 pub fn run_test_script(
     mut vm: KotoVm,
     script: &str,
+    script_path: Option<PathBuf>,
     expected_output: Option<KValue>,
 ) -> Result<()> {
     let mut loader = Loader::default();
-    let chunk = match loader.compile_script(script, None, CompilerSettings::default()) {
+    let chunk = match loader.compile_script(script, script_path, CompilerSettings::default()) {
         Ok(chunk) => chunk,
         Err(error) => {
             println!("{script}\n");

--- a/koto/tests/io.koto
+++ b/koto/tests/io.koto
@@ -1,4 +1,4 @@
-test_path = io.extend_path koto.script_dir, "data", "test.txt"
+test_path = io.extend_path koto.script_dir(), "data", "test.txt"
 
 test_contents = "\
 aaa

--- a/koto/tests/test_module/baz.koto
+++ b/koto/tests/test_module/baz.koto
@@ -1,11 +1,11 @@
 # This file is imported by ./main.koto
 
+local_value = 999
+qux = null
+
 # Testing that import works within a submodule
 from number import pi
 assert_eq pi, pi
-
-local_value = 999
-qux = null
 
 # Export using inline map syntax
 export { qux, @type: 'Baz' }
@@ -14,3 +14,14 @@ export { qux, @type: 'Baz' }
   # Redefine qux to check that main has been called
   export qux = 'O_o'
   assert_eq qux, 'O_o'
+
+@test local_value_unmodified_by_import = ||
+  # Ensure that the local value captured here wasn't affected by the earlier `import`
+  assert_eq local_value, 999
+
+@test script_dir_and_path = ||
+  # Ensure that script_dir/path are defined correctly within the module
+  assert koto.script_dir().ends_with 'test_module'
+  path = koto.script_path()
+  assert path.contains 'test_module'
+  assert path.ends_with 'baz.koto'

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -10,14 +10,23 @@ export let square: Function = |x| x * x
 
 # Export with a map block
 export
-  @type: 'test_module'
-
   baz: import baz # Re-export the neighbouring baz module
-
   tests_were_run: false
 
-  @test run_tests: ||
-    export tests_were_run = true
+# Metakeys can be assigned to directly
+@type = 'test_module'
 
-  @test local_value_unmodified_by_import: ||
-    assert_eq local_value, 123
+@test run_tests = ||
+  # Re-export `tests_were_run` when this test is run
+  export tests_were_run = true
+
+@test local_value_unmodified_by_import = ||
+  # Ensure that the local value captured here wasn't affected by the earlier `import`
+  assert_eq local_value, 123
+
+@test script_dir_and_path = ||
+  # Ensure that script_dir/path are defined correctly within the module
+  assert koto.script_dir().ends_with 'test_module'
+  path = koto.script_path()
+  assert path.contains 'test_module'
+  assert path.ends_with 'main.koto'

--- a/libs/json/tests/json.koto
+++ b/libs/json/tests/json.koto
@@ -1,6 +1,6 @@
 @test serialize_and_deserialize_json = ||
   file_data = try
-    path = io.extend_path koto.script_dir, "test.json"
+    path = io.extend_path koto.script_dir(), "test.json"
     io.read_to_string path
   catch error
     throw "Error reading file data: {error}"

--- a/libs/json/tests/koto_tests.rs
+++ b/libs/json/tests/koto_tests.rs
@@ -10,7 +10,7 @@ fn json_tests() -> Result<(), Box<dyn Error>> {
     let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "json.koto"]);
     let script = fs::read_to_string(&script_path)?;
 
-    run_test_script(vm, &script, Some(script_path), None)?;
+    run_test_script(vm, &script, Some(script_path.into()), None)?;
 
     Ok(())
 }

--- a/libs/json/tests/koto_tests.rs
+++ b/libs/json/tests/koto_tests.rs
@@ -1,21 +1,16 @@
-use koto_runtime::{prelude::*, Result};
+use koto_runtime::prelude::*;
 use koto_test_utils::run_test_script;
-use std::path::PathBuf;
+use std::{error::Error, fs, path::PathBuf};
 
 #[test]
-fn json_tests() -> Result<()> {
+fn json_tests() -> Result<(), Box<dyn Error>> {
     let vm = KotoVm::default();
     vm.prelude().insert("json", koto_json::make_module());
 
-    match vm.prelude().data_mut().get("koto") {
-        Some(KValue::Map(m)) => m.insert(
-            "script_dir",
-            PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests"])
-                .to_string_lossy()
-                .to_string(),
-        ),
-        _ => return runtime_error!("Missing koto module"),
-    }
+    let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "json.koto"]);
+    let script = fs::read_to_string(&script_path)?;
 
-    run_test_script(vm, include_str!("json.koto"), None)
+    run_test_script(vm, &script, Some(script_path), None)?;
+
+    Ok(())
 }

--- a/libs/tempfile/tests/koto_tests.rs
+++ b/libs/tempfile/tests/koto_tests.rs
@@ -1,11 +1,17 @@
-use koto_runtime::{prelude::*, Result};
+use koto_runtime::prelude::*;
 use koto_test_utils::run_test_script;
+use std::{error::Error, fs, path::PathBuf};
 
 #[test]
-fn tempfile_tests() -> Result<()> {
+fn tempfile_tests() -> Result<(), Box<dyn Error>> {
     let vm = KotoVm::default();
     vm.prelude()
         .insert("tempfile", koto_tempfile::make_module());
 
-    run_test_script(vm, include_str!("tempfile.koto"), None)
+    let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "tempfile.koto"]);
+    let script = fs::read_to_string(&script_path)?;
+
+    run_test_script(vm, &script, Some(script_path), None)?;
+
+    Ok(())
 }

--- a/libs/tempfile/tests/koto_tests.rs
+++ b/libs/tempfile/tests/koto_tests.rs
@@ -11,7 +11,7 @@ fn tempfile_tests() -> Result<(), Box<dyn Error>> {
     let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "tempfile.koto"]);
     let script = fs::read_to_string(&script_path)?;
 
-    run_test_script(vm, &script, Some(script_path), None)?;
+    run_test_script(vm, &script, Some(script_path.into()), None)?;
 
     Ok(())
 }

--- a/libs/toml/tests/koto_tests.rs
+++ b/libs/toml/tests/koto_tests.rs
@@ -10,7 +10,7 @@ fn json_tests() -> Result<(), Box<dyn Error>> {
     let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "toml.koto"]);
     let script = fs::read_to_string(&script_path)?;
 
-    run_test_script(vm, &script, Some(script_path), None)?;
+    run_test_script(vm, &script, Some(script_path.into()), None)?;
 
     Ok(())
 }

--- a/libs/toml/tests/koto_tests.rs
+++ b/libs/toml/tests/koto_tests.rs
@@ -1,21 +1,16 @@
-use koto_runtime::{prelude::*, Result};
+use koto_runtime::prelude::*;
 use koto_test_utils::run_test_script;
-use std::path::PathBuf;
+use std::{error::Error, fs, path::PathBuf};
 
 #[test]
-fn json_tests() -> Result<()> {
+fn json_tests() -> Result<(), Box<dyn Error>> {
     let vm = KotoVm::default();
     vm.prelude().insert("toml", koto_toml::make_module());
 
-    match vm.prelude().data_mut().get("koto") {
-        Some(KValue::Map(m)) => m.insert(
-            "script_dir",
-            PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests"])
-                .to_string_lossy()
-                .to_string(),
-        ),
-        _ => return runtime_error!("Missing koto module"),
-    }
+    let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "toml.koto"]);
+    let script = fs::read_to_string(&script_path)?;
 
-    run_test_script(vm, include_str!("toml.koto"), None)
+    run_test_script(vm, &script, Some(script_path), None)?;
+
+    Ok(())
 }

--- a/libs/toml/tests/toml.koto
+++ b/libs/toml/tests/toml.koto
@@ -1,5 +1,5 @@
 @test serialize_and_deserialize_toml = ||
-  path = io.extend_path koto.script_dir, "test.toml"
+  path = io.extend_path koto.script_dir(), "test.toml"
   file_data = io.read_to_string path
   data = toml.from_string file_data
 

--- a/libs/yaml/tests/koto_tests.rs
+++ b/libs/yaml/tests/koto_tests.rs
@@ -1,21 +1,16 @@
-use koto_runtime::{prelude::*, Result};
+use koto_runtime::prelude::*;
 use koto_test_utils::run_test_script;
-use std::path::PathBuf;
+use std::{error::Error, fs, path::PathBuf};
 
 #[test]
-fn json_tests() -> Result<()> {
+fn json_tests() -> Result<(), Box<dyn Error>> {
     let vm = KotoVm::default();
     vm.prelude().insert("yaml", koto_yaml::make_module());
 
-    match vm.prelude().data_mut().get("koto") {
-        Some(KValue::Map(m)) => m.insert(
-            "script_dir",
-            PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests"])
-                .to_string_lossy()
-                .to_string(),
-        ),
-        _ => return runtime_error!("Missing koto module"),
-    }
+    let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "yaml.koto"]);
+    let script = fs::read_to_string(&script_path)?;
 
-    run_test_script(vm, include_str!("yaml.koto"), None)
+    run_test_script(vm, &script, Some(script_path), None)?;
+
+    Ok(())
 }

--- a/libs/yaml/tests/koto_tests.rs
+++ b/libs/yaml/tests/koto_tests.rs
@@ -10,7 +10,7 @@ fn json_tests() -> Result<(), Box<dyn Error>> {
     let script_path = PathBuf::from_iter(&[env!("CARGO_MANIFEST_DIR"), "tests", "yaml.koto"]);
     let script = fs::read_to_string(&script_path)?;
 
-    run_test_script(vm, &script, Some(script_path), None)?;
+    run_test_script(vm, &script, Some(script_path.into()), None)?;
 
     Ok(())
 }

--- a/libs/yaml/tests/yaml.koto
+++ b/libs/yaml/tests/yaml.koto
@@ -1,5 +1,5 @@
 @test serialize_and_deserialize_yaml = ||
-  path = io.extend_path koto.script_dir, "test.yaml"
+  path = io.extend_path koto.script_dir(), "test.yaml"
   file_data = io.read_to_string path
   data = yaml.from_string file_data
 


### PR DESCRIPTION
This PR updates `koto.script_path`/`script_dir` so that they're functions that always return the correct results, irrespective of the module that they're called from. 

`Koto::set_script_path` has been removed, and the `compile`/`compile_and_run` functions now take a `CompileArgs` struct that optionally includes the script path.
