### PR TITLE
Add a feature to return the incomplete AST on parser error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The Koto project adheres to
   additional debug information when `KotoObject::display` is called.
 - `KMap::remove` and `remove_path` have been added.
   - See the `prelude_value_remove.rs` example for motivation.
+- `koto_parser` now has an `error_ast` feature, which causes the parser to include the
+  incomplete AST in `koto_parser::Error` when an error is an encountered.
 
 #### Core Library
 

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -22,6 +22,9 @@ rc = ["koto_memory/rc"]
 # Panicking be useful during development, e.g. to see the backtrace that led to the error
 panic_on_parser_error = []
 
+# When enabled, the parser will return the partially constructed AST in the error
+error_ast = []
+
 [dependencies]
 koto_lexer = { path = "../lexer", version = "^0.16.0" }
 koto_memory = { path = "../memory", version = "^0.16.0", default-features = false }

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -225,14 +225,24 @@ pub enum ErrorKind {
 pub struct Error {
     /// The error itself
     pub error: ErrorKind,
+
     /// The span in the source string where the error occurred
     pub span: Span,
+
+    /// The partially parsed AST up to the point where the error occurred
+    #[cfg(feature = "error_ast")]
+    pub ast: Option<Box<crate::Ast>>,
 }
 
 impl Error {
     /// Initializes a parser error with the specific error type and its associated span
     pub fn new(error: ErrorKind, span: Span) -> Self {
-        Self { error, span }
+        Self {
+            error,
+            span,
+            #[cfg(feature = "error_ast")]
+            ast: None,
+        }
     }
 
     /// Returns true if the error was caused by the expectation of indentation

--- a/justfile
+++ b/justfile
@@ -80,6 +80,7 @@ test_libs *args:
 
 test_parser *args:
   cargo test -p koto_lexer -p koto_parser {{args}}
+  cargo test -p koto_parser --features error_ast {{args}}
 
 test_release *args:
   just test --profile release-dev {{args}}


### PR DESCRIPTION
This allows tools like `koto-ls` to provide information about the AST up to the point where the error occurred.

This should be seen as a starting point that establishes a pattern for providing as much of the incomplete AST as possible.

Some effort is made to repair the incomplete AST so that it can be traversed without too many unattached nodes (functions and blocks are repaired, along with the main block), but there are probably still some cases where reattaching nodes would be useful.
