### PR TITLE
Add support for missing values in lists and tuple definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ The Koto project adheres to
   ```
   - The `@debug` metakey has been added to allow for additional debug information
     to be provided when formatting an object as a string.
+- Values in lists or tuples definitions can now be omitted, with `null` being used to fill the gaps.
+  - E.g.
+  ```koto
+  x = [1, , 3, , 5]
+  # -> [1, null, 3, null, 5]
+  ```
 
 #### API
 
@@ -58,6 +64,8 @@ The Koto project adheres to
 
 #### Language
 
+- Empty tuples are now created with `()`.
+  - The previous empty-tuple syntax `(,)` now evaluates as a single-element tuple that contains `null`.
 - Calls to Koto functions with the incorrect number of arguments will now throw an error.
   - Default values should be provided for optional arguments.
   - Variadic arguments should be used to capture additional arguments.

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -266,7 +266,7 @@ container, with some notable exceptions:
 ```koto
 from koto import size
 
-print! (size [1, 2, 3]), (size (,))
+print! (size [1, 2, 3]), (size ())
 check! (3, 0)
 
 print! (size 'hello'), (size 'héllø'), (size '')

--- a/crates/cli/docs/core_lib/tuple.md
+++ b/crates/cli/docs/core_lib/tuple.md
@@ -35,7 +35,7 @@ x = 99, -1, 42
 print! x.first()
 check! 99
 
-print! (,).first()
+print! ().first()
 check! null
 ```
 
@@ -78,7 +78,7 @@ Returns `true` if the tuple has a size of zero, and `false` otherwise.
 ### Example
 
 ```koto
-print! (,).is_empty()
+print! ().is_empty()
 check! true
 
 print! (1, 2, 3).is_empty()

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -276,6 +276,13 @@ print! x
 check! [10, 99, 30]
 ```
 
+If no value is given between commas then `null` is added to the list at that position.
+
+```koto
+print! [10, , 30, , 50]
+check! [10, null, 30, null, 50]
+```
+
 ### Joining Lists
 
 The `+` operator allows lists to be joined together, creating a new list that
@@ -327,6 +334,42 @@ print! x, y
 check! ((false, 10), (true, 20))
 ```
 
+If no value is given between commas then `null` is added to the tuple at that position.
+
+```koto
+x = 10, , 20, , 30
+print! x
+check! (10, null, 20, null, 30)
+```
+
+### Empty and Single Element Tuples
+
+An empty tuple (a tuple that contains zero elements) is created using empty parentheses.
+
+```koto
+x = ()
+print! x
+check! ()
+```
+
+To create a tuple that contains a single element, then a trailing comma must be included. 
+
+```koto
+# A value inside parentheses simply resolves to the value
+print! (1 + 2)
+check! 3
+
+# To place the value in a tuple, use a trailing comma 
+print! (1 + 2,)
+check! (3)
+
+# Single element tuples can also be created without parentheses
+x = 1 + 2,
+print! x
+check! (3)
+```
+
+
 ### Joining Tuples
 
 The `+` operator allows tuples to be joined together,
@@ -337,21 +380,6 @@ a = 1, 2, 3
 b = a + (4, 5, 6)
 print! b
 check! (1, 2, 3, 4, 5, 6)
-```
-
-### Creating Empty Tuples
-
-An empty pair of parentheses in Koto resolves to `null`.
-If an empty tuple is needed then use a single `,` inside parentheses.
-
-```koto
-# An empty pair of parentheses resolves to null
-print! ()
-check! null
-
-# A comma inside parentheses creates a tuple
-print! (,)
-check! ()
 ```
 
 ### Tuple Mutability

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1072,8 +1072,27 @@ min..max
         }
 
         #[test]
-        fn empty_tuple() {
-            let source = "(,)";
+        fn tuple_with_missing_value() {
+            let source = "8, , 5";
+            check_ast(
+                source,
+                &[
+                    SmallInt(8),
+                    Null,
+                    SmallInt(5),
+                    Tuple(nodes(&[0, 1, 2])),
+                    MainBlock {
+                        body: nodes(&[3]),
+                        local_count: 0,
+                    },
+                ],
+                None,
+            )
+        }
+
+        #[test]
+        fn empty_parentheses() {
+            let source = "()";
             check_ast(
                 source,
                 &[
@@ -1088,14 +1107,84 @@ min..max
         }
 
         #[test]
-        fn empty_parentheses_without_comma() {
-            let source = "()";
+        fn single_comma() {
+            let source = "(,)";
             check_ast(
                 source,
                 &[
                     Null,
+                    Tuple(nodes(&[0])),
                     MainBlock {
-                        body: nodes(&[0]),
+                        body: nodes(&[1]),
+                        local_count: 0,
+                    },
+                ],
+                None,
+            )
+        }
+
+        #[test]
+        fn two_commas() {
+            let source = "(,,)";
+            check_ast(
+                source,
+                &[
+                    Null,
+                    Null,
+                    Tuple(nodes(&[0, 1])),
+                    MainBlock {
+                        body: nodes(&[2]),
+                        local_count: 0,
+                    },
+                ],
+                None,
+            )
+        }
+
+        #[test]
+        fn nested_empty_tuple() {
+            let source = "(())";
+            check_ast(
+                source,
+                &[
+                    Tuple(nodes(&[])),
+                    Nested(0.into()),
+                    MainBlock {
+                        body: nodes(&[1]),
+                        local_count: 0,
+                    },
+                ],
+                None,
+            )
+        }
+
+        #[test]
+        fn empty_tuple_inside_tuple() {
+            let source = "((),)";
+            check_ast(
+                source,
+                &[
+                    Tuple(nodes(&[])),
+                    Tuple(nodes(&[0])),
+                    MainBlock {
+                        body: nodes(&[1]),
+                        local_count: 0,
+                    },
+                ],
+                None,
+            )
+        }
+
+        #[test]
+        fn single_entry_tuple() {
+            let source = "(1,)";
+            check_ast(
+                source,
+                &[
+                    SmallInt(1),
+                    Tuple(nodes(&[0])),
+                    MainBlock {
+                        body: nodes(&[1]),
                         local_count: 0,
                     },
                 ],
@@ -1130,23 +1219,6 @@ min..max
                     Tuple(nodes(&[0, 1, 2])),
                     MainBlock {
                         body: nodes(&[3]),
-                        local_count: 0,
-                    },
-                ],
-                None,
-            )
-        }
-
-        #[test]
-        fn single_entry_tuple() {
-            let source = "(1,)";
-            check_ast(
-                source,
-                &[
-                    SmallInt(1),
-                    Tuple(nodes(&[0])),
-                    MainBlock {
-                        body: nodes(&[1]),
                         local_count: 0,
                     },
                 ],

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -358,13 +358,6 @@ x = {foo: 42, ?}
             use super::*;
 
             #[test]
-            fn double_comma() {
-                let source = "x = [1, 2, , 3]";
-
-                check_parsing_fails(source);
-            }
-
-            #[test]
             fn space_separated_function_call_in_list() {
                 let source = "x = [1, 2, f y, 4]";
 
@@ -395,13 +388,6 @@ x = [1, 2, ?]
 
         mod tuples {
             use super::*;
-
-            #[test]
-            fn double_comma() {
-                let source = "x = (1, 2, , 3)";
-
-                check_parsing_fails(source);
-            }
 
             #[test]
             fn unexpected_token_inside_tuple() {

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -8,7 +8,6 @@ mod vm {
         #[test]
         fn null() {
             check_script_output("null", KValue::Null);
-            check_script_output("()", KValue::Null);
         }
 
         #[test]
@@ -200,10 +199,11 @@ a, b, c
 
     mod tuples {
         use super::*;
+        use KValue::Null;
 
         #[test]
         fn empty() {
-            check_script_output("(,)", KTuple::default());
+            check_script_output("()", KTuple::default());
         }
 
         #[test]
@@ -224,6 +224,24 @@ a, b, c
         #[test]
         fn two_entries_in_parens() {
             check_script_output("(1, 2)", number_tuple(&[1, 2]));
+        }
+
+        #[test]
+        fn missing_entries_without_parens() {
+            check_script_output("1, , , 2", tuple(&[1.into(), Null, Null, 2.into()]));
+        }
+
+        #[test]
+        fn missing_entries_with_parens() {
+            check_script_output(
+                "(, 1, , , 2)",
+                tuple(&[Null, 1.into(), Null, Null, 2.into()]),
+            );
+        }
+
+        #[test]
+        fn only_missing_entries_in_parens() {
+            check_script_output("(,,)", tuple(&[Null, Null]));
         }
 
         #[test]
@@ -261,6 +279,15 @@ a, b, c
         #[test]
         fn literals() {
             check_script_output("[1, 2, 3, 4]", number_list(&[1, 2, 3, 4]));
+        }
+
+        #[test]
+        fn missing_entries() {
+            use KValue::Null;
+            check_script_output(
+                "[, 1, , 2, , 3]",
+                list(&[Null, 1.into(), Null, 2.into(), Null, 3.into()]),
+            );
         }
 
         #[test]


### PR DESCRIPTION
This PR adds support for omitting values when creating lists or tuples,
with `null` being used to fill the gaps.

```coffee
x = [1, , 3, , 5]
# -> [1, null, 3, null, 5]
```

Making this behave consistently led to a breaking change when creating 0 or 1 element tuples:
- `()` now resolves to an empty tuple.
- `(,)` now resolves to a single-element tuple containing `null`.
