### PR TITLE
Add `os.command` to support spawning child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The Koto project adheres to
     - Supports checking if (e.g.) `io.stdin()` is connected to a terminal.
   - `os.command`
     - Supports executing and spawning system commands.
+  - `os.process_id`
   - `random.shuffle`
   - `string.repeat`
 - `tuple.sort_copy` now supports sorting with a key function, following the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ The Koto project adheres to
 
 - New functions:
   - `file.is_terminal`
+    - Supports checking if (e.g.) `io.stdin()` is connected to a terminal.
+  - `os.command`
+    - Supports executing and spawning system commands.
   - `random.shuffle`
   - `string.repeat`
 - `tuple.sort_copy` now supports sorting with a key function, following the 

--- a/crates/cli/docs/core_lib/os.md
+++ b/crates/cli/docs/core_lib/os.md
@@ -29,6 +29,14 @@ check! ...
 Returns a string containing the name of the current operating system, e.g.
 "linux", "macos", "windows", etc.
 
+## process_id
+
+```kototype
+|| -> Number
+```
+
+Returns the ID associated with the current process.
+
 ## start_timer
 
 ```kototype

--- a/crates/cli/docs/core_lib/os.md
+++ b/crates/cli/docs/core_lib/os.md
@@ -2,6 +2,24 @@
 
 A collection of utilities for working with the operating system.
 
+## command
+
+```kototype
+|String| -> Command
+```
+
+Creates a new [Command](#command-2)
+
+### Example
+
+```koto,skip_run
+print! os.command('ls')
+  .args('/tmp', '-al')
+  .wait_for_output()
+  .stdout()
+check! ...
+```
+
 ## name
 
 ```kototype
@@ -38,20 +56,20 @@ print "Seconds between then and now: ${t2 - t}"
 || -> DateTime
 ```
 
-Returns a DateTime set to the current time, using the local timezone.
+Returns a [DateTime](#datetime) set to the current time, using the local timezone.
 
 ```kototype
 |timestamp: Number| -> DateTime
 ```
 
-Returns a DateTime set to the provided `timestamp` in seconds,
+Returns a [DateTime](#datetime) set to the provided `timestamp` in seconds,
 using the local timezone.
 
 ```kototype
 |timestamp: Number, offset: Number| -> DateTime
 ```
 
-Returns a DateTime set to the provided `timestamp` in seconds,
+Returns a [DateTime](#datetime) set to the provided `timestamp` in seconds,
 using an `offset` in seconds.
 
 ### Example
@@ -69,6 +87,327 @@ print! now.hour()
 print! now.timestamp()
 # e.g. 1639255874.53419
 ```
+
+## Command
+
+See [`os.command`](#command-1)
+
+## Command.args
+
+```kototype
+|Command, args...| -> Command
+```
+
+Adds the given arguments to the command, and returns the command
+
+### Example
+
+```koto,skip_run
+print! os.command('ls')
+  .args('/tmp', '-al')
+  .wait_for_output()
+  .stdout()
+check! ...
+```
+
+## Command.current_dir
+
+See [`os.command`](#command-1)
+
+## Command.args
+
+```kototype
+|Command, path: String| -> Command
+```
+
+Sets the command's working directory, and returns the command.
+
+### Example
+
+```koto,skip_run
+print! os.command('ls')
+  .current_dir('/tmp')
+  .wait_for_output()
+  .stdout()
+check! ...
+```
+
+## Command.env
+
+```kototype
+|Command, key: String, value: String| -> Command
+```
+
+Sets an environment variable, and returns the command.
+
+### Example
+
+```koto,skip_run
+assert os.command('env')
+  .env 'FOO', '123'
+  .wait_for_output()
+  .stdout()
+  .contains 'FOO=123'
+```
+
+## Command.env_clear
+
+```kototype
+|Command| -> Command
+```
+
+Clears all environment variables for the command, and returns the command.
+
+This prevents the command from inheriting any environment variables from the parent process.
+
+### Example
+
+```koto,skip_run
+assert os.command('env')
+  .env_clear()
+  .wait_for_output()
+  .stdout()
+  .is_empty()
+```
+
+## Command.env_remove
+
+```kototype
+|Command, key: String| -> Command
+```
+
+Removes the environment variable matching the given key, and returns the command.
+
+### Example
+
+```koto,skip_run
+assert os.command('env')
+  .env_clear()
+  .env 'FOO', '123'
+  .env_remove 'FOO'
+  .wait_for_output()
+  .stdout()
+  .is_empty()
+```
+
+## Command.stdin
+
+```kototype
+|Command, stream_config: String| -> Command
+```
+
+Configures the command's `stdin` stream.
+
+Valid values of `stream_config` are:
+- `inherit`: the stream will be inherited from the parent process.
+- `piped`: a pipe will be created to connect the parent and child processes.
+- `null`: the stream will be ignored.
+
+The default stream behavior is `inherit` when the command is used with `spawn` or `wait_for_exit`, and `piped` when used with `wait_for_output`.
+
+## Command.stdout
+
+```kototype
+|Command, stream_config: String| -> Command
+```
+
+Configures the command's `stdout` stream.
+
+See [Command.stdin](#Command.stdin) for valid values of `stream_config`.
+
+## Command.stderr
+
+```kototype
+|Command, stream_config: String| -> Command
+```
+
+Configures the command's `stderr` stream.
+
+See [Command.stdin](#Command.stdin) for valid values of `stream_config`.
+
+## Command.spawn
+
+```kototype
+|Command| -> Child
+```
+
+Executes the command, returning the command's [Child](#child) process.
+
+### Example
+
+```koto,skip_run
+spawned = os.command('ls')
+  .stdout('piped')
+  .spawn()
+print! spawned
+  .wait_for_output()
+  .stdout()
+check! ...
+```
+
+## Command.wait_for_output
+
+```kototype
+|Command| -> CommandOutput
+```
+
+Executes the command and waits for it to exit, returning its captured [output](#CommandOutput).
+
+### Example
+
+```koto,skip_run
+print! os.command('ls').wait_for_output().stdout()
+check! ...
+```
+
+## Command.wait_for_exit
+
+```kototype
+|Command| -> Number or Null
+```
+
+Executes the command and waits for it to exit, returning its exit code if the command exited normally, or `Null` if it was interrupted.
+
+### Example
+
+```koto,skip_run
+print! os.command('ls').wait_for_exit()
+check! 0
+```
+
+
+## CommandOutput
+
+Contains captured output from a command, and information about how the command exited.
+
+See [Command.wait_for_output](#command.wait_for_output) and [Child.wait_for_output](#child.wait_for_output).
+
+## CommandOutput.exit_code
+
+```kototype
+|CommandOutput| -> Number or Null
+```
+
+Returns the command's exit code if available.
+
+## CommandOutput.success
+
+```kototype
+|CommandOutput| -> Bool
+```
+
+Returns `true` if the command exited successfully.
+
+## CommandOutput.stdout
+
+```kototype
+|CommandOutput| -> String or Null
+```
+
+Returns the contents of the command's `stdout` stream if it contains valid unicode, or `null` otherwise.
+
+### See also
+
+- [Command.stdout_bytes](#Command.stdout_bytes)
+
+## CommandOutput.stderr
+
+```kototype
+|CommandOutput| -> String or Null
+```
+
+Returns the contents of the command's `stderr` stream if it contains valid unicode, or `null` otherwise.
+
+## CommandOutput.stdout_bytes
+
+```kototype
+|CommandOutput| -> Iterator
+```
+
+Returns an iterator that yields the bytes contained in the command's `stdout` stream.
+
+## CommandOutput.stderr_bytes
+
+```kototype
+|CommandOutput| -> Iterator
+```
+
+Returns an iterator that yields the bytes contained in the command's `stderr` stream.
+
+## Child
+
+A handle to a child process, see [Command.spawn](#command.spawn).
+
+## Child.stdin
+
+```kototype
+|Child| -> File
+```
+
+Returns the child process's `stdin` standard input stream as a [File](./io.md#File) that supports write operations.
+
+### Example
+
+```koto,skip_run
+spawned = os.command('cat')
+  .stdin 'piped'
+  .spawn()
+
+stdin = spawned.stdin()
+stdin.write_line 'hello'
+stdin.write_line 'one two three'
+
+print! spawned.wait_for_output().stdout()
+check! hello
+check! one two three
+```
+
+## Child.stdout
+
+```kototype
+|Child| -> File
+```
+
+Returns the child process's `stdout` standard output stream as a [File](./io.md#File) that supports read operations.
+
+Calling this function will prevent the stream from being included in [wait_for_output](#Child.wait_for_output).
+
+## Child.stderr
+
+```kototype
+|Child| -> File
+```
+
+Returns the child process's `stderr` standard error stream as a [File](./io.md#File) that supports read operations.
+
+Calling this function will prevent the stream from being included in [wait_for_output](#Child.wait_for_output).
+
+## Child.has_exited
+
+```kototype
+|Child| -> Bool
+```
+
+Returns `true` without blocking if the child process has exited, and `false` otherwise.
+
+## Child.wait_for_output
+
+```kototype
+|Child| -> CommandOutput
+```
+
+Closes all input and output streams, waits for the command to exit, and then returns the captured output.
+
+Note that if the `stdout` or `stderr` streams were manually retrieved via [Child.stdout](#Child.stdout)/[Child.stderr](#Child.stderr) then they won't be included in the captured output.
+
+## Child.wait_for_exit
+
+```kototype
+|Child| -> Number or Null
+```
+
+Closes all input and output streams, waits for the command to exit, and then returns the command's exit code if available.
+
 
 ## DateTime
 

--- a/crates/koto/tests/koto_tests.rs
+++ b/crates/koto/tests/koto_tests.rs
@@ -107,6 +107,7 @@ mod koto_tests {
     koto_test!(line_breaks);
     koto_test!(load_and_run);
     koto_test!(meta_maps);
+    koto_test!(os);
     koto_test!(primes);
 
     koto_test!(error_handling, "error_handling_module/main.koto");

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -153,6 +153,11 @@ pub struct File(Ptr<dyn KotoFile>);
 
 #[koto_impl(runtime = crate)]
 impl File {
+    /// Creates a new [File] from a value that implements [KotoFile]
+    pub fn new(file: Ptr<dyn KotoFile>) -> Self {
+        Self(file)
+    }
+
     /// Wraps a file that implements traits typical of a system file in a buffered reader/writer
     pub fn system_file<T>(file: T, path: PathBuf) -> KValue
     where

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -59,7 +59,7 @@ pub fn make_module() -> KMap {
                 .parent()
                 .and_then(|parent| parent.to_str())
                 .and_then(|parent| source_path.with_bounds(0..parent.len()))
-                .map_or(KValue::Null, KValue::from),
+                .into(),
             None => KValue::Null,
         };
         Ok(result)

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -1,5 +1,8 @@
 //! The `os` core library module
 
+mod command;
+
+use self::command::Command;
 use crate::{derive::*, prelude::*, Result};
 use chrono::prelude::*;
 use instant::Instant;
@@ -9,6 +12,11 @@ pub fn make_module() -> KMap {
     use KValue::Number;
 
     let result = KMap::with_type("core.os");
+
+    result.add_fn("command", |ctx| match ctx.args() {
+        [KValue::Str(command)] => Ok(Command::make_value(command)),
+        unexpected => unexpected_args("|String|", unexpected),
+    });
 
     result.add_fn("name", |ctx| match ctx.args() {
         [] => Ok(std::env::consts::OS.into()),

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -23,6 +23,22 @@ pub fn make_module() -> KMap {
         unexpected => unexpected_args("||", unexpected),
     });
 
+    result.add_fn("process_id", |ctx| match ctx.args() {
+        [] => {
+            #[cfg(target_arch = "wasm32")]
+            {
+                // `process::id()` panics on wasm targets
+                return runtime_error!(crate::ErrorKind::UnsupportedPlatform);
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Ok(std::process::id().into())
+            }
+        }
+        unexpected => unexpected_args("||", unexpected),
+    });
+
     result.add_fn("start_timer", |ctx| match ctx.args() {
         [] => Ok(Timer::now()),
         unexpected => unexpected_args("||", unexpected),

--- a/crates/runtime/src/core_lib/os/command.rs
+++ b/crates/runtime/src/core_lib/os/command.rs
@@ -1,0 +1,468 @@
+//! Support for `os.command`
+
+use crate::{
+    core_lib::io::{map_io_err, File},
+    derive::*,
+    prelude::*,
+    Result,
+};
+use koto_memory::{Ptr, PtrMut};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::process;
+
+macro_rules! stdio_setter {
+    ($stream:ident, $ctx:expr) => {{
+        let this = $ctx.instance_mut()?;
+        let mut command = this.0.borrow_mut();
+
+        match $ctx.args {
+            [KValue::Str(s)] => match s.as_str() {
+                "inherit" => {
+                    command.$stream(process::Stdio::inherit());
+                }
+                "null" => {
+                    command.$stream(process::Stdio::null());
+                }
+                "piped" => {
+                    command.$stream(process::Stdio::piped());
+                }
+                unexpected => {
+                    return runtime_error!(
+                        "Expected 'inherit', 'null', or 'piped', found '{unexpected}'"
+                    )
+                }
+            },
+            unexpected => return unexpected_args("|String|", unexpected),
+        }
+
+        $ctx.instance_result()
+    }};
+}
+
+/// A wrapper for [std::process::Command], used by `os.command`
+#[derive(Clone, Debug, KotoCopy, KotoType)]
+pub struct Command(PtrMut<process::Command>);
+
+#[koto_impl(runtime = crate)]
+impl Command {
+    pub fn make_value(command: &str) -> KValue {
+        let command = make_ptr_mut!(process::Command::new(command));
+        KObject::from(Self(command)).into()
+    }
+
+    #[koto_method]
+    fn args(ctx: MethodContext<Self>) -> Result<KValue> {
+        let this = ctx.instance_mut()?;
+        let mut command = this.0.borrow_mut();
+        for arg in ctx.args {
+            match arg {
+                KValue::Str(arg) => command.arg(arg.as_str()),
+                unexpected => return unexpected_type("String as arg", unexpected),
+            };
+        }
+
+        ctx.instance_result()
+    }
+
+    #[koto_method]
+    fn current_dir(ctx: MethodContext<Self>) -> Result<KValue> {
+        let this = ctx.instance_mut()?;
+        let mut command = this.0.borrow_mut();
+
+        match ctx.args {
+            [KValue::Str(path)] => {
+                command.current_dir(path.as_str());
+            }
+            unexpected => return unexpected_args("|String|", unexpected),
+        }
+
+        ctx.instance_result()
+    }
+
+    #[koto_method]
+    fn env(ctx: MethodContext<Self>) -> Result<KValue> {
+        let this = ctx.instance_mut()?;
+        let mut command = this.0.borrow_mut();
+
+        match ctx.args {
+            [KValue::Str(key), KValue::Str(value)] => {
+                command.env(key.as_str(), value.as_str());
+            }
+            unexpected => return unexpected_args("|String, String|", unexpected),
+        }
+
+        ctx.instance_result()
+    }
+
+    #[koto_method]
+    fn env_clear(ctx: MethodContext<Self>) -> Result<KValue> {
+        ctx.instance_mut()?.0.borrow_mut().env_clear();
+        ctx.instance_result()
+    }
+
+    #[koto_method]
+    fn env_remove(ctx: MethodContext<Self>) -> Result<KValue> {
+        let this = ctx.instance_mut()?;
+        let mut command = this.0.borrow_mut();
+
+        match ctx.args {
+            [KValue::Str(key)] => {
+                command.env_remove(key.as_str());
+            }
+            unexpected => return unexpected_args("|String|", unexpected),
+        }
+
+        ctx.instance_result()
+    }
+
+    #[koto_method]
+    fn stdin(ctx: MethodContext<Self>) -> Result<KValue> {
+        stdio_setter!(stdin, ctx)
+    }
+
+    #[koto_method]
+    fn stdout(ctx: MethodContext<Self>) -> Result<KValue> {
+        stdio_setter!(stdout, ctx)
+    }
+
+    #[koto_method]
+    fn stderr(ctx: MethodContext<Self>) -> Result<KValue> {
+        stdio_setter!(stderr, ctx)
+    }
+
+    #[koto_method]
+    fn spawn(&mut self) -> Result<KValue> {
+        match self.0.borrow_mut().spawn() {
+            Ok(child) => Ok(Child::make_value(child)),
+            Err(error) => runtime_error!("{error}"),
+        }
+    }
+
+    #[koto_method]
+    fn wait_for_output(&mut self) -> Result<KValue> {
+        match self.0.borrow_mut().output() {
+            Ok(output) => Ok(CommandOutput::make_value(output)),
+            Err(error) => runtime_error!("{error}"),
+        }
+    }
+
+    #[koto_method]
+    fn wait_for_exit(&mut self) -> Result<KValue> {
+        match self.0.borrow_mut().status() {
+            Ok(status) => match status.code() {
+                Some(code) => Ok(code.into()),
+                None => Ok(KValue::Null),
+            },
+            Err(error) => runtime_error!("{error}"),
+        }
+    }
+}
+
+impl KotoObject for Command {
+    fn display(&self, ctx: &mut DisplayContext) -> Result<()> {
+        ctx.append(format!(
+            "Command('{}')",
+            self.0.borrow_mut().get_program().to_string_lossy()
+        ));
+        Ok(())
+    }
+}
+
+/// A wrapper for [std::process::Output], used by `os.command`
+#[derive(Clone, Debug, KotoCopy, KotoType)]
+struct CommandOutput(process::Output);
+
+#[koto_impl(runtime = crate)]
+impl CommandOutput {
+    fn make_value(output: process::Output) -> KValue {
+        KObject::from(Self(output)).into()
+    }
+
+    #[koto_method]
+    fn exit_code(&self) -> KValue {
+        self.0.status.code().map_or(KValue::Null, KValue::from)
+    }
+
+    #[koto_method]
+    fn success(&self) -> KValue {
+        self.0.status.success().into()
+    }
+
+    #[koto_method]
+    fn stdout(&self) -> KValue {
+        let bytes = self.0.stdout.clone();
+        String::from_utf8(bytes).map_or(KValue::Null, KValue::from)
+    }
+
+    #[koto_method]
+    fn stderr(&self) -> KValue {
+        let bytes = self.0.stderr.clone();
+        String::from_utf8(bytes).map_or(KValue::Null, KValue::from)
+    }
+
+    #[koto_method]
+    fn stdout_bytes(&self) -> Result<KValue> {
+        let bytes = self.0.stdout.clone().into();
+        let iterator = KIterator::with_bytes(bytes)?;
+        Ok(iterator.into())
+    }
+
+    #[koto_method]
+    fn stderr_bytes(&self) -> Result<KValue> {
+        let bytes = self.0.stderr.clone().into();
+        let iterator = KIterator::with_bytes(bytes)?;
+        Ok(iterator.into())
+    }
+}
+
+impl KotoObject for CommandOutput {}
+
+/// A wrapper for [std::process::Child], used by `os.command.spawn`
+#[derive(Clone, KotoCopy, KotoType)]
+struct Child {
+    handle: PtrMut<Option<process::Child>>,
+    // Keep track of stream handles that have been accessed by the user. This allows the streams to
+    // be closed without user intervention when waiting for the command to exit. This also allows us
+    // to provide a more helpful error message if the stream is reused after the command has exited.
+    stdin: Option<(ChildStdin, KValue)>,
+    stdout: Option<(ChildStdout, KValue)>,
+    stderr: Option<(ChildStderr, KValue)>,
+}
+
+macro_rules! child_stream_fn {
+    ($self:expr, $stream:ident, $buffer_wrapper:ident, $child_stream:ident) => {{
+        let mut this = $self.handle.borrow_mut();
+        let Some(child) = this.as_mut() else {
+            return runtime_error!("The process has already finished");
+        };
+
+        match child.$stream.take() {
+            Some(stream) => {
+                let stream = $child_stream(make_ptr_mut!(Some($buffer_wrapper::new(stream))));
+                let result = KValue::from(File::new(make_ptr!(stream.clone())));
+                $self.$stream = Some((stream, result.clone()));
+                Ok(result)
+            }
+            None => match $self.$stream.as_ref() {
+                Some((_, stream_value)) => Ok(stream_value.clone()),
+                None => runtime_error!("{} has already been captured", stringify!($stream)),
+            },
+        }
+    }};
+}
+
+#[koto_impl(runtime = crate)]
+impl Child {
+    pub fn make_value(child: process::Child) -> KValue {
+        KObject::from(Self {
+            handle: make_ptr_mut!(Some(child)),
+            stdin: None,
+            stdout: None,
+            stderr: None,
+        })
+        .into()
+    }
+
+    #[koto_method]
+    fn id(&self) -> Result<KValue> {
+        let mut this = self.handle.borrow_mut();
+        let Some(child) = this.as_mut() else {
+            return runtime_error!("The process has already finished");
+        };
+        Ok(child.id().into())
+    }
+
+    #[koto_method]
+    fn stdin(&mut self) -> Result<KValue> {
+        child_stream_fn!(self, stdin, BufWriter, ChildStdin)
+    }
+
+    #[koto_method]
+    fn stdout(&mut self) -> Result<KValue> {
+        child_stream_fn!(self, stdout, BufReader, ChildStdout)
+    }
+
+    #[koto_method]
+    fn stderr(&mut self) -> Result<KValue> {
+        child_stream_fn!(self, stderr, BufReader, ChildStderr)
+    }
+
+    #[koto_method]
+    fn has_exited(&mut self) -> Result<KValue> {
+        let mut this = self.handle.borrow_mut();
+        let Some(child) = this.as_mut() else {
+            return Ok(true.into());
+        };
+
+        match child.try_wait() {
+            Ok(Some(_)) => Ok(true.into()),
+            Ok(None) => Ok(false.into()),
+            Err(error) => runtime_error!("{error}"),
+        }
+    }
+
+    #[koto_method]
+    fn kill(&mut self) -> Result<KValue> {
+        let mut this = self.handle.borrow_mut();
+
+        let Some(child) = this.as_mut() else {
+            return runtime_error!("The process has already finished");
+        };
+
+        match child.kill() {
+            Ok(_) => {
+                *this = None;
+                Ok(true.into())
+            }
+            Err(_) => Ok(false.into()),
+        }
+    }
+
+    #[koto_method]
+    fn wait_for_output(&mut self) -> Result<KValue> {
+        self.close_streams();
+
+        let Some(child) = self.handle.borrow_mut().take() else {
+            return runtime_error!("The process has already finished");
+        };
+
+        match child.wait_with_output() {
+            Ok(output) => Ok(CommandOutput::make_value(output)),
+            Err(error) => runtime_error!("{error}"),
+        }
+    }
+
+    #[koto_method]
+    fn wait_for_exit(&mut self) -> Result<KValue> {
+        self.close_streams();
+
+        let mut this = self.handle.borrow_mut();
+        let Some(child) = this.as_mut() else {
+            return runtime_error!("The process has already finished");
+        };
+
+        match child.wait() {
+            Ok(status) => match status.code() {
+                Some(code) => Ok(code.into()),
+                None => Ok(KValue::Null),
+            },
+            Err(error) => runtime_error!("{error}"),
+        }
+    }
+
+    fn close_streams(&mut self) {
+        if let Some((stream, _)) = self.stdin.take() {
+            *stream.0.borrow_mut() = None;
+        }
+        if let Some((stream, _)) = self.stdout.take() {
+            *stream.0.borrow_mut() = None;
+        }
+        if let Some((stream, _)) = self.stderr.take() {
+            *stream.0.borrow_mut() = None;
+        }
+    }
+}
+
+impl KotoObject for Child {}
+
+#[derive(Clone)]
+struct ChildStdin(PtrMut<Option<BufWriter<process::ChildStdin>>>);
+
+impl KotoFile for ChildStdin {
+    fn id(&self) -> KString {
+        "_child_stdin_".into()
+    }
+}
+
+impl KotoRead for ChildStdin {}
+impl KotoWrite for ChildStdin {
+    fn write(&self, bytes: &[u8]) -> Result<()> {
+        match self.0.borrow_mut().as_mut() {
+            Some(stream) => stream.write_all(bytes).map_err(map_io_err),
+            None => runtime_error!("The stream has been closed"),
+        }
+    }
+
+    fn write_line(&self, output: &str) -> Result<()> {
+        self.write(output.as_bytes())?;
+        match self.0.borrow_mut().as_mut() {
+            Some(stream) => stream.write_all("\n".as_bytes()).map_err(map_io_err),
+            None => runtime_error!("The stream has been closed"),
+        }
+    }
+
+    fn flush(&self) -> Result<()> {
+        match self.0.borrow_mut().as_mut() {
+            Some(stream) => stream.flush().map_err(map_io_err),
+            None => runtime_error!("The stream has been closed"),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ChildStdout(PtrMut<Option<BufReader<process::ChildStdout>>>);
+
+impl KotoFile for ChildStdout {
+    fn id(&self) -> KString {
+        "_child_stdout_".into()
+    }
+}
+
+impl KotoRead for ChildStdout {
+    fn read_line(&self) -> Result<Option<String>> {
+        let mut result = String::new();
+        let bytes_read = match self.0.borrow_mut().as_mut() {
+            Some(stream) => stream.read_line(&mut result).map_err(map_io_err)?,
+            None => return runtime_error!("The stream has been closed"),
+        };
+        if bytes_read > 0 {
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn read_to_string(&self) -> Result<String> {
+        let mut result = String::new();
+        match self.0.borrow_mut().as_mut() {
+            Some(stream) => stream.read_to_string(&mut result).map_err(map_io_err)?,
+            None => return runtime_error!("The stream has been closed"),
+        };
+        Ok(result)
+    }
+}
+impl KotoWrite for ChildStdout {}
+
+#[derive(Clone)]
+struct ChildStderr(PtrMut<Option<BufReader<process::ChildStderr>>>);
+
+impl KotoFile for ChildStderr {
+    fn id(&self) -> KString {
+        "_child_stderr_".into()
+    }
+}
+
+impl KotoRead for ChildStderr {
+    fn read_line(&self) -> Result<Option<String>> {
+        let mut result = String::new();
+        let bytes_read = match self.0.borrow_mut().as_mut() {
+            Some(stream) => stream.read_line(&mut result).map_err(map_io_err)?,
+            None => return runtime_error!("The stream has been closed"),
+        };
+        if bytes_read > 0 {
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn read_to_string(&self) -> Result<String> {
+        let mut result = String::new();
+        match self.0.borrow_mut().as_mut() {
+            Some(stream) => stream.read_to_string(&mut result).map_err(map_io_err)?,
+            None => return runtime_error!("The stream has been closed"),
+        };
+        Ok(result)
+    }
+}
+impl KotoWrite for ChildStderr {}

--- a/crates/runtime/src/core_lib/os/command.rs
+++ b/crates/runtime/src/core_lib/os/command.rs
@@ -180,7 +180,7 @@ impl CommandOutput {
 
     #[koto_method]
     fn exit_code(&self) -> KValue {
-        self.0.status.code().map_or(KValue::Null, KValue::from)
+        self.0.status.code().into()
     }
 
     #[koto_method]
@@ -191,13 +191,13 @@ impl CommandOutput {
     #[koto_method]
     fn stdout(&self) -> KValue {
         let bytes = self.0.stdout.clone();
-        String::from_utf8(bytes).map_or(KValue::Null, KValue::from)
+        String::from_utf8(bytes).ok().into()
     }
 
     #[koto_method]
     fn stderr(&self) -> KValue {
         let bytes = self.0.stderr.clone();
-        String::from_utf8(bytes).map_or(KValue::Null, KValue::from)
+        String::from_utf8(bytes).ok().into()
     }
 
     #[koto_method]

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -62,6 +62,8 @@ pub enum ErrorKind {
     MissingSequenceBuilder,
     #[error("Missing string builder")]
     MissingStringBuilder,
+    #[error("This operation is unsupported on this platform")]
+    UnsupportedPlatform,
     #[error("An unexpected error occurred, please report this as a bug at https://github.com/koto-lang/koto/issues")]
     UnexpectedError,
 }

--- a/crates/runtime/src/io/stdio.rs
+++ b/crates/runtime/src/io/stdio.rs
@@ -1,4 +1,4 @@
-use crate::{core_lib::io::map_io_err, Error, KString, KotoFile, KotoRead, KotoWrite};
+use crate::{core_lib::io::map_io_err, KString, KotoFile, KotoRead, KotoWrite, Result};
 use std::io::{self, IsTerminal, Read, Write};
 
 /// The default stdin used in Koto
@@ -17,13 +17,17 @@ impl KotoFile for DefaultStdin {
 
 impl KotoWrite for DefaultStdin {}
 impl KotoRead for DefaultStdin {
-    fn read_line(&self) -> Result<Option<String>, Error> {
+    fn read_line(&self) -> Result<Option<String>> {
         let mut result = String::new();
-        io::stdin().read_line(&mut result).map_err(map_io_err)?;
-        Ok(Some(result))
+        let bytes_read = io::stdin().read_line(&mut result).map_err(map_io_err)?;
+        if bytes_read > 0 {
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
     }
 
-    fn read_to_string(&self) -> Result<String, Error> {
+    fn read_to_string(&self) -> Result<String> {
         let mut result = String::new();
         io::stdin()
             .lock()
@@ -49,18 +53,18 @@ impl KotoFile for DefaultStdout {
 
 impl KotoRead for DefaultStdout {}
 impl KotoWrite for DefaultStdout {
-    fn write(&self, bytes: &[u8]) -> Result<(), Error> {
+    fn write(&self, bytes: &[u8]) -> Result<()> {
         io::stdout().write_all(bytes).map_err(map_io_err)
     }
 
-    fn write_line(&self, output: &str) -> Result<(), Error> {
+    fn write_line(&self, output: &str) -> Result<()> {
         let stdout = io::stdout();
         let mut handle = stdout.lock();
         handle.write_all(output.as_bytes()).map_err(map_io_err)?;
         handle.write_all("\n".as_bytes()).map_err(map_io_err)
     }
 
-    fn flush(&self) -> Result<(), Error> {
+    fn flush(&self) -> Result<()> {
         io::stdout().flush().map_err(map_io_err)
     }
 }
@@ -81,18 +85,18 @@ impl KotoFile for DefaultStderr {
 
 impl KotoRead for DefaultStderr {}
 impl KotoWrite for DefaultStderr {
-    fn write(&self, bytes: &[u8]) -> Result<(), Error> {
+    fn write(&self, bytes: &[u8]) -> Result<()> {
         io::stderr().write_all(bytes).map_err(map_io_err)
     }
 
-    fn write_line(&self, output: &str) -> Result<(), Error> {
+    fn write_line(&self, output: &str) -> Result<()> {
         let stderr = io::stderr();
         let mut handle = stderr.lock();
         handle.write_all(output.as_bytes()).map_err(map_io_err)?;
         handle.write_all("\n".as_bytes()).map_err(map_io_err)
     }
 
-    fn flush(&self) -> Result<(), Error> {
+    fn flush(&self) -> Result<()> {
         io::stderr().flush().map_err(map_io_err)
     }
 }

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -425,7 +425,18 @@ impl<'a, T: KotoObject> MethodContext<'a, T> {
         self.object.cast_mut::<T>()
     }
 
-    /// Helper for methods that need to return a clone of the instance as the method result
+    /// Returns a clone of the instance as a [KValue]
+    ///
+    /// This is useful for builder methods.
+    /// e.g.
+    ///
+    /// ```koto
+    /// make_foo()
+    ///   .set_x 99
+    ///   .set_y 123
+    /// ```
+    ///
+    /// Here `set_x` and `set_y` would use `instance_result` to allow the builder chain to continue.
     pub fn instance_result(&self) -> Result<KValue> {
         Ok(self.object.clone().into())
     }

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -309,6 +309,18 @@ where
     }
 }
 
+impl<T> From<Option<T>> for KValue
+where
+    T: Into<KValue>,
+{
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(value) => value.into(),
+            None => KValue::Null,
+        }
+    }
+}
+
 /// A slice of a VM's register stack
 ///
 /// See [Value::TemporaryTuple]

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -1227,7 +1227,7 @@ impl KotoVm {
             }
             Str(s) => {
                 let index = signed_index_to_unsigned(index, s.len());
-                s.with_bounds(index..index + 1).map_or(Null, KValue::from)
+                s.with_bounds(index..index + 1).into()
             }
             Map(map) if map.contains_meta_key(&index_op) => {
                 let op = map.get_meta_value(&index_op).unwrap();
@@ -1279,17 +1279,17 @@ impl KotoVm {
             Tuple(tuple) => {
                 let index = signed_index_to_unsigned(index, tuple.len());
                 if is_slice_to {
-                    tuple.make_sub_tuple(0..index).map_or(Null, Tuple)
+                    tuple.make_sub_tuple(0..index).into()
                 } else {
-                    tuple.make_sub_tuple(index..tuple.len()).map_or(Null, Tuple)
+                    tuple.make_sub_tuple(index..tuple.len()).into()
                 }
             }
             Str(s) => {
                 let index = signed_index_to_unsigned(index, s.len());
                 if is_slice_to {
-                    s.with_bounds(0..index).map_or(Null, KValue::from)
+                    s.with_bounds(0..index).into()
                 } else {
-                    s.with_bounds(index..s.len()).map_or(Null, KValue::from)
+                    s.with_bounds(index..s.len()).into()
                 }
             }
             Map(m) if m.contains_meta_key(&index_op) => {

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -398,6 +398,21 @@ x
 ";
                 check_script_fails(script);
             }
+
+            #[test]
+            fn missing_value_on_rhs() {
+                let script = "\
+1 + foo
+#   ^^^
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 0, column: 4 },
+                        end: Position { line: 0, column: 7 },
+                    },
+                );
+            }
         }
 
         mod iterators {
@@ -555,6 +570,46 @@ x.insert (1, [2, 3]), 'hello'
 ";
                 check_script_fails(script);
             }
+
+            #[test]
+            fn missing_entry() {
+                let script = "\
+foo = {}
+foo.missing_entry()
+#   ^^^^^^^^^^^^^
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 1, column: 4 },
+                        end: Position {
+                            line: 1,
+                            column: 17,
+                        },
+                    },
+                )
+            }
+
+            #[test]
+            fn missing_entry_on_new_line() {
+                let script = "\
+foo = {bar: {}}
+foo
+  .bar
+  .missing_entry()
+#  ^^^^^^^^^^^^^
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 3, column: 3 },
+                        end: Position {
+                            line: 3,
+                            column: 16,
+                        },
+                    },
+                )
+            }
         }
 
         mod meta_maps {
@@ -609,6 +664,24 @@ x = '{foo}'
 x = r################################################################################################################################################################################################################################################################'foo'################################################################################################################################################################################################################################################################
 ";
                 check_script_fails(script);
+            }
+
+            #[test]
+            fn invalid_string_op_on_new_line() {
+                // Check that the span is correct for invalid string ops
+
+                let script = "\
+'testing'
+  .xxxx()
+#  ^^^^
+";
+                check_script_fails_with_span(
+                    script,
+                    Span {
+                        start: Position { line: 1, column: 3 },
+                        end: Position { line: 1, column: 7 },
+                    },
+                )
             }
         }
     }

--- a/koto/tests/os.koto
+++ b/koto/tests/os.koto
@@ -1,3 +1,6 @@
+@test process_id = ||
+  assert os.process_id() > 0
+
 @test wait_for_command_output = ||
   output = os.command('echo')
     .args 'testing', 'one', 'two', 'three'

--- a/koto/tests/os.koto
+++ b/koto/tests/os.koto
@@ -1,0 +1,37 @@
+@test wait_for_command_output = ||
+  output = os.command('echo')
+    .args 'testing', 'one', 'two', 'three'
+    .wait_for_output()
+
+  assert_eq output.exit_code(), 0
+  assert_eq output.stdout(), 'testing one two three\n'
+  assert_eq output.stderr(), ''
+
+@test spawn_command = ||
+  spawned = os.command('cat')
+    .stdin 'piped'
+    .stdout 'piped'
+    .stderr 'piped'
+    .spawn()
+
+  spawned.stdin().write 'abc, '
+  spawned.stdin().write '123'
+  spawned.stdin().flush()
+
+  assert spawned.id() > 0
+  assert not spawned.has_exited()
+
+  output = spawned.wait_for_output()
+  assert spawned.has_exited()
+
+  assert_eq output.exit_code(), 0
+  assert_eq output.stdout(), 'abc, 123'
+  assert_eq output.stderr(), ''
+
+@test kill_spawned_command = ||
+  spawned = os.command('cat')
+    .stdin 'piped'
+    .spawn()
+
+  assert not spawned.has_exited()
+  assert spawned.kill()


### PR DESCRIPTION
This PR introduces `os.command`, a wrapper for Rust's `std::process` library which allows for running executables and dealing with child processes. 
