### PR TITLE
Fix loading previously declared variables in the REPL

### DIFF
--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -151,7 +151,16 @@ impl Repl {
 
             self.editor.add_history_entry(&input)?;
 
-            match self.koto.compile(&input) {
+            let compile_args = CompileArgs {
+                script: &input,
+                script_path: None,
+                compiler_settings: CompilerSettings {
+                    export_top_level_ids: true,
+                    enable_type_checks: true,
+                },
+            };
+
+            match self.koto.compile(compile_args) {
                 Ok(chunk) => {
                     if self.settings.show_bytecode {
                         print_wrapped!(self.stdout, "{}\n", &Chunk::bytes_as_string(&chunk))?;

--- a/crates/koto/src/prelude.rs
+++ b/crates/koto/src/prelude.rs
@@ -1,5 +1,5 @@
 //! A collection of useful items to make it easier to work with `koto`
 
 pub use crate::{CompileArgs, Koto, KotoSettings};
-pub use koto_bytecode::{Chunk, Loader, LoaderError};
+pub use koto_bytecode::{Chunk, CompilerSettings, Loader, LoaderError};
 pub use koto_runtime::prelude::*;


### PR DESCRIPTION
The REPL was broken due to an oversight in
550bf34d07991ab6cc8ad3e92934f6494610e277

It's annoying that we don't have tests specifically for the REPL.
The 'repl mode' tests ensure that values are being exported when the
'export top-level ids' flag is set, but not that the flag is actually
being used by the REPL.
