### PR TITLE
Make the runtime single-threaded by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Test with optimizations
         run: just test_release --verbose
 
-  build_and_test_rc:
-    # We don't need to test rc builds on all platforms for now
+  build_and_test_arc:
+    # We don't need to test arc builds on all platforms for now
     runs-on: ubuntu-latest
 
     steps:
@@ -54,11 +54,11 @@ jobs:
         with:
           tool: just@1.5.0
 
-      - name: Test the rc build variant
-        run: just test_rc --verbose
+      - name: Test the arc build variant
+        run: just test_arc --verbose
 
-  build_and_test_release_rc:
-    # We don't need to test rc builds on all platforms for now
+  build_and_test_release_arc:
+    # We don't need to test arc builds on all platforms for now
     runs-on: ubuntu-latest
 
     steps:
@@ -68,8 +68,8 @@ jobs:
         with:
           tool: just@1.5.0
 
-      - name: Test the rc build variant
-        run: just test_rc --release --verbose
+      - name: Test the arc build variant
+        run: just test_arc --release --verbose
 
   code_checks:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ The Koto project adheres to
 
 #### API
 
+- The single-threaded runtime flavor (`rc`) is now the default.
+  Applications that require a multi-threaded runtime should disable default
+  features and use the `arc` feature.
 - The line and column numbers referred to in spans are now zero-based. 
 - Functions that previously took `Option<PathBuf>` now take `Option<&Path>`.
 - `AstIndex` and `ConstantIndex` are now newtypes that wrap `u32`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,27 @@ Thank you for your interest in contributing to Koto!
 
 Please feel free to [open an issue](https://github.com/koto-lang/koto/issues/new) if you find a problem in Koto.
 
-## Working on issues
-
-Please feel to take a look at the [open issues](https://github.com/koto-lang/koto/issues/) to see if there's something you'd like to work on. If you don't see anything that fits your interests then you're welcome to ask on [Discord](https://discord.gg/JeV8RuK4CT).
-
 ## Improving the docs
 
 As Koto is a new language with a goal of being easy to learn, one of the most important contributions you can make is to read the [language guide](https::/koto.dev/docs/next/language) and [core library reference](https::/koto.dev/docs/next/core_lib). If you find something confusing or incomplete, then its likely that others will to, and your suggestions for improvements will be invaluable.
 
 The documentation is maintained in [this repo](./crates/cli/docs). To see how changes to the documentation look on the website, take a look at the [website's contributing guide](https://github.com/koto-lang/koto.dev/tree/main/CONTRIBUTING.md).
 
+## Working on issues
+
+Please feel to take a look at the [open issues](https://github.com/koto-lang/koto/issues/) to see if there's something you'd like to work on. If you don't see anything that fits your interests then you're welcome to ask on [Discord](https://discord.gg/JeV8RuK4CT).
+
+## Adding new libraries
+
+The [`libs`](./libs/) directory includes several non-core libraries for Koto, and until Koto has a package management system, more could be added as long as they don't pull in large dependencies.
+
+If you would like to add a new library, please make a proposal first in a new issue or discussion.
+
+Libraries should include documentation for all new Koto functions in the [lib docs directory](./crates/cli/docs/libs/).
+
 ## Improving the website
 
-The [Koto website](https::koto.dev) is in [this repo](https://github.com/koto-lang/koto.dev) 
+The [Koto website](https::koto.dev) is in [this repo](https://github.com/koto-lang/koto.dev), please refer to [its contributing guide](https://github.com/koto-lang/koto.dev/CONTRIBUTING.md).
 
 ## Improving performance
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 members = ["crates/*", "crates/koto/examples/*", "libs/*"]
 resolver = "2"
 
+[workspace.package]
+authors = ["irh <ian.r.hobson@gmail.com>"]
+edition = "2021"
+homepage = "https://koto.dev"
+keywords = ["scripting", "language", "koto"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/koto-lang/koto"
+
 [workspace.dependencies]
 # Flexible concrete Error type built on std::error::Error
 anyhow = "1.0.75"

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "koto_bytecode"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "The bytecode compiler used by the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_memory/arc"]
 rc = ["koto_memory/rc"]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,28 +1,38 @@
 [package]
 name = "koto_cli"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A CLI and script runner for the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
+[features]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
+arc = ["koto/arc"]
+rc = ["koto/rc"]
 
 [[bin]]
 name = "koto"
 path = "src/main.rs"
 
 [dependencies]
-koto = { path = "../koto", version = "^0.15.0" }
-koto_color = { path = "../../libs/color", version = "^0.15.0" }
-koto_geometry = { path = "../../libs/geometry", version = "^0.15.0" }
-koto_json = { path = "../../libs/json", version = "^0.15.0" }
-koto_random = { path = "../../libs/random", version = "^0.15.0" }
-koto_regex = { path = "../../libs/regex", version = "^0.15.0" }
-koto_tempfile = { path = "../../libs/tempfile", version = "^0.15.0" }
-koto_toml = { path = "../../libs/toml", version = "^0.15.0" }
-koto_yaml = { path = "../../libs/yaml", version = "^0.15.0" }
+koto = { path = "../koto", version = "^0.15.0", default-features = false }
+koto_color = { path = "../../libs/color", version = "^0.15.0", default-features = false }
+koto_geometry = { path = "../../libs/geometry", version = "^0.15.0", default-features = false }
+koto_json = { path = "../../libs/json", version = "^0.15.0", default-features = false }
+koto_random = { path = "../../libs/random", version = "^0.15.0", default-features = false }
+koto_regex = { path = "../../libs/regex", version = "^0.15.0", default-features = false }
+koto_tempfile = { path = "../../libs/tempfile", version = "^0.15.0", default-features = false }
+koto_toml = { path = "../../libs/toml", version = "^0.15.0", default-features = false }
+koto_yaml = { path = "../../libs/yaml", version = "^0.15.0", default-features = false }
 
 anyhow = { workspace = true }
 home = { workspace = true }

--- a/crates/cli/docs/about.md
+++ b/crates/cli/docs/about.md
@@ -73,16 +73,19 @@ the [CLI](./cli.md), and see how well it works in your
 - **Built-in testing:** Automated testing has
   [first-class support in Koto][testing], making it natural to write tests along
   with your code.
+- **Optional multi-threaded runtime** By default, Koto has a single-threaded
+  runtime. For applications that require multi-threaded scripting,
+  a [feature flag][api-multi-threaded] enables a thread-safe runtime.
 - **Tooling:** Support for Koto is available for [several popular editors](#editors).
   [Tree-sitter](#tree-sitter) and [LSP](#lsp) implementations are also available.
   Auto-formatting and linting are future topics, contributions are welcome!
 
 ### Missing/Incomplete Features
 
-- **Async tasks:** Koto doesn't have support for asynchronous tasks,
-  support [could be added][async] in the future.
+- **Async tasks:** Koto doesn't have support for `async`/`await`-style
+  asynchronous tasks, although support [is planned][async] for the future.
 - **Integration with other languages:** There's currently no C API for Koto,
-  which would allow it to be integrated with other languages.
+  which would allow it to be integrated with languages other than Rust.
 
 ## Influences
 
@@ -106,12 +109,12 @@ Plugins that provide Koto support are available for the following editors:
 - [Vim / Neovim](https://github.com/koto-lang/koto.vim)
 - [Sublime Text](https://github.com/koto-lang/koto-sublime)
 
-The next version of [Helix](https://helix-editor.com) editor will include built-in Koto support,
-and is available now if you're happy to [build it from source](https://docs.helix-editor.com/building-from-source.html).
+The upcoming release of [Helix][helix] editor will include built-in Koto support,
+and is available now if you [build it from source][helix-build].
 
 ### Tree-sitter
 
-A [Tree-sitter][tree-sitter] implementation is [available here](https://github.com/koto-lang/tree-sitter-koto).
+A [Tree-sitter][tree-sitter] implementation is [available here][tree-sitter-koto].
 If you're using Neovim then it's easy to set up with [nvim-treesitter][nvim-treesitter].
 
 ### LSP
@@ -119,12 +122,15 @@ If you're using Neovim then it's easy to set up with [nvim-treesitter][nvim-tree
 An implementation of the [Language Server Protocol][lsp] for Koto is
 [available here][koto-ls].
 
+---
 
-
+[api-multi-threaded]: ./api.md#using-the-multi-threaded-runtime
 [async]: https://github.com/koto-lang/koto/issues/277
 [coffeescript]: https://coffeescript.org
 [discord]: https://discord.gg/JeV8RuK4CT
 [discussions]: https://github.com/koto-lang/koto/discussions
+[helix]: https://helix-editor.com
+[helix-build]: https://docs.helix-editor.com/building-from-source.html
 [issues]: https://github.com/koto-lang/koto/issues
 [iterator]: ./core_lib/iterator.md
 [koto]: https://koto.dev
@@ -139,4 +145,5 @@ An implementation of the [Language Server Protocol][lsp] for Koto is
 [rust-iterators]: https://doc.rust-lang.org/rust-by-example/trait/iter.html
 [testing]: ./language_guide.md#testing
 [tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[tree-sitter-koto]: https://github.com/koto-lang/tree-sitter-koto
 [type-hints]: https://github.com/koto-lang/koto/issues/298

--- a/crates/cli/docs/api.md
+++ b/crates/cli/docs/api.md
@@ -1,12 +1,12 @@
 A rendered version of this document can be found
 [here](https://koto.dev/docs/next/api).
 
-The Rust code examples are included from the 
+The Rust code examples are included from the
 [Koto examples dir](../../koto/examples).
 
 ---
 
-# Rust API Cookbook
+# Rust API
 
 ## Hello World
 
@@ -21,7 +21,7 @@ hello_world.rs
 The result of calling `compile_and_run` is a `KValue`, which is Koto's main
 value type.
 
-`KValue` is an enum that contains variants for each of the core Koto types, 
+`KValue` is an enum that contains variants for each of the core Koto types,
 like `Number`, `String`, etc.
 
 The type of a `KValue` as a string can be retrieved via `KValue::type_as_string`,
@@ -42,11 +42,11 @@ exported_values.rs
 
 ## Adding Values to the Prelude
 
-The runtime's prelude is a `KMap`, which is Koto's standard hashmap type. 
+The runtime's prelude is a `KMap`, which is Koto's standard hashmap type.
 
 Values can be added to the prelude via `KMap::insert`, taking any Rust value
 that implements `Into<KValue>`. Basic types like strings and numbers are
-automatically converted to corresponding Koto types. 
+automatically converted to corresponding Koto types.
 
 ```rust_include
 prelude_value.rs
@@ -64,7 +64,7 @@ args.rs
 ## Calling Rust Functions in Koto
 
 Any Rust function that implements `KotoFunction` can be made available to the
-Koto runtime. 
+Koto runtime.
 
 ```rust_include
 rust_function.rs
@@ -95,10 +95,32 @@ module.rs
 
 Any Rust type that implements `KotoObject` can be used in the Koto runtime.
 `KotoObject` requires `KotoType`, `KotoCopy`, and `KotoEntries` to be
-implemented. 
+implemented.
 
 ```rust_include
 rust_object.rs
 ```
 
 [type]: ./language_guide.md#type
+
+## Using the multi-threaded runtime
+
+By default, Koto's runtime is single-threaded, and many of its core types (e.g. `KValue`) don't
+implement `Send` or `Sync`.
+
+For applications that need to support multi-threaded scripting, the `arc` feature switches from an
+`Rc<RefCell<T>>`-based memory strategy to one using `Arc<RwLock<T>>`.
+
+Only one memory strategy can be enabled at a time, so default features need to be disabled.
+
+```toml
+# Cargo.toml
+# ...
+
+[dependencies.koto]
+version = "0.15"
+default-feautures = false
+features = ["arc"]
+```
+
+---

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1502,7 +1502,7 @@ check! hello
 
 #### `Callable`
 
-The `Callable` type hint will accept functions, or any value that can behave
+The `Callable` type hint will accept functions, or any object that can behave
 like a function.
 
 ```koto
@@ -2437,8 +2437,11 @@ check! 99
 
 ### `@test` functions and `@main`
 
-A module can export `@test` functions, which will be automatically run after
-the module has been compiled and initialized.
+A module can export `@test` functions, which by default will be automatically run
+after the module has been compiled and initialized.
+
+The runtime can be configured to skip running tests, so scripts shouldn't rely on
+tests being run.
 
 Additionally, a module can export a `@main` function.
 The `@main` function will be called after the module has been compiled and

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -1,20 +1,24 @@
 [package]
 name = "koto_derive"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "Macros for working with the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [lib]
 proc-macro = true
 
 [features]
-default = ["arc"]
-# One memory management scheme can be enabled at a time
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = []
 rc = []
 

--- a/crates/koto/Cargo.toml
+++ b/crates/koto/Cargo.toml
@@ -1,18 +1,24 @@
 [package]
 name = "koto"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A simple, expressive, embeddable programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
+
 
 [dependencies]
 koto_bytecode = { path = "../bytecode", version = "^0.15.0", default-features = false }

--- a/crates/koto/examples/poetry/Cargo.toml
+++ b/crates/koto/examples/poetry/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "koto_poetry"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
 autobins = false
 publish = false
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[example]]
 name = "poetry"

--- a/crates/koto/examples/rust_function.rs
+++ b/crates/koto/examples/rust_function.rs
@@ -1,4 +1,4 @@
-use koto::prelude::*;
+use koto::{prelude::*, runtime::Result};
 
 fn main() {
     let script = "
@@ -21,7 +21,7 @@ print plus 10, 20
     koto.compile_and_run(script).unwrap();
 }
 
-fn say_hello(ctx: &mut CallContext) -> koto::Result<KValue> {
+fn say_hello(ctx: &mut CallContext) -> Result<KValue> {
     match ctx.args() {
         [] => println!("Hello?"),
         [KValue::Str(name)] => println!("Hello, {name}"),

--- a/crates/koto/examples/rust_object.rs
+++ b/crates/koto/examples/rust_object.rs
@@ -1,4 +1,4 @@
-use koto::{derive::*, prelude::*, Result};
+use koto::{derive::*, prelude::*, runtime::Result};
 
 fn main() {
     let script = "

--- a/crates/koto/examples/wasm/Cargo.toml
+++ b/crates/koto/examples/wasm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "koto_wasm"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/koto/src/error.rs
+++ b/crates/koto/src/error.rs
@@ -1,0 +1,61 @@
+use thiserror::Error;
+
+/// The different error types that can result from [Koto](crate::Koto) operations
+#[derive(Debug, Error, Clone)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error("{0}")]
+    StringError(String),
+    #[error("missing koto module in the prelude")]
+    MissingPrelude,
+    #[error("nothing to run")]
+    NothingToRun,
+    #[error("{error}")]
+    CompileError {
+        error: String,
+        is_indentation_error: bool,
+    },
+}
+
+impl Error {
+    /// Returns true if the error was caused by the parser expecting indentation
+    pub fn is_indentation_error(&self) -> bool {
+        match self {
+            Self::CompileError {
+                is_indentation_error,
+                ..
+            } => *is_indentation_error,
+            _ => false,
+        }
+    }
+}
+
+impl From<koto_runtime::Error> for Error {
+    fn from(error: koto_runtime::Error) -> Self {
+        use koto_runtime::ErrorKind as RuntimeError;
+
+        // Runtime errors aren't Send+Sync when compiled without multi-threaded support,
+        // so render the error message to a String.
+        match error.error {
+            RuntimeError::StringError(error) => Self::StringError(error),
+            // Preserve compilation errors so they can be inspected by
+            // [`is_indentation_error`](Self::is_indentation_error).
+            RuntimeError::CompileError(error) => Self::from(error),
+            _ => Self::StringError(error.to_string()),
+        }
+    }
+}
+
+impl From<koto_bytecode::LoaderError> for Error {
+    fn from(error: koto_bytecode::LoaderError) -> Self {
+        // Loader errors aren't Send+Sync when compiled without multi-threaded support,
+        // so render the error message to a String.
+        Self::CompileError {
+            error: error.to_string(),
+            is_indentation_error: error.is_indentation_error(),
+        }
+    }
+}
+
+/// The Result type returned by [Koto](crate::Koto) operations
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/koto/src/lib.rs
+++ b/crates/koto/src/lib.rs
@@ -28,12 +28,14 @@
 
 #![warn(missing_docs)]
 
+mod error;
 mod koto;
 pub mod prelude;
 
 pub use koto_bytecode as bytecode;
 pub use koto_parser as parser;
 pub use koto_runtime as runtime;
-pub use koto_runtime::{derive, Borrow, BorrowMut, Error, ErrorKind, Ptr, PtrMut, Result};
+pub use koto_runtime::{derive, Borrow, BorrowMut, ErrorKind, Ptr, PtrMut};
 
+pub use crate::error::{Error, Result};
 pub use crate::koto::{CompileArgs, Koto, KotoSettings};

--- a/crates/koto/tests/docs_examples.rs
+++ b/crates/koto/tests/docs_examples.rs
@@ -1,4 +1,4 @@
-use koto::{prelude::*, Result};
+use koto::{prelude::*, runtime::Result};
 use koto_test_utils::run_koto_examples_in_markdown;
 use std::{fs, path::PathBuf};
 

--- a/crates/koto/tests/koto_tests.rs
+++ b/crates/koto/tests/koto_tests.rs
@@ -14,7 +14,6 @@ fn run_script(script: &str, script_path: PathBuf, expected_module_paths: &[PathB
                 run_import_tests: true,
                 ..Default::default()
             },
-            ..Default::default()
         }
         .with_module_imported_callback({
             let loaded_module_paths = loaded_module_paths.clone();

--- a/crates/koto/tests/repl_mode_tests.rs
+++ b/crates/koto/tests/repl_mode_tests.rs
@@ -25,7 +25,7 @@ fn run_repl_mode_test(inputs_and_expected_outputs: &[(&str, &str)]) {
 
     for (input, expected_output) in inputs_and_expected_outputs {
         match koto.compile(CompileArgs {
-            script: *input,
+            script: input,
             script_path: None,
             compiler_settings: CompilerSettings {
                 export_top_level_ids: true,

--- a/crates/lexer/Cargo.toml
+++ b/crates/lexer/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "koto_lexer"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "The lexer used by the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 unicode-segmentation = { workspace = true }

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -1,19 +1,21 @@
 [package]
 name = "koto_memory"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "Memory management utilities used by the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
-# One memory management scheme can be enabled at a time
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["parking_lot"]
 rc = []
 

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "koto_parser"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "The parser used by the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_memory/arc"]
 rc = ["koto_memory/rc"]
 

--- a/crates/parser/src/string_slice.rs
+++ b/crates/parser/src/string_slice.rs
@@ -228,7 +228,7 @@ mod test {
 
     #[test]
     fn split() {
-        let original = StringSlice::<usize>::try_from("hello, world!").unwrap();
+        let original = StringSlice::from("hello, world!");
         let (a, b) = original.split(6).unwrap();
         assert_eq!(a.as_str(), "hello,");
         assert_eq!(b.as_str(), " world!");

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "koto_runtime"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "The runtime used by the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_memory/arc", "koto_derive/arc"]
 rc = ["koto_memory/rc", "koto_derive/rc"]
 

--- a/crates/serialize/Cargo.toml
+++ b/crates/serialize/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "koto_serialize"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "Serde serialization support for the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "koto_test_utils"
 version = "0.15.0"
-edition = "2021"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-license = "MIT"
 description = "Testing utilities for the Koto programming language"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 itertools = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -1,10 +1,12 @@
+default: checks
+
 bench:
   cargo bench -p koto
 
-bench_rc:
-  cargo bench -p koto --no-default-features --features rc
+bench_arc:
+  cargo bench -p koto --no-default-features --features arc
 
-checks: test test_rc clippy clippy_rc fmt check_links doc wasm
+checks: test test_arc clippy clippy_arc fmt check_links doc wasm
 
 check_links:
   mlc --offline README.md
@@ -14,8 +16,8 @@ check_links:
 clippy:
   cargo clippy --all-targets -- -D warnings
 
-clippy_rc:
-  cargo clippy -p koto_memory --no-default-features --features rc -- -D warnings
+clippy_arc:
+  cargo clippy -p koto_memory --no-default-features --features arc -- -D warnings
 
 doc *args:
   RUSTDOCFLAGS="-D warnings" cargo doc --workspace --exclude koto_cli {{args}}
@@ -32,14 +34,14 @@ temp *args:
 test *args:
   cargo test {{args}}
 
-test_rc *args:
-  cargo test --tests --no-default-features --features rc \
+test_arc *args:
+  cargo test --tests --no-default-features --features arc \
     -p koto_parser \
     -p koto_bytecode \
     -p koto_runtime \
     -p koto \
     {{args}}
-  just test_libs --no-default-features --features rc
+  just test_libs --no-default-features --features arc
 
 test_benches:
   cargo test --benches

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ check_links:
   mlc --offline docs
 
 clippy:
-  cargo clippy --workspace -- -D warnings
+  cargo clippy --all-targets -- -D warnings
 
 clippy_rc:
   cargo clippy -p koto_memory --no-default-features --features rc -- -D warnings

--- a/justfile
+++ b/justfile
@@ -1,3 +1,9 @@
+bench:
+  cargo bench -p koto
+
+bench_rc:
+  cargo bench -p koto --no-default-features --features rc
+
 checks: test test_rc clippy clippy_rc fmt check_links doc wasm
 
 check_links:

--- a/libs/color/Cargo.toml
+++ b/libs/color/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "koto_color"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library containing simple color utilities"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 derive_more = { workspace = true, features = ["from"] }

--- a/libs/geometry/Cargo.toml
+++ b/libs/geometry/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "koto_geometry"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library with basic geometry types and operations"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 glam = { workspace = true }

--- a/libs/json/Cargo.toml
+++ b/libs/json/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "koto_json"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library for working with JSON data"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 

--- a/libs/random/Cargo.toml
+++ b/libs/random/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
 name = "koto_random"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library for working with random numbers"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 

--- a/libs/random/tests/shuffle.rs
+++ b/libs/random/tests/shuffle.rs
@@ -16,7 +16,7 @@ impl TestContainer {
     }
 
     #[koto_method]
-    fn to_tuple(&mut self) -> KValue {
+    fn to_tuple(&self) -> KValue {
         KTuple::from(self.data.clone()).into()
     }
 }
@@ -52,7 +52,7 @@ fn shuffle() -> StdResult<(), Box<dyn Error>> {
     prelude.insert("random", koto_random::make_module());
 
     prelude.add_fn("new_container", |ctx| {
-        let data: Vec<KValue> = ctx.args().iter().cloned().collect();
+        let data: Vec<KValue> = ctx.args().to_vec();
         Ok(KObject::from(TestContainer { data }).into())
     });
 

--- a/libs/regex/Cargo.toml
+++ b/libs/regex/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "koto_regex"
 version = "0.15.0"
-authors = ["jasal82 <johannes.asal@gmx.de>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library for working with regular expressions"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+authors = ["jasal82 <johannes.asal@gmx.de>", "irh <ian.r.hobson@gmail.com>"]
+
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 regex = { workspace = true }

--- a/libs/tempfile/Cargo.toml
+++ b/libs/tempfile/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "koto_tempfile"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library for working with temporary files"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 

--- a/libs/toml/Cargo.toml
+++ b/libs/toml/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "koto_toml"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library for working with TOML data"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto"]
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 

--- a/libs/yaml/Cargo.toml
+++ b/libs/yaml/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "koto_yaml"
 version = "0.15.0"
-authors = ["irh <ian.r.hobson@gmail.com>"]
-edition = "2021"
-license = "MIT"
 description = "A Koto library for working with YAML data"
-homepage = "https://koto.dev"
-repository = "https://github.com/koto-lang/koto"
-keywords = ["scripting", "language", "koto", "yaml"]
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
-default = ["arc"]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
 arc = ["koto_runtime/arc"]
 rc = ["koto_runtime/rc"]
 


### PR DESCRIPTION
In hindsight this should have always been the default. Multi-threaded scripting will only be required by a minority of applications, so it makes sense to default to the faster single-threaded runtime.
