### PR TITLE
Make use of trait upcasting to remove the dependency on downcast-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,12 +298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,7 +690,6 @@ name = "koto_runtime"
 version = "0.16.0"
 dependencies = [
  "chrono",
- "downcast-rs",
  "indexmap",
  "instant",
  "koto_bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,6 @@ crossterm = { version = "0.28.1", default-features = false }
 derive_more = "2.0.1"
 # Derive macro to get the name of a struct, enum or enum variant
 derive-name = "1.1.0"
-# Trait object downcasting support using only safe Rust.
-downcast-rs = { version = "2", default-features = false }
 # Normalize Windows paths to the most compatible format
 dunce = "1.0.2"
 # A small cross-platform library for retrieving random data from system source

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -26,7 +26,6 @@ koto_lexer = { path = "../lexer", version = "^0.16.0" }
 koto_memory = { path = "../memory", version = "^0.16.0", default-features = false }
 koto_parser = { path = "../parser", version = "^0.16.0", default-features = false }
 
-downcast-rs = { workspace = true }
 indexmap = { workspace = true }
 paste = { workspace = true }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
Thanks to trait upcasting in Rust 1.86 `downcast-rs` is no longer necessary.
