### PR TITLE
Fix calling a native function directly from another native function

### DIFF
--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -2663,12 +2663,15 @@ impl KotoVm {
             self.set_register(result_register, result);
         }
 
-        // External function calls don't use the push/pop frame mechanism,
-        // so drop the call args here now that the call has been completed.
-        self.truncate_registers(call_info.frame_base);
-        let min_frame_registers = self.register_base + self.frame().required_registers as usize;
-        if self.registers.len() < min_frame_registers {
-            self.registers.resize(min_frame_registers, KValue::Null);
+        if !self.call_stack.is_empty() {
+            // External function calls don't use the push/pop frame mechanism,
+            // so drop the call args here now that the call has been completed,
+            self.truncate_registers(call_info.frame_base);
+            // Ensure that the calling frame still has the required number of registers
+            let min_frame_registers = self.register_index(self.frame().required_registers);
+            if self.registers.len() < min_frame_registers {
+                self.registers.resize(min_frame_registers, KValue::Null);
+            }
         }
         Ok(())
     }

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -165,6 +165,16 @@ x.next().get()
 ";
             check_script_output(script, 36);
         }
+
+        #[test]
+        fn each_with_native_function() {
+            let script = "
+(2.5, 4.6, 6.1)
+ .each number.round
+ .to_tuple()
+";
+            check_script_output(script, number_tuple(&[3, 5, 6]));
+        }
     }
 
     mod enumerate {


### PR DESCRIPTION
This is a hangover from 351609fa6a811150bbe2e3f7547315073d439c63, there's no need to try to resize the register stack when there's no calling frame.
