### PR TITLE
Enable LTO and codegen-units = 1 optimization in a dedicated Cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,8 @@ unicode-segmentation = "1.10.0"
 wasm-bindgen = "0.2.97"
 # Internal testing crate for wasm-bindgen
 wasm-bindgen-test = "0.3.47"
+
+[profile.release-perf]
+inherits = "release"
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Related to the https://github.com/koto-lang/koto/discussions/405 discussion