### PR TITLE
String formatting improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ The Koto project adheres to
   x = 1_000_000
   y = 0xff_aa_bb
   ```
+- Interpolated values can now be formatted with alternative representations.
+  - E.g.
+  ```koto
+  print '{15:b}'
+  # -> 1111
+  ```
 
 #### API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,15 @@ The Koto project adheres to
   print '{15:b}'
   # -> 1111
   ```
+  - The `@debug` metakey has been added to allow for additional debug information
+    to be provided when formatting an object as a string.
 
 #### API
 
 - `Compiler::compile_ast` has been added, useful for tools that want to work with the AST
   after checking that it compiles correctly.
+- `DisplayContext::debug_enabled` has been added to allow native objects to provide
+  additional debug information when `KotoObject::display` is called.
 
 ### Changed
 

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -2187,6 +2187,9 @@ impl Compiler {
                                         if let Some(fill_constant) = format.fill_character {
                                             self.push_var_u32(fill_constant.into());
                                         }
+                                        if let Some(style) = format.representation {
+                                            self.bytes.push(style as u8);
+                                        }
 
                                         if expression_result.is_temporary {
                                             self.pop_register()?;

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -2162,7 +2162,7 @@ impl Compiler {
                                         );
                                         self.push_op_without_span(
                                             Op::StringPush,
-                                            &[node_register, 0],
+                                            &[node_register, StringFormatFlags::default().into()],
                                         );
 
                                         self.pop_register()?;
@@ -2176,10 +2176,7 @@ impl Compiler {
                                         let format_flags = StringFormatFlags::from(*format);
                                         self.push_op_without_span(
                                             Op::StringPush,
-                                            &[
-                                                expression_result.unwrap(self)?,
-                                                format_flags.as_byte(),
-                                            ],
+                                            &[expression_result.unwrap(self)?, format_flags.into()],
                                         );
                                         if let Some(min_width) = format.min_width {
                                             self.push_var_u32(min_width);

--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -435,12 +435,14 @@ impl From<FunctionFlags> for u8 {
 pub struct StringFormatFlags(u8);
 
 impl StringFormatFlags {
-    /// Set to true when min_width is defined
+    /// Set to true when a minimum width is defined
     pub const MIN_WIDTH: u8 = 1 << 2; // The first two bits correspond to values of StringAlignment
     /// Set to true when precision is defined
     pub const PRECISION: u8 = 1 << 3;
-    /// Set to true when fill_character is defined
+    /// Set to true when a fill character is defined
     pub const FILL_CHARACTER: u8 = 1 << 4;
+    /// Set to true when a format style is defined
+    pub const REPRESENTATION: u8 = 1 << 5;
 
     /// Returns the flag's string alignment
     pub fn alignment(&self) -> StringAlignment {
@@ -471,6 +473,11 @@ impl StringFormatFlags {
     pub fn has_fill_character(&self) -> bool {
         self.0 & Self::FILL_CHARACTER != 0
     }
+
+    /// True if an alternative representation has been defined
+    pub fn has_representation(&self) -> bool {
+        self.0 & Self::REPRESENTATION != 0
+    }
 }
 
 impl From<StringFormatOptions> for StringFormatFlags {
@@ -486,6 +493,9 @@ impl From<StringFormatOptions> for StringFormatFlags {
         if value.fill_character.is_some() {
             flags |= Self::FILL_CHARACTER;
         }
+        if value.representation.is_some() {
+            flags |= Self::REPRESENTATION;
+        }
 
         Self(flags)
     }
@@ -495,7 +505,7 @@ impl TryFrom<u8> for StringFormatFlags {
     type Error = String;
 
     fn try_from(byte: u8) -> Result<Self, Self::Error> {
-        if byte <= 0b111111 {
+        if byte <= 0b1111111 {
             Ok(Self(byte))
         } else {
             Err(format!("Invalid string format flags: {byte:#010b}"))

--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -846,7 +846,8 @@ impl fmt::Debug for Instruction {
                 id,
             } => write!(
                 f,
-                "MetaInsert      map: {register:<10} id: {id:<11}value: {value}",
+                "MetaInsert      map: {register:<10} id: {:<11} value: {value}",
+                format!("{id}")
             ),
             MetaInsertNamed {
                 register,

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -1,6 +1,6 @@
 use crate::{Chunk, FunctionFlags, Instruction, Op, StringFormatFlags};
 use koto_memory::Ptr;
-use koto_parser::StringFormatOptions;
+use koto_parser::{StringFormatOptions, StringFormatRepresentation};
 use std::mem::MaybeUninit;
 
 /// An iterator that converts bytecode into a series of [Instruction]s
@@ -665,6 +665,14 @@ impl Iterator for InstructionReader {
                             }
                             if flags.has_fill_character() {
                                 options.fill_character = Some(get_var_u32!().into());
+                            }
+                            if flags.has_representation() {
+                                match StringFormatRepresentation::try_from(get_u8!()) {
+                                    Ok(representation) => {
+                                        options.representation = Some(representation);
+                                    }
+                                    Err(e) => return Some(Error { message: e }),
+                                }
                             }
                             StringPush {
                                 value,

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -144,119 +144,119 @@ impl Iterator for InstructionReader {
         };
         self.ip += 2;
 
-        match op {
-            Op::NewFrame => Some(NewFrame {
+        let instruction = match op {
+            Op::NewFrame => NewFrame {
                 register_count: byte_a,
-            }),
-            Op::Copy => Some(Copy {
+            },
+            Op::Copy => Copy {
                 target: byte_a,
                 source: get_u8!(),
-            }),
-            Op::SetNull => Some(SetNull { register: byte_a }),
-            Op::SetFalse => Some(SetBool {
+            },
+            Op::SetNull => SetNull { register: byte_a },
+            Op::SetFalse => SetBool {
                 register: byte_a,
                 value: false,
-            }),
-            Op::SetTrue => Some(SetBool {
+            },
+            Op::SetTrue => SetBool {
                 register: byte_a,
                 value: true,
-            }),
-            Op::Set0 => Some(SetNumber {
+            },
+            Op::Set0 => SetNumber {
                 register: byte_a,
                 value: 0,
-            }),
-            Op::Set1 => Some(SetNumber {
+            },
+            Op::Set1 => SetNumber {
                 register: byte_a,
                 value: 1,
-            }),
-            Op::SetNumberU8 => Some(SetNumber {
+            },
+            Op::SetNumberU8 => SetNumber {
                 register: byte_a,
                 value: get_u8!() as i64,
-            }),
-            Op::SetNumberNegU8 => Some(SetNumber {
+            },
+            Op::SetNumberNegU8 => SetNumber {
                 register: byte_a,
                 value: -(get_u8!() as i64),
-            }),
-            Op::LoadFloat => Some(LoadFloat {
+            },
+            Op::LoadFloat => LoadFloat {
                 register: byte_a,
                 constant: get_var_u32!().into(),
-            }),
-            Op::LoadInt => Some(LoadInt {
+            },
+            Op::LoadInt => LoadInt {
                 register: byte_a,
                 constant: get_var_u32!().into(),
-            }),
-            Op::LoadString => Some(LoadString {
+            },
+            Op::LoadString => LoadString {
                 register: byte_a,
                 constant: get_var_u32!().into(),
-            }),
-            Op::LoadNonLocal => Some(LoadNonLocal {
+            },
+            Op::LoadNonLocal => LoadNonLocal {
                 register: byte_a,
                 constant: get_var_u32!().into(),
-            }),
-            Op::ValueExport => Some(ValueExport {
+            },
+            Op::ValueExport => ValueExport {
                 name: byte_a,
                 value: get_u8!(),
-            }),
-            Op::Import => Some(Import { register: byte_a }),
+            },
+            Op::Import => Import { register: byte_a },
             Op::MakeTempTuple => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(MakeTempTuple {
+                MakeTempTuple {
                     register: byte_a,
                     start: byte_b,
                     count: byte_c,
-                })
+                }
             }
-            Op::TempTupleToTuple => Some(TempTupleToTuple {
+            Op::TempTupleToTuple => TempTupleToTuple {
                 register: byte_a,
                 source: get_u8!(),
-            }),
-            Op::MakeMap => Some(MakeMap {
+            },
+            Op::MakeMap => MakeMap {
                 register: byte_a,
                 size_hint: get_var_u32!(),
-            }),
-            Op::SequenceStart => Some(SequenceStart {
+            },
+            Op::SequenceStart => SequenceStart {
                 size_hint: get_var_u32_with_first_byte!(byte_a),
-            }),
-            Op::SequencePush => Some(SequencePush { value: byte_a }),
-            Op::SequencePushN => Some(SequencePushN {
+            },
+            Op::SequencePush => SequencePush { value: byte_a },
+            Op::SequencePushN => SequencePushN {
                 start: byte_a,
                 count: get_u8!(),
-            }),
-            Op::SequenceToList => Some(SequenceToList { register: byte_a }),
-            Op::SequenceToTuple => Some(SequenceToTuple { register: byte_a }),
+            },
+            Op::SequenceToList => SequenceToList { register: byte_a },
+            Op::SequenceToTuple => SequenceToTuple { register: byte_a },
             Op::Range => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(Range {
+                Range {
                     register: byte_a,
                     start: byte_b,
                     end: byte_c,
-                })
+                }
             }
             Op::RangeInclusive => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(RangeInclusive {
+                RangeInclusive {
                     register: byte_a,
                     start: byte_b,
                     end: byte_c,
-                })
+                }
             }
-            Op::RangeTo => Some(RangeTo {
+            Op::RangeTo => RangeTo {
                 register: byte_a,
                 end: get_u8!(),
-            }),
-            Op::RangeToInclusive => Some(RangeToInclusive {
+            },
+            Op::RangeToInclusive => RangeToInclusive {
                 register: byte_a,
                 end: get_u8!(),
-            }),
-            Op::RangeFrom => Some(RangeFrom {
+            },
+            Op::RangeFrom => RangeFrom {
                 register: byte_a,
                 start: get_u8!(),
-            }),
-            Op::RangeFull => Some(RangeFull { register: byte_a }),
-            Op::MakeIterator => Some(MakeIterator {
+            },
+            Op::RangeFull => RangeFull { register: byte_a },
+            Op::MakeIterator => MakeIterator {
                 register: byte_a,
                 iterable: get_u8!(),
-            }),
+            },
             Op::Function => {
                 let register = byte_a;
                 let [arg_count, optional_arg_count, capture_count, flags, size_a, size_b] =
@@ -265,387 +265,387 @@ impl Iterator for InstructionReader {
                     Ok(flags) => {
                         let size = u16::from_le_bytes([size_a, size_b]);
 
-                        Some(Function {
+                        Function {
                             register,
                             arg_count,
                             optional_arg_count,
                             capture_count,
                             flags,
                             size,
-                        })
+                        }
                     }
-                    Err(e) => Some(Error { message: e }),
+                    Err(e) => Error { message: e },
                 }
             }
             Op::Capture => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(Capture {
+                Capture {
                     function: byte_a,
                     target: byte_b,
                     source: byte_c,
-                })
+                }
             }
-            Op::Negate => Some(Negate {
+            Op::Negate => Negate {
                 register: byte_a,
                 value: get_u8!(),
-            }),
-            Op::Not => Some(Not {
+            },
+            Op::Not => Not {
                 register: byte_a,
                 value: get_u8!(),
-            }),
+            },
             Op::Add => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(Add {
+                Add {
                     register: byte_a,
                     lhs: byte_b,
                     rhs: byte_c,
-                })
+                }
             }
             Op::Subtract => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(Subtract {
+                Subtract {
                     register: byte_a,
                     lhs: byte_b,
                     rhs: byte_c,
-                })
+                }
             }
             Op::Multiply => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(Multiply {
+                Multiply {
                     register: byte_a,
                     lhs: byte_b,
                     rhs: byte_c,
-                })
+                }
             }
             Op::Divide => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(Divide {
+                Divide {
                     register: byte_a,
                     lhs: byte_b,
                     rhs: byte_c,
-                })
+                }
             }
             Op::Remainder => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(Remainder {
+                Remainder {
                     register: byte_a,
                     lhs: byte_b,
                     rhs: byte_c,
-                })
+                }
             }
-            Op::AddAssign => Some(AddAssign {
+            Op::AddAssign => AddAssign {
                 lhs: byte_a,
                 rhs: get_u8!(),
-            }),
-            Op::SubtractAssign => Some(SubtractAssign {
+            },
+            Op::SubtractAssign => SubtractAssign {
                 lhs: byte_a,
                 rhs: get_u8!(),
-            }),
-            Op::MultiplyAssign => Some(MultiplyAssign {
+            },
+            Op::MultiplyAssign => MultiplyAssign {
                 lhs: byte_a,
                 rhs: get_u8!(),
-            }),
-            Op::DivideAssign => Some(DivideAssign {
+            },
+            Op::DivideAssign => DivideAssign {
                 lhs: byte_a,
                 rhs: get_u8!(),
-            }),
-            Op::RemainderAssign => Some(RemainderAssign {
+            },
+            Op::RemainderAssign => RemainderAssign {
                 lhs: byte_a,
                 rhs: get_u8!(),
-            }),
+            },
             Op::Less => {
                 let [lhs, rhs] = get_u8x2!();
-                Some(Less {
+                Less {
                     register: byte_a,
                     lhs,
                     rhs,
-                })
+                }
             }
             Op::LessOrEqual => {
                 let [lhs, rhs] = get_u8x2!();
-                Some(LessOrEqual {
+                LessOrEqual {
                     register: byte_a,
                     lhs,
                     rhs,
-                })
+                }
             }
             Op::Greater => {
                 let [lhs, rhs] = get_u8x2!();
-                Some(Greater {
+                Greater {
                     register: byte_a,
                     lhs,
                     rhs,
-                })
+                }
             }
             Op::GreaterOrEqual => {
                 let [lhs, rhs] = get_u8x2!();
-                Some(GreaterOrEqual {
+                GreaterOrEqual {
                     register: byte_a,
                     lhs,
                     rhs,
-                })
+                }
             }
             Op::Equal => {
                 let [lhs, rhs] = get_u8x2!();
-                Some(Equal {
+                Equal {
                     register: byte_a,
                     lhs,
                     rhs,
-                })
+                }
             }
             Op::NotEqual => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(NotEqual {
+                NotEqual {
                     register: byte_a,
                     lhs: byte_b,
                     rhs: byte_c,
-                })
+                }
             }
-            Op::Jump => Some(Jump {
+            Op::Jump => Jump {
                 offset: u16::from_le_bytes([byte_a, get_u8!()]),
-            }),
-            Op::JumpBack => Some(JumpBack {
+            },
+            Op::JumpBack => JumpBack {
                 offset: u16::from_le_bytes([byte_a, get_u8!()]),
-            }),
-            Op::JumpIfTrue => Some(JumpIfTrue {
+            },
+            Op::JumpIfTrue => JumpIfTrue {
                 register: byte_a,
                 offset: get_u16!(),
-            }),
-            Op::JumpIfFalse => Some(JumpIfFalse {
+            },
+            Op::JumpIfFalse => JumpIfFalse {
                 register: byte_a,
                 offset: get_u16!(),
-            }),
-            Op::JumpIfNull => Some(JumpIfNull {
+            },
+            Op::JumpIfNull => JumpIfNull {
                 register: byte_a,
                 offset: get_u16!(),
-            }),
+            },
             Op::Call => {
                 let [function, frame_base, arg_count, unpacked_arg_count] = get_u8x4!();
-                Some(Call {
+                Call {
                     result: byte_a,
                     function,
                     frame_base,
                     arg_count,
                     packed_arg_count: unpacked_arg_count,
-                })
+                }
             }
             Op::CallInstance => {
                 let [function, instance, frame_base, arg_count, unpacked_arg_count] = get_u8x5!();
-                Some(CallInstance {
+                CallInstance {
                     result: byte_a,
                     function,
                     instance,
                     frame_base,
                     arg_count,
                     packed_arg_count: unpacked_arg_count,
-                })
+                }
             }
-            Op::Return => Some(Return { register: byte_a }),
-            Op::Yield => Some(Yield { register: byte_a }),
-            Op::Throw => Some(Throw { register: byte_a }),
-            Op::Size => Some(Size {
+            Op::Return => Return { register: byte_a },
+            Op::Yield => Yield { register: byte_a },
+            Op::Throw => Throw { register: byte_a },
+            Op::Size => Size {
                 register: byte_a,
                 value: get_u8!(),
-            }),
+            },
             Op::IterNext => {
                 let [byte_b, byte_c, byte_d] = get_u8x3!();
-                Some(IterNext {
+                IterNext {
                     result: Some(byte_a),
                     iterator: byte_b,
                     jump_offset: u16::from_le_bytes([byte_c, byte_d]),
                     temporary_output: false,
-                })
+                }
             }
             Op::IterNextTemp => {
                 let [byte_b, byte_c, byte_d] = get_u8x3!();
-                Some(IterNext {
+                IterNext {
                     result: Some(byte_a),
                     iterator: byte_b,
                     jump_offset: u16::from_le_bytes([byte_c, byte_d]),
                     temporary_output: true,
-                })
+                }
             }
-            Op::IterNextQuiet => Some(IterNext {
+            Op::IterNextQuiet => IterNext {
                 result: None,
                 iterator: byte_a,
                 jump_offset: get_u16!(),
                 temporary_output: false,
-            }),
-            Op::IterUnpack => Some(IterNext {
+            },
+            Op::IterUnpack => IterNext {
                 result: Some(byte_a),
                 iterator: get_u8!(),
                 jump_offset: 0,
                 temporary_output: false,
-            }),
+            },
             Op::TempIndex => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(TempIndex {
+                TempIndex {
                     register: byte_a,
                     value: byte_b,
                     index: byte_c as i8,
-                })
+                }
             }
             Op::SliceFrom => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(SliceFrom {
+                SliceFrom {
                     register: byte_a,
                     value: byte_b,
                     index: byte_c as i8,
-                })
+                }
             }
             Op::SliceTo => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(SliceTo {
+                SliceTo {
                     register: byte_a,
                     value: byte_b,
                     index: byte_c as i8,
-                })
+                }
             }
             Op::Index => {
                 let [value, index] = get_u8x2!();
-                Some(Index {
+                Index {
                     register: byte_a,
                     value,
                     index,
-                })
+                }
             }
             Op::IndexMut => {
                 let [index, value] = get_u8x2!();
-                Some(IndexMut {
+                IndexMut {
                     register: byte_a,
                     index,
                     value,
-                })
+                }
             }
             Op::MapInsert => {
                 let [key, value] = get_u8x2!();
-                Some(MapInsert {
+                MapInsert {
                     register: byte_a,
                     key,
                     value,
-                })
+                }
             }
             Op::MetaInsert => {
                 let register = byte_a;
                 let [meta_id, value] = get_u8x2!();
                 if let Ok(id) = meta_id.try_into() {
                     {
-                        Some(MetaInsert {
+                        MetaInsert {
                             register,
                             value,
                             id,
-                        })
+                        }
                     }
                 } else {
-                    Some(Error {
+                    Error {
                         message: format!(
                             "Unexpected meta id {meta_id} found at instruction {op_ip}",
                         ),
-                    })
+                    }
                 }
             }
             Op::MetaInsertNamed => {
                 let register = byte_a;
                 let [meta_id, name, value] = get_u8x3!();
                 if let Ok(id) = meta_id.try_into() {
-                    Some(MetaInsertNamed {
+                    MetaInsertNamed {
                         register,
                         value,
                         id,
                         name,
-                    })
+                    }
                 } else {
-                    Some(Error {
+                    Error {
                         message: format!(
                             "Unexpected meta id {meta_id} found at instruction {op_ip}",
                         ),
-                    })
+                    }
                 }
             }
             Op::MetaExport => {
                 let meta_id = byte_a;
                 let value = get_u8!();
                 if let Ok(id) = meta_id.try_into() {
-                    Some(MetaExport { id, value })
+                    MetaExport { id, value }
                 } else {
-                    Some(Error {
+                    Error {
                         message: format!(
                             "Unexpected meta id {meta_id} found at instruction {op_ip}",
                         ),
-                    })
+                    }
                 }
             }
             Op::MetaExportNamed => {
                 let meta_id = byte_a;
                 let [name, value] = get_u8x2!();
                 if let Ok(id) = meta_id.try_into() {
-                    Some(MetaExportNamed { id, value, name })
+                    MetaExportNamed { id, value, name }
                 } else {
-                    Some(Error {
+                    Error {
                         message: format!(
                             "Unexpected meta id {meta_id} found at instruction {op_ip}",
                         ),
-                    })
+                    }
                 }
             }
             Op::Access => {
                 let [value, key_a] = get_u8x2!();
-                Some(Access {
+                Access {
                     register: byte_a,
                     value,
                     key: get_var_u32_with_first_byte!(key_a).into(),
-                })
+                }
             }
             Op::AccessString => {
                 let [byte_b, byte_c] = get_u8x2!();
-                Some(AccessString {
+                AccessString {
                     register: byte_a,
                     value: byte_b,
                     key: byte_c,
-                })
+                }
             }
-            Op::TryStart => Some(TryStart {
+            Op::TryStart => TryStart {
                 arg_register: byte_a,
                 catch_offset: get_u16!(),
-            }),
-            Op::TryEnd => Some(TryEnd),
-            Op::Debug => Some(Debug {
+            },
+            Op::TryEnd => TryEnd,
+            Op::Debug => Debug {
                 register: byte_a,
                 constant: get_var_u32!().into(),
-            }),
-            Op::CheckSizeEqual => Some(CheckSizeEqual {
+            },
+            Op::CheckSizeEqual => CheckSizeEqual {
                 register: byte_a,
                 size: get_u8!() as usize,
-            }),
-            Op::CheckSizeMin => Some(CheckSizeMin {
+            },
+            Op::CheckSizeMin => CheckSizeMin {
                 register: byte_a,
                 size: get_u8!() as usize,
-            }),
-            Op::AssertType => Some(AssertType {
+            },
+            Op::AssertType => AssertType {
                 value: byte_a,
                 allow_null: false,
                 type_string: get_var_u32!().into(),
-            }),
-            Op::CheckType => Some(CheckType {
+            },
+            Op::CheckType => CheckType {
                 value: byte_a,
                 allow_null: false,
                 type_string: get_var_u32!().into(),
                 jump_offset: get_u16!(),
-            }),
-            Op::AssertOptionalType => Some(AssertType {
+            },
+            Op::AssertOptionalType => AssertType {
                 value: byte_a,
                 allow_null: true,
                 type_string: get_var_u32!().into(),
-            }),
-            Op::CheckOptionalType => Some(CheckType {
+            },
+            Op::CheckOptionalType => CheckType {
                 value: byte_a,
                 allow_null: true,
                 type_string: get_var_u32!().into(),
                 jump_offset: get_u16!(),
-            }),
-            Op::StringStart => Some(StringStart {
+            },
+            Op::StringStart => StringStart {
                 size_hint: get_var_u32_with_first_byte!(byte_a),
-            }),
+            },
             Op::StringPush => {
                 let value = byte_a;
                 let flags = get_u8!();
@@ -666,25 +666,27 @@ impl Iterator for InstructionReader {
                             if flags.has_fill_character() {
                                 options.fill_character = Some(get_var_u32!().into());
                             }
-                            Some(StringPush {
+                            StringPush {
                                 value,
                                 format_options: Some(options),
-                            })
+                            }
                         }
-                        Err(e) => Some(Error { message: e }),
+                        Err(e) => Error { message: e },
                     }
                 } else {
-                    Some(StringPush {
+                    StringPush {
                         value,
                         format_options: None,
-                    })
+                    }
                 }
             }
-            Op::StringFinish => Some(StringFinish { register: byte_a }),
-            _ => Some(Error {
+            Op::StringFinish => StringFinish { register: byte_a },
+            _ => Error {
                 message: format!("Unexpected opcode {op:?} found at instruction {op_ip}"),
-            }),
-        }
+            },
+        };
+
+        Some(instruction)
     }
 }
 

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -155,7 +155,7 @@ pub enum Op {
     ///
     /// Values will be rendered and then formatted according to the specified format flags.
     ///
-    /// See [StringFormatFlags](crate::StringFormatFlags) for a description of the the format flags.
+    /// See [`StringFormatFlags`](crate::StringFormatFlags) for a description of the format flags.
     ///
     /// `[*value, format_flags, ?@min_width, ?@precision, ?@fill_character]`
     StringPush,
@@ -167,7 +167,7 @@ pub enum Op {
 
     /// Makes a Function
     ///
-    /// The flags are a bitfield constructed from [FunctionFlags](crate::FunctionFlags).
+    /// The flags are a bitfield constructed from [`FunctionFlags`](crate::FunctionFlags).
     /// The bytes following this instruction make up the body of the function.
     ///
     /// `[*target, arg count, optional arg count, capture count, flags, function size[2]]`

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -157,7 +157,7 @@ pub enum Op {
     ///
     /// See [`StringFormatFlags`](crate::StringFormatFlags) for a description of the format flags.
     ///
-    /// `[*value, format_flags, ?@min_width, ?@precision, ?@fill_character]`
+    /// `[*value, format_flags, ?@min_width, ?@precision, ?@fill_character, ?style]`
     StringPush,
 
     /// Places the finished string in the target register

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1703,6 +1703,36 @@ print! '{x:.4}'
 check! 0.3333
 ```
 
+### Representation
+
+Values can be formatted with alternative representations, with representations chosen with a character at the end of the format options.
+
+The following representations are only supported for numbers:
+- `e` - exponential (lower-case)
+- `E` - exponential (upper-case)
+
+The following representations are only supported for integers:
+- `b` - binary
+- `o` - octal
+- `x` - hexadecimal (lower-case)
+- `X` - hexadecimal (upper-case)
+
+```koto
+z = 60
+print! '{z:x}'
+check! 3c
+print! '0x{z:X}'
+check! 0x3C
+print! '{z:o}'
+check! 74
+print! '0b{z:08b}'
+check! 0b00111100
+print! '{z * 1000:e}'
+check! 6e4
+print! '{z * 1_000_000:E}'
+check! 6E7
+```
+
 ## Advanced Functions
 
 Functions in Koto have some advanced features that are worth exploring.

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -1707,6 +1707,8 @@ check! 0.3333
 
 Values can be formatted with alternative representations, with representations chosen with a character at the end of the format options.
 
+- `?` - The value will be formatted with additional debug information when available.
+
 The following representations are only supported for numbers:
 - `e` - exponential (lower-case)
 - `E` - exponential (upper-case)
@@ -1719,6 +1721,8 @@ The following representations are only supported for integers:
 
 ```koto
 z = 60
+print! '{z:?}'
+check! 60
 print! '{z:x}'
 check! 3c
 print! '0x{z:X}'
@@ -2213,6 +2217,24 @@ x = foo -1
 print! "The value of x is '{x}'"
 check! The value of x is 'Foo(-1)'
 ```
+
+#### `@debug`
+
+The `@debug` metakey defines how an object should be represented when
+displaying the object in a debug context, e.g. when using [`debug`](#debug-1),
+or when the [`?` representation](#representation) is used in an interpolated expression.
+
+```koto
+foo = |n|
+  data: n
+  @display: || 'Foo({self.data})'
+  @debug: || '!!{self}!!'
+
+print! "{foo(123):?}"
+check! !!Foo(123)!!
+```
+
+If `@debug` isn't defined, then `@display` will be used as a fallback.
 
 #### `@type`
 

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -38,7 +38,7 @@ comment.
 -#
 ```
 
-### Numbers
+### Numbers and Arithmetic
 
 Numbers and arithmetic are expressed in a familiar way.
 
@@ -58,8 +58,15 @@ check! 12
 print! 9 / 2
 check! 4.5
 
-print! 12 % 5
-check! 2
+print! 12.5 % 5
+check! 2.5
+```
+
+Underscores can be used as separators to aid readability in long numbers.
+
+```koto
+print! 1_000_000
+check! 1000000
 ```
 
 #### Parentheses
@@ -75,6 +82,24 @@ check! 11
 # With parentheses, the additions are performed first
 print! (1 + 2) * (3 + 4)
 check! 21
+```
+
+#### Non-decimal Numbers
+
+Numbers can be expressed with non-decimal bases.
+
+```koto
+# Hexadecimal numbers begin with 0x
+print! 0xcafe
+check! 51966
+
+# Octal numbers begin with 0o
+print! 0o7060
+check! 3632
+
+# Binary numbers begin with 0b
+print! 0b1001
+check! 9
 ```
 
 ### Booleans

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -18,7 +18,7 @@ pub use crate::{
     node::*,
     parser::Parser,
     string::KString,
-    string_format_options::{StringAlignment, StringFormatOptions},
+    string_format_options::{StringAlignment, StringFormatOptions, StringFormatRepresentation},
     string_slice::StringSlice,
 };
 pub use koto_lexer::{Position, RawStringDelimiter, Span, StringQuote, StringType};

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -558,6 +558,8 @@ pub enum MetaKeyId {
     /// @index_mut
     IndexMut,
 
+    /// @debug
+    Debug,
     /// @display
     Display,
     /// @iterator
@@ -637,6 +639,7 @@ impl fmt::Display for MetaKeyId {
                 NotEqual => "!=",
                 Index => "index",
                 IndexMut => "index_mut",
+                Debug => "debug",
                 Display => "display",
                 Iterator => "iterator",
                 Next => "next",

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -2100,6 +2100,7 @@ impl<'source> Parser<'source> {
             Some(Token::GreaterOrEqual) => MetaKeyId::GreaterOrEqual,
             Some(Token::Equal) => MetaKeyId::Equal,
             Some(Token::NotEqual) => MetaKeyId::NotEqual,
+            Some(Token::Debug) => MetaKeyId::Debug,
             Some(Token::Id) => match self.current_token.slice(self.source) {
                 "call" => MetaKeyId::Call,
                 "display" => MetaKeyId::Display,

--- a/crates/parser/src/string_format_options.rs
+++ b/crates/parser/src/string_format_options.rs
@@ -16,6 +16,8 @@ pub struct StringFormatOptions {
     pub precision: Option<u32>,
     /// The character that padded strings should use to fill empty space
     pub fill_character: Option<ConstantIndex>,
+    /// An alternative representation that can be applied to the formatted string
+    pub representation: Option<StringFormatRepresentation>,
 }
 
 impl StringFormatOptions {
@@ -66,6 +68,30 @@ impl StringFormatOptions {
                 ('.', Some(_), Start | MinWidth | Precision) => {
                     let first_digit = chars.next().unwrap();
                     result.precision = Some(consume_u32(first_digit, &mut chars)?);
+                    position = Type;
+                }
+                ('b', _, Start | MinWidth | Precision | Type) => {
+                    result.representation = Some(StringFormatRepresentation::Binary);
+                    position = End;
+                }
+                ('o', _, Start | MinWidth | Precision | Type) => {
+                    result.representation = Some(StringFormatRepresentation::Octal);
+                    position = End;
+                }
+                ('x', _, Start | MinWidth | Precision | Type) => {
+                    result.representation = Some(StringFormatRepresentation::HexLower);
+                    position = End;
+                }
+                ('X', _, Start | MinWidth | Precision | Type) => {
+                    result.representation = Some(StringFormatRepresentation::HexUpper);
+                    position = End;
+                }
+                ('e', _, Start | MinWidth | Precision | Type) => {
+                    result.representation = Some(StringFormatRepresentation::ExpLower);
+                    position = End;
+                }
+                ('E', _, Start | MinWidth | Precision | Type) => {
+                    result.representation = Some(StringFormatRepresentation::ExpUpper);
                     position = End;
                 }
                 (_, _, Start) => {
@@ -93,6 +119,7 @@ enum FormatParsePosition {
     Alignment,
     MinWidth,
     Precision,
+    Type,
     End,
 }
 
@@ -129,6 +156,41 @@ pub enum StringAlignment {
     Left,
     Center,
     Right,
+}
+
+/// Alternative representations formatted strings
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
+#[repr(u8)]
+pub enum StringFormatRepresentation {
+    HexLower,
+    HexUpper,
+    Binary,
+    Octal,
+    ExpLower,
+    ExpUpper,
+}
+
+impl TryFrom<u8> for StringFormatRepresentation {
+    type Error = String;
+
+    fn try_from(byte: u8) -> Result<Self, Self::Error> {
+        if byte == Self::HexLower as u8 {
+            Ok(Self::HexLower)
+        } else if byte == Self::HexUpper as u8 {
+            Ok(Self::HexUpper)
+        } else if byte == Self::Binary as u8 {
+            Ok(Self::Binary)
+        } else if byte == Self::Octal as u8 {
+            Ok(Self::Octal)
+        } else if byte == Self::ExpLower as u8 {
+            Ok(Self::ExpLower)
+        } else if byte == Self::ExpUpper as u8 {
+            Ok(Self::ExpUpper)
+        } else {
+            Err(format!("Invalid string format style: {byte:#010b}"))
+        }
+    }
 }
 
 /// An error that represents a problem with the Parser's internal logic, rather than a user error
@@ -222,6 +284,7 @@ mod tests {
                     fill_character: Some(0.into()),
                     min_width: Some(20),
                     precision: Some(10),
+                    ..Default::default()
                 },
             ),
             (
@@ -251,5 +314,39 @@ mod tests {
                 },
             ),
         ])
+    }
+
+    #[test]
+    fn style() {
+        test_parse_format_string(&[
+            (
+                "x",
+                StringFormatOptions {
+                    representation: Some(StringFormatRepresentation::HexLower),
+                    ..Default::default()
+                },
+            ),
+            (
+                "X",
+                StringFormatOptions {
+                    representation: Some(StringFormatRepresentation::HexUpper),
+                    ..Default::default()
+                },
+            ),
+            (
+                "o",
+                StringFormatOptions {
+                    representation: Some(StringFormatRepresentation::Octal),
+                    ..Default::default()
+                },
+            ),
+            (
+                "b",
+                StringFormatOptions {
+                    representation: Some(StringFormatRepresentation::Binary),
+                    ..Default::default()
+                },
+            ),
+        ]);
     }
 }

--- a/crates/parser/src/string_format_options.rs
+++ b/crates/parser/src/string_format_options.rs
@@ -70,6 +70,10 @@ impl StringFormatOptions {
                     result.precision = Some(consume_u32(first_digit, &mut chars)?);
                     position = Type;
                 }
+                ('?', _, Start | MinWidth | Precision | Type) => {
+                    result.representation = Some(StringFormatRepresentation::Debug);
+                    position = End;
+                }
                 ('b', _, Start | MinWidth | Precision | Type) => {
                     result.representation = Some(StringFormatRepresentation::Binary);
                     position = End;
@@ -163,6 +167,7 @@ pub enum StringAlignment {
 #[allow(missing_docs)]
 #[repr(u8)]
 pub enum StringFormatRepresentation {
+    Debug,
     HexLower,
     HexUpper,
     Binary,
@@ -175,7 +180,9 @@ impl TryFrom<u8> for StringFormatRepresentation {
     type Error = String;
 
     fn try_from(byte: u8) -> Result<Self, Self::Error> {
-        if byte == Self::HexLower as u8 {
+        if byte == Self::Debug as u8 {
+            Ok(Self::Debug)
+        } else if byte == Self::HexLower as u8 {
             Ok(Self::HexLower)
         } else if byte == Self::HexUpper as u8 {
             Ok(Self::HexUpper)

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -381,7 +381,7 @@ null"#;
         #[test]
         fn string_with_formatted_expression() {
             let source = "
-'!{a:_>3.2}!'
+'!{a:_>3.2x}!'
 ";
             check_ast(
                 source,
@@ -398,6 +398,7 @@ null"#;
                                     min_width: Some(3),
                                     precision: Some(2),
                                     fill_character: Some(2.into()),
+                                    representation: Some(StringFormatRepresentation::HexLower),
                                 },
                             },
                             StringNode::Literal(0.into()),

--- a/crates/runtime/src/display_context.rs
+++ b/crates/runtime/src/display_context.rs
@@ -13,6 +13,8 @@ pub struct DisplayContext<'a> {
     // - Strings should be displayed with quotes when they're inside a container.
     // - Containers should check the parent list to avoid recursive display operations.
     parent_containers: Vec<Address>,
+    /// True when the resulting string is to be used in a debug context.
+    debug: bool,
 }
 
 impl<'a> DisplayContext<'a> {
@@ -22,6 +24,7 @@ impl<'a> DisplayContext<'a> {
             result: String::default(),
             vm: Some(vm),
             parent_containers: Vec::default(),
+            debug: false,
         }
     }
 
@@ -31,12 +34,14 @@ impl<'a> DisplayContext<'a> {
             result: String::with_capacity(capacity),
             vm: Some(vm),
             parent_containers: Vec::default(),
+            debug: false,
         }
     }
 
-    /// Appends to the end of the string
-    pub fn append<'b>(&mut self, s: impl Into<StringBuilderAppend<'b>>) {
-        s.into().append(&mut self.result);
+    /// Enables the debug flag on the display context
+    pub fn enable_debug(mut self) -> Self {
+        self.debug = true;
+        self
     }
 
     /// Returns the resulting string and consumes the context
@@ -44,9 +49,22 @@ impl<'a> DisplayContext<'a> {
         self.result
     }
 
+    /// Appends to the end of the string
+    pub fn append<'b>(&mut self, s: impl Into<StringBuilderAppend<'b>>) {
+        s.into().append(&mut self.result);
+    }
+
     /// Returns a reference to the context's VM
     pub fn vm(&self) -> &Option<&'a KotoVm> {
         &self.vm
+    }
+
+    /// True if the resulting string will be used in a debug context
+    ///
+    /// This is true when a `debug` expression is being used, or when using the `?` representation
+    /// in a formatted string.
+    pub fn debug_enabled(&self) -> bool {
+        self.debug
     }
 
     /// Returns true if the value that's being displayed is in a container

--- a/crates/runtime/src/types/meta_map.rs
+++ b/crates/runtime/src/types/meta_map.rs
@@ -195,6 +195,8 @@ impl fmt::Display for BinaryOp {
 /// See [MetaKey::UnaryOp]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum UnaryOp {
+    /// `@debug`
+    Debug,
     /// `@display`
     Display,
     /// `@iterator`
@@ -237,6 +239,7 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<KString>) -> Result<MetaKey> {
         MetaKeyId::Next => MetaKey::UnaryOp(Next),
         MetaKeyId::NextBack => MetaKey::UnaryOp(NextBack),
         MetaKeyId::Negate => MetaKey::UnaryOp(Negate),
+        MetaKeyId::Debug => MetaKey::UnaryOp(Debug),
         MetaKeyId::Display => MetaKey::UnaryOp(Display),
         MetaKeyId::Size => MetaKey::UnaryOp(Size),
         MetaKeyId::Call => MetaKey::Call,

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -117,7 +117,8 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     /// By default, the object's type is used as the display string.
     ///
     /// The [`DisplayContext`] is used to append strings to the result, and provides information
-    /// about any parent containers.
+    /// about how the contents should be formatted,
+    /// e.g. the value is in a container, or the result should be displayed with debug information.
     fn display(&self, ctx: &mut DisplayContext) -> Result<()> {
         ctx.append(self.type_string());
         Ok(())

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -1,6 +1,6 @@
 //! The core value type used in the Koto runtime
 
-use crate::{prelude::*, KFunction, Result};
+use crate::{prelude::*, KFunction, Ptr, Result};
 use std::{
     fmt::{self, Write},
     result::Result as StdResult,
@@ -192,14 +192,26 @@ impl KValue {
             Bool(b) => write!(ctx, "{b}"),
             Number(n) => write!(ctx, "{n}"),
             Range(r) => write!(ctx, "{r}"),
-            Function(_) => write!(ctx, "||"),
-            NativeFunction(_) => write!(ctx, "||"),
+            Function(f) => {
+                if ctx.debug_enabled() {
+                    write!(ctx, "|| ({})", Ptr::address(&f.chunk))
+                } else {
+                    write!(ctx, "||")
+                }
+            }
+            NativeFunction(f) => {
+                if ctx.debug_enabled() {
+                    write!(ctx, "|| ({})", Ptr::address(&f.function))
+                } else {
+                    write!(ctx, "||")
+                }
+            }
             Iterator(_) => write!(ctx, "Iterator"),
             TemporaryTuple(RegisterSlice { start, count }) => {
                 write!(ctx, "TemporaryTuple [{start}..{}]", start + count)
             }
             Str(s) => {
-                if ctx.is_contained() {
+                if ctx.is_contained() || ctx.debug_enabled() {
                     write!(ctx, "\'{s}\'")
                 } else {
                     write!(ctx, "{s}")

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -424,6 +424,7 @@ impl KotoVm {
         self.registers.push(value); // `value_register`
 
         match op {
+            Debug => self.run_debug_op(result_register, value_register)?,
             Display => self.run_display(result_register, value_register)?,
             Negate => self.run_negate(result_register, value_register)?,
             Iterator => self.run_make_iterator(result_register, value_register, false)?,
@@ -969,7 +970,7 @@ impl KotoVm {
             TryEnd => {
                 self.frame_mut().catch_stack.pop();
             }
-            Debug { register, constant } => self.run_debug(register, constant)?,
+            Debug { register, constant } => self.run_debug_instruction(register, constant)?,
             CheckSizeEqual { register, size } => self.run_check_size_equal(register, size)?,
             CheckSizeMin { register, size } => self.run_check_size_min(register, size)?,
             AssertType {
@@ -1462,6 +1463,27 @@ impl KotoVm {
         self.set_register(result, result_bool.into());
 
         Ok(())
+    }
+
+    fn run_debug_op(&mut self, result: u8, value: u8) -> Result<()> {
+        use UnaryOp::Debug;
+
+        match self.clone_register(value) {
+            KValue::Map(m) if m.contains_meta_key(&Debug.into()) => {
+                let op = m.get_meta_value(&Debug.into()).unwrap();
+                self.call_overridden_unary_op(Some(result), value, op)
+            }
+            other => {
+                let mut display_context = DisplayContext::with_vm(self).enable_debug();
+                match other.display(&mut display_context) {
+                    Ok(_) => {
+                        self.set_register(result, display_context.result().into());
+                        Ok(())
+                    }
+                    Err(_) => runtime_error!("failed to get display value"),
+                }
+            }
+        }
     }
 
     fn run_display(&mut self, result: u8, value: u8) -> Result<()> {
@@ -2929,9 +2951,13 @@ impl KotoVm {
         Ok(())
     }
 
-    fn run_debug(&mut self, register: u8, expression_constant: ConstantIndex) -> Result<()> {
+    fn run_debug_instruction(
+        &mut self,
+        register: u8,
+        expression_constant: ConstantIndex,
+    ) -> Result<()> {
         let value = self.clone_register(register);
-        let value_string = match self.run_unary_op(UnaryOp::Display, value)? {
+        let value_string = match self.run_unary_op(UnaryOp::Debug, value)? {
             KValue::Str(s) => s,
             unexpected => return unexpected_type("a displayable value", &unexpected),
         };
@@ -3105,6 +3131,7 @@ impl KotoVm {
                 (_, Some(representation)) => {
                     let n = i64::from(n);
                     match representation {
+                        StringFormatRepresentation::Debug => format!("{n:?}"),
                         StringFormatRepresentation::HexLower => format!("{n:x}"),
                         StringFormatRepresentation::HexUpper => format!("{n:X}"),
                         StringFormatRepresentation::Binary => format!("{n:b}"),
@@ -3118,20 +3145,41 @@ impl KotoVm {
                 }
                 _ => n.to_string(),
             },
-            other => match self.run_unary_op(UnaryOp::Display, other)? {
-                KValue::Str(rendered) => match precision {
-                    Some(precision) => {
-                        // `precision` acts as a maximum width for non-number values
-                        let mut truncated =
-                            String::with_capacity((precision as usize).min(rendered.len()));
-                        for grapheme in rendered.graphemes(true).take(precision as usize) {
-                            truncated.push_str(grapheme);
-                        }
-                        truncated
+            other => match representation {
+                Some(StringFormatRepresentation::Debug) => {
+                    match self.run_unary_op(UnaryOp::Debug, other)? {
+                        KValue::Str(rendered) => match precision {
+                            Some(precision) => {
+                                // `precision` acts as a maximum width for non-number values
+                                let mut truncated =
+                                    String::with_capacity((precision as usize).min(rendered.len()));
+                                for grapheme in rendered.graphemes(true).take(precision as usize) {
+                                    truncated.push_str(grapheme);
+                                }
+                                truncated
+                            }
+                            None => rendered.to_string(),
+                        },
+                        other => return unexpected_type("String", &other),
                     }
-                    None => rendered.to_string(),
-                },
-                other => return unexpected_type("String", &other),
+                }
+                _ => {
+                    match self.run_unary_op(UnaryOp::Display, other)? {
+                        KValue::Str(rendered) => match precision {
+                            Some(precision) => {
+                                // `precision` acts as a maximum width for non-number values
+                                let mut truncated =
+                                    String::with_capacity((precision as usize).min(rendered.len()));
+                                for grapheme in rendered.graphemes(true).take(precision as usize) {
+                                    truncated.push_str(grapheme);
+                                }
+                                truncated
+                            }
+                            None => rendered.to_string(),
+                        },
+                        other => return unexpected_type("String", &other),
+                    }
+                }
             },
         };
 

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -115,7 +115,16 @@ mod objects {
 
     impl KotoObject for TestObject {
         fn display(&self, ctx: &mut DisplayContext) -> Result<()> {
+            if ctx.debug_enabled() {
+                ctx.append('{');
+            }
+
             ctx.append(format!("{}: {}", self.type_string(), self.x));
+
+            if ctx.debug_enabled() {
+                ctx.append('}');
+            }
+
             Ok(())
         }
 
@@ -443,6 +452,12 @@ else
         fn display() {
             let script = "'{make_object 42}'";
             test_object_script(script, "TestObject: 42");
+        }
+
+        #[test]
+        fn debug() {
+            let script = "'{make_object 42:?}'";
+            test_object_script(script, "{TestObject: 42}");
         }
 
         #[test]

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -3179,6 +3179,12 @@ x = ('foo', 'bar')
         #[test_case("'{'hello':.2}'", "he"; "precision with string")]
         #[test_case("'{'hello':10}'", "hello     "; "min width with string")]
         #[test_case("'{'hello':~>4.2}'", "~~he"; "right-aligned truncated string")]
+        #[test_case("'{51966:x}'", "cafe"; "hex lower")]
+        #[test_case("'{51966:X}'", "CAFE"; "hex upper")]
+        #[test_case("'{32:b}'", "100000"; "binary")]
+        #[test_case("'{64:o}'", "100"; "octal")]
+        #[test_case("'{1_000_000:e}'", "1e6"; "exp lower")]
+        #[test_case("'{123456:E}'", "1.23456E5"; "exp upper")]
         fn formatted_expression(input: &str, expected: &str) {
             check_script_output(input, expected);
         }

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -3118,10 +3118,24 @@ m.'key{x}'
         #[test]
         fn value_with_overridden_display() {
             let script = "
-foo = {@display: || 'Foo'}
-'{foo}'
+foo =
+  @display: || 'Foo'
+
+'{foo} - {foo:?}' # Check that debug falls back to @display
 ";
-            check_script_output(script, "Foo");
+            check_script_output(script, "Foo - Foo");
+        }
+
+        #[test]
+        fn value_with_overridden_debug() {
+            let script = "
+foo =
+  @display: || 'Foo'
+  @debug: || '(Foo)'
+
+'{foo} - {foo:?}'
+";
+            check_script_output(script, "Foo - (Foo)");
         }
 
         #[test]
@@ -3181,10 +3195,12 @@ x = ('foo', 'bar')
         #[test_case("'{'hello':~>4.2}'", "~~he"; "right-aligned truncated string")]
         #[test_case("'{51966:x}'", "cafe"; "hex lower")]
         #[test_case("'{51966:X}'", "CAFE"; "hex upper")]
+        #[test_case("'{51966:_^10x}'", "___cafe___"; "hex with padding")]
         #[test_case("'{32:b}'", "100000"; "binary")]
         #[test_case("'{64:o}'", "100"; "octal")]
         #[test_case("'{1_000_000:e}'", "1e6"; "exp lower")]
         #[test_case("'{123456:E}'", "1.23456E5"; "exp upper")]
+        #[test_case("'{'hello':?}'", "'hello'"; "debug representation")]
         fn formatted_expression(input: &str, expected: &str) {
             check_script_output(input, expected);
         }


### PR DESCRIPTION
This PR adds support for alternative representations when formatting values as strings, such as `x` for hexadecimal number formatting, or `?` to show a value's debug representation.
