### PR TITLE
Use extra optimizations for release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ The Koto project adheres to
   - Default values should be provided for optional arguments.
   - Variadic arguments should be used to capture additional arguments.
 
+#### CLI
+
+- The CLI is now built with extra optimizations by default,
+  resulting in a faster binary at the expense of longer build times.
+
 ### Fixed
 
 #### Core Library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,13 @@ wasm-bindgen = "0.2.97"
 # Internal testing crate for wasm-bindgen
 wasm-bindgen-test = "0.3.47"
 
-[profile.release-perf]
-inherits = "release"
+# Enable extra optimizations for release builds
+[profile.release]
 codegen-units = 1
 lto = true
+
+# Re-enables default release profile settings, used for CI and local testing
+[profile.release-dev]
+inherits = "release"
+codegen-units = 16
+lto = false

--- a/justfile
+++ b/justfile
@@ -82,7 +82,7 @@ test_parser *args:
   cargo test -p koto_lexer -p koto_parser {{args}}
 
 test_release *args:
-  just test --release {{args}}
+  just test --profile release-dev {{args}}
 
 test_runtime *args:
   cargo test -p koto_runtime -p koto_bytecode {{args}}


### PR DESCRIPTION
Following on from #406, this PR makes the `release-perf` the default profile, and introduces `release-dev` for CI and local testing which applies the default `release` settings.
