### PR TITLE
0.15 backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The Koto project adheres to
 
 ## [0.15.1] Unreleased
 
+#### CLI
+
+- The CLI is now built with extra optimizations by default,
+  resulting in a faster binary at the expense of longer build times.
+
 ### Fixed
 
 #### Core Library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,13 @@ wasm-bindgen = "0.2.97"
 # Internal testing crate for wasm-bindgen
 wasm-bindgen-test = "0.3.47"
 
-[profile.release-perf]
-inherits = "release"
+# Enable extra optimizations for release builds
+[profile.release]
 codegen-units = 1
 lto = true
+
+# Re-enables default release profile settings, used for CI and local testing
+[profile.release-dev]
+inherits = "release"
+codegen-units = 16
+lto = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,8 @@ unicode-segmentation = "1.10.0"
 wasm-bindgen = "0.2.97"
 # Internal testing crate for wasm-bindgen
 wasm-bindgen-test = "0.3.47"
+
+[profile.release-perf]
+inherits = "release"
+codegen-units = 1
+lto = true

--- a/crates/parser/src/string.rs
+++ b/crates/parser/src/string.rs
@@ -1,6 +1,7 @@
 use crate::StringSlice;
 use koto_memory::Ptr;
 use std::{
+    cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
     ops::{Deref, Range},
@@ -156,6 +157,12 @@ impl From<PathBuf> for KString {
     }
 }
 
+impl PartialEq<KString> for &str {
+    fn eq(&self, other: &KString) -> bool {
+        *self == other.as_str()
+    }
+}
+
 impl PartialEq<&str> for KString {
     fn eq(&self, other: &&str) -> bool {
         self.as_str() == *other
@@ -168,6 +175,30 @@ impl PartialEq for KString {
     }
 }
 impl Eq for KString {}
+
+impl PartialOrd<KString> for &str {
+    fn partial_cmp(&self, other: &KString) -> Option<Ordering> {
+        PartialOrd::partial_cmp(*self, other.as_str())
+    }
+}
+
+impl PartialOrd<&str> for KString {
+    fn partial_cmp(&self, other: &&str) -> Option<Ordering> {
+        PartialOrd::partial_cmp(self.as_str(), *other)
+    }
+}
+
+impl PartialOrd for KString {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Ord::cmp(self, other))
+    }
+}
+
+impl Ord for KString {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
 
 impl Hash for KString {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -2654,12 +2654,15 @@ impl KotoVm {
             self.set_register(result_register, result);
         }
 
-        // External function calls don't use the push/pop frame mechanism,
-        // so drop the call args here now that the call has been completed.
-        self.truncate_registers(call_info.frame_base);
-        let min_frame_registers = self.register_base + self.frame().required_registers as usize;
-        if self.registers.len() < min_frame_registers {
-            self.registers.resize(min_frame_registers, KValue::Null);
+        if !self.call_stack.is_empty() {
+            // External function calls don't use the push/pop frame mechanism,
+            // so drop the call args here now that the call has been completed,
+            self.truncate_registers(call_info.frame_base);
+            // Ensure that the calling frame still has the required number of registers
+            let min_frame_registers = self.register_index(self.frame().required_registers);
+            if self.registers.len() < min_frame_registers {
+                self.registers.resize(min_frame_registers, KValue::Null);
+            }
         }
         Ok(())
     }

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -165,6 +165,16 @@ x.next().get()
 ";
             check_script_output(script, 36);
         }
+
+        #[test]
+        fn each_with_native_function() {
+            let script = "
+(2.5, 4.6, 6.1)
+ .each number.round
+ .to_tuple()
+";
+            check_script_output(script, number_tuple(&[3, 5, 6]));
+        }
     }
 
     mod enumerate {

--- a/justfile
+++ b/justfile
@@ -82,7 +82,7 @@ test_parser *args:
   cargo test -p koto_lexer -p koto_parser {{args}}
 
 test_release *args:
-  just test --release {{args}}
+  just test --profile release-dev {{args}}
 
 test_runtime *args:
   cargo test -p koto_runtime -p koto_bytecode {{args}}


### PR DESCRIPTION
- **feat: enable LTO and codegen-units = 1 optimization (#406)**
- **Add more `PartialEq` and `PartialOrd` impls for `KString` (#411)**
- **Fix calling a native function directly from another native function (#413)**
- **Use release-perf profile by default, add release-dev for faster CI (#414)**
