### PR TITLE
Add Compiler::compile_ast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The Koto project adheres to
 
 ## [0.16.0] Unreleased 
 
+### Added
+
+#### API
+
+- `Compiler::compile_ast` has been added, useful for tools that want to work with the AST
+  after checking that it compiles correctly.
+
 ### Changed
 
 #### Language

--- a/crates/bytecode/src/module_loader.rs
+++ b/crates/bytecode/src/module_loader.rs
@@ -119,6 +119,7 @@ impl ModuleLoader {
         settings: CompilerSettings,
     ) -> Result<Ptr<Chunk>, ModuleLoaderError> {
         Compiler::compile(script, script_path.clone(), settings)
+            .map(Ptr::from)
             .map_err(|e| ModuleLoaderError::from_compiler_error(e, script, script_path))
     }
 


### PR DESCRIPTION
Compiling an AST directly was removed in
e8546bb3b5acd0207d58ebefe338331cedc15746 but it turns out that this is
useful in some cases, particularly for tools like `koto-ls` that want to
process an AST after checking that it compiles correctly.
