### PR TITLE
Don't allow functions to be called with more arguments than expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The Koto project adheres to
 
 ## [0.16.0] Unreleased 
 
+### Changed
+
+#### Language
+
+- Calls to functions with more arguments than expected by the function will now throw an error.
+
 ### Fixed
 
 #### Core Library

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -33,6 +33,8 @@ pub enum ErrorKind {
         expected: String,
         unexpected: Vec<KValue>,
     },
+    #[error("Too many arguments - expected {expected}, found {actual}")]
+    TooManyArguments { expected: u8, actual: u8 },
     #[error("Unexpected type - expected: '{expected}', found: '{}'", unexpected.type_as_string())]
     UnexpectedType {
         expected: String,

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -1151,15 +1151,6 @@ foo 42
         }
 
         #[test]
-        fn call_with_extra_args() {
-            let script = "
-foo = |a, b| a + b
-foo 10, 20, 30, 40
-";
-            check_script_output(script, 30);
-        }
-
-        #[test]
         fn nested_call_without_parens() {
             let script = "
 add = |a, b|


### PR DESCRIPTION
This was originally enabled when making function calls more flexible.

Calling with fewer arguments than expected by a function has use cases, but I can't think of a good reason to allow calling a function with extra arguments.

Resolves #397.
