### PR TITLE
Overridden operator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,19 @@ The Koto project adheres to
     generated_3
     # -> 3
     ```
+- Overridden operator improvements
+  - Objects can now implement arithmetic operations when the object is on the right-hand side of the
+    operation via the `@r+`, `@r-`, `@r*`, `@r/`, and `@r%` metakeys.
+    - If the LHS value doesn't implement the operation, then the RHS value is checked for an
+      available implementation.
+  - `!=` now derives its result by default from `@==`.
+  - If `@<` and `@==` are implemented, then the remaining comparison operators are now derived by
+    default.
 
 #### API
 
+- `KotoObject` has been extended with `_rhs` functions to support arithmetic operations
+  where the object can appear on the right-hand side of the expression.
 - `Compiler::compile_ast` has been added, useful for tools that want to work with the AST
   after checking that it compiles correctly.
 - `DisplayContext::debug_enabled` has been added to allow native objects to provide
@@ -77,6 +87,8 @@ The Koto project adheres to
   - `string.strip_prefix` / `string.strip_suffix`
   - `string.trim_start` / `string.trim_end`
     - `string.trim` now also accepts a pattern to match against.
+- `koto.unimplemented` has been added to allow overridden left-hand side arithmetic operators to
+   defer to right-hand side implementations.
 
 #### CLI
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,7 @@ dependencies = [
  "koto_memory",
  "koto_parser",
  "koto_test_utils",
+ "paste",
  "rustc-hash",
  "saturating_cast",
  "smallvec",
@@ -992,6 +993,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ mimalloc = { version = "0.1.39", default-features = false }
 palette = "0.7.6"
 # More compact and efficient implementations of the standard synchronization primitives.
 parking_lot = "0.12.1"
+# Macros for all your token pasting needs
+paste = "1.0.15"
 # An ultra simple CLI arguments parser.
 pico-args = { version = "0.5.0" }
 # A substitute implementation of the compiler's `proc_macro` API

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -254,3 +254,46 @@ foo =
 print! koto.type foo
 check! Foo
 ```
+
+
+## unimplemented
+
+```kototype
+Unimplemented
+```
+
+An instance of `Unimplemented`, which should be thrown from [overridden arithmetic operators][guide-arithmetic] when the
+operation isn't supported with the given input type.
+
+### Example
+
+```koto
+foo = |n|
+  data: n
+  @type: 'Foo'
+  @display: || 'Foo({self.data})'
+  @+: |other|
+    # Throw an `unimplemented` error if the rhs isn't a Foo
+    match type other
+      'Foo' then foo self.data + other.data
+      else throw koto.unimplemented
+
+bar = |n|
+  data: n
+  @type: 'Bar'
+  @display: || 'Bar({self.data})'
+  @r+: |other|
+
+    match type other
+      'Foo' or 'Bar' then bar other.data + self.data
+      else throw koto.unimplemented
+
+print! (foo 10) + (foo 20)
+check! Foo(30)
+
+print! (foo 2) + (bar 3)
+check! Bar(5)
+```
+
+
+[guide-arithmetic]: ../language_guide.md#arithmetic-operators

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -2018,8 +2018,8 @@ An object is any map that includes one or more _metakeys_
 Whenever operations are performed on the object, the runtime checks its metamap
 for corresponding metakeys.
 
-In the following example, addition and subtraction operators are overridden for
-a custom `Foo` object:
+In the following example, the addition and multiply-assignment operators are
+implemented for a custom `Foo` object:
 
 ```koto
 # Declare a function that makes Foo objects
@@ -2029,13 +2029,13 @@ foo = |n|
   # Declare the object's type
   @type: 'Foo'
 
-  # Override the addition operator
+  # Implement the addition operator
   @+: |other|
     # A new Foo is made using the result
     # of adding the two data values together
     foo self.data + other.data
 
-  # Overriding the multiply-assignment operator
+  # Implement the multiply-assignment operator
   @*=: |other|
     self.data *= other.data
     self
@@ -2095,6 +2095,42 @@ check! 6
 
 print! (10 * a).data
 check! 20
+```
+
+### Comparison Operators
+
+Comparison operators can also be implemented in an object's metamap
+by using the metakeys `@==`, `@!=`, `@<`, `@<=`, `@>`, and `@>=`.
+
+By default, `@!=` will invert the result of calling `@==`,
+so it's only necessary to implement it for types with special equality properties.
+
+Types that represent a [total order][total-order] only need to implement `@<` and `@==`,
+and the runtime will automatically derive results for `@<=`, `@>`, and `@>=`.
+
+```koto
+foo = |n|
+  data: n
+
+  @==: |other| self.data == other.data
+  @<: |other| self.data < other.data
+
+a = foo 100
+b = foo 200
+
+print! a == a
+check! true
+
+# The result of != is derived by inverting the result of @==
+print! a != a
+check! false
+
+print! a < b
+check! true
+
+# The result of > is derived from the implementations of @< and @==
+print! a > b
+check! false
 ```
 
 ### Metakeys
@@ -2817,5 +2853,6 @@ test.run_tests my_tests
 [to_map]: ./core_lib/iterator.md#to_map
 [to_string]: ./core_lib/iterator.md#to_string
 [to_tuple]: ./core_lib/iterator.md#to_tuple
+[total-order]: https://en.wikipedia.org/wiki/Total_order
 [utf-8]: https://en.wikipedia.org/wiki/UTF-8
 [variadic]: https://en.wikipedia.org/wiki/Variadic_function

--- a/crates/cli/docs/libs/geometry.md
+++ b/crates/cli/docs/libs/geometry.md
@@ -333,7 +333,7 @@ check! Rect{x: 0, y: 0, width: 200, height: 200}
 
 The `Vec2` type represents a 2-dimensional vector, with `x` and `y` coordinates.
 
-All operators are implemented, and the vector's coordinates are iterable.
+Arithmetic operations are supported, and the vector's coordinates are iterable.
 
 ### Example
 
@@ -344,12 +344,12 @@ print! (vec2 10, 20) + (vec2 30, 40)
 check! Vec2{x: 40, y: 60}
 
 v = vec2 50, 100
-v *= vec2 0.5, 2
+v *= 2 * vec2 0.5, 2
 x, y = v
 print! x, y
-check! (25.0, 200.0)
-print! v -= 50
-check! Vec2{x: -25, y: 150}
+check! (50.0, 400.0)
+print! v -= 100
+check! Vec2{x: -50, y: 300}
 ```
 
 ## Vec2.angle
@@ -438,7 +438,7 @@ check! 4.0
 
 The `Vec3` type represents a 3-dimensional vector, with `x`, `y`, and `z` coordinates.
 
-All operators are implemented, and the vector's coordinates are iterable.
+Arithmetic operations are supported, and the vector's coordinates are iterable.
 
 ### Example
 
@@ -448,7 +448,7 @@ from geometry import vec3
 print! (vec3 10, 20, 30) + (vec3 40, 50, 60)
 check! Vec3{x: 50, y: 70, z: 90}
 
-v = vec3 50, 100, 150
+v = 10 * vec3 5, 10, 15
 v *= vec3 0.5, 2, -1
 x, y, z = v
 print! x, y, z

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -530,6 +530,16 @@ pub enum MetaKeyId {
     Divide,
     /// @%
     Remainder,
+    /// @r+
+    AddRhs,
+    /// @r-
+    SubtractRhs,
+    /// @r*
+    MultiplyRhs,
+    /// @r/
+    DivideRhs,
+    /// @r%
+    RemainderRhs,
     /// @+=
     AddAssign,
     /// @-=
@@ -626,6 +636,11 @@ impl fmt::Display for MetaKeyId {
                 Multiply => "*",
                 Divide => "/",
                 Remainder => "%",
+                AddRhs => "r+",
+                SubtractRhs => "r-",
+                MultiplyRhs => "r*",
+                DivideRhs => "r/",
+                RemainderRhs => "r%",
                 AddAssign => "+=",
                 SubtractAssign => "-=",
                 MultiplyAssign => "*=",

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -2116,6 +2116,14 @@ impl<'source> Parser<'source> {
             Some(Token::NotEqual) => MetaKeyId::NotEqual,
             Some(Token::Debug) => MetaKeyId::Debug,
             Some(Token::Id) => match self.current_token.slice(self.source) {
+                "r" => match self.consume_next_token_on_same_line() {
+                    Some(Token::Add) => MetaKeyId::AddRhs,
+                    Some(Token::Subtract) => MetaKeyId::SubtractRhs,
+                    Some(Token::Multiply) => MetaKeyId::MultiplyRhs,
+                    Some(Token::Divide) => MetaKeyId::DivideRhs,
+                    Some(Token::Remainder) => MetaKeyId::RemainderRhs,
+                    _ => return self.error(SyntaxError::UnexpectedMetaKey),
+                },
                 "call" => MetaKeyId::Call,
                 "display" => MetaKeyId::Display,
                 "index" => MetaKeyId::Index,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -28,6 +28,7 @@ koto_parser = { path = "../parser", version = "^0.16.0", default-features = fals
 
 downcast-rs = { workspace = true }
 indexmap = { workspace = true }
+paste = { workspace = true }
 rustc-hash = { workspace = true }
 saturating_cast = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -76,6 +76,8 @@ pub fn make_module() -> KMap {
         unexpected => unexpected_args("|Any|", unexpected),
     });
 
+    result.insert("unimplemented", KObject::from(Unimplemented));
+
     result.add_fn("load", |ctx| match ctx.args() {
         [KValue::Str(s)] => Ok(try_load_koto_script(ctx, s)?.into()),
         unexpected => unexpected_args("|String|", unexpected),
@@ -140,3 +142,10 @@ impl From<Chunk> for KValue {
         KObject::from(chunk).into()
     }
 }
+
+/// A type error type used in the koto module
+#[derive(Clone, KotoCopy, KotoType)]
+pub struct Unimplemented;
+
+impl KotoEntries for Unimplemented {}
+impl KotoObject for Unimplemented {}

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -178,15 +178,15 @@ impl KotoObject for Timer {
         Ok(())
     }
 
-    fn subtract(&self, rhs: &KValue) -> Result<KValue> {
-        match rhs {
+    fn subtract(&self, other: &KValue) -> Result<KValue> {
+        match other {
             KValue::Object(o) if o.is_a::<Self>() => {
-                let rhs = o.cast::<Self>().unwrap();
+                let other_timer = o.cast::<Self>().unwrap();
 
-                let result = if self.0 >= rhs.0 {
-                    self.0.duration_since(rhs.0).as_secs_f64()
+                let result = if self.0 >= other_timer.0 {
+                    self.0.duration_since(other_timer.0).as_secs_f64()
                 } else {
-                    -(rhs.0.duration_since(self.0).as_secs_f64())
+                    -(other_timer.0.duration_since(self.0).as_secs_f64())
                 };
 
                 Ok(result.into())

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -144,6 +144,11 @@ impl Error {
         }
     }
 
+    /// Returns true if the error kind is [`ErrorKind::Unimplemented`]
+    pub fn is_unimplemented_error(&self) -> bool {
+        matches!(&self.error, ErrorKind::Unimplemented { .. })
+    }
+
     /// Initializes an error from a thrown Koto value
     pub(crate) fn from_koto_value(thrown_value: KValue) -> Self {
         Self::new(ErrorKind::KotoError {

--- a/crates/runtime/src/types/meta_map.rs
+++ b/crates/runtime/src/types/meta_map.rs
@@ -134,6 +134,16 @@ pub enum BinaryOp {
     Divide,
     /// `@%`
     Remainder,
+    /// `@r+`
+    AddRhs,
+    /// `@r-`
+    SubtractRhs,
+    /// `@r*`
+    MultiplyRhs,
+    /// `@r/`
+    DivideRhs,
+    /// `@r%`
+    RemainderRhs,
     /// `@+=`
     AddAssign,
     /// `@-=`
@@ -168,11 +178,11 @@ impl fmt::Display for BinaryOp {
             f,
             "{}",
             match self {
-                Add => "+",
-                Subtract => "-",
-                Multiply => "*",
-                Divide => "/",
-                Remainder => "%",
+                Add | AddRhs => "+",
+                Subtract | SubtractRhs => "-",
+                Multiply | MultiplyRhs => "*",
+                Divide | DivideRhs => "/",
+                Remainder | RemainderRhs => "%",
                 AddAssign => "+=",
                 SubtractAssign => "-=",
                 MultiplyAssign => "*=",
@@ -222,6 +232,11 @@ pub fn meta_id_to_key(id: MetaKeyId, name: Option<KString>) -> Result<MetaKey> {
         MetaKeyId::Multiply => MetaKey::BinaryOp(Multiply),
         MetaKeyId::Divide => MetaKey::BinaryOp(Divide),
         MetaKeyId::Remainder => MetaKey::BinaryOp(Remainder),
+        MetaKeyId::AddRhs => MetaKey::BinaryOp(AddRhs),
+        MetaKeyId::SubtractRhs => MetaKey::BinaryOp(SubtractRhs),
+        MetaKeyId::MultiplyRhs => MetaKey::BinaryOp(MultiplyRhs),
+        MetaKeyId::DivideRhs => MetaKey::BinaryOp(DivideRhs),
+        MetaKeyId::RemainderRhs => MetaKey::BinaryOp(RemainderRhs),
         MetaKeyId::AddAssign => MetaKey::BinaryOp(AddAssign),
         MetaKeyId::SubtractAssign => MetaKey::BinaryOp(SubtractAssign),
         MetaKeyId::MultiplyAssign => MetaKey::BinaryOp(MultiplyAssign),

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -296,21 +296,56 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     }
 
     /// The `<=` less-than-or-equal operator
+    ///
+    /// The default implementation derives its result from [Self::less] and [Self::equal].
     fn less_or_equal(&self, other: &KValue) -> Result<bool> {
-        let _ = other;
-        unimplemented_error("@<=", self.type_string())
+        match self.less(other) {
+            Ok(true) => Ok(true),
+            Ok(false) => match self.equal(other) {
+                Ok(result) => Ok(result),
+                Err(error) if error.is_unimplemented_error() => {
+                    unimplemented_error("@<=", self.type_string())
+                }
+                error => error,
+            },
+            Err(error) if error.is_unimplemented_error() => {
+                unimplemented_error("@<=", self.type_string())
+            }
+            error => error,
+        }
     }
 
     /// The `>` greater-than operator
+    ///
+    /// The default implementation derives its result from [Self::less] and [Self::equal].
     fn greater(&self, other: &KValue) -> Result<bool> {
-        let _ = other;
-        unimplemented_error("@>", self.type_string())
+        match self.less(other) {
+            Ok(true) => Ok(false),
+            Ok(false) => match self.equal(other) {
+                Ok(result) => Ok(!result),
+                Err(error) if error.is_unimplemented_error() => {
+                    unimplemented_error("@>", self.type_string())
+                }
+                error => error,
+            },
+            Err(error) if error.is_unimplemented_error() => {
+                unimplemented_error("@>", self.type_string())
+            }
+            error => error,
+        }
     }
 
     /// The `>=` greater-than-or-equal operator
+    ///
+    /// The default implementation derives its result from [Self::less].
     fn greater_or_equal(&self, other: &KValue) -> Result<bool> {
-        let _ = other;
-        unimplemented_error("@>=", self.type_string())
+        match self.less(other) {
+            Ok(result) => Ok(!result),
+            Err(error) if error.is_unimplemented_error() => {
+                unimplemented_error("@>=", self.type_string())
+            }
+            error => error,
+        }
     }
 
     /// The `==` equality operator
@@ -320,9 +355,16 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     }
 
     /// The `!=` inequality operator
+    ///
+    /// The default implementation derives its result from [Self::equal].
     fn not_equal(&self, other: &KValue) -> Result<bool> {
-        let _ = other;
-        unimplemented_error("@!=", self.type_string())
+        match self.equal(other) {
+            Ok(result) => Ok(!result),
+            Err(error) if error.is_unimplemented_error() => {
+                unimplemented_error("@!=", self.type_string())
+            }
+            error => error,
+        }
     }
 
     /// Declares to the runtime whether or not the object is iterable

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -177,19 +177,56 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     }
 
     /// The `+` addition operator
+    ///
+    /// This will be called by the runtime when the object is on the LHS.
+    ///
+    /// To specialize the behaviour of `+` when the object is on the RHS, see [Self::add_rhs].
     fn add(&self, other: &KValue) -> Result<KValue> {
         let _ = other;
         unimplemented_error("@+", self.type_string())
     }
 
+    /// The `+` addition operator when the object is on the RHS
+    ///
+    /// This will be called when the value on the LHS doesn't implement the operation.
+    fn add_rhs(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
+        unimplemented_error("@+", self.type_string())
+    }
+
     /// The `-` subtraction operator
+    ///
+    /// This will be called by the runtime when the object is on the LHS of the operation,
+    /// or as a fallback if the value on the LHS doesn't support the operation.
+    ///
+    /// To specialize the behaviour of `-` when the object is on the RHS, see [Self::subtract_rhs].
     fn subtract(&self, other: &KValue) -> Result<KValue> {
         let _ = other;
         unimplemented_error("@-", self.type_string())
     }
 
+    /// The `-` addition operator when the object is on the RHS
+    ///
+    /// This will be called when the value on the LHS doesn't implement the operation.
+    fn subtract_rhs(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
+        unimplemented_error("@-", self.type_string())
+    }
+
     /// The `*` multiplication operator
+    ///
+    /// This will be called by the runtime when the object is on the LHS.
+    ///
+    /// To specialize the behaviour of `*` when the object is on the RHS, see [Self::multiply_rhs].
     fn multiply(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
+        unimplemented_error("@*", self.type_string())
+    }
+
+    /// The `*` addition operator when the object is on the RHS
+    ///
+    /// This will be called when the value on the LHS doesn't implement the operation.
+    fn multiply_rhs(&self, other: &KValue) -> Result<KValue> {
         let _ = other;
         unimplemented_error("@*", self.type_string())
     }
@@ -200,8 +237,24 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
         unimplemented_error("@/", self.type_string())
     }
 
+    /// The `/` addition operator when the object is on the RHS
+    ///
+    /// This will be called when the value on the LHS doesn't implement the operation.
+    fn divide_rhs(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
+        unimplemented_error("@/", self.type_string())
+    }
+
     /// The `%` remainder operator
     fn remainder(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
+        unimplemented_error("@%", self.type_string())
+    }
+
+    /// The `%` addition operator when the object is on the RHS
+    ///
+    /// This will be called when the value on the LHS doesn't implement the operation.
+    fn remainder_rhs(&self, other: &KValue) -> Result<KValue> {
         let _ = other;
         unimplemented_error("@%", self.type_string())
     }

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -127,14 +127,16 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     /// Called for indexing operations, e.g. `x[0]`
     ///
     /// See also: [KotoObject::size]
-    fn index(&self, _index: &KValue) -> Result<KValue> {
+    fn index(&self, index: &KValue) -> Result<KValue> {
+        let _ = index;
         unimplemented_error("@index", self.type_string())
     }
 
     /// Called when mutating an object via indexing, e.g. `x[0] = 99`
     ///
     /// See also: [KotoObject::size]
-    fn index_mut(&mut self, _index: &KValue, _value: &KValue) -> Result<()> {
+    fn index_mut(&mut self, index: &KValue, value: &KValue) -> Result<()> {
+        let _ = (index, value);
         unimplemented_error("@index_mut", self.type_string())
     }
 
@@ -164,7 +166,8 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     /// Allows the object to behave as a function
     ///
     /// Objects that implement `call` should return `true` from [`KotoObject::call`].
-    fn call(&mut self, _ctx: &mut CallContext) -> Result<KValue> {
+    fn call(&mut self, ctx: &mut CallContext) -> Result<KValue> {
+        let _ = ctx;
         unimplemented_error("@||", self.type_string())
     }
 
@@ -173,83 +176,99 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
         unimplemented_error("@negate", self.type_string())
     }
 
-    /// The `+` addition operator ()
-    fn add(&self, _rhs: &KValue) -> Result<KValue> {
+    /// The `+` addition operator
+    fn add(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
         unimplemented_error("@+", self.type_string())
     }
 
     /// The `-` subtraction operator
-    fn subtract(&self, _rhs: &KValue) -> Result<KValue> {
+    fn subtract(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
         unimplemented_error("@-", self.type_string())
     }
 
     /// The `*` multiplication operator
-    fn multiply(&self, _rhs: &KValue) -> Result<KValue> {
+    fn multiply(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
         unimplemented_error("@*", self.type_string())
     }
 
     /// The `/` division operator
-    fn divide(&self, _rhs: &KValue) -> Result<KValue> {
+    fn divide(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
         unimplemented_error("@/", self.type_string())
     }
 
     /// The `%` remainder operator
-    fn remainder(&self, _rhs: &KValue) -> Result<KValue> {
+    fn remainder(&self, other: &KValue) -> Result<KValue> {
+        let _ = other;
         unimplemented_error("@%", self.type_string())
     }
 
     /// The `+=` in-place addition operator
-    fn add_assign(&mut self, _rhs: &KValue) -> Result<()> {
+    fn add_assign(&mut self, other: &KValue) -> Result<()> {
+        let _ = other;
         unimplemented_error("@+=", self.type_string())
     }
 
     /// The `-=` in-place subtraction operator
-    fn subtract_assign(&mut self, _rhs: &KValue) -> Result<()> {
+    fn subtract_assign(&mut self, other: &KValue) -> Result<()> {
+        let _ = other;
         unimplemented_error("@-=", self.type_string())
     }
 
     /// The `*=` in-place multiplication operator
-    fn multiply_assign(&mut self, _rhs: &KValue) -> Result<()> {
+    fn multiply_assign(&mut self, other: &KValue) -> Result<()> {
+        let _ = other;
         unimplemented_error("@*=", self.type_string())
     }
 
     /// The `/=` in-place division operator
-    fn divide_assign(&mut self, _rhs: &KValue) -> Result<()> {
+    fn divide_assign(&mut self, other: &KValue) -> Result<()> {
+        let _ = other;
         unimplemented_error("@/=", self.type_string())
     }
 
     /// The `%=` in-place remainder operator
-    fn remainder_assign(&mut self, _rhs: &KValue) -> Result<()> {
+    fn remainder_assign(&mut self, other: &KValue) -> Result<()> {
+        let _ = other;
         unimplemented_error("@%=", self.type_string())
     }
 
     /// The `<` less-than operator
-    fn less(&self, _rhs: &KValue) -> Result<bool> {
+    fn less(&self, other: &KValue) -> Result<bool> {
+        let _ = other;
         unimplemented_error("@<", self.type_string())
     }
 
     /// The `<=` less-than-or-equal operator
-    fn less_or_equal(&self, _rhs: &KValue) -> Result<bool> {
+    fn less_or_equal(&self, other: &KValue) -> Result<bool> {
+        let _ = other;
         unimplemented_error("@<=", self.type_string())
     }
 
     /// The `>` greater-than operator
-    fn greater(&self, _rhs: &KValue) -> Result<bool> {
+    fn greater(&self, other: &KValue) -> Result<bool> {
+        let _ = other;
         unimplemented_error("@>", self.type_string())
     }
 
     /// The `>=` greater-than-or-equal operator
-    fn greater_or_equal(&self, _rhs: &KValue) -> Result<bool> {
+    fn greater_or_equal(&self, other: &KValue) -> Result<bool> {
+        let _ = other;
         unimplemented_error("@>=", self.type_string())
     }
 
     /// The `==` equality operator
-    fn equal(&self, _rhs: &KValue) -> Result<bool> {
+    fn equal(&self, other: &KValue) -> Result<bool> {
+        let _ = other;
         unimplemented_error("@==", self.type_string())
     }
 
     /// The `!=` inequality operator
-    fn not_equal(&self, _rhs: &KValue) -> Result<bool> {
+    fn not_equal(&self, other: &KValue) -> Result<bool> {
+        let _ = other;
         unimplemented_error("@!=", self.type_string())
     }
 
@@ -266,7 +285,8 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     /// If [`IsIterable::Iterable`] is returned from [`is_iterable`](Self::is_iterable),
     /// then the runtime will call this function when the object is used in iterable contexts,
     /// expecting a [`KIterator`] to be returned.
-    fn make_iterator(&self, _vm: &mut KotoVm) -> Result<KIterator> {
+    fn make_iterator(&self, vm: &mut KotoVm) -> Result<KIterator> {
+        let _ = vm;
         unimplemented_error("@iterator", self.type_string())
     }
 
@@ -277,7 +297,8 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     /// [is_iterable](Self::is_iterable), then the object will be wrapped in a [`KIterator`]
     /// whenever it's used in an iterable context. This function will then be called each time
     /// [`KIterator::next`] is invoked.
-    fn iterator_next(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
+    fn iterator_next(&mut self, vm: &mut KotoVm) -> Option<KIteratorOutput> {
+        let _ = vm;
         None
     }
 
@@ -287,7 +308,8 @@ pub trait KotoObject: KotoType + KotoCopy + KotoEntries + KotoSend + KotoSync + 
     /// [`is_iterable`](Self::is_iterable), then the object will be wrapped in a [`KIterator`]
     /// whenever it's used in an iterable context. This function will then be called each time
     /// [`KIterator::next_back`] is invoked.
-    fn iterator_next_back(&mut self, _vm: &mut KotoVm) -> Option<KIteratorOutput> {
+    fn iterator_next_back(&mut self, vm: &mut KotoVm) -> Option<KIteratorOutput> {
+        let _ = vm;
         None
     }
 }

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -50,13 +50,13 @@ mod objects {
     }
 
     macro_rules! arithmetic_op {
-        ($self:ident, $rhs:expr, $op:tt) => {
+        ($self:ident, $other:expr, $op:tt) => {
             {
                 use KValue::*;
-                match $rhs {
-                    Object(rhs) if rhs.is_a::<Self>() => {
-                        let rhs = rhs.cast::<Self>().unwrap();
-                        Ok(Self::make_value($self.x $op rhs.x))
+                match $other {
+                    Object(other) if other.is_a::<Self>() => {
+                        let other = other.cast::<Self>().unwrap();
+                        Ok(Self::make_value($self.x $op other.x))
                     }
                     Number(n) => {
                         Ok(Self::make_value($self.x $op i64::from(n)))
@@ -70,13 +70,13 @@ mod objects {
     }
 
     macro_rules! assignment_op {
-        ($self:ident, $rhs:expr, $op:tt) => {
+        ($self:ident, $other:expr, $op:tt) => {
             {
                 use KValue::*;
-                match $rhs {
-                    Object(rhs) if rhs.is_a::<Self>() => {
-                        let rhs = rhs.cast::<Self>().unwrap();
-                        $self.x $op rhs.x;
+                match $other {
+                    Object(other) if other.is_a::<Self>() => {
+                        let other = other.cast::<Self>().unwrap();
+                        $self.x $op other.x;
                         Ok(())
                     }
                     Number(n) => {
@@ -92,14 +92,14 @@ mod objects {
     }
 
     macro_rules! comparison_op {
-        ($self:ident, $rhs:expr, $op:tt) => {
+        ($self:ident, $other:expr, $op:tt) => {
             {
                 use KValue::*;
-                match $rhs {
-                    Object(rhs) if rhs.is_a::<Self>() => {
-                        let rhs = rhs.cast::<Self>().unwrap();
+                match $other {
+                    Object(other) if other.is_a::<Self>() => {
+                        let other = other.cast::<Self>().unwrap();
                         #[allow(clippy::float_cmp)]
-                        Ok($self.x $op rhs.x)
+                        Ok($self.x $op other.x)
                     }
                     Number(n) => {
                         #[allow(clippy::float_cmp)]
@@ -181,68 +181,68 @@ mod objects {
             Ok(Self::make_value(-self.x))
         }
 
-        fn add(&self, rhs: &KValue) -> Result<KValue> {
-            arithmetic_op!(self, rhs, +)
+        fn add(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op!(self, other, +)
         }
 
-        fn subtract(&self, rhs: &KValue) -> Result<KValue> {
-            arithmetic_op!(self, rhs, -)
+        fn subtract(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op!(self, other, -)
         }
 
-        fn multiply(&self, rhs: &KValue) -> Result<KValue> {
-            arithmetic_op!(self, rhs, *)
+        fn multiply(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op!(self, other, *)
         }
 
-        fn divide(&self, rhs: &KValue) -> Result<KValue> {
-            arithmetic_op!(self, rhs, /)
+        fn divide(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op!(self, other, /)
         }
 
-        fn remainder(&self, rhs: &KValue) -> Result<KValue> {
-            arithmetic_op!(self, rhs, %)
+        fn remainder(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op!(self, other, %)
         }
 
-        fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
-            assignment_op!(self, rhs, +=)
+        fn add_assign(&mut self, other: &KValue) -> Result<()> {
+            assignment_op!(self, other, +=)
         }
 
-        fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
-            assignment_op!(self, rhs, -=)
+        fn subtract_assign(&mut self, other: &KValue) -> Result<()> {
+            assignment_op!(self, other, -=)
         }
 
-        fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
-            assignment_op!(self, rhs, *=)
+        fn multiply_assign(&mut self, other: &KValue) -> Result<()> {
+            assignment_op!(self, other, *=)
         }
 
-        fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
-            assignment_op!(self, rhs, /=)
+        fn divide_assign(&mut self, other: &KValue) -> Result<()> {
+            assignment_op!(self, other, /=)
         }
 
-        fn remainder_assign(&mut self, rhs: &KValue) -> Result<()> {
-            assignment_op!(self, rhs, %=)
+        fn remainder_assign(&mut self, other: &KValue) -> Result<()> {
+            assignment_op!(self, other, %=)
         }
 
-        fn less(&self, rhs: &KValue) -> Result<bool> {
-            comparison_op!(self, rhs, <)
+        fn less(&self, other: &KValue) -> Result<bool> {
+            comparison_op!(self, other, <)
         }
 
-        fn less_or_equal(&self, rhs: &KValue) -> Result<bool> {
-            comparison_op!(self, rhs, <=)
+        fn less_or_equal(&self, other: &KValue) -> Result<bool> {
+            comparison_op!(self, other, <=)
         }
 
-        fn greater(&self, rhs: &KValue) -> Result<bool> {
-            comparison_op!(self, rhs, >)
+        fn greater(&self, other: &KValue) -> Result<bool> {
+            comparison_op!(self, other, >)
         }
 
-        fn greater_or_equal(&self, rhs: &KValue) -> Result<bool> {
-            comparison_op!(self, rhs, >=)
+        fn greater_or_equal(&self, other: &KValue) -> Result<bool> {
+            comparison_op!(self, other, >=)
         }
 
-        fn equal(&self, rhs: &KValue) -> Result<bool> {
-            comparison_op!(self, rhs, ==)
+        fn equal(&self, other: &KValue) -> Result<bool> {
+            comparison_op!(self, other, ==)
         }
 
-        fn not_equal(&self, rhs: &KValue) -> Result<bool> {
-            comparison_op!(self, rhs, !=)
+        fn not_equal(&self, other: &KValue) -> Result<bool> {
+            comparison_op!(self, other, !=)
         }
 
         fn is_iterable(&self) -> IsIterable {

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -69,6 +69,21 @@ mod objects {
         }
     }
 
+    macro_rules! arithmetic_op_rhs {
+        ($self:ident, $other:expr, $op:tt) => {
+            {
+                match $other {
+                    KValue::Number(n) => {
+                        Ok(Self::make_value(i64::from(n) $op $self.x))
+                    }
+                    unexpected => {
+                        unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
+                    }
+                }
+            }
+        }
+    }
+
     macro_rules! assignment_op {
         ($self:ident, $other:expr, $op:tt) => {
             {
@@ -185,20 +200,40 @@ mod objects {
             arithmetic_op!(self, other, +)
         }
 
+        fn add_rhs(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op_rhs!(self, other, +)
+        }
+
         fn subtract(&self, other: &KValue) -> Result<KValue> {
             arithmetic_op!(self, other, -)
+        }
+
+        fn subtract_rhs(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op_rhs!(self, other, -)
         }
 
         fn multiply(&self, other: &KValue) -> Result<KValue> {
             arithmetic_op!(self, other, *)
         }
 
+        fn multiply_rhs(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op_rhs!(self, other, *)
+        }
+
         fn divide(&self, other: &KValue) -> Result<KValue> {
             arithmetic_op!(self, other, /)
         }
 
+        fn divide_rhs(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op_rhs!(self, other, /)
+        }
+
         fn remainder(&self, other: &KValue) -> Result<KValue> {
             arithmetic_op!(self, other, %)
+        }
+
+        fn remainder_rhs(&self, other: &KValue) -> Result<KValue> {
+            arithmetic_op_rhs!(self, other, %)
         }
 
         fn add_assign(&mut self, other: &KValue) -> Result<()> {
@@ -503,8 +538,9 @@ make_object(10)
         #[test]
         fn add() {
             let script = "
-x = (make_object 11) + (make_object 22) + 33
-x.as_number()
+x = (make_object 11) + (make_object 22)
+y = 33 + x
+y.as_number()
 ";
             test_object_script(script, 66);
         }
@@ -512,8 +548,9 @@ x.as_number()
         #[test]
         fn subtract() {
             let script = "
-x = (make_object 99) - (make_object 90) - 9
-x.as_number()
+x = (make_object 99) - (make_object 90) - 1
+y = 8 - x
+y.as_number()
 ";
             test_object_script(script, 0);
         }
@@ -522,27 +559,30 @@ x.as_number()
         fn multiply() {
             let script = "
 x = (make_object 3) * (make_object 11)
-x.as_number()
+y = 10 * x
+y.as_number()
 ";
-            test_object_script(script, 33);
+            test_object_script(script, 330);
         }
 
         #[test]
         fn divide() {
             let script = "
 x = (make_object 90) / (make_object 10)
-x.as_number()
+y = 9 / x
+y.as_number()
 ";
-            test_object_script(script, 9);
+            test_object_script(script, 1);
         }
 
         #[test]
         fn remainder() {
             let script = "
 x = (make_object 45) % (make_object 10)
-x.as_number()
+y = 12 % x
+y.as_number()
 ";
-            test_object_script(script, 5);
+            test_object_script(script, 2);
         }
 
         #[test]

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -3477,16 +3477,28 @@ catch _
 locals = {}
 foo = |x| {x}.with_meta locals.foo_meta
 locals.foo_meta =
+  @type: 'Foo'
   @+: |other| foo self.x + other.x
   @-: |other| foo self.x - other.x
   @*: |other| foo self.x * other.x
   @/: |other| foo self.x / other.x
   @%: |other| foo self.x % other.x
+  @r+: |other| foo other + self.x
+  @r-: |other| foo other - self.x
+  @r*: |other| foo other * self.x
+  @r/: |other| foo other / self.x
+  @r%: |other| foo other % self.x
 
-z = ((foo 2) * (foo 10) / (foo 4) + (foo 1) - (foo 2)) % foo 3
+
+y = foo 2
+z = ((2 + y) + y) # (4) 6
+    * (2 * y)     # (12) 24
+    / (4 / y)     # (2) 12
+    % (5 % y)     # (2) 0
+    - (5 - y)     # (3) -3
 z.x
 ";
-            check_script_output(script, 1);
+            check_script_output(script, -3);
         }
 
         #[test]

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -8,12 +8,34 @@ foo = |x|
 # Declaring the overridden operators once and then cloning the meta map into the foo
 # instance is more efficient than declaring them each time foo is called.
 globals.foo_meta =
-  # Arithmetic operators
-  @+: |other| foo self.x + other.x
-  @-: |other| foo self.x - other.x
-  @*: |other| foo self.x * other.x
-  @/: |other| foo self.x / other.x
-  @%: |other| foo self.x % other.x
+  # Arithmetic operators for when self is on the LHS
+  @+: |other|
+    match other
+      _: Foo then foo self.x + other.x
+      _: Number then foo self.x + other
+  @-: |other|
+    match other
+      _: Foo then foo self.x - other.x
+      _: Number then foo self.x - other
+  @*: |other|
+    match other
+      _: Foo then foo self.x * other.x
+      _: Number then foo self.x * other
+  @/: |other|
+    match other
+      _: Foo then foo self.x / other.x
+      _: Number then foo self.x / other
+  @%: |other|
+    match other
+      _: Foo then foo self.x % other.x
+      _: Number then foo self.x % other
+
+  # Arithmetic operators for when self is on the RHS
+  @r+: |other| foo other + self.x
+  @r-: |other| foo other - self.x
+  @r*: |other| foo other * self.x
+  @r/: |other| foo other / self.x
+  @r%: |other| foo other % self.x
 
   # Compound assignment operators
   @+=: |other|
@@ -94,18 +116,23 @@ globals.foo_meta =
 export
   @test add: ||
     assert_eq (foo(10) + foo(20)), foo 30
+    assert_eq (1 + foo(2)), foo 3
 
   @test subtract: ||
     assert_eq (foo(99) - foo(100)), foo -1
+    assert_eq (101 - foo(100)), foo 1
 
   @test multiply: ||
     assert_eq (foo(6) * foo(7)), foo 42
+    assert_eq (11 * foo(3)), foo 33
 
   @test divide: ||
     assert_eq (foo(42) / foo(2)), foo 21
+    assert_eq (10 / foo(5)), foo 2
 
   @test remainder: ||
     assert_eq (foo(42) % foo(10)), foo 2
+    assert_eq (10 % foo(3)), foo 1
 
   @test add_assign: ||
     assert_eq (foo(10) += 20), foo 30

--- a/koto/tests/meta_maps.koto
+++ b/koto/tests/meta_maps.koto
@@ -56,11 +56,13 @@ globals.foo_meta =
 
   # Comparison operators
   @<: |other| self.x < other.x
-  @<=: |other| self.x <= other.x
-  @>: |other| self.x > other.x
-  @>=: |other| self.x >= other.x
   @==: |other| self.x == other.x
-  @!=: |other| not self == other
+
+  # The remaining comparison operators are derived from @< and @== by default. 
+  # @<=: |other| self.x <= other.x
+  # @>: |other| self.x > other.x
+  # @>=: |other| self.x >= other.x
+  # @!=: |other| not self == other
 
   # Negation (e.g. -foo)
   @negate: || foo -self.x

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -180,21 +180,21 @@ impl KotoObject for Color {
         Ok(())
     }
 
-    fn equal(&self, rhs: &KValue) -> Result<bool> {
-        match rhs {
-            KValue::Object(rhs) if rhs.is_a::<Self>() => {
-                let rhs = rhs.cast::<Self>().unwrap();
-                Ok(*self == *rhs)
+    fn equal(&self, other: &KValue) -> Result<bool> {
+        match other {
+            KValue::Object(o) if o.is_a::<Self>() => {
+                let other = o.cast::<Self>().unwrap();
+                Ok(*self == *other)
             }
             unexpected => unexpected_type(Self::type_static(), unexpected),
         }
     }
 
-    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
-        match rhs {
-            KValue::Object(rhs) if rhs.is_a::<Self>() => {
-                let rhs = rhs.cast::<Self>().unwrap();
-                Ok(*self != *rhs)
+    fn not_equal(&self, other: &KValue) -> Result<bool> {
+        match other {
+            KValue::Object(o) if o.is_a::<Self>() => {
+                let other = o.cast::<Self>().unwrap();
+                Ok(*self != *other)
             }
             unexpected => unexpected_type(Self::type_static(), unexpected),
         }

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -3,11 +3,6 @@ use koto_runtime::{Result, derive::*, prelude::*};
 use palette::FromColor;
 use std::fmt;
 
-#[macro_export]
-macro_rules! color_comparison_op {
-    ($self:ident, $rhs:expr, $op:tt) => {{}};
-}
-
 #[derive(Copy, Clone, PartialEq, KotoCopy, KotoType)]
 #[koto(use_copy)]
 pub struct Color {

--- a/libs/geometry/src/macros.rs
+++ b/libs/geometry/src/macros.rs
@@ -61,12 +61,12 @@ macro_rules! impl_arithmetic_ops {
 
 #[macro_export]
 macro_rules! geometry_arithmetic_op {
-    ($self:ident, $rhs:expr, $op:tt) => {
+    ($self:ident, $other:expr, $op:tt) => {
         {
-            match $rhs {
-                KValue::Object(rhs) if rhs.is_a::<Self>() => {
-                    let rhs = rhs.cast::<Self>().unwrap();
-                    Ok((*$self $op *rhs).into())
+            match $other {
+                KValue::Object(other) if other.is_a::<Self>() => {
+                    let other = other.cast::<Self>().unwrap();
+                    Ok((*$self $op *other).into())
                 }
                 KValue::Number(n) => {
                     Ok((*$self $op f64::from(n)).into())
@@ -81,12 +81,12 @@ macro_rules! geometry_arithmetic_op {
 
 #[macro_export]
 macro_rules! geometry_compound_assign_op {
-    ($self:ident, $rhs:expr, $op:tt) => {
+    ($self:ident, $other:expr, $op:tt) => {
         {
-            match $rhs {
-                KValue::Object(rhs) if rhs.is_a::<Self>() => {
-                    let rhs = rhs.cast::<Self>().unwrap();
-                    *$self $op *rhs;
+            match $other {
+                KValue::Object(other) if other.is_a::<Self>() => {
+                    let other = other.cast::<Self>().unwrap();
+                    *$self $op *other;
                     Ok(())
                 }
                 KValue::Number(n) => {
@@ -103,12 +103,12 @@ macro_rules! geometry_compound_assign_op {
 
 #[macro_export]
 macro_rules! geometry_comparison_op {
-    ($self:ident, $rhs:expr, $op:tt) => {
+    ($self:ident, $other:expr, $op:tt) => {
         {
-            match $rhs {
-                KValue::Object(rhs) if rhs.is_a::<Self>() => {
-                    let rhs = rhs.cast::<Self>().unwrap();
-                    Ok(*$self $op *rhs)
+            match $other {
+                KValue::Object(other) if other.is_a::<Self>() => {
+                    let other = other.cast::<Self>().unwrap();
+                    Ok(*$self $op *other)
                 }
                 unexpected => {
                     unexpected_type(&format!("a {}", Self::type_static()), unexpected)

--- a/libs/geometry/src/macros.rs
+++ b/libs/geometry/src/macros.rs
@@ -80,6 +80,22 @@ macro_rules! geometry_arithmetic_op {
 }
 
 #[macro_export]
+macro_rules! geometry_arithmetic_op_rhs {
+    ($self:ident, $other:expr, $op:tt) => {
+        {
+            match $other {
+                KValue::Number(n) => {
+                    Ok((Self::from(f64::from(n)) $op *$self).into())
+                }
+                unexpected => {
+                    unexpected_type(&format!("a {} or Number", Self::type_static()), unexpected)
+                }
+            }
+        }
+    }
+}
+
+#[macro_export]
 macro_rules! geometry_compound_assign_op {
     ($self:ident, $other:expr, $op:tt) => {
         {

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -120,10 +120,6 @@ impl KotoObject for Rect {
         geometry_comparison_op!(self, value, ==)
     }
 
-    fn not_equal(&self, value: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, value, !=)
-    }
-
     fn is_iterable(&self) -> IsIterable {
         IsIterable::Iterable
     }

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -116,12 +116,12 @@ impl KotoObject for Rect {
         Ok(())
     }
 
-    fn equal(&self, rhs: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, rhs, ==)
+    fn equal(&self, value: &KValue) -> Result<bool> {
+        geometry_comparison_op!(self, value, ==)
     }
 
-    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, rhs, !=)
+    fn not_equal(&self, value: &KValue) -> Result<bool> {
+        geometry_comparison_op!(self, value, !=)
     }
 
     fn is_iterable(&self) -> IsIterable {

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -52,16 +52,32 @@ impl KotoObject for Vec2 {
         geometry_arithmetic_op!(self, other, +)
     }
 
+    fn add_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, +)
+    }
+
     fn subtract(&self, other: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, other, -)
+    }
+
+    fn subtract_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, -)
     }
 
     fn multiply(&self, other: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, other, *)
     }
 
+    fn multiply_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, *)
+    }
+
     fn divide(&self, other: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, other, /)
+    }
+
+    fn divide_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, /)
     }
 
     fn add_assign(&mut self, other: &KValue) -> Result<()> {
@@ -128,6 +144,12 @@ impl From<Inner> for Vec2 {
 impl From<Vec2> for KValue {
     fn from(point: Vec2) -> Self {
         KObject::from(point).into()
+    }
+}
+
+impl From<f64> for Vec2 {
+    fn from(x: f64) -> Self {
+        Self::new(x, x)
     }
 }
 

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -100,10 +100,6 @@ impl KotoObject for Vec2 {
         geometry_comparison_op!(self, other, ==)
     }
 
-    fn not_equal(&self, other: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, other, !=)
-    }
-
     fn index(&self, index: &KValue) -> Result<KValue> {
         match index {
             KValue::Number(n) => match usize::from(n) {

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -48,44 +48,44 @@ impl KotoObject for Vec2 {
         Ok(Self(-self.0).into())
     }
 
-    fn add(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, +)
+    fn add(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, +)
     }
 
-    fn subtract(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, -)
+    fn subtract(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, -)
     }
 
-    fn multiply(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, *)
+    fn multiply(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, *)
     }
 
-    fn divide(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, /)
+    fn divide(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, /)
     }
 
-    fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, +=)
+    fn add_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, +=)
     }
 
-    fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, -=)
+    fn subtract_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, -=)
     }
 
-    fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, *=)
+    fn multiply_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, *=)
     }
 
-    fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, /=)
+    fn divide_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, /=)
     }
 
-    fn equal(&self, rhs: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, rhs, ==)
+    fn equal(&self, other: &KValue) -> Result<bool> {
+        geometry_comparison_op!(self, other, ==)
     }
 
-    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, rhs, !=)
+    fn not_equal(&self, other: &KValue) -> Result<bool> {
+        geometry_comparison_op!(self, other, !=)
     }
 
     fn index(&self, index: &KValue) -> Result<KValue> {

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -95,10 +95,6 @@ impl KotoObject for Vec3 {
         geometry_comparison_op!(self, other, ==)
     }
 
-    fn not_equal(&self, other: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, other, !=)
-    }
-
     fn index(&self, index: &KValue) -> Result<KValue> {
         match index {
             KValue::Number(n) => match usize::from(n) {

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -43,44 +43,44 @@ impl KotoObject for Vec3 {
         Ok(Self(-self.0).into())
     }
 
-    fn add(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, +)
+    fn add(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, +)
     }
 
-    fn subtract(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, -)
+    fn subtract(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, -)
     }
 
-    fn multiply(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, *)
+    fn multiply(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, *)
     }
 
-    fn divide(&self, rhs: &KValue) -> Result<KValue> {
-        geometry_arithmetic_op!(self, rhs, /)
+    fn divide(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op!(self, other, /)
     }
 
-    fn add_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, +=)
+    fn add_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, +=)
     }
 
-    fn subtract_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, -=)
+    fn subtract_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, -=)
     }
 
-    fn multiply_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, *=)
+    fn multiply_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, *=)
     }
 
-    fn divide_assign(&mut self, rhs: &KValue) -> Result<()> {
-        geometry_compound_assign_op!(self, rhs, /=)
+    fn divide_assign(&mut self, other: &KValue) -> Result<()> {
+        geometry_compound_assign_op!(self, other, /=)
     }
 
-    fn equal(&self, rhs: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, rhs, ==)
+    fn equal(&self, other: &KValue) -> Result<bool> {
+        geometry_comparison_op!(self, other, ==)
     }
 
-    fn not_equal(&self, rhs: &KValue) -> Result<bool> {
-        geometry_comparison_op!(self, rhs, !=)
+    fn not_equal(&self, other: &KValue) -> Result<bool> {
+        geometry_comparison_op!(self, other, !=)
     }
 
     fn index(&self, index: &KValue) -> Result<KValue> {

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -47,16 +47,32 @@ impl KotoObject for Vec3 {
         geometry_arithmetic_op!(self, other, +)
     }
 
+    fn add_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, +)
+    }
+
     fn subtract(&self, other: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, other, -)
+    }
+
+    fn subtract_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, -)
     }
 
     fn multiply(&self, other: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, other, *)
     }
 
+    fn multiply_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, *)
+    }
+
     fn divide(&self, other: &KValue) -> Result<KValue> {
         geometry_arithmetic_op!(self, other, /)
+    }
+
+    fn divide_rhs(&self, other: &KValue) -> Result<KValue> {
+        geometry_arithmetic_op_rhs!(self, other, /)
     }
 
     fn add_assign(&mut self, other: &KValue) -> Result<()> {
@@ -119,6 +135,12 @@ impl KotoObject for Vec3 {
 impl From<DVec3> for Vec3 {
     fn from(v: DVec3) -> Self {
         Self(v)
+    }
+}
+
+impl From<f64> for Vec3 {
+    fn from(x: f64) -> Self {
+        Self::new(x, x, x)
     }
 }
 


### PR DESCRIPTION
**Allow arithmetic operators to fall back to overrides provided by the RHS**

This resolves #434 by adding `_rhs` functions to `KotoObject` for binary
arithmetic expressions, along with equivalent RHS metakeys (`@r+`, `@r-`, etc).

`koto.unimplemented` has been added to allow LHS metakeys to tell the runtime to defer to the RHS.

**Derive default implementations for comparison operators**

`@!=` now defers to `@==` by default, and if `@<` is implemented along with `@==`,
then the other comparison operations are also derived.
