### PR TITLE
Add support for optional type hints

### DIFF
--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -336,10 +336,12 @@ pub enum Instruction {
     },
     AssertType {
         value: u8,
+        allow_null: bool,
         type_string: ConstantIndex,
     },
     CheckType {
         value: u8,
+        allow_null: bool,
         type_string: ConstantIndex,
         jump_offset: u16,
     },
@@ -775,17 +777,26 @@ impl fmt::Debug for Instruction {
             CheckSizeMin { register, size } => {
                 write!(f, "CheckSizeMin\tvalue: {register}\tsize: {size}")
             }
-            AssertType { value, type_string } => {
-                write!(f, "AssertType\tvalue: {value}\ttype: {type_string}")
+            AssertType {
+                value,
+                type_string,
+                allow_null,
+            } => {
+                write!(
+                    f,
+                    "AssertType\tvalue: {value}\ttype: {type_string}\tallow null: {allow_null}"
+                )
             }
             CheckType {
                 value,
                 jump_offset,
                 type_string,
+                allow_null,
             } => {
                 write!(
                     f,
-                    "CheckType\tvalue: {value}\ttype: {type_string}\toffset: {jump_offset}"
+                    "CheckType\tvalue: {value}\ttype: {type_string}\tallow null: {allow_null}\
+                    \toffset: {jump_offset}"
                 )
             }
             StringStart { size_hint } => {

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -612,10 +612,23 @@ impl Iterator for InstructionReader {
             }),
             Op::AssertType => Some(AssertType {
                 value: byte_a,
+                allow_null: false,
                 type_string: get_var_u32!().into(),
             }),
             Op::CheckType => Some(CheckType {
                 value: byte_a,
+                allow_null: false,
+                type_string: get_var_u32!().into(),
+                jump_offset: get_u16!(),
+            }),
+            Op::AssertOptionalType => Some(AssertType {
+                value: byte_a,
+                allow_null: true,
+                type_string: get_var_u32!().into(),
+            }),
+            Op::CheckOptionalType => Some(CheckType {
+                value: byte_a,
+                allow_null: true,
                 type_string: get_var_u32!().into(),
                 jump_offset: get_u16!(),
             }),

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -527,6 +527,14 @@ pub enum Op {
     /// `[*value, @type constant]`
     AssertType,
 
+    /// Throws an error if the value doesn't match the provided type
+    ///
+    /// This is used for type hints on variable declarations, and can be disabled via the
+    /// compiler's `enable_type_checks` flag.
+    ///
+    /// `[*value, @type constant]`
+    AssertOptionalType,
+
     /// Checks if the value matches the provided type
     ///
     /// If the value doesn't match the type then the instruction pointer will be jumped forward to
@@ -537,9 +545,17 @@ pub enum Op {
     /// `[*value, @type constant, jump_offset[2]]`
     CheckType,
 
+    /// Checks if the value matches the provided type
+    ///
+    /// If the value doesn't match the type then the instruction pointer will be jumped forward to
+    /// the location referred to by the jump offset.
+    ///
+    /// This is used for type hints that can affect conditional logic, like match patterns.
+    ///
+    /// `[*value, @type constant, jump_offset[2]]`
+    CheckOptionalType,
+
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused87,
-    Unused88,
     Unused89,
     Unused90,
     Unused91,

--- a/crates/cli/docs/core_lib/io.md
+++ b/crates/cli/docs/core_lib/io.md
@@ -27,10 +27,10 @@ f.read_to_string()
 ## current_dir
 
 ```kototype
-|| -> String
+|| -> String?
 ```
 
-Returns the current working directory as a String, or Null if the current
+Returns the current working directory as a String, or `null` if the current
 directory can't be retrieved.
 
 ## exists
@@ -281,12 +281,12 @@ Returns the file's path.
 ## File.read_line
 
 ```kototype
-|File| -> String or Null
+|File| -> String?
 ```
 
 Reads a line of output from the file as a string, not including the newline.
 
-When the end of the file is reached, Null will be returned.
+When the end of the file is reached, `null` will be returned.
 
 ### Errors
 

--- a/crates/cli/docs/core_lib/iterator.md
+++ b/crates/cli/docs/core_lib/iterator.md
@@ -221,7 +221,7 @@ check! [(0, 'a'), (1, 'b'), (2, 'c')]
 ## find
 
 ```kototype
-|Iterable, test: |Any| -> Bool| -> Any
+|Iterable, test: |Any| -> Bool| -> Any?
 ```
 
 Returns the first value in the iterable that passes the test function.
@@ -430,7 +430,7 @@ check! (0, 2, 4, 6, 8)
 ## last
 
 ```kototype
-|Iterable| -> Any
+|Iterable| -> Any?
 ```
 
 Consumes the iterator, returning the last yielded value.
@@ -540,7 +540,7 @@ check! (-3, 99)
 ## next
 
 ```kototype
-|Iterable| -> IteratorOutput
+|Iterable| -> IteratorOutput?
 ```
 
 Returns the next value from the iterator wrapped in an 
@@ -572,7 +572,7 @@ check! a
 ## next_back
 
 ```kototype
-|Iterable| -> IteratorOutput
+|Iterable| -> IteratorOutput?
 ```
 
 Returns the next value from the end of the iterator wrapped in an 

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -152,10 +152,10 @@ check! {a: 1, c: 3}
 ## hash
 
 ```kototype
-|value: Any| -> Number or Null
+|value: Any| -> Number?
 ```
 
-Returns the value's hash as an integer, or Null if the value is not hashable.
+Returns the value's hash as an integer, or `null` if the value is not hashable.
 
 ### Example
 
@@ -228,7 +228,7 @@ check! 10
 ## script_dir
 
 ```kototype
-|| -> String or Null
+|| -> String?
 ```
 
 Returns the path of the directory containing the current script, if available.
@@ -236,7 +236,7 @@ Returns the path of the directory containing the current script, if available.
 ## script_path
 
 ```kototype
-|| -> String or Null
+|| -> String?
 ```
 
 Returns the path of the file containing the current script, if available.

--- a/crates/cli/docs/core_lib/list.md
+++ b/crates/cli/docs/core_lib/list.md
@@ -80,10 +80,10 @@ check! [99, 99, 99]
 ## first
 
 ```kototype
-|List| -> Any
+|List| -> Any?
 ```
 
-Returns the first value in the list, or Null if the list is empty.
+Returns the first value in the list, or `null` if the list is empty.
 
 ### Example
 
@@ -103,10 +103,10 @@ check! null
 ## get
 
 ```kototype
-|List, index: Number| -> Any
+|List, index: Number| -> Any?
 ```
 ```kototype
-|List, index: Number, default: Any| -> Any
+|List, index: Number, default: Any| -> Any?
 ```
 
 Gets the element at the given `index` in the list.
@@ -184,10 +184,10 @@ check! false
 ## last
 
 ```kototype
-|List| -> Any
+|List| -> Any?
 ```
 
-Returns the last value in the list, or Null if the list is empty.
+Returns the last value in the list, or `null` if the list is empty.
 
 ### Example
 
@@ -207,12 +207,12 @@ check! null
 ## pop
 
 ```kototype
-|List| -> Any
+|List| -> Any?
 ```
 
 Removes the last value from the list and returns it.
 
-If the list is empty then Null is returned.
+If the list is empty then `null` is returned.
 
 ### Example
 
@@ -235,7 +235,7 @@ check! null
 ## push
 
 ```kototype
-|List, value: Any| -> Any
+|List, value: Any| -> List
 ```
 
 Adds the `value` to the end of the list, and returns the list.
@@ -260,9 +260,9 @@ check! [99, -1, 'hello']
 |List, position: Number| -> Any
 ```
 
-Removes the value at the given position from the list and returns it.
+Removes the value at the given position from the list, and returns the removed value.
 
-Throws an error if the position isn't a valid index in the list.
+An error is thrown if the position isn't a valid index in the list.
 
 ### Example
 

--- a/crates/cli/docs/core_lib/map.md
+++ b/crates/cli/docs/core_lib/map.md
@@ -67,7 +67,7 @@ check! c!
 Returns the value corresponding to the given key, or the provided default value
 if the map doesn't contain the key.
 
-If no default value is provided then Null is returned.
+If no default value is provided then `null` is returned.
 
 ### Example
 
@@ -103,7 +103,7 @@ check! xyz
 Returns the entry at the given index as a key/value tuple, or the provided
 default value if the map doesn't contain an entry at that index.
 
-If no default value is provided then Null is returned.
+If no default value is provided then `null` is returned.
 
 ### Example
 
@@ -169,7 +169,7 @@ Inserts an entry into the map with the given key and value.
 Inserts an entry into the map with the given key, and `null` as its value.
 
 If the key already existed in the map, then the old value is returned.
-If the key didn't already exist, then Null is returned.
+If the key didn't already exist, then `null` is returned.
 
 See the [language guide](../language_guide.md#map-key-types) for a description 
 of the types of values that can be used as map keys.
@@ -267,7 +267,7 @@ check! null
 
 Removes the entry that matches the given key.
 
-If the entry existed then its value is returned, otherwise Null is returned.
+If the entry existed then its value is returned, otherwise `null` is returned.
 
 ### Example
 

--- a/crates/cli/docs/core_lib/os.md
+++ b/crates/cli/docs/core_lib/os.md
@@ -270,10 +270,10 @@ check! ...
 ## Command.wait_for_exit
 
 ```kototype
-|Command| -> Number or Null
+|Command| -> Number?
 ```
 
-Executes the command and waits for it to exit, returning its exit code if the command exited normally, or `Null` if it was interrupted.
+Executes the command and waits for it to exit, returning its exit code if the command exited normally, or `null` if it was interrupted.
 
 ### Example
 
@@ -292,7 +292,7 @@ See [Command.wait_for_output](#command-wait_for_output) and [Child.wait_for_outp
 ## CommandOutput.exit_code
 
 ```kototype
-|CommandOutput| -> Number or Null
+|CommandOutput| -> Number?
 ```
 
 Returns the command's exit code if available.
@@ -308,7 +308,7 @@ Returns `true` if the command exited successfully.
 ## CommandOutput.stdout
 
 ```kototype
-|CommandOutput| -> String or Null
+|CommandOutput| -> String?
 ```
 
 Returns the contents of the command's `stdout` stream if it contains valid unicode, or `null` otherwise.
@@ -320,7 +320,7 @@ Returns the contents of the command's `stdout` stream if it contains valid unico
 ## CommandOutput.stderr
 
 ```kototype
-|CommandOutput| -> String or Null
+|CommandOutput| -> String?
 ```
 
 Returns the contents of the command's `stderr` stream if it contains valid unicode, or `null` otherwise.
@@ -410,7 +410,7 @@ Note that if the `stdout` or `stderr` streams were manually retrieved via [Child
 ## Child.wait_for_exit
 
 ```kototype
-|Child| -> Number or Null
+|Child| -> Number?
 ```
 
 Closes all input and output streams, waits for the command to exit, and then returns the command's exit code if available.

--- a/crates/cli/docs/core_lib/range.md
+++ b/crates/cli/docs/core_lib/range.md
@@ -93,7 +93,7 @@ check! -5..5
 ## intersection
 
 ```kototype
-|Range, Range| -> Range
+|Range, Range| -> Range?
 ```
 
 Returns a range representing the intersecting region of the two input ranges.

--- a/crates/cli/docs/core_lib/string.md
+++ b/crates/cli/docs/core_lib/string.md
@@ -298,7 +298,7 @@ check! o_o
 ## to_number
 
 ```kototype
-|String| -> Number
+|String| -> Number?
 ```
 
 Returns the string converted into a number.
@@ -307,10 +307,10 @@ Returns the string converted into a number.
 - Otherwise the number is assumed to be base 10, and the presence of a decimal
   point will produce a float instead of an integer.
 
-If a number can't be produced then `Null` is returned.
+If a number can't be produced then `null` is returned.
 
 ```kototype
-|String, base: Number| -> Number
+|String, base: Number| -> Number?
 ```
 
 Returns the string converted into a number given the specified `base`.

--- a/crates/cli/docs/core_lib/tuple.md
+++ b/crates/cli/docs/core_lib/tuple.md
@@ -23,10 +23,10 @@ check! false
 ## first
 
 ```kototype
-|Tuple| -> Any
+|Tuple| -> Any?
 ```
 
-Returns the first value in the tuple, or Null if the tuple is empty.
+Returns the first value in the tuple, or `null` if the tuple is empty.
 
 ### Example
 
@@ -42,15 +42,15 @@ check! null
 ## get
 
 ```kototype
-|Tuple, index: Number| -> Any
+|Tuple, index: Number| -> Any?
 ```
 ```kototype
-|Tuple, index: Number, default: Any| -> Any
+|Tuple, index: Number, default: Any| -> Any?
 ```
 
 Gets the Nth value in the tuple.
 If the tuple doesn't contain a value at that position then the provided `default`
-value is returned. If no default value is provided then Null is returned.
+value is returned. If no default value is provided then `null` is returned.
 
 ### Example
 
@@ -70,10 +70,10 @@ check! abc
 ## last
 
 ```kototype
-|Tuple| -> Any
+|Tuple| -> Any?
 ```
 
-Returns the last value in the tuple, or Null if the tuple is empty.
+Returns the last value in the tuple, or `null` if the tuple is empty.
 
 ### Example
 

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1489,6 +1489,25 @@ print! match 'abc'
 check! ('a', 'b', 'c')
 ```
 
+### Optional Values
+
+Sometimes a value can either be of a particular type, or otherwise it should `null`.
+
+These kinds of values are referred to as [_optional_][optional-type],
+and are useful for functions or expressions that return either a valid value, or nothing at all.
+
+Optional value types are expressed by appending `?` to the type hint.
+
+```koto
+m = {foo: 'hi!'}
+
+print! let foo: String? = m.get('foo')?.to_uppercase()
+check! HI!
+
+print! let bar: String? = m.get('bar')?.to_uppercase()
+check! null
+```
+
 ### Special Types
 
 #### `Any`
@@ -2502,6 +2521,7 @@ and if `foo.koto` isn't found then the runtime will look for `foo/main.koto`.
 [lazy]: https://en.wikipedia.org/wiki/Lazy_evaluation
 [next]: ./core_lib/iterator.md#next
 [once]: ./core_lib/iterator.md#once
+[optional-type]: https://en.wikipedia.org/wiki/Option_type
 [operation-order]: https://en.wikipedia.org/wiki/Order_of_operations#Conventional_order
 [repeat]: ./core_lib/iterator.md#repeat
 [rust-format-options]: https://doc.rust-lang.org/std/fmt/#formatting-parameters

--- a/crates/cli/docs/libs/color.md
+++ b/crates/cli/docs/libs/color.md
@@ -125,7 +125,7 @@ check! Color(HSV, h: 90, s: 0.5, v: 1, a: 1)
 ## named
 
 ```kototype
-|name: String| -> Color or Null
+|name: String| -> Color? 
 ```
 
 Returns a color corresponding to one of the named colors listed in the

--- a/crates/cli/docs/libs/random.md
+++ b/crates/cli/docs/libs/random.md
@@ -80,7 +80,7 @@ check! 0.168
 ## pick
 
 ```kototype
-|Indexable| -> Any
+|Indexable| -> Any?
 ```
 
 Selects a random value from the input using the current thread's generator.

--- a/crates/cli/docs/libs/regex.md
+++ b/crates/cli/docs/libs/regex.md
@@ -41,7 +41,7 @@ check! false
 ## Regex.find
 
 ```kototype
-|Regex, input: String| -> Match or Null
+|Regex, input: String| -> Match?
 ```
 
 If the given `input` string matches the regular expression, then an instance of
@@ -64,7 +64,7 @@ check! null
 ## Regex.find_all
 
 ```kototype
-|Regex, input: String| -> Matches or Null
+|Regex, input: String| -> Matches?
 ```
 
 If the given `input` string matches the regular expression, then an instance of
@@ -87,7 +87,7 @@ check! ('gh', 9..11)
 ## Regex.captures
 
 ```kototype
-|Regex, input: String| -> Map or Null
+|Regex, input: String| -> Map?
 ```
 
 If the given string matches the regular expression, then a map is returned

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -271,7 +271,12 @@ pub enum Node {
     ///
     /// E.g. `let x: Number = 0`
     ///            ^~~ This is the beginning of the type hint
-    Type(ConstantIndex),
+    Type {
+        /// The expected type as a string
+        type_index: ConstantIndex,
+        /// True if the type was specified with a `?` suffix
+        allow_null: bool,
+    },
 }
 
 /// A function definition

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -144,7 +144,7 @@ let foo: Indexable = null
             #[test]
             fn expected_iterable() {
                 let script = "\
-let foo: Iterable = true
+let foo: Iterable? = true
 #   ^^^
 ";
                 check_script_fails_with_span(
@@ -205,7 +205,7 @@ f 'hello'
             #[test]
             fn nested_arg_with_type() {
                 let script = "\
-f = |(foo: Number)| foo
+f = |(foo: Number?)| foo
 #     ^^^
 f ('hello',)
 ";
@@ -253,7 +253,7 @@ f ('hello',)
             #[test]
             fn function_with_output_type_and_implicit_return() {
                 let script = "\
-f = |x: Number| -> String
+f = |x: Number| -> String?
   x + x
 # ^^^^^
 f 42

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -520,6 +520,15 @@ x
         }
 
         #[test]
+        fn assigning_an_optional_string() {
+            let script = "
+let x: String? = null
+x
+";
+            check_script_output(script, KValue::Null);
+        }
+
+        #[test]
         fn multi_assignment() {
             let script = "
 let x: String, y: Bool, z: Number = 'foo', true, 123


### PR DESCRIPTION
This PR adds support for optional type hints, using `?` as a type suffix, borrowing from Swift's optional shorthand syntax.

```coffee
let x: String? = get_an_optional_string()
```