### PR TITLE
Allow iterator adaptors to be used as standalone functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The Koto project adheres to
 
 ## [0.15.1] Unreleased
 
+### Fixed
+
+#### Core Library
+
+- Iterator adaptors can now be used as standalone functions.
+  - e.g. `for i, n in iterator.enumerate 'abc'` would previously throw an error.
+
 ## [0.15.0] 2025.01.07
 
 ### Added 

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -136,7 +136,15 @@ impl KValue {
     pub fn is_iterable(&self) -> bool {
         use KValue::*;
         match self {
-            Range(_) | List(_) | Tuple(_) | Map(_) | Str(_) | Iterator(_) => true,
+            Range(_) | List(_) | Tuple(_) | Str(_) | Iterator(_) => true,
+            Map(m) => {
+                if m.meta_map().is_some() {
+                    m.contains_meta_key(&UnaryOp::Iterator.into())
+                        || m.contains_meta_key(&UnaryOp::Next.into())
+                } else {
+                    true
+                }
+            }
             Object(o) => o
                 .try_borrow()
                 .is_ok_and(|o| !matches!(o.is_iterable(), IsIterable::NotIterable)),

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -171,6 +171,15 @@ x.next().get()
         use super::*;
 
         #[test]
+        fn as_standalone_function() {
+            let script = "
+x = iterator.enumerate 'abc'
+x.next().get()
+";
+            check_script_output(script, tuple(&[0.into(), "a".into()]));
+        }
+
+        #[test]
         fn make_copy() {
             let script = "
 x = (10..20).enumerate()


### PR DESCRIPTION
Backport of e2bf2b5144e091bcd268fa0bdfe7336dce2de8f2 for `0.15.1`.

See #401.