### PR TITLE
Change default algorithm in the random lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,12 @@ The Koto project adheres to
 - `iterator.skip` now skips when the iterator is advanced instead of immediately when `skip` is called.
 - `koto.args` has been moved to `os.args`.
 
+#### Extra Libs
+
+- The `random` library now uses xoshiro256++ as its default random generator.
+  - This is a faster and simpler algorithm than the previously used ChaCha8.
+  - Seeded sequences will now be stable in future updates.
+
 #### API
 
 - The `vm` argument has been removed from `KotoObject::negate`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ checksum = "50fd5174866dc2fa2ddc96e8fb800852d37f064f32a45c7b7c2f8fa2c64c77fa"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "by_address"
@@ -91,9 +91,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.35"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -234,7 +234,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix 1.0.5",
+ "rustix",
  "winapi",
 ]
 
@@ -349,13 +349,13 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fd-lock"
-version = "4.0.2"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 0.38.39",
- "windows-sys 0.52.0",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -424,11 +424,11 @@ checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -524,9 +524,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -585,7 +585,7 @@ dependencies = [
  "rustyline",
  "test_bin",
  "textwrap",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ name = "koto_lexer"
 version = "0.16.0"
 dependencies = [
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
  "unicode-xid",
 ]
 
@@ -823,12 +823,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
@@ -851,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -947,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -1069,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1089,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1222,19 +1216,6 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
@@ -1242,9 +1223,15 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustyline"
@@ -1261,7 +1248,7 @@ dependencies = [
  "memchr",
  "nix",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
  "utf8parse",
  "windows-sys 0.59.0",
 ]
@@ -1286,12 +1273,6 @@ name = "saturating_cast"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc4972f129a0ea378b69fa7c186d63255606e362ad00795f00b869dea5265eb"
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1380,9 +1361,9 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1391,14 +1372,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
- "rustix 0.38.39",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -1443,13 +1424,13 @@ checksum = "8e7a7de15468c6e65dd7db81cf3822c1ec94c71b2a3c1a976ea8e4696c91115c"
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1515,9 +1496,9 @@ checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1530,12 +1511,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -1588,24 +1563,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1614,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1627,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1637,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1650,20 +1625,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.47"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d919bb60ebcecb9160afee6c71b43a58a4f0517a2de0054cd050d02cec08201"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
 dependencies = [
  "js-sys",
  "minicov",
- "once_cell",
- "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -1671,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.47"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ebde6ea87fbfa6bdd2e9f1fd8a91d60aee5db68792632176c4e16a74fc7d8"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1682,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1712,7 +1688,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1737,15 +1713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bpaf"
@@ -226,14 +226,15 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
+ "document-features",
  "parking_lot",
- "rustix",
+ "rustix 1.0.5",
  "winapi",
 ]
 
@@ -292,6 +293,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,12 +321,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -344,7 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.39",
  "windows-sys 0.52.0",
 ]
 
@@ -786,9 +796,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -806,7 +816,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall",
 ]
@@ -816,6 +826,18 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -876,7 +898,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -888,7 +910,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1060,7 +1082,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "memchr",
  "unicase",
 ]
@@ -1160,7 +1182,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1204,11 +1226,24 @@ version = "0.38.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1217,7 +1252,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -1363,7 +1398,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.39",
  "windows-sys 0.59.0",
 ]
 
@@ -1858,7 +1893,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,12 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,13 +380,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -660,7 +655,7 @@ dependencies = [
  "koto_random",
  "lazy_static",
  "pico-args",
- "rand",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -672,8 +667,8 @@ dependencies = [
  "koto_runtime",
  "koto_test_utils",
  "lazy_static",
- "rand",
- "rand_chacha",
+ "rand 0.9.0",
+ "rand_xoshiro",
 ]
 
 [[package]]
@@ -871,7 +866,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -1010,7 +1005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1043,9 +1038,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -1080,24 +1075,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1105,8 +1115,23 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1518,6 +1543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,20 +1853,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "byteorder",
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ derive-name = "1.1.0"
 # Normalize Windows paths to the most compatible format
 dunce = "1.0.2"
 # A small cross-platform library for retrieving random data from system source
-getrandom = "0.2.4"
+getrandom = "0.3.2"
 # A simple and fast 3D math library for games and graphics
 glam = "0.30.1"
 # Shared definitions of home directories.
@@ -61,9 +61,9 @@ pulldown-cmark = { version = "0.13.0", default-features = false }
 # Quasi-quoting macro quote!(...)
 quote = "1.0.33"
 # Random number generators and other randomness functionality.
-rand = "0.8.5"
-# ChaCha random number generator
-rand_chacha = "0.3.1"
+rand = { version = "0.9.0", default-features = false }
+# Xoshiro, xoroshiro and splitmix64 random number generators
+rand_xoshiro = "0.7.0"
 # A regular expression library
 regex = "1.10.2"
 # A speedy, non-cryptographic hash used in rustc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ circular-buffer = "1.1.0"
 # Statistics-driven micro-benchmarking library
 criterion2 = "2.0.0"
 # A crossplatform terminal library for manipulating terminals.
-crossterm = { version = "0.28.1", default-features = false }
+crossterm = { version = "0.29", default-features = false }
 # Adds #[derive(x)] macros for more traits
 derive_more = "2.0.1"
 # Derive macro to get the name of a struct, enum or enum variant

--- a/crates/cli/docs/api.md
+++ b/crates/cli/docs/api.md
@@ -63,7 +63,7 @@ prelude_value_remove.rs
 
 ## Passing Arguments to Koto
 
-The arguments that are accessible in a script from `koto.args` can be set via
+The arguments that are accessible in a script from `os.args` can be set via
 `Koto::set_args`.
 
 ```rust_include

--- a/crates/cli/docs/cli.md
+++ b/crates/cli/docs/cli.md
@@ -26,11 +26,11 @@ Hello!
 
 ### Command Arguments
 
-Arguments following the script are made available via [`koto.args`][koto-args].
+Arguments following the script are made available via [`os.args`][os-args].
 
 ```
 » cat print_args.koto
-for i, arg in koto.args.enumerate()
+for i, arg in os.args.enumerate()
   print '{i + 1}: {arg}'
 
 » koto print_args.koto a b c
@@ -106,7 +106,7 @@ Welcome to Koto
 
 [cli]: https://en.wikipedia.org/wiki/Command-line_interface
 [core]: ./core_lib/
-[koto-args]: ./core_lib/koto.md#args
+[os-args]: ./core_lib/os.md#args
 [guide]: ./language_guide.md
 [repl]: https://en.wikipedia.org/wiki/Read–eval–print_loop
 [rust]: https://rust-lang.org

--- a/crates/cli/docs/libs/random.md
+++ b/crates/cli/docs/libs/random.md
@@ -6,13 +6,16 @@ At the core of the module is the `Rng` type, which is a seedable random
 number generator. Each thread has access to a generator with a randomly
 selected seed, or unique generators can be created with [`random.generator`](#generator).
 
+The [xoshiro256++][xoshiro] algorithm is used to generate random values,
+which is fast and portable, but _not_ cryptographically secure.
+
 ## bool
 
 ```kototype
 || -> Bool
 ```
 
-Generates a random bool using the current thread's generator.
+Generates a random boolean using the current thread's generator.
 
 ### Example
 
@@ -47,9 +50,9 @@ Creates an [`Rng`](#rng) with a specified seed.
 ```koto
 rng = random.generator 99
 print! rng.pick (1, 2, 3)
-check! 3
+check! 1
 print! rng.bool()
-check! false
+check! true
 ```
 
 
@@ -72,9 +75,9 @@ random.seed 123
 
 # Print random floats up to 3 decimal places
 print '{random.number():.3}'
-check! 0.853
+check! 0.646
 print '{random.number():.3}'
-check! 0.168
+check! 0.838
 ```
 
 ## pick
@@ -100,11 +103,11 @@ Selects a random value from the input using the current thread's generator.
 random.seed -1
 
 print! random.pick (123, -1, 99)
-check! 99
+check! -1
 print! random.pick 10..20
-check! 14
+check! 19
 print! random.pick {foo: 42, bar: 99, baz: 123}
-check! ('bar', 99)
+check! ('baz', 123)
 print! random.pick []
 check! null
 ```
@@ -128,15 +131,15 @@ pick_3 = || generate((|| pick 1..=10), 3).to_tuple()
 
 seed 1
 print! pick_3()
-check! (5, 3, 8)
+check! (9, 8, 2)
 
 seed 2
 print! pick_3()
-check! (6, 9, 3)
+check! (8, 6, 7)
 
 seed 1
 print! pick_3()
-check! (5, 3, 8)
+check! (9, 8, 2)
 ```
 
 ## shuffle
@@ -155,24 +158,23 @@ x = [1, 2, 3, 4, 5]
 
 seed 2
 print! shuffle x
-check! [4, 1, 2, 3, 5]
+check! [1, 5, 4, 3, 2]
 print! shuffle x
-check! [5, 2, 4, 3, 1]
+check! [3, 1, 4, 2, 5]
 
 y = {a: 1, b: 2, c: 3}
 print! shuffle y
-check! {b: 2, a: 1, c: 3}
+check! {c: 3, a: 1, b: 2}
 print! shuffle y
-check! {a: 1, c: 3, b: 2}
+check! {c: 3, b: 2, a: 1}
 ```
 
 ## Rng
 
 `Rng` is the `random` module's core random generator.
 
-The ChaCha algorithm with 8 rounds from the `rand_chacha` crate is used to
-generate random values.
-See the [implementation's docs][chacha-docs] for more information.
+The [xoshiro256++][xoshiro] algorithm is used to generate random values,
+which is fast and portable, but _not cryptographically secure_.
 
 ## Rng.bool
 
@@ -194,5 +196,4 @@ See [random.shuffle](#shuffle).
 
 See [random.seed](#seed).
 
-
-[chacha-docs]: https://docs.rs/rand_chacha/latest/rand_chacha/struct.ChaCha8Rng.html
+[xoshiro]: https://prng.di.unimi.it

--- a/crates/koto/examples/poetry/Cargo.toml
+++ b/crates/koto/examples/poetry/Cargo.toml
@@ -21,4 +21,4 @@ hotwatch = { workspace = true }
 indexmap = { workspace = true }
 lazy_static = { workspace = true }
 pico-args = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["std", "thread_rng"] }

--- a/crates/koto/examples/poetry/src/poetry.rs
+++ b/crates/koto/examples/poetry/src/poetry.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexMap;
-use rand::{Rng, seq::SliceRandom, thread_rng};
+use rand::{Rng, seq::IndexedRandom};
 use std::sync::Arc;
 
 /// A basic Markov chain,
@@ -40,7 +40,7 @@ impl Poetry {
                     .get(previous)
                     .map(|words| {
                         // Given some links, choose the next word
-                        let mut rng = thread_rng();
+                        let mut rng = rand::rng();
                         words.choose(&mut rng)
                     })
                     .unwrap_or(None)
@@ -51,7 +51,7 @@ impl Poetry {
             Some(result.clone())
         } else {
             // If no link was found, choose a new starting point
-            let start = thread_rng().gen_range(0..self.links.len());
+            let start = rand::rng().random_range(0..self.links.len());
             self.links
                 .get_index(start)
                 .map(|(key, _value)| key)

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -147,7 +147,7 @@ impl Koto {
         self.runtime.loader().borrow_mut().clear_cache();
     }
 
-    /// Sets the arguments that can be accessed from within the script via `koto.args()`
+    /// Sets the arguments that can be accessed from within the script via `os.args()`
     pub fn set_args(&mut self, args: impl IntoIterator<Item = String>) -> Result<()> {
         let koto_args = args.into_iter().map(KValue::from).collect::<Vec<_>>();
 

--- a/koto/benches/enumerate.koto
+++ b/koto/benches/enumerate.koto
@@ -1,5 +1,5 @@
 @main = ||
-  n = koto.args.first()?.to_number() or 4
+  n = os.args.first()?.to_number() or 4
 
   a = []
   for i in 0..n

--- a/koto/benches/fannkuch.koto
+++ b/koto/benches/fannkuch.koto
@@ -60,13 +60,13 @@ fannkuch = |n|
         p.insert (i + 1), t
 
 @main = ||
-  n = match koto.args.get 0
+  n = match os.args.get 0
     null then 4
     arg then arg.to_number()
 
   sum, flips = fannkuch n
 
-  if (koto.args.get 1) != 'quiet'
+  if (os.args.get 1) != 'quiet'
     print sum
     print 'Pfannkuchen({n}) = {flips}'
 

--- a/koto/benches/fib_recursive.koto
+++ b/koto/benches/fib_recursive.koto
@@ -5,7 +5,7 @@ fib = |n|
     else (fib n - 1) + (fib n - 2)
 
 @main = ||
-  n = koto.args.first()?.to_number() or 8
+  n = os.args.first()?.to_number() or 8
   fib n
 
 @test fib = ||

--- a/koto/benches/n_body.koto
+++ b/koto/benches/n_body.koto
@@ -110,11 +110,11 @@ run_nbody = |n|
   initial_energy, end_energy
 
 @main = ||
-  n = koto.args.first()?.to_number() or 100
+  n = os.args.first()?.to_number() or 100
 
   initial_energy, end_energy = run_nbody n
 
-  quiet = (koto.args.get 1) == 'quiet'
+  quiet = (os.args.get 1) == 'quiet'
   if not quiet
     print '{initial_energy:.9}'
     print '{end_energy:.9}'

--- a/libs/random/Cargo.toml
+++ b/libs/random/Cargo.toml
@@ -21,8 +21,8 @@ rc = ["koto_runtime/rc"]
 
 [dependencies]
 lazy_static = { workspace = true }
-rand = { workspace = true }
-rand_chacha = { workspace = true }
+rand = { workspace = true, features = ["std", "os_rng"] }
+rand_xoshiro = { workspace = true }
 
 [dependencies.koto_runtime]
 path = "../../crates/runtime"

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -2,7 +2,7 @@
 
 use koto_runtime::{Result, derive::*, prelude::*};
 use rand::{Rng, SeedableRng, seq::SliceRandom};
-use rand_chacha::ChaCha8Rng;
+use rand_xoshiro::Xoshiro256PlusPlus;
 use std::cell::RefCell;
 
 pub fn make_module() -> KMap {
@@ -16,13 +16,13 @@ pub fn make_module() -> KMap {
     result.add_fn("generator", |ctx| {
         let rng = match ctx.args() {
             // No seed, make RNG from entropy
-            [] => ChaCha8Rng::from_entropy(),
+            [] => Xoshiro256PlusPlus::from_os_rng(),
             // RNG from seed
-            [KValue::Number(n)] => ChaCha8Rng::seed_from_u64(n.to_bits()),
+            [KValue::Number(n)] => Xoshiro256PlusPlus::seed_from_u64(n.to_bits()),
             unexpected => return unexpected_args("||, or |Number|", unexpected),
         };
 
-        Ok(ChaChaRng::make_value(rng))
+        Ok(Xoshiro256PlusPlusRng::make_value(rng))
     });
 
     result.add_fn("number", |ctx| match ctx.args() {
@@ -53,22 +53,22 @@ pub fn make_module() -> KMap {
 
 #[derive(Clone, Debug, KotoCopy, KotoType)]
 #[koto(type_name = "Rng")]
-struct ChaChaRng(ChaCha8Rng);
+struct Xoshiro256PlusPlusRng(Xoshiro256PlusPlus);
 
 #[koto_impl(runtime = koto_runtime)]
-impl ChaChaRng {
-    fn make_value(rng: ChaCha8Rng) -> KValue {
+impl Xoshiro256PlusPlusRng {
+    fn make_value(rng: Xoshiro256PlusPlus) -> KValue {
         KObject::from(Self(rng)).into()
     }
 
     #[koto_method]
     fn bool(&mut self) -> Result<KValue> {
-        Ok(self.0.r#gen::<bool>().into())
+        Ok(self.0.random::<bool>().into())
     }
 
     #[koto_method]
     fn number(&mut self) -> Result<KValue> {
-        Ok(self.0.r#gen::<f64>().into())
+        Ok(self.0.random::<f64>().into())
     }
 
     #[koto_method]
@@ -87,7 +87,7 @@ impl ChaChaRng {
         match arg {
             List(l) => {
                 if !l.is_empty() {
-                    let index = self.0.gen_range(0..l.len());
+                    let index = self.0.random_range(0..l.len());
                     Ok(l.data()[index].clone())
                 } else {
                     Ok(Null)
@@ -95,7 +95,7 @@ impl ChaChaRng {
             }
             Tuple(t) => {
                 if !t.is_empty() {
-                    let index = self.0.gen_range(0..t.len());
+                    let index = self.0.random_range(0..t.len());
                     Ok(t[index].clone())
                 } else {
                     Ok(Null)
@@ -104,7 +104,7 @@ impl ChaChaRng {
             Range(r) => {
                 let full_range = r.as_sorted_range();
                 if !full_range.is_empty() {
-                    let result = self.0.gen_range(full_range);
+                    let result = self.0.random_range(full_range);
                     Ok(result.into())
                 } else {
                     Ok(Null)
@@ -112,7 +112,7 @@ impl ChaChaRng {
             }
             Map(m) if !m.contains_meta_key(&BinaryOp::Index.into()) => {
                 if !m.is_empty() {
-                    let index = self.0.gen_range(0..m.len());
+                    let index = self.0.random_range(0..m.len());
                     match m.data().get_index(index) {
                         Some((key, value)) => {
                             Ok(Tuple(KTuple::from(&[key.value().clone(), value.clone()])))
@@ -127,7 +127,7 @@ impl ChaChaRng {
             input => match vm.run_unary_op(UnaryOp::Size, input.clone())? {
                 Number(size) => {
                     if size > 0 {
-                        let index = self.0.gen_range(0..usize::from(size));
+                        let index = self.0.random_range(0..usize::from(size));
                         vm.run_binary_op(BinaryOp::Index, input.clone(), index.into())
                     } else {
                         Ok(Null)
@@ -143,7 +143,7 @@ impl ChaChaRng {
         use KValue::*;
         match args {
             [Number(n)] => {
-                self.0 = ChaCha8Rng::seed_from_u64(n.to_bits());
+                self.0 = Xoshiro256PlusPlus::seed_from_u64(n.to_bits());
                 Ok(Null)
             }
             unexpected => unexpected_args("|Number|", unexpected),
@@ -170,7 +170,7 @@ impl ChaChaRng {
             Map(m) if !m.contains_meta_key(&MetaKey::IndexMut) => {
                 let mut data = m.data_mut();
                 for i in (1..data.len()).rev() {
-                    let j = self.0.gen_range(0..(i + 1));
+                    let j = self.0.random_range(0..(i + 1));
                     data.swap_indices(i, j);
                 }
             }
@@ -184,7 +184,7 @@ impl ChaChaRng {
                         }
 
                         for i in (1..usize::from(size)).rev() {
-                            let j = self.0.gen_range(0..(i + 1));
+                            let j = self.0.random_range(0..(i + 1));
                             if i == j {
                                 continue;
                             }
@@ -214,7 +214,7 @@ impl ChaChaRng {
                 };
 
                 for i in (1..size).rev() {
-                    let j = self.0.gen_range(0..(i + 1));
+                    let j = self.0.random_range(0..(i + 1));
                     if i == j {
                         continue;
                     }
@@ -233,8 +233,9 @@ impl ChaChaRng {
     }
 }
 
-impl KotoObject for ChaChaRng {}
+impl KotoObject for Xoshiro256PlusPlusRng {}
 
 thread_local! {
-    static THREAD_RNG: RefCell<ChaChaRng> = RefCell::new(ChaChaRng(ChaCha8Rng::from_entropy()));
+    static THREAD_RNG: RefCell<Xoshiro256PlusPlusRng>
+        = RefCell::new(Xoshiro256PlusPlusRng(Xoshiro256PlusPlus::from_os_rng()));
 }

--- a/libs/random/tests/shuffle.koto
+++ b/libs/random/tests/shuffle.koto
@@ -8,14 +8,14 @@
 
   random.seed 42
   random.shuffle my_container
-  assert_eq my_container.data, [50, 30, 10, 20, 40]
+  assert_eq my_container.data, [10, 40, 30, 20, 50]
   random.shuffle my_container
-  assert_eq my_container.data, [30, 50, 20, 40, 10]
+  assert_eq my_container.data, [50, 40, 10, 30, 20]
 
 @test shuffle_external_object = ||
   x = new_container 'a', 'b', 'c', 'd'
-  rng = random.generator 100
+  rng = random.generator 1
   rng.shuffle x
-  assert_eq x.to_tuple(), ('b', 'a', 'd', 'c')
+  assert_eq x.to_tuple(), ('b', 'a', 'c', 'd')
   rng.shuffle x
-  assert_eq x.to_tuple(), ('d', 'a', 'c', 'b')
+  assert_eq x.to_tuple(), ('d', 'a', 'b', 'c')


### PR DESCRIPTION
- **Switch to using xoshiro256++ as the random lib's default RNG algorithm**

The update to the 2024 edition caused a change in the output of the `rand_chacha` ChaCha8 output. Rather than vendoring the old implementation to avoid breakage, I reevaluated the choice of algorithm, and decided that it makes more sense to use xoshiro256++ as the default. It's simpler and faster, and more likely to remain stable in future updates (if not then it'll be a much lighter maintenance burden if it needs to be vendored).

ChaCha8 was chosen as the default given its stronger security properties, but at this point I'd rather add a disclaimer that the RNG isn't cryptographically secure, and favour a faster/simpler algorithm which will be more appropriate for typical Koto use-cases.
