### PR TITLE
Fix standalone calls to `iterator` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The Koto project adheres to
 
 ## [0.16.0] Unreleased 
 
+### Fixed
+
+#### Core Library
+
+- Iterator adaptors can now be used as standalone functions.
+  - e.g. `for i, n in iterator.enumerate 'abc'` would previously throw an error.
 
 ## [0.15.0] 2025.01.07
 

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1280,19 +1280,25 @@ in any iterator chain.
 ```koto
 # Make an iterator adaptor that yields every
 # other value from the adapted iterator
-iterator.every_other = ||
+iterator.every_other = |iter|
   n = 0
-  # When the generator is created, self is initialized with the previous
-  # iterator in the chain, allowing its output to be adapted.
-  for output in self
+  # If the iterator to be adapted is provided as an argument then use it,
+  # otherwise defer to `self`, which is set by the runtime when the
+  # generator is used in an iterator chain.
+  for output in iter or self
     # If n is even, then yield a value
     if n % 2 == 0
       yield output
     n += 1
 
+# The adaptor can be called directly...
+print! iterator.every_other('abcdef').to_string()
+check! ace
+
+# ...or anywhere in an iterator chain
 print! (1, 2, 3, 4, 5)
   .each |n| n * 10
-  .every_other() # Skip over every other value in the iterator chain
+  .every_other()
   .to_list()
 check! [10, 30, 50]
 ```

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -136,7 +136,15 @@ impl KValue {
     pub fn is_iterable(&self) -> bool {
         use KValue::*;
         match self {
-            Range(_) | List(_) | Tuple(_) | Map(_) | Str(_) | Iterator(_) => true,
+            Range(_) | List(_) | Tuple(_) | Str(_) | Iterator(_) => true,
+            Map(m) => {
+                if m.meta_map().is_some() {
+                    m.contains_meta_key(&UnaryOp::Iterator.into())
+                        || m.contains_meta_key(&UnaryOp::Next.into())
+                } else {
+                    true
+                }
+            }
             Object(o) => o
                 .try_borrow()
                 .is_ok_and(|o| !matches!(o.is_iterable(), IsIterable::NotIterable)),

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -171,6 +171,15 @@ x.next().get()
         use super::*;
 
         #[test]
+        fn as_standalone_function() {
+            let script = "
+x = iterator.enumerate 'abc'
+x.next().get()
+";
+            check_script_output(script, tuple(&[0.into(), "a".into()]));
+        }
+
+        #[test]
         fn make_copy() {
             let script = "
 x = (10..20).enumerate()


### PR DESCRIPTION
See #397.

- **Allow iterator adaptors to be used as standalone functions**
- **Update the guide's section on custom iterator adaptors**
