### PR TITLE
Export improvements and other tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ The Koto project adheres to
 
 - `iterator.skip` now skips when the iterator is advanced instead of immediately when `skip` is called.
 
+#### API
+
+- The `vm` argument has been removed from `KotoObject::negate`.
+
 #### CLI
 
 - The CLI is now built with extra optimizations by default,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format of this changelog is based on
 The Koto project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.0] Unreleased 
+## [0.16.0] Unreleased
 
 ### Added
 
@@ -104,13 +104,13 @@ The Koto project adheres to
 
 ## [0.15.0] 2025.01.07
 
-### Added 
+### Added
 
 #### Language
 
 - Type hints have been added, enabling runtime type checks.
   - `let` is used for type-checked assignments, e.g. `let x: String = 'abc'`.
-  - Other bindings (`for` values, function arguments, etc.) can be similarly 
+  - Other bindings (`for` values, function arguments, etc.) can be similarly
     annotated with a type hints.
   - Runtime checks can be optionally disabled via
     `KotoSettings::enable_type_checks`.
@@ -122,7 +122,7 @@ The Koto project adheres to
   - E.g. expressions like `export a, b, c = foo()` are now allowed.
 - Maps now support `[]` indexing, returning the Nth entry as a tuple.
   - Entries can also be replaced by index by assigning a key/value tuple.
-- The `@index_mut` metakey has been added to define custom behaviour for 
+- The `@index_mut` metakey has been added to define custom behaviour for
   index-assignment operations.
 - Objects that implement `KotoObject::call` can now be used in operations that
   expect functions.
@@ -140,7 +140,7 @@ The Koto project adheres to
   - `os.process_id`
   - `string.repeat`
   - `tuple.is_empty`
-- `tuple.sort_copy` now supports sorting with a key function, following the 
+- `tuple.sort_copy` now supports sorting with a key function, following the
   behaviour of `list.sort`.
 
 #### Extra Libs
@@ -165,7 +165,7 @@ The Koto project adheres to
 #### Language
 
 - The `>>` pipe operator has been replaced with `->`.
-  - This aligns it with the `->` function output type syntax, which avoids 
+  - This aligns it with the `->` function output type syntax, which avoids
     having two different special-case operators related to function output.
 - The type of a number is now always `Number`, rather than distinguishing
   between `Int` and `Float`.
@@ -175,7 +175,7 @@ The Koto project adheres to
 - `@||` has been renamed to `@call`, and `@[]` has been renamed to `@index`.
 - `:` placement following keys in maps is now more flexible.
   ([#368](https://github.com/koto-lang/koto/issues/368))
-- When a map is used with `export`, the map entries now get added to the 
+- When a map is used with `export`, the map entries now get added to the
   local scope. Local variables with names that match an exported map key
   will be updated.
 
@@ -188,28 +188,28 @@ The Koto project adheres to
 - The single-threaded runtime flavor (`rc`) is now the default.
   Applications that require a multi-threaded runtime should disable default
   features and use the `arc` feature.
-- The line and column numbers referred to in spans are now zero-based. 
+- The line and column numbers referred to in spans are now zero-based.
 - Functions that previously took `Option<PathBuf>` now take `Option<&Path>`.
 - `AstIndex` and `ConstantIndex` are now newtypes that wrap `u32`.
-- `Node::Lookup` has been renamed to `Node::Chain`, and `LookupNode` is now 
+- `Node::Lookup` has been renamed to `Node::Chain`, and `LookupNode` is now
   `ChainNode`.
-- `type_error` has been renamed to `unexpected_type`.  
+- `type_error` has been renamed to `unexpected_type`.
   - `type_error_with_slice` has been replaced by `unexpected_args` and
-    `unexpected_args_after_instance`. 
+    `unexpected_args_after_instance`.
 - `From` impls for `KNumber` now saturate integer values that are out of the
   target type's bounds, instead of wrapping.
 - `Koto::compile` and `compile_and_run` now take `CompileArgs` which include
-  compiler settings. The equivalent compiler settings have been removed from 
+  compiler settings. The equivalent compiler settings have been removed from
   `KotoSettings`.
 - `Compiler::compile` now takes a string rather than an `Ast`, and returns
-  a `Chunk` with prepared debug info.  
+  a `Chunk` with prepared debug info.
 - `Loader` has been renamed `ModuleLoader` to clarify its purpose.
 - `Koto::set_args` now accepts any value that implements
   `IntoIterator<Item = String>`, which includes the output of `std::env::args()`.
 
 #### Libs
 
-- The `color` module has been reworked to support working with alternative 
+- The `color` module has been reworked to support working with alternative
   color spaces.
   - `Oklab` and `Oklch` color spaces have been added.
   - `color.hex` has been added to support initializing colors with hex triples.
@@ -218,20 +218,20 @@ The Koto project adheres to
 
 #### Language
 
-- The `@tests` metakey has been removed, with `@test` functions now exported directly 
+- The `@tests` metakey has been removed, with `@test` functions now exported directly
   in the module.
   - Before:
     ```koto
     @tests =
       @test foo: || assert something()
       @test bar: || assert something_else()
-    ``` 
+    ```
     After:
     ```koto
     @test foo = || assert something()
     @test bar = || assert something_else()
     ```
-    - If you have a file with a lot of tests, you can replace `@tests =` with `export` 
+    - If you have a file with a lot of tests, you can replace `@tests =` with `export`
       to simplify the transition.
       ```koto
       export
@@ -241,7 +241,7 @@ The Koto project adheres to
 
 #### API
 
-- `koto_parser::MapKey` and `IdOrString` have been removed, map keys and import 
+- `koto_parser::MapKey` and `IdOrString` have been removed, map keys and import
   IDs are now represented as AST nodes.
 - `Node::NamedCall` has been removed, with all calls represented by expression
   chains.
@@ -257,11 +257,11 @@ The Koto project adheres to
 
 ## [0.14.0] 2024.04.17
 
-### Added 
+### Added
 
 #### API
 
-- `KMap::get` has been introduced as simpler alternative to 
+- `KMap::get` has been introduced as simpler alternative to
   `KMap::data().get().cloned()`.
 
 #### Libs
@@ -271,10 +271,10 @@ The Koto project adheres to
 
 ### Changed
 
-#### API 
+#### API
 
 - The use of `CallArgs` has been simplified with the introduction of `From`
-  implementations for single values, arrays, and slices. 
+  implementations for single values, arrays, and slices.
   - `CallArgs::None` has been removed, instead you can pass in `&[]`.
 - The `run_function`/`run_instance_function` methods in `Koto` and `KotoVm` have
   been renamed to `call_function` and `call_instance_function`.
@@ -295,7 +295,7 @@ The Koto project adheres to
 
 - `Koto::run_exported_function` has been removed. Functions can be accessed via
   `Koto::exports().get()` and then called with `Koto::call_function()`.
-- `Koto::run_with_args` has been removed. For equivalent behaviour, 
+- `Koto::run_with_args` has been removed. For equivalent behaviour,
   `Koto::set_args` can be called before calling `Koto::run`.
 
 ### Fixed
@@ -318,10 +318,10 @@ The Koto project adheres to
 - Formatting options have been added for interpolated strings.
 - `import` expressions can now use `as` for more ergonomic item renaming.
 - Assignments can now be used in `while`/`until` conditions.
-- Unpacked assignments with a single value on the RHS are now accepted, 
+- Unpacked assignments with a single value on the RHS are now accepted,
   with remaining values being set to `null`.
   - e.g. `a, b, c = 42` will assign `42` to `a`, and `null` to `b` and `c`.
-- The `@size` metakey (along with `KObject::size`) has been added to allow 
+- The `@size` metakey (along with `KObject::size`) has been added to allow
   custom value types to work with argument unpacking and pattern matching.
   - The general rule is now that matching works with any value that declares a
     size and supports indexing.
@@ -333,14 +333,14 @@ The Koto project adheres to
 - `Koto::run_instance_function` has been added.
 - `Ptr`/`PtrMut` now have an associated `ref_count` function.
 - `KMap::clear` has been added.
-- A maximum execution duration can now be defined in `KotoVmSettings`, 
+- A maximum execution duration can now be defined in `KotoVmSettings`,
   with a timeout error being returned when the deadline is reached.
 
 #### Core Library
 
-- Dynamic compilation and evaluation features (`koto.load` and `koto.run`) have 
+- Dynamic compilation and evaluation features (`koto.load` and `koto.run`) have
   been added, thanks to [@alisomay](https://github.com/alisomay).
-- `koto.size` has been added (and added to the prelude), 
+- `koto.size` has been added (and added to the prelude),
   replacing the various type-specific `.size()` functions.
 - `string.char_indices` has been added to support the switch to byte-based
   indexing.
@@ -361,17 +361,17 @@ The Koto project adheres to
     e.g. `'$foo` is now `{foo}`
   - The `\$` escape sequence has been replaced with `\{`.
 - Pattern matching and function argument unpacking now use parentheses for all
-  container types. 
+  container types.
   - Any uses of `[]` brackets to match against lists can be updated to use
     parentheses instead.
 - Indexing operations on strings now access bytes instead of grapheme clusters.
   - This is to avoid the non-linear performance cost of indexing by cluster.
   - To access clusters via indexing, `string.char_indices` can be called first to
-    retrieve valid indices. 
+    retrieve valid indices.
 
 #### Core Library
 
-- `io.print` no longer implicitly treats its first argument as a format string. 
+- `io.print` no longer implicitly treats its first argument as a format string.
   Interpolated strings should be used instead.
 - `iterator.next`/`next_back` and `Peekble.peek`/`peek_back` now return
   `IteratorOutput` for output values, and `null` when the iterator is exhausted.
@@ -392,7 +392,7 @@ The Koto project adheres to
   runtime value types, and to avoid polluting the prelude with a generic name.
 - The VM-specific parts of `KotoSettings` are now defined via `KotoVmSettings`.
 - The `KotoLookup` trait has been replaced with `KotoEntries`.
-- Objects can be compared with `null` on the LHS without having to implement 
+- Objects can be compared with `null` on the LHS without having to implement
   `KotoObject::equal` and/or `not_equal`.
 - `KRange` initialization has been revamped to support `From` for
   `RangeBounds<i64>`.
@@ -407,12 +407,12 @@ The Koto project adheres to
 #### CLI
 
 - The REPL `config.koto` settings have all been moved into a `repl` sub-map.
-  - e.g. 
+  - e.g.
     `export { edit_mode: 'vi' }` is now `export { repl: { edit_mode: 'vi' }}`
 - The `--import_tests`/`-T` CLI option will now run tests in the main script
   along with any tests from imported modules.
 
-### Removed 
+### Removed
 
 #### Core Library
 
@@ -433,7 +433,7 @@ The Koto project adheres to
 
 #### Language
 
-- Chained compound assignment operators are now right-associative and all share 
+- Chained compound assignment operators are now right-associative and all share
   the same precedence.
 
 
@@ -444,22 +444,22 @@ The Koto project adheres to
 #### Language
 
 - Ellipses can now be used when unpacking nested function args.
-  - e.g. 
+  - e.g.
     ```koto
     f = |(a, b, others...)| a * b + others.sum()
     f (10, 100, 1, 2, 3)
     # 1006
     ```
 - Meta map improvements
-  - Compound assignment operators (`@+=`, `@*=`, etc.) can now be implemented 
+  - Compound assignment operators (`@+=`, `@*=`, etc.) can now be implemented
     in meta maps and external values.
-  - The function call operator (`@||`) can be implemented to values that behave 
+  - The function call operator (`@||`) can be implemented to values that behave
     like functions.
   - Values that implement `@[]` can now be used in unpacking assignment
     expressions.
   - `@next` and `@next_back` meta keys have been added to enable custom iterators.
 - `export` can now be used with maps as well as single-value assignments.
-  - e.g. 
+  - e.g.
     ```koto
     a, b, c = 1, 2, 3
     export { a, b, c, foo: 42 }
@@ -467,14 +467,14 @@ The Koto project adheres to
 
 #### Libs
 
-- New `color` and `geometry` libs have been added, and are available by default 
+- New `color` and `geometry` libs have been added, and are available by default
   in the CLI.
 - `koto.hash` has been added to allow value hashes to be accessed.
-- The `copy`/`deep_copy` functions have been merged into the `koto` module, 
+- The `copy`/`deep_copy` functions have been merged into the `koto` module,
   and made available in the prelude.
 - `range` additions:
   - `range.contains` can now accept a range as an argument.
-    - e.g. 
+    - e.g.
       ```koto
       (10..30).contains 15..25
       # true
@@ -488,7 +488,7 @@ The Koto project adheres to
 
 #### Internals
 
-- The `KotoObject` trait has been introduced to simplify creating custom object 
+- The `KotoObject` trait has been introduced to simplify creating custom object
   types, replacing `ExternalValue`.
 - Preludes are now available in the `koto` and `koto_runtime` crates.
 - `Ptr<T>` and `PtrMut<T>` wrappers have been introduced as the core memory
@@ -498,7 +498,7 @@ The Koto project adheres to
 
 - Added support for disabling colored output with the `NO_COLOR` environment
   variable.
-- The REPL has been reimplemented with 
+- The REPL has been reimplemented with
   [rustyline](https://github.com/kkawakam/rustyline)
   - History is now maintained between sessions.
   - Emacs / VI key bindings have been added.
@@ -521,7 +521,7 @@ The Koto project adheres to
     # 10, 20, 30
     ```
   - Iteration is also used when unpacking for loop arguments.
-    - e.g. 
+    - e.g.
     ```koto
     for a, b, c in (1..10).windows 3
       debug a, b, c
@@ -531,14 +531,14 @@ The Koto project adheres to
     ```
 - Ranges now preserve whether or not they're inclusive.
 - `File`s now implement `@display`, showing their paths.
-- `Tuple`s now share data when sub-tuples are made via indexing or unpacking, 
-    avoiding unnecessary copies. 
+- `Tuple`s now share data when sub-tuples are made via indexing or unpacking,
+    avoiding unnecessary copies.
 - Import nested items directly is no longer allowed
   - e.g. `import foo.bar` now needs to be written as `from foo import bar`.
 
 ### Libs
 
-- The various `.copy`/`.deep_copy` module functions have been merged into 
+- The various `.copy`/`.deep_copy` module functions have been merged into
   `koto.copy`/`koto.deep_copy`, which have also been added to the prelude.
 - `iterator.chunks`, `.cycle`, and `.windows` now cache initial iterator output
   rather than relying on copying the adapted iterator.
@@ -552,12 +552,12 @@ The Koto project adheres to
   provides access to the VM and its arguments.
   - Functions that need access to the `self` instance can access it via
     `CallContext::instance`.
-- The core Koto runtime types have been renamed for consistency, 
-  and now use a `K` prefix to help disambiguate them in context 
+- The core Koto runtime types have been renamed for consistency,
+  and now use a `K` prefix to help disambiguate them in context
   (e.g. `KIterator` vs. `Iterator`).
 - `KTuple::data` has been removed, with a `Deref` impl to `&[Value]` taking
   its place.
-- Type strings and strings returned by `KotoFile` implementations are now 
+- Type strings and strings returned by `KotoFile` implementations are now
   expected to be `KString`s.
 - `unexpected_type_error_with_slice` has been renamed to
   `type_error_with_slice`, and has had the prefix argument removed.
@@ -574,7 +574,7 @@ The Koto project adheres to
 #### Packed number removal
 
 - The `Num2` and `Num4` types have been removed.
-  - Some of the use cases for these types are covered by the new `color` and 
+  - Some of the use cases for these types are covered by the new `color` and
     `geometry` libs.
   - See https://github.com/koto-lang/koto/issues/201 for removal rationale.
 
@@ -588,7 +588,7 @@ The Koto project adheres to
     # You can use:
     iterator.repeat('x', 5).to_list()
     ```
-- `string.slice` has been removed in favour of `[]` indexing. 
+- `string.slice` has been removed in favour of `[]` indexing.
   - e.g.
     ```koto
     # Instead of:
@@ -599,9 +599,9 @@ The Koto project adheres to
 
 ### Fixed
 
-- Ignored values (i.e. `_` or values with a `_` prefix) will now trigger a 
+- Ignored values (i.e. `_` or values with a `_` prefix) will now trigger a
   compilation error when they're accessed.
-  - e.g. 
+  - e.g.
     ```koto
     _x = 42
     debug _x
@@ -664,16 +664,16 @@ The Koto project adheres to
     ```
 - Loop improvements
   - The result of loop expressions (`for`, `while`, `until`, and `loop`) can now
-    be assigned to a value, with the default result being the final expression 
-    in the loop body. 
+    be assigned to a value, with the default result being the final expression
+    in the loop body.
     - If no loop iterations are performed then the result is `null`.
-  - The `break` keyword can now take an expression, which will be returned as 
+  - The `break` keyword can now take an expression, which will be returned as
     the result of the loop.
-    - e.g. 
+    - e.g.
       ```koto
       y = for x in 0..=10
         if x == 5
-          break x * x 
+          break x * x
       y
       # 25
       ```
@@ -776,7 +776,7 @@ The Koto project adheres to
     f = || x
     # Re-exporting x doesn't affect the value of x captured when f was created
     export x = 99
-    f() 
+    f()
     # 123
     ```
 - Arms in `match` and `switch` expressions that have indented blocks as their
@@ -793,7 +793,7 @@ The Koto project adheres to
         ]
     ```
 - Curly braces are now required when declaring a Map with inline syntax.
-  - This reverts a change made in 0.9 which created too many ambiguous parsing 
+  - This reverts a change made in 0.9 which created too many ambiguous parsing
     situations in practice.
 
 #### Core Library
@@ -861,7 +861,7 @@ The Koto project adheres to
   been removed. These value types should be treated as immutable; the `with`
   functions can be used to create new values with modified elements.
 - `list.sort_copy` has been removed in favour of `.copy().sort()`.
-  - e.g. 
+  - e.g.
     ```koto
     x = [3, 2, 1]
     y = x.copy().sort()
@@ -877,7 +877,7 @@ The Koto project adheres to
     print 'hello'
     #--#
     ```
-- The `+` operator is no longer implemented for Lists and Maps, 
+- The `+` operator is no longer implemented for Lists and Maps,
   `list.extend` and `map.extend` can be used as an alternative.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The Koto project adheres to
 #### Core Library
 
 - `iterator.skip` now skips when the iterator is advanced instead of immediately when `skip` is called.
+- `koto.args` has been moved to `os.args`.
 
 #### API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,13 @@ The Koto project adheres to
   resulting in a faster binary at the expense of longer build times.
 - Ctrl+C in the REPL now clears the line rather than exiting.
 
+### Removed
+
+#### Core Library
+
+- `koto.exports` has been removed.
+  - `export` now accepts any iterable value which provides support for exporting generated keys.
+
 ### Fixed
 
 #### Core Library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ The Koto project adheres to
     x = [1, , 3, , 5]
     # -> [1, null, 3, null, 5]
     ```
+- `export` can now take any iterable that yields key/value pairs.
+  - E.g.
+    ```koto
+    export (1..=3).each |i| 'generated_i', i
+    generated_3
+    # -> 3
+    ```
 
 #### API
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ language for [Rust][rust] applications, or as a standalone scripting language.
 ## Development
 
 The top-level [justfile](./justfile) contains some useful commands for working
-with the repo, for example `just checks` which runs all available checks and 
+with the repo, for example `just checks` which runs all available checks and
 tests.
 
 After installing [just][just], you can run `just setup` to install additional

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -3042,7 +3042,6 @@ impl Compiler {
                 if let Some(function_register) = self.frame().get_local_assigned_register(*id) {
                     self.compile_call(function_register, &[], pipe_register, None, ctx)
                 } else {
-                    let result = self.assign_result_register(ctx)?;
                     let call_result_register = if let Some(result_register) = result.register {
                         ResultRegister::Fixed(result_register)
                     } else {

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -158,6 +158,18 @@ impl<'a> CompileNodeContext<'a> {
         }
     }
 
+    fn with_fixed_register_or_any(self) -> Self {
+        let result_register = if matches!(self.result_register, ResultRegister::Fixed(_)) {
+            self.result_register
+        } else {
+            ResultRegister::Any
+        };
+        Self {
+            result_register,
+            ..self
+        }
+    }
+
     fn compile_for_side_effects(self) -> Self {
         Self {
             result_register: ResultRegister::None,
@@ -1344,7 +1356,7 @@ impl Compiler {
     fn compile_value_export(&mut self, id: ConstantIndex, value_register: u8) -> Result<()> {
         let id_register = self.push_register()?;
         self.compile_load_string_constant(id_register, id);
-        self.push_op(Op::ValueExport, &[id_register, value_register]);
+        self.push_op(Op::ExportValue, &[id_register, value_register]);
         self.pop_register()?;
         self.frame_mut().add_to_exported_ids(id);
         Ok(())
@@ -1580,11 +1592,34 @@ impl Compiler {
                 targets,
                 expression,
             } => self.compile_multi_assign(targets, *expression, true, ctx),
+            // Maps can be exported directly rather than relying on the iterator logic below
             Node::Map(entries) => self.compile_make_map(entries, true, ctx),
-            unexpected => self.error(ErrorKind::UnexpectedNode {
-                expected: "an assignment or a Map to export".into(),
-                unexpected: unexpected.clone(),
-            }),
+            // Other expressions can be evaluated and then assumed to be iterable
+            _ => {
+                // Evaluate the expression and convert the result into an iterator
+                let result = self.compile_node(expression, ctx.with_fixed_register_or_any())?;
+                let expression_register = result.unwrap(self)?;
+                let stack_count = self.stack_count();
+                let iterator_register = self.push_register()?;
+                self.push_op(Op::MakeIterator, &[iterator_register, expression_register]);
+
+                // Consume the expression iterator, exporting each output entry
+                let iter_start_ip = self.bytes.len();
+                let output_register = self.push_register()?;
+                self.push_op(Op::IterNextTemp, &[output_register, iterator_register]);
+                let iter_finished_offset = self.push_offset_placeholder();
+
+                self.push_op(Op::ExportEntry, &[output_register]);
+
+                // Jump back to get more iterator output
+                self.push_jump_back_op(Op::JumpBack, &[], iter_start_ip);
+
+                // Finished, update the IterNextTemp offset and clean up the temporary registers
+                self.update_offset_placeholder(iter_finished_offset)?;
+                self.truncate_register_stack(stack_count)?;
+
+                Ok(result)
+            }
         }
     }
 
@@ -2928,7 +2963,7 @@ impl Compiler {
                 }
 
                 if export_entry {
-                    self.push_op_without_span(ValueExport, &[key_register, value_register]);
+                    self.push_op_without_span(ExportValue, &[key_register, value_register]);
                 }
 
                 self.pop_register()?;
@@ -2945,7 +2980,7 @@ impl Compiler {
                 }
 
                 if export_entry {
-                    self.push_op_without_span(ValueExport, &[key_register, value_register]);
+                    self.push_op_without_span(ExportValue, &[key_register, value_register]);
                 }
 
                 self.pop_register()?;

--- a/crates/bytecode/src/instruction.rs
+++ b/crates/bytecode/src/instruction.rs
@@ -45,9 +45,12 @@ pub enum Instruction {
         register: u8,
         constant: ConstantIndex,
     },
-    ValueExport {
-        name: u8,
+    ExportValue {
+        key: u8,
         value: u8,
+    },
+    ExportEntry {
+        entry: u8,
     },
     Import {
         register: u8,
@@ -561,9 +564,10 @@ impl fmt::Debug for Instruction {
                     "LoadNonLocal    result: {register:<7} constant: {constant}"
                 )
             }
-            ValueExport { name, value } => {
-                write!(f, "ValueExport     name: {name:<7} value: {value}")
+            ExportValue { key, value } => {
+                write!(f, "ExportValue     key: {key:<10} value: {value}")
             }
+            ExportEntry { entry } => write!(f, "ExportEntry     entry: {entry}"),
             Import { register } => write!(f, "Import          register: {register}"),
             MakeTempTuple {
                 register,

--- a/crates/bytecode/src/instruction_reader.rs
+++ b/crates/bytecode/src/instruction_reader.rs
@@ -183,10 +183,11 @@ impl Iterator for InstructionReader {
                 register: byte_a,
                 constant: get_var_u32!().into(),
             },
-            Op::ValueExport => ValueExport {
-                name: byte_a,
+            Op::ExportValue => ExportValue {
+                key: byte_a,
                 value: get_u8!(),
             },
+            Op::ExportEntry => ExportEntry { entry: byte_a },
             Op::Import => Import { register: byte_a },
             Op::MakeTempTuple => {
                 let [byte_b, byte_c] = get_u8x2!();

--- a/crates/bytecode/src/op.rs
+++ b/crates/bytecode/src/op.rs
@@ -470,12 +470,21 @@ pub enum Op {
     /// `[*key, *name, *value]`
     MetaExportNamed,
 
-    /// Exports a value by adding it to the module's exports map
+    /// Exports a key/value pair by adding it to the module's exports map
     ///
     /// Used for expressions like `export foo = ...`
     ///
-    /// `[*name, *value]`
-    ValueExport,
+    /// `[*key, *value]`
+    ExportValue,
+
+    /// Exports an entry by adding it to the module's exports map
+    ///
+    /// - If the entry is a tuple, then it's assumed to be a key/value pair.
+    /// - If the entry is an iterator, then it's unpacked into a key/value pair.
+    /// - Otherwise an error will be thrown.
+    ///
+    /// `[*entry]`
+    ExportEntry,
 
     /// Accesses a contained value via a constant key
     ///
@@ -566,7 +575,6 @@ pub enum Op {
     CheckOptionalType,
 
     // Unused opcodes, allowing for a direct transmutation from a byte to an Op.
-    Unused89,
     Unused90,
     Unused91,
     Unused92,

--- a/crates/bytecode/tests/compile_failures.rs
+++ b/crates/bytecode/tests/compile_failures.rs
@@ -137,26 +137,6 @@ match [1, 2, 3]
             }
         }
 
-        mod export {
-            use super::*;
-
-            #[test]
-            fn id_without_assignment() {
-                let source = "
-export x
-";
-                check_compilation_fails(source);
-            }
-
-            #[test]
-            fn list() {
-                let source = "
-export [1, 2, 3]
-";
-                check_compilation_fails(source);
-            }
-        }
-
         mod functions {
             use super::*;
 

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -2,29 +2,6 @@
 
 A collection of utilities for working with the Koto runtime.
 
-## args
-
-```kototype
-Tuple
-```
-
-Provides access to the arguments that were passed into the script when running
-the `koto` CLI application.
-
-If no arguments were provided then the list is empty.
-
-### Example
-
-```koto
-# Assuming that the script was run with `koto script.koto -- 1 2 "hello"`
-size koto.args
-# 3
-koto.args.first()
-# 1
-koto.args.last()
-# hello
-```
-
 ## copy
 
 ```kototype

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -126,29 +126,6 @@ check! [[1, 2], [3, [4, 5]]]
 - [`koto.copy`](#copy)
 
 
-## exports
-
-```kototype
-|| -> Map
-```
-
-Returns the current module's `export` map.
-
-Although typically module items are exported with `export` expressions,
-it can be useful to export items programatically.
-
-### Example
-
-```koto
-export a, b, c = 1, 2, 3
-print! koto.exports()
-check! {a: 1, b: 2, c: 3}
-
-koto.exports().remove 'b'
-print! koto.exports()
-check! {a: 1, c: 3}
-```
-
 ## hash
 
 ```kototype

--- a/crates/cli/docs/core_lib/os.md
+++ b/crates/cli/docs/core_lib/os.md
@@ -2,6 +2,29 @@
 
 A collection of utilities for working with the operating system.
 
+## args
+
+```kototype
+Tuple
+```
+
+Provides access to the arguments that were passed into the script when running
+the `koto` CLI application.
+
+If no arguments were provided then the list is empty.
+
+### Example
+
+```koto
+# Assuming that the script was run with `koto script.koto -- 1 2 "hello"`
+size os.args
+# 3
+os.args.first()
+# 1
+os.args.last()
+# hello
+```
+
 ## command
 
 ```kototype

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -2578,34 +2578,22 @@ print! y
 check! 42
 ```
 
-The exports map can be accessed and modified directly via [`koto.exports`][koto-exports].
-
-```koto
-export a, b = 1, 2
-
-# koto.exports() returns the current module's exports map
-print! exports = koto.exports()
-check! {a: 1, b: 2}
-
-# Values can be inserted directly into the exports map
-exports.insert 'c', 3
-print! c
-check! 3
-```
-
-Assigning a new value to a variable that was previously exported won't change
-the exported value. If you need to update the exported value, then use `export`
-(or update the exports map via [`koto.exports`][koto-exports]).
+Assigning a new value locally to a previously exported variable won't change
+the exported value. If you need to update the exported value,
+then it needs to be re-exported.
 
 ```koto
 export x = 99
 
-# Reassigning a new value to x doesn't affect the previously exported value
+# Reassigning a new value to x locally doesn't affect the previously exported value
 print! x = 123
 check! 123
 
-print! koto.exports().x
-check! 99
+# x has a local value of 123, but the exported value of x is still 99.
+export x = -1
+# x now has an exported and local value of -1
+print! x
+check! -1
 ```
 
 ### `@main`

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -2525,7 +2525,8 @@ To add a [type check](#type_checks) to an exported assignment, use a `let` expre
 export let foo: Number = -1
 ```
 
-`export` also supports map syntax, which can be convenient when exporting a lot of values:
+`export` also accepts maps, or any other iterable value that yields a series of key/value pairs.
+This is convenient when exporting a lot of values, or generating exports programatically.
 
 ```koto
 ##################
@@ -2542,6 +2543,9 @@ export { a, b, c, foo: 42 }
 export
   bar: 99
   baz: 'baz'
+
+# Any iterable value that yields key/value pairs can be used with export
+export (1..=3).each |i| 'generated_{i}', i
 ```
 
 Once a value has been exported, it becomes available anywhere in the module.

--- a/crates/koto/examples/args.rs
+++ b/crates/koto/examples/args.rs
@@ -2,7 +2,7 @@ use koto::{Result, prelude::*};
 
 fn main() -> Result<()> {
     let script = "
-from koto import args
+from os import args
 
 if (size args) > 1
   for i, arg in args.enumerate()

--- a/crates/koto/src/error.rs
+++ b/crates/koto/src/error.rs
@@ -6,8 +6,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("{0}")]
     StringError(String),
-    #[error("missing koto module in the prelude")]
-    MissingPrelude,
+    #[error("missing os module in the prelude")]
+    MissingOsModule,
     #[error("nothing to run")]
     NothingToRun,
     #[error("{error}")]

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -151,12 +151,12 @@ impl Koto {
     pub fn set_args(&mut self, args: impl IntoIterator<Item = String>) -> Result<()> {
         let koto_args = args.into_iter().map(KValue::from).collect::<Vec<_>>();
 
-        match self.runtime.prelude().data_mut().get("koto") {
+        match self.runtime.prelude().data_mut().get("os") {
             Some(KValue::Map(map)) => {
                 map.insert("args", KValue::Tuple(koto_args.into()));
                 Ok(())
             }
-            _ => Err(Error::MissingPrelude),
+            _ => Err(Error::MissingOsModule),
         }
     }
 

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -14,8 +14,6 @@ use std::{
 pub fn make_module() -> KMap {
     let result = KMap::with_type("core.koto");
 
-    result.insert("args", KValue::Tuple(KTuple::default()));
-
     result.add_fn("copy", |ctx| match ctx.args() {
         [KValue::Iterator(iter)] => Ok(iter.make_copy()?.into()),
         [KValue::List(l)] => Ok(KList::with_data(l.data().clone()).into()),

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -36,11 +36,6 @@ pub fn make_module() -> KMap {
         unexpected => unexpected_args("|Any|", unexpected),
     });
 
-    result.add_fn("exports", |ctx| match ctx.args() {
-        [] => Ok(KValue::Map(ctx.vm.exports().clone())),
-        unexpected => unexpected_args("||", unexpected),
-    });
-
     result.add_fn("hash", |ctx| match ctx.args() {
         [value] => match ValueKey::try_from(value.clone()) {
             Ok(key) => {

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -13,6 +13,8 @@ pub fn make_module() -> KMap {
 
     let result = KMap::with_type("core.os");
 
+    result.insert("args", KValue::Tuple(KTuple::default()));
+
     result.add_fn("command", |ctx| match ctx.args() {
         [KValue::Str(command)] => Ok(Command::make_value(command)),
         unexpected => unexpected_args("|String|", unexpected),

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -169,7 +169,7 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     }
 
     /// Defines the behavior of negation (e.g. `-x`)
-    fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
+    fn negate(&self) -> Result<KValue> {
         unimplemented_error("@negate", self.type_string())
     }
 

--- a/crates/runtime/src/types/tuple.rs
+++ b/crates/runtime/src/types/tuple.rs
@@ -40,6 +40,11 @@ impl KTuple {
         }
     }
 
+    /// Returns the tuple's values as a slice
+    pub fn data(&self) -> &[KValue] {
+        self.deref()
+    }
+
     /// Returns true if the tuple contains only immutable values
     pub fn is_hashable(&self) -> bool {
         self.iter().all(KValue::is_hashable)

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -180,7 +180,7 @@ impl KValue {
                 |o| o.type_string(),
             ),
             Iterator(_) => "Iterator".into(),
-            TemporaryTuple { .. } => "Temporary_tuple".into(),
+            TemporaryTuple { .. } => "TemporaryTuple".into(),
         }
     }
 

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -1468,7 +1468,7 @@ impl KotoVm {
                 let op = m.get_meta_value(&Negate.into()).unwrap();
                 return self.call_overridden_unary_op(Some(result), value, op);
             }
-            Object(o) => o.try_borrow()?.negate(self)?,
+            Object(o) => o.try_borrow()?.negate()?,
             unexpected => return unexpected_type("negatable value", &unexpected),
         };
         self.set_register(result, result_value);

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -177,7 +177,7 @@ mod objects {
             Ok(self.x.into())
         }
 
-        fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
+        fn negate(&self) -> Result<KValue> {
             Ok(Self::make_value(-self.x))
         }
 

--- a/crates/runtime/tests/runtime_failures.rs
+++ b/crates/runtime/tests/runtime_failures.rs
@@ -791,6 +791,35 @@ x.reversed().next()
             }
         }
 
+        mod export {
+            use super::*;
+
+            #[test]
+            fn export_single_value() {
+                let script = "
+export 99
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn export_list() {
+                let script = "
+x = [1, 2, 3]
+export x
+";
+                check_script_fails(script);
+            }
+
+            #[test]
+            fn export_iterator_with_non_key_pair_output() {
+                let script = "
+export (1..=3).each |i| i, i, i
+";
+                check_script_fails(script);
+            }
+        }
+
         mod strings {
             use super::*;
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -4083,7 +4083,7 @@ x + y";
         }
 
         #[test]
-        fn map_export() {
+        fn map_literal() {
             let script = "
 export
   x: 1
@@ -4091,6 +4091,27 @@ export
 x + y
 ";
             check_script_output(script, 3);
+        }
+
+        #[test]
+        fn map_variable() {
+            let script = "
+m =
+  x: 1
+  y: 2
+export m
+x + y
+";
+            check_script_output(script, 3);
+        }
+
+        #[test]
+        fn iterator() {
+            let script = "
+export (1..=3).each |i| 'generated_{i}', i
+generated_1 + generated_2 + generated_3
+";
+            check_script_output(script, 6);
         }
 
         #[test]

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -47,11 +47,11 @@ spectral_norm = |n|
   (vBv / vv).sqrt()
 
 @main = ||
-  n = koto.args.first()?.to_number() or 4
+  n = os.args.first()?.to_number() or 4
 
   result = spectral_norm n
 
-  if (koto.args.get 1) != 'quiet'
+  if (os.args.get 1) != 'quiet'
     print result
 
 @test spectral_norm_5 = ||

--- a/koto/benches/string_formatting.koto
+++ b/koto/benches/string_formatting.koto
@@ -27,13 +27,13 @@ number_to_english = |n|
     else '???'
 
 @main = ||
-  n = koto.args.first()?.to_number() or 50
+  n = os.args.first()?.to_number() or 50
 
   result = -n..=n
     .each |x| number_to_english x
     .to_tuple()
 
-  if not (koto.args.get 1) == 'quiet'
+  if (os.args.get 1) != 'quiet'
     print result
 
 @test number_to_english = ||

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -63,8 +63,10 @@ export
   @test import_item_exported_with_string_id: ||
     assert_eq test_module.exported_with_string_id, 99
 
-  @test import_item_exported_via_inserting_into_exports_map: ||
-    assert_eq test_module.exported_via_insert, -123
+  @test import_generated_items: ||
+    assert_eq test_module.generated_export_1, 1
+    assert_eq test_module.generated_export_2, 2
+    assert_eq test_module.generated_export_3, 3
 
   @test tests_should_be_run_when_importing_a_module: ||
     # Tests will be run when importing a module when the 'run import tests' setting is set

--- a/koto/tests/import.koto
+++ b/koto/tests/import.koto
@@ -73,8 +73,3 @@ export
     # in the runtime.
     from test_module import tests_were_run
     assert tests_were_run
-
-  @test dynamic_exported_value: ||
-    x = "value_x"
-    map.insert koto.exports(), x, 99
-    assert_eq value_x, 99

--- a/koto/tests/test_module/main.koto
+++ b/koto/tests/test_module/main.koto
@@ -14,8 +14,9 @@ export
   baz: import baz # Re-export the neighbouring baz module
   'exported_with_string_id': 99
 
-# Export by inserting an entry to koto.exports()
-koto.exports().insert 'exported_via_insert', -123
+# Export via an iterator that yields (name, value) tuples
+export (1..=3).each |i|
+  'generated_export_{i}', i
 
 # Metakeys can be assigned to directly
 @type = 'test_module'

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -44,7 +44,7 @@ impl KotoObject for Vec2 {
         Ok(())
     }
 
-    fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
+    fn negate(&self) -> Result<KValue> {
         Ok(Self(-self.0).into())
     }
 

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -39,7 +39,7 @@ impl KotoObject for Vec3 {
         Ok(())
     }
 
-    fn negate(&self, _vm: &mut KotoVm) -> Result<KValue> {
+    fn negate(&self) -> Result<KValue> {
         Ok(Self(-self.0).into())
     }
 


### PR DESCRIPTION
- **Allow export to be used with any iterable that yields key/value pairs**
- **Remove koto.exports**

`koto.exports` has a quirk in behaviour whereby if its accessed within a module after its been initialized then it may refer to a different map; it returns the _runtime's_ exports map, rather than the _module's_ exports map, which is rather surprising. 

It was introduced in #47 to support programmatic generation of exported values, so this PR extends `export` to allow any iterable value to provide key/value pairs to be added to the exports map, which allows `koto.exports` to be removed.

If there's a good reason to reintroduce access to the exports map from within Koto I think we would need to limit access to the runtime's top-level module, preventing access in imported modules post-initialization.

- **Remove the vm argument from KotoObject::negate**

Resolves #433.

- **Move koto.args -> os.args**

`koto.args` was introduced before the `os` module was created, which seems like a more appropriate home for accessing CLI args.
