### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ The Koto project adheres to
 
 #### Core Library
 
+- The argument order for the bounded version of `iterator.generate` has been swapped to make it
+  consistent with the bounded version of `iterator.repeat`.
+  - E.g. Instead of `iterator.generate(3, f)` you should write `iterator.generate(f, 3)`.
 - `iterator.skip` now skips when the iterator is advanced instead of immediately when `skip` is called.
 - `koto.args` has been moved to `os.args`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,11 @@ The Koto project adheres to
 
 ### Fixed
 
+#### Language
+
+- Compound assignments in parenthesized comparisons are now evaluated correctly.
+  - E.g. `x = [0]; (x[0] += 1) == 0` would previously evaluate to `true`.
+
 #### Core Library
 
 - Iterator adaptors can now be used as standalone functions.

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -144,6 +144,13 @@ impl<'a> CompileNodeContext<'a> {
         }
     }
 
+    fn with_fixed_register_or_none(self, register: Option<u8>) -> Self {
+        Self {
+            result_register: register.map_or(ResultRegister::None, ResultRegister::Fixed),
+            ..self
+        }
+    }
+
     fn with_any_register(self) -> Self {
         Self {
             result_register: ResultRegister::Any,
@@ -1953,8 +1960,16 @@ impl Compiler {
         let rhs_register = rhs.unwrap(self)?;
 
         let lhs_node = ctx.node(lhs);
-        let result = if let Node::Chain(chain_node) = lhs_node {
-            self.compile_chain(chain_node, None, Some(rhs_register), Some(op), ctx)?
+        if let Node::Chain(chain_node) = lhs_node {
+            // Place the chain's result the result register
+            // e.g. `x[0] += 1` - The new value of x[0] should end up in the result register
+            self.compile_chain(
+                chain_node,
+                None,
+                Some(rhs_register),
+                Some(op),
+                ctx.with_fixed_register_or_none(result.register),
+            )?;
         } else {
             let lhs = self.compile_node(lhs, ctx.with_any_register())?;
             let lhs_register = lhs.unwrap(self)?;
@@ -1976,8 +1991,6 @@ impl Compiler {
             if lhs.is_temporary {
                 self.pop_register()?;
             }
-
-            result
         };
 
         if rhs.is_temporary {
@@ -2014,7 +2027,6 @@ impl Compiler {
         };
 
         let result = self.assign_result_register(ctx)?;
-
         let stack_count = self.stack_count();
 
         // Use the result register for comparisons, or a temporary
@@ -2038,13 +2050,13 @@ impl Compiler {
                 Less | LessOrEqual | Greater | GreaterOrEqual | Equal | NotEqual => {
                     // If the rhs is also a comparison, then chain the operations.
                     // e.g.
-                    //   `a < (b < c)`
+                    //   `a < b < c`
                     // needs to become equivalent to:
                     //   `(a < b) and (b < c)`
-                    // To achieve this,
-                    //   - use the lhs of the rhs as the rhs of the current operation
-                    //   - use the temp value as the lhs for the current operation
-                    //   - chain the two comparisons together with an And
+                    // To achieve this:
+                    //   1. Use the lhs of the rhs as the rhs of the current operation.
+                    //   2. Use the temp value as the lhs for the current operation.
+                    //   3. Chain the two comparisons together with an And.
 
                     let rhs_lhs_register = self
                         .compile_node(*rhs_lhs, ctx.with_any_register())?

--- a/crates/bytecode/src/frame.rs
+++ b/crates/bytecode/src/frame.rs
@@ -250,7 +250,10 @@ impl Frame {
         }
     }
 
-    // Provides the next temporary register
+    // Pushes a temporary register to the stack
+    //
+    // The register must be returned by the caller,
+    // either by calling pop_register() or truncate_register_stack().
     pub fn push_register(&mut self) -> Result<u8, FrameError> {
         let new_register = self.temporary_base + self.temporary_count;
 
@@ -265,7 +268,7 @@ impl Frame {
         }
     }
 
-    // Returns the most recently used temporary register to the stack
+    // Removes the most recently used temporary register from the stack
     pub fn pop_register(&mut self) -> Result<u8, FrameError> {
         let Some(register) = self.register_stack.pop() else {
             return Err(FrameError::EmptyRegisterStack);

--- a/crates/cli/docs/core_lib/iterator.md
+++ b/crates/cli/docs/core_lib/iterator.md
@@ -370,7 +370,7 @@ print! generate(f)
   .to_list()
 check! [1, 2, 3, 4, 5]
 
-print! generate(3, f).to_tuple()
+print! generate(f, 3).to_tuple()
 check! (6, 7, 8)
 ```
 

--- a/crates/cli/docs/libs/random.md
+++ b/crates/cli/docs/libs/random.md
@@ -124,7 +124,7 @@ from iterator import generate
 from random import pick, seed
 
 # Returns a tuple containing three numbers from 1 to 10
-pick_3 = || generate(3, || pick 1..=10).to_tuple()
+pick_3 = || generate((|| pick 1..=10), 3).to_tuple()
 
 seed 1
 print! pick_3()

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -343,12 +343,12 @@ pub fn make_module() -> KMap {
                 let result = generators::Generate::new(f.clone(), ctx.vm);
                 Ok(KIterator::new(result).into())
             }
-            [KValue::Number(n), f] if f.is_callable() => {
+            [f, KValue::Number(n)] if *n >= 0 && f.is_callable() => {
                 let result = generators::GenerateN::new(n.into(), f.clone(), ctx.vm);
                 Ok(KIterator::new(result).into())
             }
             unexpected => unexpected_args(
-                "|generator: || -> Any|, or |n: Number, generator: || -> Any|",
+                "|generator: || -> Any|, or |generator: || -> Any, n: Number >= 0|",
                 unexpected,
             ),
         }

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -668,7 +668,7 @@ pub fn make_module() -> KMap {
                 let result = generators::RepeatN::new(value.clone(), n.into());
                 Ok(KIterator::new(result).into())
             }
-            unexpected => unexpected_args("|Any|, or |Number >= 0, Any|", unexpected),
+            unexpected => unexpected_args("|Any|, or |Any, Number >= 0|", unexpected),
         }
     });
 

--- a/crates/runtime/src/types/value.rs
+++ b/crates/runtime/src/types/value.rs
@@ -194,7 +194,7 @@ impl KValue {
             Range(r) => write!(ctx, "{r}"),
             Function(f) => {
                 if ctx.debug_enabled() {
-                    write!(ctx, "|| ({})", Ptr::address(&f.chunk))
+                    write!(ctx, "|| (chunk: {}, ip: {})", Ptr::address(&f.chunk), f.ip)
                 } else {
                     write!(ctx, "||")
                 }

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -457,6 +457,19 @@ y.next().get()
 ";
             check_script_output(script, number_tuple(&[3, 13]));
         }
+
+        #[test]
+        fn for_loop_over_many_zipped_values() {
+            // This ensures that unpacking temporary value pairs in a for loop
+            // doesn't overflow the register stack.
+            let script = "
+r = 1..=128
+for a, b in r.zip r
+  () # no-op
+b
+";
+            check_script_output(script, 128);
+        }
     }
 }
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -2703,6 +2703,18 @@ f()(8)
             check_script_output(script, 64);
         }
 
+        #[test]
+        fn index_mut_in_if_condition() {
+            let script = "
+x = [0]
+if (x[0] += 1) == 0
+  1
+else
+  99
+";
+            check_script_output(script, 99);
+        }
+
         mod optional_chaining {
             use super::*;
 


### PR DESCRIPTION
- **Fix overflows when using iterators that output pairs in a for loop**
- **Improve debug display of Koto functions**
- **Ensure that compound assignments in parentheses are evaluated correctly**
- **Fix iterator.repeat error message**
- **Swap the argument order of the bounded version of iterator.generate**
