### PR TITLE
API improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.5.0
 
       - name: Build
         run: cargo build --verbose
@@ -26,8 +29,8 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
-      - name: Run poetry example
-        run: cargo run --example poetry -- -s crates/koto/examples/poetry/scripts/readme.koto
+      - name: Run examples
+        run: just test_examples
 
   build_and_test_release:
     # We don't need to test release builds on all platforms for now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ The Koto project adheres to
 - `Koto::compile` and `compile_and_run` now take `CompileArgs` which include
   compiler settings. The equivalent compiler settings have been removed from 
   `KotoSettings`.
+- `Koto::set_args` now accepts any value that implements
+  `IntoIterator<Item = String>`, which includes the output of `std::env::args()`.
 
 #### Libs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The Koto project adheres to
     - Supports executing and spawning system commands.
   - `os.process_id`
   - `string.repeat`
+  - `tuple.is_empty`
 - `tuple.sort_copy` now supports sorting with a key function, following the 
   behaviour of `list.sort`.
 

--- a/crates/cli/docs/api.md
+++ b/crates/cli/docs/api.md
@@ -129,8 +129,16 @@ default-feautures = false
 features = ["arc"]
 ```
 
+## Using Koto in a REPL
+
+Some applications (like REPLs) require assigned variables to persist between each script evaluation.
+This can be achieved by enabling the `export_top_level_ids` flag,
+which will result in all top-level assignments being exported.
+
+```rust_include
+using_koto_in_a_repl.rs
+```
+
 ---
 
 [type]: ./language_guide.md#type
-
-

--- a/crates/cli/docs/api.md
+++ b/crates/cli/docs/api.md
@@ -83,7 +83,6 @@ koto_function.rs
 
 ## Adding a Module to the Prelude
 
-
 A module in Koto is simply a `KMap`, conventionally with a defined
 [`@type`][type].
 
@@ -101,7 +100,14 @@ implemented.
 rust_object.rs
 ```
 
-[type]: ./language_guide.md#type
+## Disabling type checks
+
+Runtime type checks are enabled by default, the compiler can be prevented from
+emitting type check instructions by disabling the `enable_type_checks` flag.
+
+```rust_include
+disabling_type_checks.rs
+```
 
 ## Using the multi-threaded runtime
 
@@ -124,3 +130,7 @@ features = ["arc"]
 ```
 
 ---
+
+[type]: ./language_guide.md#type
+
+

--- a/crates/cli/docs/core_lib/tuple.md
+++ b/crates/cli/docs/core_lib/tuple.md
@@ -67,6 +67,24 @@ print! x.get 5, "abc"
 check! abc
 ```
 
+## is_empty
+
+```kototype
+|Tuple| -> Bool
+```
+
+Returns `true` if the tuple has a size of zero, and `false` otherwise.
+
+### Example
+
+```koto
+print! (,).is_empty()
+check! true
+
+print! (1, 2, 3).is_empty()
+check! false
+```
+
 ## last
 
 ```kototype

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -182,7 +182,7 @@ fn main() -> Result<()> {
                         Chunk::instructions_as_string(chunk, &script_lines)
                     );
                 }
-                koto.set_args(&args.script_args)?;
+                koto.set_args(args.script_args)?;
                 match koto.run() {
                     Ok(_) => {}
                     Err(error) if error.source().is_some() => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -264,45 +264,44 @@ fn load_config(config_path: Option<&String>) -> Result<Config> {
         let script = fs::read_to_string(&config_path).context("Failed to load the config file")?;
 
         let mut koto = Koto::new();
-        match koto.compile_and_run(CompileArgs::with_path(&script, config_path)) {
-            Ok(_) => {
-                let exports = koto.exports().data();
-                match exports.get("repl") {
-                    Some(KValue::Map(repl_config)) => {
-                        let repl_config = repl_config.data();
-                        match repl_config.get("colored_output") {
-                            Some(KValue::Bool(value)) => config.colored_output = *value,
-                            Some(_) => bail!("expected bool for colored_output setting"),
-                            None => {}
-                        }
-                        match repl_config.get("edit_mode") {
-                            Some(KValue::Str(value)) => match value.as_str() {
-                                "emacs" => config.edit_mode = EditMode::Emacs,
-                                "vi" => config.edit_mode = EditMode::Vi,
-                                other => {
-                                    bail!(
-                                        "invalid edit mode '{other}',
+        if let Err(e) = koto.compile_and_run(CompileArgs::new(&script).script_path(config_path)) {
+            bail!("error while loading config: {e}");
+        }
+
+        let exports = koto.exports().data();
+        match exports.get("repl") {
+            Some(KValue::Map(repl_config)) => {
+                let repl_config = repl_config.data();
+                match repl_config.get("colored_output") {
+                    Some(KValue::Bool(value)) => config.colored_output = *value,
+                    Some(_) => bail!("expected bool for colored_output setting"),
+                    None => {}
+                }
+                match repl_config.get("edit_mode") {
+                    Some(KValue::Str(value)) => match value.as_str() {
+                        "emacs" => config.edit_mode = EditMode::Emacs,
+                        "vi" => config.edit_mode = EditMode::Vi,
+                        other => {
+                            bail!(
+                                "invalid edit mode '{other}',
                                          valid options are 'emacs' or 'vi'"
-                                    )
-                                }
-                            },
-                            Some(_) => bail!("expected string for edit_mode setting"),
-                            None => {}
+                            )
                         }
-                        match repl_config.get("max_history") {
-                            Some(KValue::Number(value)) => match i64::from(value) {
-                                value if value > 0 => config.max_history = value as usize,
-                                _ => bail!("expected positive number for max_history setting"),
-                            },
-                            Some(_) => bail!("expected positive number for max_history setting"),
-                            None => {}
-                        }
-                    }
-                    Some(_) => bail!("expected map for repl settings"),
+                    },
+                    Some(_) => bail!("expected string for edit_mode setting"),
+                    None => {}
+                }
+                match repl_config.get("max_history") {
+                    Some(KValue::Number(value)) => match i64::from(value) {
+                        value if value > 0 => config.max_history = value as usize,
+                        _ => bail!("expected positive number for max_history setting"),
+                    },
+                    Some(_) => bail!("expected positive number for max_history setting"),
                     None => {}
                 }
             }
-            Err(e) => bail!("error while loading config: {e}",),
+            Some(_) => bail!("expected map for repl settings"),
+            None => {}
         }
     }
 

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -151,15 +151,7 @@ impl Repl {
 
             self.editor.add_history_entry(&input)?;
 
-            let compile_args = CompileArgs {
-                script: &input,
-                script_path: None,
-                compiler_settings: CompilerSettings {
-                    export_top_level_ids: true,
-                    enable_type_checks: true,
-                },
-            };
-
+            let compile_args = CompileArgs::new(&input).export_top_level_ids(true);
             match self.koto.compile(compile_args) {
                 Ok(chunk) => {
                     if self.settings.show_bytecode {

--- a/crates/koto/benches/koto_benchmark.rs
+++ b/crates/koto/benches/koto_benchmark.rs
@@ -10,7 +10,7 @@ struct BenchmarkRunner {
 }
 
 impl BenchmarkRunner {
-    fn setup(script_path: &str, args: &[String]) -> Self {
+    fn setup(script_path: &str, args: &[&str]) -> Self {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("..");
         path.push("..");
@@ -25,7 +25,9 @@ impl BenchmarkRunner {
 
         match runtime.compile(&script) {
             Ok(_) => {
-                runtime.set_args(args).unwrap();
+                runtime
+                    .set_args(args.iter().map(|s| s.to_string()))
+                    .unwrap();
                 if let Err(error) = runtime.run() {
                     panic!("{error}");
                 }
@@ -61,33 +63,25 @@ pub fn koto_benchmark(c: &mut Criterion) {
         })
     });
     c.bench_function("string_formatting", |b| {
-        let mut runner = BenchmarkRunner::setup(
-            "string_formatting.koto",
-            &["70".to_string(), "quiet".to_string()],
-        );
+        let mut runner = BenchmarkRunner::setup("string_formatting.koto", &["70", "quiet"]);
         b.iter(|| {
             runner.run();
         })
     });
     c.bench_function("spectral_norm", |b| {
-        let mut runner = BenchmarkRunner::setup(
-            "spectral_norm.koto",
-            &["2".to_string(), "quiet".to_string()],
-        );
+        let mut runner = BenchmarkRunner::setup("spectral_norm.koto", &["2", "quiet"]);
         b.iter(|| {
             runner.run();
         })
     });
     c.bench_function("fannkuch", |b| {
-        let mut runner =
-            BenchmarkRunner::setup("fannkuch.koto", &["4".to_string(), "quiet".to_string()]);
+        let mut runner = BenchmarkRunner::setup("fannkuch.koto", &["4", "quiet"]);
         b.iter(|| {
             runner.run();
         })
     });
     c.bench_function("n_body", |b| {
-        let mut runner =
-            BenchmarkRunner::setup("n_body.koto", &["10".to_string(), "quiet".to_string()]);
+        let mut runner = BenchmarkRunner::setup("n_body.koto", &["10", "quiet"]);
         b.iter(|| {
             runner.run();
         })

--- a/crates/koto/examples/args.rs
+++ b/crates/koto/examples/args.rs
@@ -4,7 +4,7 @@ fn main() {
     let script = "
 from koto import args
 
-if (size args) > 0
+if (size args) > 1
   for i, arg in args.enumerate()
     print '{i + 1}: {arg}'
 else

--- a/crates/koto/examples/args.rs
+++ b/crates/koto/examples/args.rs
@@ -1,6 +1,6 @@
-use koto::prelude::*;
+use koto::{prelude::*, Result};
 
-fn main() {
+fn main() -> Result<()> {
     let script = "
 from koto import args
 
@@ -10,8 +10,11 @@ if (size args) > 1
 else
   print 'No arguments'
 ";
+
     let mut koto = Koto::default();
-    let args: Vec<_> = std::env::args().collect();
-    koto.set_args(&args).unwrap();
-    koto.compile_and_run(script).unwrap();
+
+    koto.set_args(std::env::args())?;
+    koto.compile_and_run(script)?;
+
+    Ok(())
 }

--- a/crates/koto/examples/disabling_type_checks.rs
+++ b/crates/koto/examples/disabling_type_checks.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use koto::prelude::*;
+
+fn main() -> Result<()> {
+    let script = "
+let x: String = 123
+";
+    let mut koto = Koto::default();
+
+    // Type checks are enabled by default. Running the script will produce an error.
+    let result = koto.compile_and_run(script);
+    assert!(result.is_err());
+
+    // Type checks can disabled via `CompileArgs::enable_type_checks`.
+    // It should go without saying that checks should only be disabled if you're confident that your
+    // code is correct!
+    let result = koto.compile_and_run(CompileArgs::new(script).enable_type_checks(false));
+    assert!(result.is_ok());
+
+    Ok(())
+}

--- a/crates/koto/examples/disabling_type_checks.rs
+++ b/crates/koto/examples/disabling_type_checks.rs
@@ -1,5 +1,4 @@
-use anyhow::Result;
-use koto::prelude::*;
+use koto::{prelude::*, Result};
 
 fn main() -> Result<()> {
     let script = "

--- a/crates/koto/examples/koto_function.rs
+++ b/crates/koto/examples/koto_function.rs
@@ -1,5 +1,4 @@
-use anyhow::Result;
-use koto::prelude::*;
+use koto::{prelude::*, Result};
 
 fn main() -> Result<()> {
     let script = "
@@ -7,9 +6,9 @@ export my_fn = |a, b| '{a} + {b} is {a + b}'
 ";
     let mut koto = Koto::default();
 
-    // Running the script exports the `foo` function
+    // Running the script exports the `my_fn` function
     koto.compile_and_run(script).unwrap();
-    let my_fn = koto.exports().get("foo").unwrap();
+    let my_fn = koto.exports().get("my_fn").unwrap();
     assert!(my_fn.is_callable());
 
     let result = koto.call_function(my_fn, &[1.into(), 2.into()])?;

--- a/crates/koto/examples/rust_function.rs
+++ b/crates/koto/examples/rust_function.rs
@@ -1,4 +1,4 @@
-use koto::{prelude::*, runtime::Result};
+use koto::{prelude::*, runtime};
 
 fn main() {
     let script = "
@@ -21,7 +21,7 @@ print plus 10, 20
     koto.compile_and_run(script).unwrap();
 }
 
-fn say_hello(ctx: &mut CallContext) -> Result<KValue> {
+fn say_hello(ctx: &mut CallContext) -> runtime::Result<KValue> {
     match ctx.args() {
         [] => println!("Hello?"),
         [KValue::Str(name)] => println!("Hello, {name}"),

--- a/crates/koto/examples/rust_object.rs
+++ b/crates/koto/examples/rust_object.rs
@@ -1,4 +1,4 @@
-use koto::{derive::*, prelude::*, runtime::Result};
+use koto::{derive::*, prelude::*, runtime};
 
 fn main() {
     let script = "
@@ -36,13 +36,13 @@ impl MyType {
 
     // A simple getter function
     #[koto_method]
-    fn get(&self) -> Result<KValue> {
+    fn get(&self) -> runtime::Result<KValue> {
         Ok(self.0.into())
     }
 
     // A function that returns the object instance as the result
     #[koto_method]
-    fn set(ctx: MethodContext<Self>) -> Result<KValue> {
+    fn set(ctx: MethodContext<Self>) -> runtime::Result<KValue> {
         match ctx.args {
             [KValue::Number(n)] => {
                 ctx.instance_mut()?.0 = n.into();
@@ -55,7 +55,7 @@ impl MyType {
 
 impl KotoObject for MyType {
     // KotoObject::Display allows mytype to be used with Koto's print function
-    fn display(&self, ctx: &mut DisplayContext) -> Result<()> {
+    fn display(&self, ctx: &mut DisplayContext) -> runtime::Result<()> {
         ctx.append(format!("MyType({})", self.0));
         Ok(())
     }

--- a/crates/koto/examples/using_koto_in_a_repl.rs
+++ b/crates/koto/examples/using_koto_in_a_repl.rs
@@ -1,0 +1,22 @@
+use anyhow::{bail, Result};
+use koto::prelude::*;
+
+fn main() -> Result<()> {
+    let mut koto = Koto::default();
+
+    // When using Koto in a REPL, variables from previous evaluations need to be made available
+    // for the next evaluation.
+    //
+    // This is achieved by telling the compiler to treat each top-level assignment as if it had been
+    // exported. i.e., the compiler turns the script `x = 1` into `export x = 1`.
+    koto.compile_and_run(CompileArgs::new("x = 1").export_top_level_ids(true))?;
+    assert!(koto.exports().get("x").is_some());
+
+    // The exports map gets reused by the Koto instance for each run.
+    match koto.compile_and_run(CompileArgs::new("x + x").export_top_level_ids(true))? {
+        KValue::Number(result) => assert_eq!(result, KNumber::from(2)),
+        _ => bail!("unexpected result"),
+    }
+
+    Ok(())
+}

--- a/crates/koto/examples/using_koto_in_a_repl.rs
+++ b/crates/koto/examples/using_koto_in_a_repl.rs
@@ -1,5 +1,4 @@
-use anyhow::{bail, Result};
-use koto::prelude::*;
+use koto::{prelude::*, Result};
 
 fn main() -> Result<()> {
     let mut koto = Koto::default();
@@ -15,7 +14,7 @@ fn main() -> Result<()> {
     // The exports map gets reused by the Koto instance for each run.
     match koto.compile_and_run(CompileArgs::new("x + x").export_top_level_ids(true))? {
         KValue::Number(result) => assert_eq!(result, KNumber::from(2)),
-        _ => bail!("unexpected result"),
+        unexpected => unexpected_type("Number", &unexpected)?,
     }
 
     Ok(())

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -148,17 +148,12 @@ impl Koto {
     }
 
     /// Sets the arguments that can be accessed from within the script via `koto.args()`
-    pub fn set_args(&mut self, args: &[String]) -> Result<()> {
-        use KValue::{Map, Str, Tuple};
-
-        let koto_args = args
-            .iter()
-            .map(|arg| Str(arg.as_str().into()))
-            .collect::<Vec<_>>();
+    pub fn set_args(&mut self, args: impl IntoIterator<Item = String>) -> Result<()> {
+        let koto_args = args.into_iter().map(KValue::from).collect::<Vec<_>>();
 
         match self.runtime.prelude().data_mut().get("koto") {
-            Some(Map(map)) => {
-                map.insert("args", Tuple(koto_args.into()));
+            Some(KValue::Map(map)) => {
+                map.insert("args", KValue::Tuple(koto_args.into()));
                 Ok(())
             }
             _ => Err(Error::MissingPrelude),

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -285,13 +285,31 @@ pub struct CompileArgs<'a> {
 }
 
 impl<'a> CompileArgs<'a> {
-    /// A convenience initializer for when the script has been loaded from a path
-    pub fn with_path(script: &'a str, script_path: impl Into<KString>) -> Self {
+    /// Initializes CompileArgs with the given script and default settings
+    pub fn new(script: &'a str) -> Self {
         Self {
             script,
-            script_path: Some(script_path.into()),
-            compiler_settings: Default::default(),
+            script_path: None,
+            compiler_settings: CompilerSettings::default(),
         }
+    }
+
+    /// Sets the script's path
+    pub fn script_path(mut self, script_path: impl Into<KString>) -> Self {
+        self.script_path = Some(script_path.into());
+        self
+    }
+
+    /// Sets the [`CompilerSettings::enable_type_checks`] flag, enabled by default.
+    pub fn enable_type_checks(mut self, enabled: bool) -> Self {
+        self.compiler_settings.enable_type_checks = enabled;
+        self
+    }
+
+    /// Sets the [`CompilerSettings::export_top_level_ids`] flag, disabled by default.
+    pub fn export_top_level_ids(mut self, enabled: bool) -> Self {
+        self.compiler_settings.export_top_level_ids = enabled;
+        self
     }
 }
 

--- a/crates/runtime/src/core_lib/tuple.rs
+++ b/crates/runtime/src/core_lib/tuple.rs
@@ -82,6 +82,15 @@ pub fn make_module() -> KMap {
         }
     });
 
+    result.add_fn("is_empty", |ctx| {
+        let expected_error = "|Tuple|";
+
+        match ctx.instance_and_args(is_tuple, expected_error)? {
+            (KValue::Tuple(t), []) => Ok(t.is_empty().into()),
+            (instance, args) => unexpected_args_after_instance(expected_error, instance, args),
+        }
+    });
+
     result.add_fn("sort_copy", |ctx| {
         let expected_error = "|Tuple|, or |Tuple, |Any| -> Any|";
 

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ bench:
 bench_arc:
   cargo bench -p koto --no-default-features --features arc
 
-checks: test test_arc clippy clippy_arc fmt check_links doc wasm
+checks: fmt test test_arc test_examples clippy clippy_arc check_links doc wasm
 
 check_links:
   mlc --offline README.md
@@ -57,6 +57,14 @@ test_docs:
     --test tempfile_docs \
     --test toml_docs \
     --test yaml_docs
+
+test_examples:
+  #!/usr/bin/env sh
+  set -e pipefail
+  for example in crates/koto/examples/*.rs; do
+    cargo run --example "$(basename "${example%.rs}")" -- $args
+  done
+  cargo run --example poetry -- -s crates/koto/examples/poetry/scripts/readme.koto
 
 test_koto:
   cargo test --test koto_tests


### PR DESCRIPTION
- **Switch to the builder pattern for initializing CompileArgs**
- **Add an API example showing how to disable type checks**
- **Add an API example showing how to use Koto in a REPL**
- **Add tuple.is_empty**
- **Make it easier to set args from std::env::args**
- **Clean up the API examples a bit**
- **Add a command to run all examples as part of the regular checks**
