### PR TITLE
Improve parsing of optional parentheses in containers / call args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The Koto project adheres to
 #### Language
 
 - Default argument values have been introduced to make it easier to implement optional arguments.
-  - E.g. Instead of:
+  - For example, instead of:
     ```koto
     f = |a, b|
       a + (b or 42)
@@ -25,16 +25,14 @@ The Koto project adheres to
     ```
 - When calling a function, arguments can be now be unpacked at the call site.
   [#418](https://github.com/koto-lang/koto/issues/418)
-  - E.g.
-    ```koto
+  - ```koto
     f = |a, b, c| a + b + c
     x = 1, 2, 3
     f x...
     # -> 6
     ```
-- A power operator `^` has been added for exponentiaton operations, replacing `number.pow`.
-  - E.g.
-    ```koto
+- A power operator `^` has been added for exponentiation operations, replacing `number.pow`.
+  - ```koto
     x = 2 ^ 3
     # -> 8
     x ^= 2
@@ -42,28 +40,24 @@ The Koto project adheres to
     ```
 - Number literals can now include underscores.
   [#399](https://github.com/koto-lang/koto/issues/399)
-  - E.g.
-    ```koto
+  - ```koto
     x = 1_000_000
     y = 0xff_aa_bb
     ```
 - Interpolated values can now be formatted with alternative representations.
-  - E.g.
-    ```koto
+  - ```koto
     print '{15:b}'
     # -> 1111
     ```
   - The `@debug` metakey has been added to allow for additional debug information
     to be provided when formatting an object as a string.
 - Values in lists or tuples definitions can now be omitted, with `null` being used to fill the gaps.
-  - E.g.
-    ```koto
+  - ```koto
     x = [1, , 3, , 5]
     # -> [1, null, 3, null, 5]
     ```
 - `export` can now take any iterable that yields key/value pairs.
-  - E.g.
-    ```koto
+  - ```koto
     export (1..=3).each |i| 'generated_i', i
     generated_3
     # -> 3
@@ -114,6 +108,15 @@ The Koto project adheres to
 - Calls to Koto functions with the incorrect number of arguments will now throw an error.
   - Default values should be provided for optional arguments.
   - Variadic arguments should be used to capture additional arguments.
+- Commas inside container definitions that were previously parsed as call arguments or inline function bodies
+  are now more consistently parsed as entry separators.
+  - `[foo x, bar y]` is now parsed as `[foo(x), bar(y)]`, not `[foo(x, bar(y))]`.
+  - This allows functions to be more easily defined inside containers.
+    - `{square: |x| x ^ 2, cube: |x| x ^ 3}` would have previously triggered a parsing error.
+  - Inline function bodies that return tuples now require parentheses.
+    - `{swap: |a, b| b, a}` should now written as `{swap: |a, b| (b, a)}`
+  - Parentheses-free calls with multiple arguments that were wrapped in parentheses will need to be adjusted.
+    - `(foo 1, 2, 3)` will now be parsed as `(foo(1), 2, 3)` and should be rewritten as `foo(1, 2, 3)`.
 
 #### Core Library
 

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -593,8 +593,7 @@ check! 234
 
 ### Optional Call Parentheses
 
-The parentheses for arguments when calling a function are optional and can be
-omitted in simple expressions.
+In simple expressions the parentheses for function call arguments are optional and can be omitted.
 
 ```koto
 square = |x| x * x
@@ -605,15 +604,13 @@ add = |x, y| x + y
 print! add 2, 3
 check! 5
 
-# Equivalent to square(add(2, 3))
-print! square add 2, 3
+print! square add 2, 3 # Equivalent to square(add(2, 3))
 check! 25
-```
 
-Something to watch out for is that whitespace is important in Koto, and because
-of optional parentheses, `f(1, 2)` is _not the same_ as `f (1, 2)`. The former
-is parsed as a call to `f` with two arguments, whereas the latter is a call to
-`f` with a tuple as the single argument.
+first = |x| x[0]
+print! first ('a', 'b') # Equivalent to first(('a', 'b'))
+check! a
+```
 
 ### Return
 

--- a/crates/cli/docs/libs/geometry.md
+++ b/crates/cli/docs/libs/geometry.md
@@ -32,7 +32,7 @@ check! Rect{x: 0, y: 0, width: 0, height: 0}
 print! rect 10, 20, 30, 40
 check! Rect{x: 10, y: 20, width: 30, height: 40}
 
-print! rect (vec2 -1, 2), (vec2 99, 100)
+print! rect vec2(-1, 2), vec2(99, 100)
 check! Rect{x: -1, y: 2, width: 99, height: 100}
 ```
 
@@ -114,7 +114,7 @@ check! Vec3{x: -1, y: 3, z: 0}
 print! vec3 10, 20, 30
 check! Vec3{x: 10, y: 20, z: 30}
 
-print! vec3 (vec2 -1, -2), 5
+print! vec3 vec2(-1, -2), 5
 check! Vec3{x: -1, y: -2, z: 5}
 ```
 
@@ -340,7 +340,7 @@ Arithmetic operations are supported, and the vector's coordinates are iterable.
 ```koto
 from geometry import vec2
 
-print! (vec2 10, 20) + (vec2 30, 40)
+print! vec2(10, 20) + vec2(30, 40)
 check! Vec2{x: 40, y: 60}
 
 v = vec2 50, 100
@@ -365,13 +365,13 @@ Returns the angle of the vector, expressed in radians.
 ```koto
 from geometry import vec2
 
-print! (vec2 1, 0).angle()
+print! vec2(1, 0).angle()
 check! 0.0
-print '{(vec2 0, 1).angle():.3}'
+print '{vec2(0, 1).angle():.3}'
 check! 1.571
-print '{(vec2 -1, 0).angle():.3}'
+print '{vec2(-1, 0).angle():.3}'
 check! 3.142
-print '{(vec2 0, -1).angle():.3}'
+print '{vec2(0, -1).angle():.3}'
 check! -1.571
 ```
 
@@ -388,11 +388,11 @@ Returns the length of the vector.
 ```koto
 from geometry import vec2
 
-print! (vec2 0, 0).length()
+print! vec2(0, 0).length()
 check! 0.0
-print! (vec2 3, 4).length()
+print! vec2(3, 4).length()
 check! 5.0
-print! (vec2 -4, -3).length()
+print! vec2(-4, -3).length()
 check! 5.0
 ```
 
@@ -409,9 +409,9 @@ Returns the `x` coordinate of the vector.
 ```koto
 from geometry import vec2
 
-print! (vec2 -1, 0).x()
+print! vec2(-1, 0).x()
 check! -1.0
-print! (vec2 3, 4).x()
+print! vec2(3, 4).x()
 check! 3.0
 ```
 
@@ -428,9 +428,9 @@ Returns the `y` coordinate of the vector.
 ```koto
 from geometry import vec2
 
-print! (vec2 0, -2).y()
+print! vec2(0, -2).y()
 check! -2.0
-print! (vec2 3, 4).y()
+print! vec2(3, 4).y()
 check! 4.0
 ```
 
@@ -445,7 +445,7 @@ Arithmetic operations are supported, and the vector's coordinates are iterable.
 ```koto
 from geometry import vec3
 
-print! (vec3 10, 20, 30) + (vec3 40, 50, 60)
+print! vec3(10, 20, 30) + vec3(40, 50, 60)
 check! Vec3{x: 50, y: 70, z: 90}
 
 v = 10 * vec3 5, 10, 15
@@ -468,7 +468,7 @@ Returns the `x` coordinate of the vector.
 ```koto
 from geometry import vec3
 
-print! (vec3 -1, 0, 1).x()
+print! vec3(-1, 0, 1).x()
 check! -1.0
 ```
 
@@ -486,7 +486,7 @@ Returns the `y` coordinate of the vector.
 ```koto
 from geometry import vec3
 
-print! (vec3 -1, -2, -3).y()
+print! vec3(-1, -2, -3).y()
 check! -2.0
 ```
 
@@ -503,7 +503,7 @@ Returns the `z` coordinate of the vector.
 ```koto
 from geometry import vec3
 
-print! (vec3 10, 20, 30).z()
+print! vec3(10, 20, 30).z()
 check! 30.0
 ```
 
@@ -520,8 +520,8 @@ Returns the length of the vector.
 ```koto
 from geometry import vec3
 
-print! (vec3 0, 0, 10).length()
+print! vec3(0, 0, 10).length()
 check! 10.0
-print! (vec3 1, 2, 2).length()
+print! vec3(1, 2, 2).length()
 check! 3.0
 ```

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -3038,7 +3038,7 @@ f x";
 
         #[test]
         fn recursive_calls_multi_assign() {
-            let source = "f, g = (|x| f x), (|x| g x)";
+            let source = "f, g = (|x| f x, |x| g x)";
             check_ast(
                 source,
                 &[
@@ -3058,29 +3058,27 @@ f x";
                         is_generator: false,
                         output_type: None,
                     }),
-                    Nested(7.into()),
                     id(2), // x
-                    id(1), // 10 - g
-                    id(2), // x
-                    chain_call(&[11], false, None),
-                    chain_root(10, Some(12)),
+                    id(1), // g
+                    id(2), // 10 -x
+                    chain_call(&[10], false, None),
+                    chain_root(9, Some(11)),
                     Function(koto_parser::Function {
-                        args: nodes(&[9]),
+                        args: nodes(&[8]),
                         local_count: 1,
                         accessed_non_locals: constants(&[1]),
-                        body: 13.into(),
+                        body: 12.into(),
                         is_variadic: false,
                         is_generator: false,
                         output_type: None,
                     }),
-                    Nested(14.into()), // 15
-                    TempTuple(nodes(&[8, 15])),
+                    Tuple(nodes(&[7, 13])),
                     MultiAssign {
                         targets: nodes(&[0, 1]),
-                        expression: 16.into(),
-                    },
+                        expression: 14.into(),
+                    }, // 15
                     MainBlock {
-                        body: nodes(&[17]),
+                        body: nodes(&[15]),
                         local_count: 2,
                     },
                 ],

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -358,13 +358,6 @@ x = {foo: 42, ?}
             use super::*;
 
             #[test]
-            fn space_separated_function_call_in_list() {
-                let source = "x = [1, 2, f y, 4]";
-
-                check_parsing_fails(source);
-            }
-
-            #[test]
             fn unexpected_token_inside_list() {
                 let source = "\
 x = [1, 2, ?]

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -235,6 +235,19 @@ y.next().get()
         }
     }
 
+    mod generate {
+        use super::*;
+
+        #[test]
+        fn with_inline_function() {
+            let script = "
+add = |a, b| a + b
+iterator.generate(|| add(2, 3), 5).to_tuple()
+";
+            check_script_output(script, number_tuple(&[5, 5, 5, 5, 5]));
+        }
+    }
+
     mod keep {
         use super::*;
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -1192,11 +1192,11 @@ add 2, add 3, 4";
         }
 
         #[test]
-        fn nested_call_in_parens() {
+        fn nested_call_with_parens() {
             let script = "
 add = |a, b|
   a + b
-add(5, add 6, 7)";
+add(5, add(6, 7))";
             check_script_output(script, 18);
         }
 
@@ -1393,7 +1393,7 @@ f 42";
                 let script = "
 f = |a, b, c...|
   a + b + c.fold 0, |x, y| x + y
-f (f 5, 10, 20, 30), 40, 50";
+f f(5, 10, 20, 30), 40, 50";
                 check_script_output(script, 155);
             }
 
@@ -1500,7 +1500,7 @@ add 10, 20";
         fn nested_calls() {
             let script = "
 add = |a, b| a + b
-add 10, (add 20, 30)";
+add 10, add(20, 30)";
             check_script_output(script, 60);
         }
 
@@ -1526,7 +1526,7 @@ fib = |n|
   else if n == 1
     1
   else
-    (fib n - 1) + (fib n - 2)
+    fib(n - 1) + fib(n - 2)
 fib 4
 ";
             check_script_output(script, 3);
@@ -1538,7 +1538,7 @@ fib 4
 f, g =
   (|n| if n == 0 then 1 else f n - 1),
   (|n| if n == 0 then 2 else g n - 1)
-(f 4), (g 4)
+f(4), g(4)
 ";
             check_script_output(script, number_tuple(&[1, 2]));
         }
@@ -2472,6 +2472,14 @@ m =
 m.foo 1, 2, 3
 ";
             check_script_output(script, 6);
+        }
+
+        #[test]
+        fn functions_in_braced_map() {
+            let script = "
+m = {square: |x| x ^ 2, cube: |x| x ^ 3}
+m.square(2) + m.cube(2)";
+            check_script_output(script, 12);
         }
 
         #[test]

--- a/koto/benches/spectral_norm.koto
+++ b/koto/benches/spectral_norm.koto
@@ -17,7 +17,7 @@ Av = |x, y, n|
     i2 = i + 1
     y[i] = x
       .enumerate()
-      .each |(j, n)| n * (A i2, (j + 1))
+      .each |(j, n)| n * A(i2, (j + 1))
       .sum()
 
 Atv = |x, y, n|
@@ -25,7 +25,7 @@ Atv = |x, y, n|
     i2 = i + 1
     y[i] = x
       .enumerate()
-      .each |(j, n)| n * (A (j + 1), i2)
+      .each |(j, n)| n * A((j + 1), i2)
       .sum()
 
 AtAv = |x, y, t, n|

--- a/koto/tests/enums.koto
+++ b/koto/tests/enums.koto
@@ -1,7 +1,7 @@
 make_enum = |entries...|
   entries
     .enumerate()
-    .each |(index, id)| id, index
+    .each |(index, id)| (id, index)
     .to_map()
 
 make_bidirectional_enum = |entries...|


### PR DESCRIPTION
This started out as an effort to support inline function bodies in braced map definitions, but the guiding principle that commas should split the enclosing container rather than ommitted parentheses is an overall improvement that's extended here to cover all containers and call args.
