### PR TITLE
Introduce `koto_format`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "koto_format"
+version = "0.16.0"
+dependencies = [
+ "koto_lexer",
+ "koto_parser",
+]
+
+[[package]]
 name = "koto_geometry"
 version = "0.16.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ version = "0.16.0"
 dependencies = [
  "koto_lexer",
  "koto_parser",
+ "unicode-width",
 ]
 
 [[package]]

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -395,7 +395,7 @@ impl Compiler {
             Node::List(elements) => {
                 self.compile_make_sequence(elements, Op::SequenceToList, ctx)?
             }
-            Node::Map(entries) => self.compile_make_map(entries, false, ctx)?,
+            Node::Map { entries, .. } => self.compile_make_map(entries, false, ctx)?,
             Node::Self_ => {
                 // self is always in register 0
                 match ctx.result_register {
@@ -1600,7 +1600,7 @@ impl Compiler {
                 expression,
             } => self.compile_multi_assign(targets, *expression, true, ctx),
             // Maps can be exported directly rather than relying on the iterator logic below
-            Node::Map(entries) => self.compile_make_map(entries, true, ctx),
+            Node::Map { entries, .. } => self.compile_make_map(entries, true, ctx),
             // Other expressions can be evaluated and then assumed to be iterable
             _ => {
                 // Evaluate the expression and convert the result into an iterator

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -396,6 +396,11 @@ impl Compiler {
                 self.compile_make_sequence(elements, Op::SequenceToList, ctx)?
             }
             Node::Map { entries, .. } => self.compile_make_map(entries, false, ctx)?,
+            Node::MapEntry(_, value) => {
+                // We only get here when evaluating map entries for side-effects,
+                // so we only need to compile the value here.
+                self.compile_node(*value, ctx)?
+            }
             Node::Self_ => {
                 // self is always in register 0
                 match ctx.result_register {
@@ -2353,7 +2358,7 @@ impl Compiler {
 
     fn compile_make_map(
         &mut self,
-        entries: &[(AstIndex, Option<AstIndex>)],
+        entries: &[AstIndex],
         export_entries: bool,
         ctx: CompileNodeContext,
     ) -> Result<CompileNodeOutput> {
@@ -2370,40 +2375,46 @@ impl Compiler {
 
         // Process the map's entries
         if result.register.is_some() || export_entries {
-            for (key, maybe_value_node) in entries.iter() {
-                let key_node = ctx.node(*key);
-                let value = match (key_node, maybe_value_node) {
-                    // An ID key with a value, and we're in an export expression
-                    (Node::Id(id, ..), Some(value_node)) if export_entries => {
-                        // The value is being exported, and should be made available in scope
-                        let value_register = self.reserve_local_register(*id)?;
-                        let value_node = *value_node;
-                        let result =
-                            self.compile_node(value_node, ctx.with_fixed_register(value_register))?;
-                        // Commit the register now that the value has been compiled.
-                        self.commit_local_register(value_register)?;
-                        result
+            for entry in entries.iter() {
+                let (key, value) = match ctx.node(*entry) {
+                    Node::MapEntry(key, value) => {
+                        let result = match ctx.node(*key) {
+                            Node::Id(id, _) if export_entries => {
+                                // The value is being exported, and should be made available in scope
+                                let value_register = self.reserve_local_register(*id)?;
+                                let value = *value;
+                                let result = self
+                                    .compile_node(value, ctx.with_fixed_register(value_register))?;
+                                // Commit the register now that the value has been compiled.
+                                self.commit_local_register(value_register)?;
+                                result
+                            }
+                            _ => {
+                                // A regular entry
+                                let value_node = *value;
+                                self.compile_node(value_node, ctx.with_any_register())?
+                            }
+                        };
+                        (*key, result)
                     }
-                    // A key with a value
-                    (_, Some(value_node)) => {
-                        let value_node = *value_node;
-                        self.compile_node(value_node, ctx.with_any_register())?
+                    Node::Id(key, _) => {
+                        // An ID key without a value, a value with matching ID should be available
+                        let value = match self.frame().get_local_assigned_register(*key) {
+                            Some(register) => CompileNodeOutput::with_assigned(register),
+                            None => {
+                                let register = self.push_register()?;
+                                self.compile_load_non_local(register, *key);
+                                CompileNodeOutput::with_temporary(register)
+                            }
+                        };
+                        (*entry, value)
                     }
-                    // An ID key without a value, a value with matching ID should be available
-                    (Node::Id(id, ..), None) => match self.frame().get_local_assigned_register(*id)
-                    {
-                        Some(register) => CompileNodeOutput::with_assigned(register),
-                        None => {
-                            let register = self.push_register()?;
-                            self.compile_load_non_local(register, *id);
-                            CompileNodeOutput::with_temporary(register)
-                        }
-                    },
-                    // No value provided for a string or meta key
-                    (_, None) => return self.error(ErrorKind::MissingValueForMapEntry),
+                    _ => return self.error(ErrorKind::MissingValueForMapEntry), // todo - update error
                 };
+
                 let value_register = value.unwrap(self)?;
 
+                let key_node = ctx.node(key);
                 self.compile_map_insert(
                     value_register,
                     key_node,
@@ -2418,10 +2429,8 @@ impl Compiler {
             }
         } else {
             // The map is unused, but the entry values should be compiled for side-effects
-            for (_key, value_node) in entries.iter() {
-                if let Some(value_node) = value_node {
-                    self.compile_node(*value_node, ctx.compile_for_side_effects())?;
-                }
+            for entry in entries.iter() {
+                self.compile_node(*entry, ctx.compile_for_side_effects())?;
             }
         }
 

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -21,3 +21,5 @@ rc = ["koto_parser/rc"]
 [dependencies]
 koto_lexer = { path = "../lexer", version = "^0.16.0" }
 koto_parser = { path = "../parser", version = "^0.16.0", default-features = false }
+
+unicode-width = { workspace = true }

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "koto_format"
+version = "0.16.0"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
+[features]
+default = ["rc"]
+
+# Only one memory management strategy can be enabled at a time.
+# To use `arc`, default features must be disabled.
+arc = ["koto_parser/arc"]
+rc = ["koto_parser/rc"]
+
+[dependencies]
+koto_lexer = { path = "../lexer", version = "^0.16.0" }
+koto_parser = { path = "../parser", version = "^0.16.0", default-features = false }

--- a/crates/format/src/format.rs
+++ b/crates/format/src/format.rs
@@ -1,0 +1,439 @@
+#![expect(unused)]
+
+use std::{iter::Peekable, thread::LocalKey};
+
+use crate::{
+    FormatOptions, Result, Trivia,
+    trivia::{TriviaItem, TriviaIterator, TriviaToken},
+};
+use koto_lexer::Position;
+use koto_parser::{
+    Ast, AstIndex, AstNode, AstUnaryOp, AstVec, ConstantIndex, KString, Node, Span, StringSlice,
+};
+
+/// Returns the input source formatted according to the provided options
+pub fn format(source: &str, options: FormatOptions) -> Result<String> {
+    let trivia = Trivia::parse(source)?;
+    let ast = koto_parser::Parser::parse(source)?;
+
+    if let Some(entry_point) = ast.entry_point() {
+        let context = FormatContext { source, ast: &ast };
+        let output = format_node(entry_point, context, &mut trivia.iter());
+        let mut result = String::new();
+        output.render(&mut result, &options, 0);
+        Ok(result)
+    } else {
+        Ok(String::new())
+    }
+}
+
+fn format_node<'source>(
+    node_index: AstIndex,
+    ctx: FormatContext<'source>,
+    trivia: &mut TriviaIterator<'source>,
+) -> FormatItem<'source> {
+    let node = ctx.node(node_index);
+
+    match &node.node {
+        Node::Null => FormatItem::Str("null"),
+        Node::Nested(nested) => GroupBuilder::new(3, node, ctx, trivia)
+            .char('(')
+            .node(*nested)
+            .char(')')
+            .build(),
+        Node::Id(index, type_hint) => {
+            if let Some(type_hint) = type_hint {
+                todo!()
+            } else {
+                ctx.string_constant(*index).into()
+            }
+        }
+        Node::Meta(meta_key_id, maybe_name) => {
+            if let Some(name) = maybe_name {
+                GroupBuilder::new(3, node, ctx, trivia)
+                    .string(meta_key_id.as_str())
+                    .soft_break()
+                    .string_constant(*name)
+                    .build()
+            } else {
+                meta_key_id.as_str().into()
+            }
+        }
+        Node::Chain(_) => todo!(),
+        Node::BoolTrue => "true".into(),
+        Node::BoolFalse => "false".into(),
+        Node::SmallInt(n) => FormatItem::SmallInt(*n),
+        Node::Int(index) => FormatItem::Int(ctx.ast.constants().get_i64(*index)),
+        Node::Float(index) => FormatItem::Float(ctx.ast.constants().get_f64(*index)),
+        Node::Str(ast_string) => todo!(),
+        Node::List(elements) => GroupBuilder::new(elements.len() * 2 + 2, node, ctx, trivia)
+            .char('[')
+            .elements(elements)
+            .char(']')
+            .build(),
+        Node::Tuple(elements) => GroupBuilder::new(elements.len() * 2 + 2, node, ctx, trivia)
+            .char('(')
+            .elements(elements)
+            .char(')')
+            .build(),
+        Node::TempTuple(elements) => GroupBuilder::new(elements.len() * 2, node, ctx, trivia)
+            .elements(elements)
+            .build(),
+        Node::Range {
+            start,
+            end,
+            inclusive,
+        } => todo!(),
+        Node::RangeFrom { start } => todo!(),
+        Node::RangeTo { end, inclusive } => todo!(),
+        Node::RangeFull => todo!(),
+        Node::Map(small_vec) => todo!(),
+        Node::Self_ => "self".into(),
+        Node::MainBlock { body, .. } => {
+            let mut group = GroupBuilder::new(body.len(), node, ctx, trivia);
+            for block_node in body {
+                group = group.node(*block_node).line_break()
+            }
+            group.build_main_block()
+        }
+        Node::Block(body) => {
+            let mut group = GroupBuilder::new(body.len(), node, ctx, trivia).line_break();
+            for block_node in body {
+                group = group.node(*block_node).line_break()
+            }
+            group.build_block()
+        }
+        Node::Function(function) => todo!(),
+        Node::Import { from, items } => todo!(),
+        Node::Export(ast_index) => todo!(),
+        Node::Assign { target, expression } => GroupBuilder::new(3, node, ctx, trivia)
+            .node(*target)
+            .soft_break()
+            .nested(|trivia| {
+                GroupBuilder::new(3, node, ctx, trivia)
+                    .char('=')
+                    .soft_break()
+                    .node(*expression)
+                    .build()
+            })
+            .build(),
+        Node::MultiAssign {
+            targets,
+            expression,
+        } => todo!(),
+        Node::UnaryOp { op, value } => match op {
+            AstUnaryOp::Negate => GroupBuilder::new(2, node, ctx, trivia)
+                .string(op.as_str())
+                .node(*value)
+                .build(),
+            AstUnaryOp::Not => GroupBuilder::new(3, node, ctx, trivia)
+                .string(op.as_str())
+                .soft_break()
+                .node(*value)
+                .build(),
+        },
+        Node::BinaryOp { op, lhs, rhs } => GroupBuilder::new(3, node, ctx, trivia)
+            .node(*lhs)
+            .soft_break()
+            .nested(|trivia| {
+                GroupBuilder::new(3, node, ctx, trivia)
+                    .string(op.as_str())
+                    .soft_break()
+                    .node(*rhs)
+                    .build()
+            })
+            .build(),
+        Node::If(ast_if) => todo!(),
+        Node::Match { expression, arms } => todo!(),
+        Node::Switch(small_vec) => todo!(),
+        Node::Wildcard(constant_index, ast_index) => todo!(),
+        Node::PackedId(constant_index) => todo!(),
+        Node::PackedExpression(ast_index) => todo!(),
+        Node::For(ast_for) => todo!(),
+        Node::Loop { body } => GroupBuilder::new(2, node, ctx, trivia)
+            .string("loop")
+            .node(*body)
+            .build(),
+        Node::While { condition, body } => todo!(),
+        Node::Until { condition, body } => todo!(),
+        Node::Break(value) => match value {
+            Some(value) => GroupBuilder::new(3, node, ctx, trivia)
+                .string("break")
+                .soft_break()
+                .node(*value)
+                .build(),
+            None => "break".into(),
+        },
+        Node::Continue => "continue".into(),
+        Node::Return(value) => match value {
+            Some(value) => GroupBuilder::new(3, node, ctx, trivia)
+                .string("return")
+                .soft_break()
+                .node(*value)
+                .build(),
+            None => "return".into(),
+        },
+        Node::Try(ast_try) => todo!(),
+        Node::Throw(ast_index) => todo!(),
+        Node::Yield(ast_index) => todo!(),
+        Node::Debug {
+            expression_string,
+            expression,
+        } => todo!(),
+        Node::Type {
+            type_index,
+            allow_null,
+        } => {
+            let type_string = ctx.string_constant(*type_index).into();
+            if *allow_null {
+                FormatItem::Group(vec![type_string, "?".into()])
+            } else {
+                type_string
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FormatContext<'source> {
+    source: &'source str,
+    ast: &'source Ast,
+}
+
+impl<'source> FormatContext<'source> {
+    fn node(&self, ast_index: AstIndex) -> &AstNode {
+        self.ast.node(ast_index)
+    }
+
+    fn span(&self, node: &AstNode) -> &Span {
+        self.ast.span(node.span)
+    }
+
+    fn string_constant(&self, constant: ConstantIndex) -> &'source str {
+        self.ast.constants().get_str(constant)
+    }
+}
+
+struct GroupBuilder<'source, 'trivia> {
+    items: Vec<FormatItem<'source>>,
+    group_span: Span,
+    ctx: FormatContext<'source>,
+    trivia: &'trivia mut TriviaIterator<'source>,
+    current_line: u32,
+}
+
+impl<'source, 'trivia> GroupBuilder<'source, 'trivia> {
+    fn new(
+        capacity: usize,
+        group_node: &AstNode,
+        ctx: FormatContext<'source>,
+        trivia: &'trivia mut TriviaIterator<'source>,
+    ) -> Self {
+        let group_span = *ctx.span(group_node);
+        let current_line = group_span.start.line;
+        Self {
+            items: Vec::with_capacity(capacity),
+            group_span,
+            ctx,
+            trivia,
+            current_line,
+        }
+    }
+
+    fn build(mut self) -> FormatItem<'source> {
+        self.add_trivia(self.group_span.end);
+        FormatItem::Group(self.items)
+    }
+
+    fn build_block(mut self) -> FormatItem<'source> {
+        self.add_trivia(self.group_span.end);
+        FormatItem::Block(self.items)
+    }
+
+    fn build_main_block(mut self) -> FormatItem<'source> {
+        self.add_trivia(self.group_span.end);
+        // Remove trailing linebreaks
+        while self
+            .items
+            .last()
+            .is_some_and(|item| matches!(item, FormatItem::LineBreak))
+        {
+            self.items.pop();
+        }
+        FormatItem::MainBlock(self.items)
+    }
+
+    fn char(mut self, c: char) -> Self {
+        self.items.push(c.into());
+        self
+    }
+
+    fn string(mut self, s: &'source str) -> Self {
+        self.items.push(s.into());
+        self
+    }
+
+    fn string_constant(mut self, constant: ConstantIndex) -> Self {
+        self.items.push(self.ctx.string_constant(constant).into());
+        self
+    }
+
+    fn soft_break(mut self) -> Self {
+        self.items.push(FormatItem::SoftBreak);
+        self
+    }
+
+    fn line_break(mut self) -> Self {
+        // Add any trailing comments for the current line
+        self.add_trivia(self.next_line());
+        self.items.push(FormatItem::LineBreak);
+        self
+    }
+
+    fn node(mut self, node_index: AstIndex) -> Self {
+        let node_span = self.ctx.span(self.ctx.node(node_index));
+        let node_end_line = node_span.end.line;
+        self.add_trivia(node_span.start);
+        self.items
+            .push(format_node(node_index, self.ctx, self.trivia));
+        self.current_line = node_end_line;
+        self
+    }
+
+    fn nested(
+        mut self,
+        nested_fn: impl Fn(&mut TriviaIterator<'source>) -> FormatItem<'source>,
+    ) -> Self {
+        self.items.push(nested_fn(self.trivia));
+        self
+    }
+
+    fn elements(mut self, elements: &[AstIndex]) -> Self {
+        for (i, element) in elements.iter().enumerate() {
+            self = self.node(*element);
+            if i < elements.len() - 1 {
+                self = self.char(',').soft_break();
+            }
+        }
+        self
+    }
+
+    fn add_trivia(&mut self, position: Position) {
+        // Add any trivia items that belong before the format item to the group
+        while let Some(item) = self.trivia.peek() {
+            let item_start = item.span.start;
+            if item_start < position {
+                // Advance the trivia iterator
+                let item = *item;
+                self.trivia.next();
+
+                match item.token {
+                    TriviaToken::EmptyLine => {
+                        self.items.push(FormatItem::LineBreak);
+                    }
+                    TriviaToken::CommentSingle(text) => {
+                        // Insert a space if it's a trailing comment
+                        if item_start.line == self.current_line {
+                            self.items.push(' '.into());
+                        }
+
+                        self.items.push(text.into());
+                    }
+                    TriviaToken::CommentMulti(text) => {
+                        self.items.push(text.into());
+                        self.items.push(FormatItem::SoftBreak);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn next_line(&self) -> Position {
+        Position {
+            line: self.current_line + 1,
+            column: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum FormatItem<'source> {
+    // A single character
+    Char(char),
+    // A `&str`, either static or from the source file
+    Str(&'source str),
+    // A small int
+    SmallInt(i16),
+    /// An integer outside of the range -255..=255
+    Int(i64),
+    /// A float literal
+    Float(f64),
+    // A linebreak
+    LineBreak,
+    // A space or indented linebreak
+    SoftBreak,
+    // A grouped sequence of items
+    // Ideally the group will be rendered on a single line, or with softbreaks replace with indents
+    Group(Vec<FormatItem<'source>>),
+    // Asequence of expressions, each on a separate line.
+    MainBlock(Vec<FormatItem<'source>>),
+    // An indented sequence of expressions, each on a separate line.
+    Block(Vec<FormatItem<'source>>),
+}
+
+impl FormatItem<'_> {
+    fn render(&self, output: &mut String, options: &FormatOptions, column: usize) {
+        match self {
+            Self::Char(c) => output.push(*c),
+            Self::Str(s) => output.push_str(s),
+            Self::SmallInt(n) => output.push_str(&n.to_string()),
+            Self::Int(n) => output.push_str(&n.to_string()),
+            Self::Float(n) => output.push_str(&n.to_string()),
+            Self::LineBreak => output.push('\n'),
+            Self::SoftBreak => output.push(' '),
+            Self::Group(items) => {
+                for item in items {
+                    item.render(output, options, column);
+                }
+            }
+            Self::MainBlock(items) => {
+                for item in items {
+                    item.render(output, options, column);
+                }
+                // A newline may already be present at the end of the output, if not add one now.
+                if !output.ends_with('\n') {
+                    output.push('\n');
+                }
+            }
+            Self::Block(items) => {
+                let block_column = column + options.indent_width as usize;
+                let indent = " ".repeat(block_column);
+                let mut last_item_was_linebreak = false;
+                for item in items {
+                    last_item_was_linebreak =
+                        if !matches!(item, FormatItem::LineBreak) && last_item_was_linebreak {
+                            output.push_str(&indent);
+                            false
+                        } else {
+                            true
+                        };
+                    item.render(output, options, block_column);
+                }
+            }
+        }
+    }
+}
+
+impl From<char> for FormatItem<'_> {
+    fn from(c: char) -> Self {
+        Self::Char(c)
+    }
+}
+
+impl<'source> From<&'source str> for FormatItem<'source> {
+    fn from(s: &'source str) -> Self {
+        Self::Str(s)
+    }
+}

--- a/crates/format/src/format.rs
+++ b/crates/format/src/format.rs
@@ -158,10 +158,20 @@ fn format_node<'source>(
             start,
             end,
             inclusive,
-        } => todo!(),
-        Node::RangeFrom { start } => todo!(),
-        Node::RangeTo { end, inclusive } => todo!(),
-        Node::RangeFull => todo!(),
+        } => GroupBuilder::new(3, node, ctx, trivia)
+            .node(*start)
+            .str(if *inclusive { "..=" } else { ".." })
+            .node(*end)
+            .build(),
+        Node::RangeFrom { start } => GroupBuilder::new(2, node, ctx, trivia)
+            .node(*start)
+            .str("..")
+            .build(),
+        Node::RangeTo { end, inclusive } => GroupBuilder::new(2, node, ctx, trivia)
+            .str(if *inclusive { "..=" } else { ".." })
+            .node(*end)
+            .build(),
+        Node::RangeFull => "..".into(),
         Node::Map(small_vec) => todo!(),
         Node::Self_ => "self".into(),
         Node::MainBlock { body, .. } => {

--- a/crates/format/src/format.rs
+++ b/crates/format/src/format.rs
@@ -46,7 +46,12 @@ fn format_node<'source>(
             .build(),
         Node::Id(index, type_hint) => {
             if let Some(type_hint) = type_hint {
-                todo!()
+                GroupBuilder::new(4, node, ctx, trivia)
+                    .string_constant(*index)
+                    .char(':')
+                    .space_or_indent()
+                    .node(*type_hint)
+                    .build()
             } else {
                 ctx.string_constant(*index).into()
             }
@@ -311,7 +316,16 @@ fn format_node<'source>(
         }
         Node::Match { expression, arms } => todo!(),
         Node::Switch(small_vec) => todo!(),
-        Node::Wildcard(constant_index, ast_index) => todo!(),
+        Node::Wildcard(id, type_hint) => {
+            let mut group = GroupBuilder::new(1, node, ctx, trivia).char('_');
+            if let Some(id) = id {
+                group = group.string_constant(*id);
+            }
+            if let Some(type_hint) = type_hint {
+                group = group.char(':').space_or_indent().node(*type_hint);
+            }
+            group.build()
+        }
         Node::PackedId(constant_index) => todo!(),
         Node::PackedExpression(ast_index) => todo!(),
         Node::For(AstFor {

--- a/crates/format/src/lib.rs
+++ b/crates/format/src/lib.rs
@@ -1,0 +1,6 @@
+mod format;
+mod options;
+mod trivia;
+
+pub use crate::{format::format, options::FormatOptions, trivia::Trivia};
+pub use koto_parser::Result;

--- a/crates/format/src/options.rs
+++ b/crates/format/src/options.rs
@@ -3,10 +3,15 @@
 pub struct FormatOptions {
     /// The width in characters to use when inserting indents (default: 2)
     pub indent_width: u8,
+    /// The maximum line length (default: 100)
+    pub line_length: u8,
 }
 
 impl Default for FormatOptions {
     fn default() -> Self {
-        Self { indent_width: 2 }
+        Self {
+            indent_width: 2,
+            line_length: 100,
+        }
     }
 }

--- a/crates/format/src/options.rs
+++ b/crates/format/src/options.rs
@@ -1,0 +1,12 @@
+/// Formatting options provided to [`format`]
+#[derive(Clone, Copy)]
+pub struct FormatOptions {
+    /// The width in characters to use when inserting indents (default: 2)
+    pub indent_width: u8,
+}
+
+impl Default for FormatOptions {
+    fn default() -> Self {
+        Self { indent_width: 2 }
+    }
+}

--- a/crates/format/src/options.rs
+++ b/crates/format/src/options.rs
@@ -5,6 +5,9 @@ pub struct FormatOptions {
     pub indent_width: u8,
     /// The maximum line length (default: 100)
     pub line_length: u8,
+    /// If true, indented linebreaks will always be used after `then` and `else`
+    /// in `match` and `switch` arms (default: false)
+    pub match_and_switch_always_indent_arm_bodies: bool,
 }
 
 impl Default for FormatOptions {
@@ -12,6 +15,7 @@ impl Default for FormatOptions {
         Self {
             indent_width: 2,
             line_length: 100,
+            match_and_switch_always_indent_arm_bodies: false,
         }
     }
 }

--- a/crates/format/src/trivia.rs
+++ b/crates/format/src/trivia.rs
@@ -1,0 +1,192 @@
+use crate::Result;
+use koto_lexer::{Lexer, Token};
+use koto_parser::{Span, SyntaxError};
+
+/// Captures non-AST 'trivia' items that are needed for formatting, like comments and newlines
+#[derive(Default)]
+pub struct Trivia<'source> {
+    // Captured trivia items
+    items: Vec<TriviaItem<'source>>,
+}
+
+impl<'source> Trivia<'source> {
+    pub fn parse(source: &'source str) -> Result<Self> {
+        let mut items = Vec::default();
+
+        // Used to keep track of the how many newlines in a row are found in the input
+        let mut newline_count = 0;
+
+        for token in Lexer::new(source) {
+            // Reset the newline count if any token other than newlines or whitespace is encountered
+            if !matches!(token.token, Token::NewLine | Token::Whitespace) {
+                newline_count = 0;
+            }
+
+            let maybe_trivia = match token.token {
+                Token::CommentSingle => {
+                    Some(TriviaToken::CommentSingle(&source[token.source_bytes]))
+                }
+                Token::CommentMulti => Some(TriviaToken::CommentMulti(&source[token.source_bytes])),
+                Token::NewLine => {
+                    newline_count += 1;
+                    // Capture an `EmptyLine` item if 2 newlines after each other are encountered
+                    if newline_count == 2 {
+                        Some(TriviaToken::EmptyLine)
+                    } else {
+                        None
+                    }
+                }
+                Token::Whitespace => None,
+                Token::Error => {
+                    return Err(koto_parser::Error::new(
+                        SyntaxError::UnexpectedToken.into(),
+                        token.span,
+                    ));
+                }
+                // Other tokens can be skipped
+                _ => None,
+            };
+
+            if let Some(trivia_token) = maybe_trivia {
+                items.push(TriviaItem {
+                    token: trivia_token,
+                    span: token.span,
+                });
+            }
+        }
+
+        Ok(Self { items })
+    }
+
+    pub fn iter(&self) -> TriviaIterator {
+        self.items.iter().peekable()
+    }
+}
+
+pub type TriviaIterator<'source> =
+    std::iter::Peekable<std::slice::Iter<'source, TriviaItem<'source>>>;
+
+#[derive(Clone, Copy, Debug)]
+pub struct TriviaItem<'source> {
+    pub token: TriviaToken<'source>,
+    pub span: Span,
+}
+
+/// Tokens that are captured as [Trivia] for formatting a Koto source file
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TriviaToken<'source> {
+    /// Empty lines are captured once
+    /// (i.e two empty lines in a row are capture as a single empty line)
+    EmptyLine,
+    /// A single-line comment
+    CommentSingle(&'source str),
+    /// A multi-line comment
+    CommentMulti(&'source str),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use koto_parser::Position;
+
+    fn check_trivia_items(source: &str, expected_items: &[(TriviaToken, Span)]) {
+        let trivia = match Trivia::parse(source) {
+            Ok(trivia) => trivia,
+            Err(error) => panic!("failed to parse trivia: {error}"),
+        };
+
+        for (i, ((token, span), actual)) in expected_items.iter().zip(trivia.iter()).enumerate() {
+            assert_eq!(*token, actual.token, "Item mismatch at position {i}");
+            assert_eq!(*span, actual.span, "Span mismatch at position {i}");
+        }
+
+        assert_eq!(
+            expected_items.len(),
+            trivia.items.len(),
+            "Item count mismatch"
+        );
+    }
+
+    #[test]
+    fn comments_and_empty_lines() {
+        let source = "\
+# Hello
+x = 1 # abcdef
+
+#-
+Multiline comment
+-#
+
+x = #- Inline comment -# x + 1
+
+return x
+";
+
+        use TriviaToken::*;
+        check_trivia_items(
+            source,
+            &[
+                (
+                    CommentSingle("# Hello"),
+                    Span {
+                        start: Position { line: 0, column: 0 },
+                        end: Position { line: 0, column: 7 },
+                    },
+                ),
+                (
+                    CommentSingle("# abcdef"),
+                    Span {
+                        start: Position { line: 1, column: 6 },
+                        end: Position {
+                            line: 1,
+                            column: 14,
+                        },
+                    },
+                ),
+                (
+                    EmptyLine,
+                    Span {
+                        start: Position { line: 2, column: 0 },
+                        end: Position { line: 3, column: 0 },
+                    },
+                ),
+                (
+                    CommentMulti(
+                        "\
+#-
+Multiline comment
+-#",
+                    ),
+                    Span {
+                        start: Position { line: 3, column: 0 },
+                        end: Position { line: 5, column: 2 },
+                    },
+                ),
+                (
+                    EmptyLine,
+                    Span {
+                        start: Position { line: 6, column: 0 },
+                        end: Position { line: 7, column: 0 },
+                    },
+                ),
+                (
+                    CommentMulti("#- Inline comment -#"),
+                    Span {
+                        start: Position { line: 7, column: 4 },
+                        end: Position {
+                            line: 7,
+                            column: 24,
+                        },
+                    },
+                ),
+                (
+                    EmptyLine,
+                    Span {
+                        start: Position { line: 8, column: 0 },
+                        end: Position { line: 9, column: 0 },
+                    },
+                ),
+            ],
+        );
+    }
+}

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -458,4 +458,52 @@ foo
             );
         }
     }
+
+    mod import_and_export {
+        use super::*;
+
+        #[test]
+        fn export() {
+            check_format_output(
+                &["\
+export   #- abc -#   foo     # xyz
+"],
+                "\
+export #- abc -# foo # xyz
+",
+            );
+        }
+
+        #[test]
+        fn import_single_line() {
+            check_format_output(
+                &["\
+from    foo   import #- abc -#   bar     # xyz
+"],
+                "\
+from foo import #- abc -# bar # xyz
+",
+            );
+        }
+
+        #[test]
+        fn import_multiline() {
+            check_format_output_with_options(
+                &["\
+from foo.bar.baz import     #- abc -#   bar as   aaa  , baz   as   bbb       # xyz
+"],
+                "\
+from
+  foo.bar.baz
+import
+  #- abc -# bar as aaa,
+  baz as bbb # xyz
+",
+                FormatOptions {
+                    line_length: 25,
+                    ..Default::default()
+                },
+            );
+        }
+    }
 }

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -412,4 +412,50 @@ else # baz
             );
         }
     }
+
+    mod chains {
+        use super::*;
+
+        #[test]
+        fn call_without_parens() {
+            check_format_output(
+                &["\
+f   1,   2,  3
+"],
+                "\
+f 1, 2, 3
+",
+            );
+        }
+
+        #[test]
+        fn single_line_with_parens() {
+            check_format_output(
+                &["\
+foo.bar[  #- foo -# 0  ]?.'baz'( 1 ,  2 ,  3  )
+"],
+                "\
+foo.bar[#- foo -# 0]?.'baz'(1, 2, 3)
+",
+            );
+        }
+
+        #[test]
+        fn long_chain() {
+            check_format_output_with_options(
+                &["\
+foo.bar[  #- foo -# 0  ]?.baz( 1 ,  2 ,  3  )
+"],
+                "\
+foo
+  .bar[#- foo -# 0]?
+  .baz(1, 2, 3)
+",
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
+    }
 }

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -509,13 +509,10 @@ for #- abc -# x in y # xyz
             check_format_output(
                 &["\
 if   #- abc -#   x >   10 # foo
-   x = 1
    return x
-else if   x   < 5
-    x = 0
+else if   x   < 5 # ---
     return x     # bar
 else if     x ==   0 # xyz
-     x = -1
      return x
 else # baz
  x     =    42      # 42
@@ -523,13 +520,10 @@ else # baz
 "],
                 "\
 if #- abc -# x > 10 # foo
-  x = 1
   return x
-else if x < 5
-  x = 0
+else if x < 5 # ---
   return x # bar
 else if x == 0 # xyz
-  x = -1
   return x
 else # baz
   x = 42 # 42

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -365,16 +365,19 @@ a, b, c =
                 &["\
 x =
   foo  :
-    99
+    99     # abc
+
   bar: some_long_function()
-  'baz'  : 1 + 1
+  'baz'  : #- xyz -# 1 + 1
 "],
                 "\
 x =
-  foo: 99
+  foo: 99 # abc
+
   bar:
     some_long_function()
-  'baz': 1 + 1
+  'baz':
+    #- xyz -# 1 + 1
 ",
                 FormatOptions {
                     line_length: 20,

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -339,6 +339,49 @@ a, b, c =
                 },
             );
         }
+
+        #[test]
+        fn map_with_braces() {
+            check_format_output_with_options(
+                &["\
+{ foo:42,bar,      baz: 99    }
+"],
+                "\
+{
+  foo: 42, bar,
+  baz: 99
+}
+",
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
+
+        #[test]
+        fn map_blocks() {
+            check_format_output_with_options(
+                &["\
+x =
+  foo  :
+    99
+  bar: some_long_function()
+  'baz'  : 1 + 1
+"],
+                "\
+x =
+  foo: 99
+  bar:
+    some_long_function()
+  'baz': 1 + 1
+",
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
     }
 
     mod loops {

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -31,7 +31,10 @@ Output:
                         )
                     }
                 }
-                Err(error) => panic!("error while formatting: {error}\ninput:\n{input}"),
+                Err(error) => panic!(
+                    "error while formatting (line: {}, column: {}): {error}\ninput:\n{input}",
+                    error.span.start.line, error.span.start.column
+                ),
             }
         }
     }
@@ -345,6 +348,44 @@ for     #- abc -#x in   y# xyz
                 "\
 for #- abc -# x in y # xyz
   x += 99
+",
+            );
+        }
+    }
+
+    mod conditionals {
+        use super::*;
+
+        #[test]
+        fn if_block() {
+            check_format_output(
+                &["\
+if   #- abc -#   x >   10 # foo
+   x = 1
+   return x
+else if   x   < 5
+    x = 0
+    return x     # bar
+else if     x ==   0 # xyz
+     x = -1
+     return x
+else # baz
+ x     =    42      # 42
+ return x
+"],
+                "\
+if #- abc -# x > 10 # foo
+  x = 1
+  return x
+else if x < 5
+  x = 0
+  return x # bar
+else if x == 0 # xyz
+  x = -1
+  return x
+else # baz
+  x = 42 # 42
+  return x
 ",
             );
         }

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -26,8 +26,9 @@ Expected:
 
 Output:
 ---
-{output}
----"
+{}
+---",
+                            output.replace("\n", "⏎\n")
                         )
                     }
                 }
@@ -297,6 +298,28 @@ r###'raw!'###
 ",
             );
         }
+
+        #[test]
+        fn tuple_multi_line() {
+            check_format_output_with_options(
+                &["\
+(11111  ,
+    22222,33333,   #- foo -#     44444
+)
+"],
+                "\
+(
+  11111, 22222,
+  33333, #- foo -#
+  44444
+)
+",
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
     }
 
     mod loops {
@@ -496,11 +519,10 @@ from foo.bar.baz import     #- abc -#   bar as   aaa  , baz   as   bbb       # x
 from
   foo.bar.baz
 import
-  #- abc -# bar as aaa,
-  baz as bbb # xyz
+  #- abc -# bar as aaa, baz as bbb # xyz
 ",
                 FormatOptions {
-                    line_length: 25,
+                    line_length: 40,
                     ..Default::default()
                 },
             );

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -94,6 +94,24 @@ return #- abc -# foo
     }
 
     #[test]
+    fn return_with_line_comment() {
+        check_format_output(
+            &[
+                "\
+return      # abc
+       foo",
+                "\
+return  # abc
+  foo",
+            ],
+            "\
+return # abc
+  foo
+",
+        );
+    }
+
+    #[test]
     fn return_with_long_value() {
         check_format_output_with_options(
             &[
@@ -146,6 +164,25 @@ return
             ],
             "\
 (#- xyz -# null)
+",
+        );
+    }
+
+    #[test]
+    fn arithmetic_with_line_comment() {
+        check_format_output(
+            &[
+                "\
+1   +  # abc
+ 2 * 3",
+                "\
+1 + # abc
+    2
+      * 3",
+            ],
+            "\
+1 + # abc
+  2 * 3
 ",
         );
     }

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -528,4 +528,48 @@ import
             );
         }
     }
+
+    mod functions {
+        use super::*;
+
+        #[test]
+        fn inline() {
+            check_format_output(
+                &["\
+f   =   |  a : Number ,  b: Number, c...  |   g(a  +  b, c...)
+"],
+                "\
+f = |a: Number, b: Number, c...| g(a + b, c...)
+",
+            );
+        }
+
+        #[test]
+        fn block_with_long_lines() {
+            check_format_output_with_options(
+                &["\
+f   =   |  (aaaa,  bbbb, ( ..., c, d  ))  |   ->   Number   # abc
+    x =   aaaa +  bbbb  +c+   d
+    yield   x   *   2
+"],
+                "\
+f = |
+  (
+    aaaa, bbbb,
+    (..., c, d)
+  )
+| -> Number # abc
+  x = aaaa
+    + bbbb
+    + c
+    + d
+  yield x * 2
+",
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
+    }
 }

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -432,10 +432,10 @@ f 1, 2, 3
         fn single_line_with_parens() {
             check_format_output(
                 &["\
-foo.bar[  #- foo -# 0  ]?.'baz'( 1 ,  2 ,  3  )
+foo.bar[  #- foo -# 1..  ]?.'baz'( x[..] ,  2 ,  3  )
 "],
                 "\
-foo.bar[#- foo -# 0]?.'baz'(1, 2, 3)
+foo.bar[#- foo -# 1..]?.'baz'(x[..], 2, 3)
 ",
             );
         }
@@ -444,12 +444,12 @@ foo.bar[#- foo -# 0]?.'baz'(1, 2, 3)
         fn long_chain() {
             check_format_output_with_options(
                 &["\
-foo.bar[  #- foo -# 0  ]?.baz( 1 ,  2 ,  3  )
+foo.bar[  #- foo -# ..9  ]?.baz( 1 ,  2 ,  3..=4  )
 "],
                 "\
 foo
-  .bar[#- foo -# 0]?
-  .baz(1, 2, 3)
+  .bar[#- foo -# ..9]?
+  .baz(1, 2, 3..=4)
 ",
                 FormatOptions {
                     line_length: 20,

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -434,6 +434,115 @@ else # baz
 ",
             );
         }
+
+        #[test]
+        fn switch() {
+            check_format_output(
+                &["\
+switch
+  x   ==   0   then x # abc
+  y   ==0    then
+    debug y
+    f(y)
+  else # xyz
+    42
+"],
+                "\
+switch
+  x == 0 then x # abc
+  y == 0 then
+    debug y
+    f(y)
+  else # xyz
+    42
+",
+            );
+        }
+
+        #[test]
+        fn switch_always_break() {
+            check_format_output_with_options(
+                &["\
+switch
+  x   ==   0   then x # abc
+  y   ==0    then
+    debug y
+    f(y)
+  else  42 # xyz
+"],
+                "\
+switch
+  x == 0 then # abc
+    x
+  y == 0 then
+    debug y
+    f(y)
+  else
+    42 # xyz
+",
+                FormatOptions {
+                    match_and_switch_always_indent_arm_bodies: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        #[test]
+        fn match_expression() {
+            check_format_output_with_options(
+                &["
+match   foo()    # abc
+  'hello'   then
+                  'xyz'
+  1   or   2   or 3   or   4 then   -1
+  ('a', 'b'  )or(   'c', 'd')if bar()then baz()      # xyz
+  else
+    0
+"],
+                "\
+match foo() # abc
+  'hello' then 'xyz'
+  1 or 2 or 3 or 4 then -1
+  ('a', 'b') or ('c', 'd') if bar() then
+    baz() # xyz
+  else 0
+",
+                FormatOptions {
+                    line_length: 50,
+                    ..Default::default()
+                },
+            );
+        }
+
+        #[test]
+        fn match_expression_always_break() {
+            check_format_output_with_options(
+                &["
+match   foo()    # abc
+  'hello'   then
+                  'xyz'
+  1   or   2   or 3   or   4 then   -1
+  ('a', 'b'  )or(   'c', 'd')if bar()then baz()      # xyz
+  else
+    0
+"],
+                "\
+match foo() # abc
+  'hello' then
+    'xyz'
+  1 or 2 or 3 or 4 then
+    -1
+  ('a', 'b') or ('c', 'd') if bar() then # xyz
+    baz()
+  else
+    0
+",
+                FormatOptions {
+                    match_and_switch_always_indent_arm_bodies: true,
+                    ..Default::default()
+                },
+            );
+        }
     }
 
     mod chains {

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -13,7 +13,7 @@ mod format {
                     if expected != output {
                         panic!(
                             "\
-Mismatch in format output.
+Mismatch in format output at char {}.
 Input:
 ---
 {input}
@@ -28,6 +28,11 @@ Output:
 ---
 {}
 ---",
+                            expected
+                                .chars()
+                                .zip(output.chars())
+                                .take_while(|(a, b)| a == b)
+                                .count(),
                             output.replace("\n", "⏎\n")
                         )
                     }
@@ -601,6 +606,39 @@ match foo() # abc
     baz()
   else
     0
+",
+                FormatOptions {
+                    match_and_switch_always_indent_arm_bodies: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        #[test]
+        fn try_catch_finally() {
+            check_format_output_with_options(
+                &["
+try     # abc
+  foo()
+  bar()
+catch i  :   Int
+    debug i
+    throw   '{i}'
+catch    other
+  throw other
+finally
+    print 'bye'"],
+                "\
+try # abc
+  foo()
+  bar()
+catch i: Int
+  debug i
+  throw '{i}'
+catch other
+  throw other
+finally
+  print 'bye'
 ",
                 FormatOptions {
                     match_and_switch_always_indent_arm_bodies: true,

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -278,6 +278,39 @@ a, b, c =
                 },
             );
         }
+
+        #[test]
+        fn integers_with_alt_bases() {
+            check_format_output_with_options(
+                &["\
+0b101   +     0xabad_cafe *   0o707
+"],
+                "\
+0b101
+  + 0xabad_cafe * 0o707
+",
+                FormatOptions {
+                    line_length: 25,
+                    ..Default::default()
+                },
+            );
+        }
+
+        #[test]
+        fn floats() {
+            check_format_output_with_options(
+                &["\
+1.0e-3    * 2e99
+"],
+                "\
+1.0e-3 * 2e99
+",
+                FormatOptions {
+                    line_length: 25,
+                    ..Default::default()
+                },
+            );
+        }
     }
 
     mod containers {

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -175,6 +175,28 @@ return
         );
     }
 
+    mod strings {
+        use super::*;
+
+        #[test]
+        fn with_line_comment() {
+            check_format_output(
+                &["
+'foo'    # abc
+\"bar\"     # xyz
+r###'raw!'###
+'baz - { 1 +   #- hi -#     1:_^3.3}!'
+"],
+                "\
+'foo' # abc
+\"bar\" # xyz
+r###'raw!'###
+'baz - {1 + #- hi -# 1:_^3.3}!'
+",
+            );
+        }
+    }
+
     mod arithmetic {
         use super::*;
 

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -36,21 +36,24 @@ Output:
         }
     }
 
-    #[test]
-    fn comments_and_keywords() {
-        check_format_output(
-            &[
-                "
+    mod keywords {
+        use super::*;
+
+        #[test]
+        fn null_true_and_false() {
+            check_format_output(
+                &[
+                    "
 null# null
 true
 
 false",
-                "
+                    "
 null    # null
 true
 
 false",
-                "\
+                    "\
 null      # null
 true
 
@@ -63,75 +66,76 @@ false
 
 
 ",
-            ],
-            "\
+                ],
+                "\
 null # null
 true
 
 false
 ",
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn return_with_inline_comment() {
-        check_format_output(
-            &[
-                "\
+        #[test]
+        fn return_with_inline_comment() {
+            check_format_output(
+                &[
+                    "\
 return #- abc -#foo",
-                "\
+                    "\
 return  #- abc -#     foo",
-                "\
+                    "\
   return  #- abc -#   foo",
-                "
+                    "
 return  #- abc -#
   foo",
-            ],
-            "\
+                ],
+                "\
 return #- abc -# foo
 ",
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn return_with_line_comment() {
-        check_format_output(
-            &[
-                "\
+        #[test]
+        fn return_with_line_comment() {
+            check_format_output(
+                &[
+                    "\
 return      # abc
        foo",
-                "\
+                    "\
 return  # abc
   foo",
-            ],
-            "\
+                ],
+                "\
 return # abc
   foo
 ",
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn return_with_long_value() {
-        check_format_output_with_options(
-            &[
-                "\
+        #[test]
+        fn return_with_long_value() {
+            check_format_output_with_options(
+                &[
+                    "\
 return #- abc -# xxxxxxxxxxxxxxxxxxxx
 ",
-                "\
+                    "\
 return  #- abc -#    xxxxxxxxxxxxxxxxxxxx
 ",
-            ],
-            "\
+                ],
+                "\
 return
   #- abc -#
   xxxxxxxxxxxxxxxxxxxx
 ",
-            FormatOptions {
-                line_length: 20,
-                ..Default::default()
-            },
-        );
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
     }
 
     #[test]
@@ -168,108 +172,181 @@ return
         );
     }
 
-    #[test]
-    fn arithmetic_with_line_comment() {
-        check_format_output(
-            &[
-                "\
+    mod arithmetic {
+        use super::*;
+
+        #[test]
+        fn with_line_comment() {
+            check_format_output(
+                &[
+                    "\
 1   +  # abc
  2 * 3",
-                "\
+                    "\
 1 + # abc
     2
       * 3",
-            ],
-            "\
+                ],
+                "\
 1 + # abc
   2 * 3
 ",
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn arithmetic_with_inline_comment() {
-        check_format_output(
-            &[
-                "\
+        #[test]
+        fn with_inline_comment() {
+            check_format_output(
+                &[
+                    "\
 1   +  #- abc -#  x- -3*2   ",
-                "\
+                    "\
 1+#- abc -#x    - -3 *2",
-            ],
-            "\
+                ],
+                "\
 1 + #- abc -# x - -3 * 2
 ",
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn arithmetic_expression_longer_than_line_length() {
-        check_format_output_with_options(
-            &["\
+        #[test]
+        fn expression_longer_than_line_length() {
+            check_format_output_with_options(
+                &["\
 1 + 2 * 3 - 4 / 5 % 6 + #- xyz -# 7 ^ 8 - (9 + a)
 "],
-            "\
+                "\
 1
   + 2 * 3
   - 4 / 5 % 6
   + #- xyz -# 7 ^ 8
   - (9 + a)
 ",
-            FormatOptions {
-                line_length: 20,
-                ..Default::default()
-            },
-        );
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
     }
 
-    #[test]
-    fn tuple_and_list() {
-        check_format_output(
-            &[
+    mod containers {
+        use super::*;
+
+        #[test]
+        fn tuple_single_line() {
+            check_format_output(
+                &[
+                    "\
+(1  ,
+    #- foo -#    2,3,    4
+)
+",
+                    "\
+(1,#- foo -#2,3,4)
+",
+                ],
                 "\
-(1  ,   #- foo -#    2,3,    4)
+(1, #- foo -# 2, 3, 4)
+",
+            );
+        }
+
+        #[test]
+        fn list_single_line() {
+            check_format_output(
+                &[
+                    "\
 [  #- bar -#   a
     ,
         b
             , c
 ]
 ",
-                "\
-(1,#- foo -#2,3,4)
+                    "\
 [#- bar -#a,b,c]
 ",
-            ],
-            "\
-(1, #- foo -# 2, 3, 4)
+                ],
+                "\
 [#- bar -# a, b, c]
 ",
-        );
+            );
+        }
     }
 
-    #[test]
-    fn loop_block() {
-        check_format_output(
-            &[
-                "\
+    mod loops {
+        use super::*;
+
+        #[test]
+        fn loop_() {
+            check_format_output(
+                &[
+                    "\
 loop     # abc
     x =   1
     break  not    #- foo -#    true
     continue
 
 ",
-                "\
+                    "\
 loop# abc
  x =   1
  break not#- foo -#true
  continue
 ",
-            ],
-            "\
+                ],
+                "\
 loop # abc
   x = 1
   break not #- foo -# true
   continue
 ",
-        );
+            );
+        }
+
+        #[test]
+        fn while_() {
+            check_format_output(
+                &[
+                    "\
+while   x < 10     # abc
+    # xyz
+    x += 1
+
+",
+                    "\
+while   x  <     10# abc
+ # xyz
+ x += 1
+
+",
+                ],
+                "\
+while x < 10 # abc
+  # xyz
+  x += 1
+",
+            );
+        }
+
+        #[test]
+        fn for_single_arg() {
+            check_format_output(
+                &[
+                    "\
+for #- abc -#      x     in y      # xyz
+  x     +=   99
+",
+                    "\
+for     #- abc -#x in   y# xyz
+  x     +=   99
+",
+                ],
+                "\
+for #- abc -# x in y # xyz
+  x += 99
+",
+            );
+        }
     }
 }

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -1,0 +1,191 @@
+mod format {
+    use koto_format::{FormatOptions, format};
+    use std::iter::once;
+
+    fn check_format_output(inputs: &[&str], expected: &str) {
+        for input in inputs.iter().chain(once(&expected)) {
+            match format(input, FormatOptions::default()) {
+                Ok(output) => {
+                    if expected != output {
+                        panic!(
+                            "\
+Mismatch in format output.
+Input:
+---
+{input}
+---
+
+Expected:
+---
+{expected}
+---
+
+Output:
+---
+{output}
+---"
+                        )
+                    }
+                }
+                Err(error) => panic!("error while formatting: {error}\ninput:\n{input}"),
+            }
+        }
+    }
+
+    #[test]
+    fn comments_and_keywords() {
+        check_format_output(
+            &[
+                "
+null# null
+true
+
+false",
+                "
+null    # null
+true
+
+false",
+                "\
+null      # null
+true
+
+
+
+
+false
+
+
+
+
+",
+            ],
+            "\
+null # null
+true
+
+false
+",
+        );
+    }
+
+    #[test]
+    fn return_foo() {
+        check_format_output(
+            &[
+                "\
+return foo",
+                "\
+return   foo",
+                "\
+  return     foo",
+                "
+return
+  foo",
+            ],
+            "\
+return foo
+",
+        );
+    }
+
+    #[test]
+    fn nested() {
+        check_format_output(
+            &[
+                "(null)",
+                "(null )",
+                "( null)",
+                "
+(
+  null
+)",
+            ],
+            "\
+(null)
+",
+        );
+    }
+
+    #[test]
+    fn nested_with_comment() {
+        check_format_output(
+            &[
+                "( #- xyz -# null)",
+                "(
+                #- xyz -#
+                null
+                )",
+            ],
+            "\
+(#- xyz -# null)
+",
+        );
+    }
+
+    #[test]
+    fn binary_op_single_line() {
+        check_format_output(
+            &[
+                "\
+1   +  #- abc -#  x- -3*2   ",
+                "\
+1+#- abc -#x    - -3 *2",
+            ],
+            "\
+1 + #- abc -# x - -3 * 2
+",
+        );
+    }
+
+    #[test]
+    fn tuple_and_list() {
+        check_format_output(
+            &[
+                "\
+(1  ,   #- foo -#    2,3,    4)
+[  #- bar -#   a
+    ,
+        b
+            , c
+]
+",
+                "\
+(1,#- foo -#2,3,4)
+[#- bar -#a,b,c]
+",
+            ],
+            "\
+(1, #- foo -# 2, 3, 4)
+[#- bar -# a, b, c]
+",
+        );
+    }
+
+    #[test]
+    fn loop_block() {
+        check_format_output(
+            &[
+                "\
+loop     # abc
+    x =   1
+    break  not    #- foo -#    true
+    continue
+
+",
+                "\
+loop# abc
+ x =   1
+ break not#- foo -#true
+ continue
+",
+            ],
+            "\
+loop # abc
+  x = 1
+  break not #- foo -# true
+  continue
+",
+        );
+    }
+}

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -225,12 +225,12 @@ r###'raw!'###
             check_format_output(
                 &[
                     "\
-1   +  #- abc -#  x- -3*2   ",
+x   =   1   +  #- abc -#  x- -3*2   ",
                     "\
-1+#- abc -#x    - -3 *2",
+x =   1+#- abc -#x    - -3 *2",
                 ],
                 "\
-1 + #- abc -# x - -3 * 2
+x = 1 + #- abc -# x - -3 * 2
 ",
             );
         }
@@ -247,6 +247,25 @@ r###'raw!'###
   - 4 / 5 % 6
   + #- xyz -# 7 ^ 8
   - (9 + a)
+",
+                FormatOptions {
+                    line_length: 20,
+                    ..Default::default()
+                },
+            );
+        }
+
+        #[test]
+        fn multi_assignment() {
+            check_format_output_with_options(
+                &["\
+a,   b,   c =
+    11+11, 22   + 22,    33   + 33
+"],
+                "\
+a, b, c =
+  11 + 11, 22 + 22,
+  33 + 33
 ",
                 FormatOptions {
                     line_length: 20,

--- a/crates/lexer/src/lexer.rs
+++ b/crates/lexer/src/lexer.rs
@@ -142,6 +142,16 @@ pub enum StringQuote {
     Single,
 }
 
+impl StringQuote {
+    /// Returns a char representing the quote
+    pub fn as_char(&self) -> char {
+        match self {
+            Self::Double => '"',
+            Self::Single => '\'',
+        }
+    }
+}
+
 impl TryFrom<char> for StringQuote {
     type Error = ();
 

--- a/crates/lexer/src/span.rs
+++ b/crates/lexer/src/span.rs
@@ -1,5 +1,5 @@
 /// Represents a line/column position in a script
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Position {
     /// The position's line, counting from 0
     pub line: u32,
@@ -8,7 +8,7 @@ pub struct Position {
 }
 
 /// A span is a range in the source code, represented by a start and end position
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Span {
     /// The span's start position
     pub start: Position,

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -69,7 +69,7 @@ pub enum ExpectedIndentation {
     WhileBody,
 }
 
-/// A syntax error encountered by the [Parser]
+/// A syntax error encountered by the [Parser][crate::Parser]
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
 pub enum SyntaxError {
@@ -205,7 +205,7 @@ pub enum SyntaxError {
     UnterminatedString,
 }
 
-/// See [`ParserError`]
+/// See [`Error`][crate::Error]
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
 pub enum ErrorKind {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -14,7 +14,7 @@ mod string_slice;
 pub use crate::{
     ast::*,
     constant_pool::{Constant, ConstantIndex, ConstantPool},
-    error::{Error, Result, format_source_excerpt},
+    error::{Error, ErrorKind, ExpectedIndentation, Result, SyntaxError, format_source_excerpt},
     node::*,
     parser::Parser,
     string::KString,

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -388,6 +388,22 @@ pub enum AstUnaryOp {
     Not,
 }
 
+impl AstUnaryOp {
+    /// The binary op as a str
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AstUnaryOp::Negate => "-",
+            AstUnaryOp::Not => "not",
+        }
+    }
+}
+
+impl fmt::Display for AstUnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// An operation used in BinaryOp expressions
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(missing_docs)]
@@ -413,6 +429,41 @@ pub enum AstBinaryOp {
     And,
     Or,
     Pipe,
+}
+
+impl AstBinaryOp {
+    /// The binary op as a str
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AstBinaryOp::Add => "+",
+            AstBinaryOp::Subtract => "-",
+            AstBinaryOp::Multiply => "*",
+            AstBinaryOp::Divide => "/",
+            AstBinaryOp::Remainder => "%",
+            AstBinaryOp::Power => "^",
+            AstBinaryOp::AddAssign => "+=",
+            AstBinaryOp::SubtractAssign => "-=",
+            AstBinaryOp::MultiplyAssign => "*=",
+            AstBinaryOp::DivideAssign => "/=",
+            AstBinaryOp::RemainderAssign => "%=",
+            AstBinaryOp::PowerAssign => "^=",
+            AstBinaryOp::Equal => "==",
+            AstBinaryOp::NotEqual => "!=",
+            AstBinaryOp::Less => "<",
+            AstBinaryOp::LessOrEqual => "<=",
+            AstBinaryOp::Greater => ">",
+            AstBinaryOp::GreaterOrEqual => ">=",
+            AstBinaryOp::And => "and",
+            AstBinaryOp::Or => "or",
+            AstBinaryOp::Pipe => "->",
+        }
+    }
+}
+
+impl fmt::Display for AstBinaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// A try expression definition
@@ -618,6 +669,57 @@ pub enum MetaKeyId {
     Invalid,
 }
 
+impl MetaKeyId {
+    /// Returns the key id as a static str
+    pub fn as_str(&self) -> &'static str {
+        use MetaKeyId::*;
+        match self {
+            Add => "@+",
+            Subtract => "@-",
+            Multiply => "@*",
+            Divide => "@/",
+            Remainder => "@%",
+            Power => "@^",
+            AddRhs => "@r+",
+            SubtractRhs => "@r-",
+            MultiplyRhs => "@r*",
+            DivideRhs => "@r/",
+            RemainderRhs => "@r%",
+            PowerRhs => "@r^",
+            AddAssign => "@+=",
+            SubtractAssign => "@-=",
+            MultiplyAssign => "@*=",
+            DivideAssign => "@/=",
+            RemainderAssign => "@%=",
+            PowerAssign => "@^=",
+            Less => "@<",
+            LessOrEqual => "@<=",
+            Greater => "@>",
+            GreaterOrEqual => "@>=",
+            Equal => "@==",
+            NotEqual => "@!=",
+            Index => "@index",
+            IndexMut => "@index_mut",
+            Debug => "@debug",
+            Display => "@display",
+            Iterator => "@iterator",
+            Next => "@next",
+            NextBack => "@next_back",
+            Negate => "@negate",
+            Size => "@size",
+            Type => "@type",
+            Base => "@base",
+            Call => "@call",
+            Test => "@test",
+            PreTest => "@pre_test",
+            PostTest => "@post_test",
+            Main => "@main",
+            Named => "@meta",
+            Invalid => unreachable!(),
+        }
+    }
+}
+
 impl TryFrom<u8> for MetaKeyId {
     type Error = u8;
 
@@ -634,56 +736,7 @@ impl TryFrom<u8> for MetaKeyId {
 // Display impl used by koto-ls
 impl fmt::Display for MetaKeyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use MetaKeyId::*;
-
-        write!(
-            f,
-            "@{}",
-            match self {
-                Add => "+",
-                Subtract => "-",
-                Multiply => "*",
-                Divide => "/",
-                Remainder => "%",
-                Power => "^",
-                AddRhs => "r+",
-                SubtractRhs => "r-",
-                MultiplyRhs => "r*",
-                DivideRhs => "r/",
-                RemainderRhs => "r%",
-                PowerRhs => "r^",
-                AddAssign => "+=",
-                SubtractAssign => "-=",
-                MultiplyAssign => "*=",
-                DivideAssign => "/=",
-                RemainderAssign => "%=",
-                PowerAssign => "^=",
-                Less => "<",
-                LessOrEqual => "<=",
-                Greater => ">",
-                GreaterOrEqual => ">=",
-                Equal => "==",
-                NotEqual => "!=",
-                Index => "index",
-                IndexMut => "index_mut",
-                Debug => "debug",
-                Display => "display",
-                Iterator => "iterator",
-                Next => "next",
-                NextBack => "next_back",
-                Negate => "negate",
-                Size => "size",
-                Type => "type",
-                Base => "base",
-                Call => "call",
-                Test => "test",
-                PreTest => "pre_test",
-                PostTest => "post_test",
-                Main => "main",
-                Named => "meta",
-                Invalid => unreachable!(),
-            }
-        )
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -209,7 +209,8 @@ pub enum Node {
     /// Used as a placeholder for unused function arguments or unpacked values, or as a wildcard
     /// in match expressions.
     ///
-    /// Comes with an optional name, e.g. `_foo` will have `foo` stored as a constant.
+    /// Comes with an optional name (e.g. `_foo` will have `foo` stored as a constant),
+    /// and an optional type hint.
     Wildcard(Option<ConstantIndex>, Option<AstIndex>),
 
     /// Used when capturing variadic arguments, and when unpacking list or tuple arguments.

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -105,15 +105,19 @@ pub enum Node {
 
     /// A map literal, containing a series of key/value entries
     Map {
-        /// The map's entries as key/value pairs.
+        /// The map's entries.
         ///
-        /// Keys will either be Id, String, or Meta nodes.
-        ///
-        /// If the map has braces, then values are optional.
-        entries: AstVec<(AstIndex, Option<AstIndex>)>,
+        /// If the map has braces, then values are optional and the valueless keys will point
+        /// directly to an Id instead of a MapEntry.
+        entries: AstVec<AstIndex>,
         /// Whether or not the map was defined using braces.
         braces: bool,
     },
+
+    /// A key/value pair representing a Map entry.
+    ///
+    /// Keys will either be Id, String, or Meta nodes.
+    MapEntry(AstIndex, AstIndex),
 
     /// The `self` keyword
     Self_,

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -103,12 +103,17 @@ pub enum Node {
     /// Used when indexing a list or tuple, and the full contents are to be returned.
     RangeFull,
 
-    /// A map literal, with a series of keys and values
-    ///
-    /// Keys will either be Id, String, or Meta nodes.
-    ///
-    /// Values are optional for inline maps.
-    Map(AstVec<(AstIndex, Option<AstIndex>)>),
+    /// A map literal, containing a series of key/value entries
+    Map {
+        /// The map's entries as key/value pairs.
+        ///
+        /// Keys will either be Id, String, or Meta nodes.
+        ///
+        /// If the map has braces, then values are optional.
+        entries: AstVec<(AstIndex, Option<AstIndex>)>,
+        /// Whether or not the map was defined using braces.
+        braces: bool,
+    },
 
     /// The `self` keyword
     Self_,

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -65,9 +65,10 @@ pub enum Node {
 
     /// A temporary tuple
     ///
-    /// Used in contexts where the result won't be exposed directly to the use, e.g.
-    /// `x, y = 1, 2` - here `x` and `y` are indexed from the temporary tuple.
-    /// `match foo, bar...` - foo and bar will be stored in a temporary tuple for comparison.
+    /// Used in contexts where the result won't be exposed directly to the user,
+    /// e.g.
+    /// - `x, y = 1, 2`: x and y are indexed from the temporary tuple.
+    /// - `match foo, bar...`: foo and bar will be stored in a temporary tuple for comparison.
     TempTuple(AstVec<AstIndex>),
 
     /// A range with a defined start and end

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -2817,7 +2817,7 @@ impl<'source> Parser<'source> {
         };
 
         let start_span = self.current_span();
-        let from_context = ExpressionContext::restricted();
+        let from_context = ExpressionContext::permissive();
 
         let from = if importing_from {
             // Parse the from module path: a nested path is allowed, but only a single path

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1907,8 +1907,6 @@ impl<'source> Parser<'source> {
     }
 
     fn consume_number(&mut self, negate: bool, context: &ExpressionContext) -> Result<AstIndex> {
-        use Node::*;
-
         self.consume_token_with_context(context); // Token::Number
 
         let slice = self.current_token.slice(self.source);
@@ -1933,11 +1931,11 @@ impl<'source> Parser<'source> {
             // Should we store the number as a SmallInt or as a stored constant?
             if u8::try_from(n).is_ok() {
                 let n = if negate { -n } else { n };
-                SmallInt(n as i16)
+                Node::SmallInt(n as i16)
             } else {
                 let n = if negate { -n } else { n };
                 if let Ok(constant_index) = self.constants.add_i64(n) {
-                    Int(constant_index)
+                    Node::Int(constant_index)
                 } else {
                     return self.error(InternalError::ConstantPoolCapacityOverflow);
                 }
@@ -1945,7 +1943,7 @@ impl<'source> Parser<'source> {
         } else if let Ok(n) = f64::from_str(&slice) {
             let n = if negate { -n } else { n };
             if let Ok(constant_index) = self.constants.add_f64(n) {
-                Float(constant_index)
+                Node::Float(constant_index)
             } else {
                 return self.error(InternalError::ConstantPoolCapacityOverflow);
             }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -2094,7 +2094,13 @@ impl<'source> Parser<'source> {
             entries.push((key, Some(self.consume_map_block_value()?)));
         }
 
-        self.push_node_with_start_span(Node::Map(entries), start_span)
+        self.push_node_with_start_span(
+            Node::Map {
+                entries,
+                braces: false,
+            },
+            start_span,
+        )
     }
 
     fn consume_map_block_value(&mut self) -> Result<AstIndex> {
@@ -2120,7 +2126,13 @@ impl<'source> Parser<'source> {
             &ExpressionContext::inside_braces(),
         )?;
 
-        let map_node = self.push_node_with_start_span(Node::Map(entries), start_span)?;
+        let map_node = self.push_node_with_start_span(
+            Node::Map {
+                entries,
+                braces: true,
+            },
+            start_span,
+        )?;
         self.check_for_chain_after_node(
             map_node,
             &context.with_expected_indentation(Indentation::GreaterThan(start_indent)),

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -119,26 +119,22 @@ mod parser {
         }
     }
 
-    fn map_with_braces(entries: &[(u32, Option<u32>)]) -> Node {
-        let entries = entries
-            .iter()
-            .map(|(key, maybe_value)| (AstIndex::from(*key), maybe_value.map(AstIndex::from)))
-            .collect();
+    fn map_with_braces(entries: &[u32]) -> Node {
         Node::Map {
-            entries,
+            entries: nodes(entries),
             braces: true,
         }
     }
 
-    fn map_block(entries: &[(u32, u32)]) -> Node {
-        let entries = entries
-            .iter()
-            .map(|(key, value)| (AstIndex::from(*key), Some(AstIndex::from(*value))))
-            .collect();
+    fn map_block(entries: &[u32]) -> Node {
         Node::Map {
-            entries,
+            entries: nodes(entries),
             braces: false,
         }
+    }
+
+    fn map_entry(key: u32, value: u32) -> Node {
+        Node::MapEntry(key.into(), value.into())
     }
 
     fn range(start: u32, end: u32, inclusive: bool) -> Node {
@@ -661,15 +657,18 @@ x =
                     id(0),                                  // x
                     string_literal(1, StringQuote::Single), // 'foo'
                     SmallInt(42),
-                    id(2),                                  // bar
-                    id(3),                                  // 5 - baz
+                    map_entry(2, 3),
+                    id(2),                                  // 5 - bar
+                    id(3),                                  // baz
                     string_literal(4, StringQuote::Single), // 'hello'
+                    map_entry(6, 7),
                     Meta(MetaKeyId::Add, None),
-                    SmallInt(99),
-                    map_with_braces(&[(2, Some(3)), (4, None), (5, Some(6)), (7, Some(8))]),
-                    assign(1, 9), // 10
+                    SmallInt(99), // 10
+                    map_entry(9, 10),
+                    map_with_braces(&[4, 5, 8, 11]),
+                    assign(1, 12),
                     MainBlock {
-                        body: nodes(&[0, 10]),
+                        body: nodes(&[0, 13]),
                         local_count: 1,
                     },
                 ],
@@ -679,55 +678,6 @@ x =
                     Constant::Str("bar"),
                     Constant::Str("baz"),
                     Constant::Str("hello"),
-                ]),
-            )
-        }
-
-        #[test]
-        fn map_block_syntax() {
-            let sources = [
-                r#"
-x =
-  foo: 42
-  "baz":
-    foo: 0
-  @-: -1
-x
-"#,
-                r#"
-x   =
-    foo: 42
-    "baz" :
-          foo   : 0
-    @-  : -1
-x
-"#,
-            ];
-
-            check_ast_for_equivalent_sources(
-                &sources,
-                &[
-                    id(0), // x
-                    id(1), // foo
-                    SmallInt(42),
-                    string_literal(2, StringQuote::Double), // baz
-                    id(1),                                  // foo
-                    SmallInt(0),                            // 5
-                    map_block(&[(4, 5)]),
-                    Meta(MetaKeyId::Subtract, None),
-                    SmallInt(-1),
-                    map_block(&[(1, 2), (3, 6), (7, 8)]),
-                    assign(0, 9), //10
-                    id(0),
-                    MainBlock {
-                        body: nodes(&[10, 11]),
-                        local_count: 1,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("x"),
-                    Constant::Str("foo"),
-                    Constant::Str("baz"),
                 ]),
             )
         }
@@ -744,10 +694,11 @@ x =
                     id(0), // x
                     string_literal(1, StringQuote::Double),
                     SmallInt(42),
-                    map_block(&[(1, 2)]),
-                    assign(0, 3),
+                    map_entry(1, 2),
+                    map_block(&[3]),
+                    assign(0, 4), // 5
                     MainBlock {
-                        body: nodes(&[4]),
+                        body: nodes(&[5]),
                         local_count: 1,
                     },
                 ],
@@ -769,11 +720,13 @@ x =
                     id(1), // foo
                     id(2), // bar
                     SmallInt(42),
-                    map_block(&[(2, 3)]),
-                    map_block(&[(1, 4)]), // 5
-                    assign(0, 5),
+                    map_entry(2, 3),
+                    map_block(&[4]), // 5
+                    map_entry(1, 5),
+                    map_block(&[6]),
+                    assign(0, 7),
                     MainBlock {
-                        body: nodes(&[6]),
+                        body: nodes(&[8]),
                         local_count: 1,
                     },
                 ],
@@ -812,11 +765,12 @@ x =
                     SmallInt(10),
                     SmallInt(20),
                     SmallInt(30),
-                    Tuple(nodes(&[2, 3, 4])), //5
-                    map_block(&[(1, 5)]),
-                    assign(0, 6),
+                    Tuple(nodes(&[2, 3, 4])), // 5
+                    map_entry(1, 5),
+                    map_block(&[6]),
+                    assign(0, 7),
                     MainBlock {
-                        body: nodes(&[7]),
+                        body: nodes(&[8]),
                         local_count: 1,
                     },
                 ],
@@ -851,15 +805,17 @@ x =
                     id(0), // x
                     id(1), // foo
                     SmallInt(1),
-                    id(2),        // bar
-                    id(3),        // baz
-                    SmallInt(42), // 5
-                    chain_call(&[5], false, None),
-                    chain_root(4, Some(6)),
-                    map_block(&[(1, 2), (3, 7)]),
-                    assign(0, 8),
+                    map_entry(1, 2),
+                    id(2), // bar
+                    id(3), // 5 - baz
+                    SmallInt(42),
+                    chain_call(&[6], false, None),
+                    chain_root(5, Some(7)),
+                    map_entry(4, 8),
+                    map_block(&[3, 9]), // 10
+                    assign(0, 10),
                     MainBlock {
-                        body: nodes(&[9]),
+                        body: nodes(&[11]),
                         local_count: 1,
                     },
                 ],
@@ -886,14 +842,17 @@ x =
                     id(0), // x
                     Meta(MetaKeyId::Add, None),
                     SmallInt(0),
+                    map_entry(1, 2),
                     Meta(MetaKeyId::Subtract, None),
-                    SmallInt(1),
-                    Meta(MetaKeyId::Named, Some(1.into())), // 5
+                    SmallInt(1), // 5
+                    map_entry(4, 5),
+                    Meta(MetaKeyId::Named, Some(1.into())),
                     SmallInt(0),
-                    map_block(&[(1, 2), (3, 4), (5, 6)]),
-                    assign(0, 7),
+                    map_entry(7, 8),
+                    map_block(&[3, 6, 9]),
+                    assign(0, 10),
                     MainBlock {
-                        body: nodes(&[8]),
+                        body: nodes(&[11]),
                         local_count: 1,
                     },
                 ],
@@ -1742,12 +1701,14 @@ export
                 &[
                     id(0), // a
                     SmallInt(123),
+                    map_entry(0, 1),
                     id(1), // b
                     SmallInt(99),
-                    map_block(&[(0, 1), (2, 3)]),
-                    Export(4.into()), //  5
+                    map_entry(3, 4), // 5
+                    map_block(&[2, 5]),
+                    Export(6.into()),
                     MainBlock {
-                        body: nodes(&[5]),
+                        body: nodes(&[7]),
                         local_count: 2,
                     },
                 ],
@@ -3161,167 +3122,43 @@ foo.bar x
         }
 
         #[test]
-        fn instance_function() {
-            let source = "{foo: 42, bar: |x| self.foo = x}";
-            check_ast(
-                source,
-                &[
-                    id(0), // foo
-                    SmallInt(42),
-                    id(1),             // bar
-                    id(2),             // x
-                    Self_,             // self
-                    chain_id(0, None), // 5
-                    chain_root(4, Some(5)),
-                    id(2),
-                    assign(6, 7),
-                    Function(koto_parser::Function {
-                        args: nodes(&[3]),
-                        local_count: 1,
-                        accessed_non_locals: constants(&[]),
-                        body: 8.into(),
-                        is_variadic: false,
-                        is_generator: false,
-                        output_type: None,
-                    }),
-                    map_with_braces(&[(0, Some(1)), (2, Some(9))]), // 10
-                    MainBlock {
-                        body: nodes(&[10]),
-                        local_count: 0,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("foo"),
-                    Constant::Str("bar"),
-                    Constant::Str("x"),
-                ]),
-            )
-        }
-
-        #[test]
-        fn function_map_block() {
-            let source = "
-f = ||
-  foo: x
-  bar: 0
-";
-            check_ast(
-                source,
-                &[
-                    id(0), // f
-                    id(1), // foo
-                    id(2), // x
-                    id(3), // bar
-                    SmallInt(0),
-                    map_block(&[(1, 2), (3, 4)]), // 5
-                    Function(koto_parser::Function {
-                        args: nodes(&[]),
-                        local_count: 0,
-                        accessed_non_locals: constants(&[2]),
-                        body: 5.into(),
-                        is_variadic: false,
-                        is_generator: false,
-                        output_type: None,
-                    }),
-                    assign(0, 6),
-                    MainBlock {
-                        body: nodes(&[7]),
-                        local_count: 1,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("f"),
-                    Constant::Str("foo"),
-                    Constant::Str("x"),
-                    Constant::Str("bar"),
-                ]),
-            )
-        }
-
-        #[test]
-        fn function_map_block_with_nested_map_as_first_entry() {
-            let source = "
-f = ||
-  foo:
-    bar: x
-  baz: 0
-";
-            check_ast(
-                source,
-                &[
-                    id(0), // f
-                    id(1), // foo
-                    id(2), // bar
-                    id(3), // x
-                    map_block(&[(2, 3)]),
-                    id(4), // 5 - baz
-                    SmallInt(0),
-                    map_block(&[(1, 4), (5, 6)]),
-                    Function(koto_parser::Function {
-                        args: nodes(&[]),
-                        local_count: 0,
-                        accessed_non_locals: constants(&[3]),
-                        body: 7.into(),
-                        is_variadic: false,
-                        is_generator: false,
-                        output_type: None,
-                    }),
-                    assign(0, 8),
-                    MainBlock {
-                        body: nodes(&[9]),
-                        local_count: 1,
-                    },
-                ],
-                Some(&[
-                    Constant::Str("f"),
-                    Constant::Str("foo"),
-                    Constant::Str("bar"),
-                    Constant::Str("x"),
-                    Constant::Str("baz"),
-                ]),
-            )
-        }
-
-        #[test]
         fn instance_function_block() {
             let source = "
 f = ||
-  foo: 42
   bar: |x| self.foo = x
 f()";
             check_ast(
                 source,
                 &[
                     id(0), // f
-                    id(1), // foo
-                    SmallInt(42),
-                    id(2),             // bar
-                    id(3),             // x
-                    Self_,             // 5
-                    chain_id(1, None), // foo
-                    chain_root(5, Some(6)),
-                    id(3), // x
-                    assign(7, 8),
+                    id(1), // bar
+                    id(2), // x
+                    Self_,
+                    chain_id(3, None),      // foo
+                    chain_root(3, Some(4)), // 5
+                    id(2),                  // x
+                    assign(5, 6),
                     Function(koto_parser::Function {
-                        args: nodes(&[4]),
+                        args: nodes(&[2]),
                         local_count: 1,
                         accessed_non_locals: constants(&[]),
-                        body: 9.into(),
-                        is_variadic: false,
-                        is_generator: false,
-                        output_type: None,
-                    }), // 10
-                    map_block(&[(1, 2), (3, 10)]),
-                    Function(koto_parser::Function {
-                        args: nodes(&[]),
-                        local_count: 0,
-                        accessed_non_locals: constants(&[]),
-                        body: 11.into(),
+                        body: 7.into(),
                         is_variadic: false,
                         is_generator: false,
                         output_type: None,
                     }),
-                    assign(0, 12),
+                    map_entry(1, 8),
+                    map_block(&[9]), // 10
+                    Function(koto_parser::Function {
+                        args: nodes(&[]),
+                        local_count: 0,
+                        accessed_non_locals: constants(&[]),
+                        body: 10.into(),
+                        is_variadic: false,
+                        is_generator: false,
+                        output_type: None,
+                    }),
+                    assign(0, 11),
                     id(0), // f
                     Chain((
                         ChainNode::Call {
@@ -3329,18 +3166,18 @@ f()";
                             with_parens: true,
                         },
                         None,
-                    )), // 15
-                    chain_root(14, Some(15)),
+                    )),
+                    chain_root(13, Some(14)), // 15
                     MainBlock {
-                        body: nodes(&[13, 16]),
+                        body: nodes(&[12, 15]),
                         local_count: 1,
                     },
                 ],
                 Some(&[
                     Constant::Str("f"),
-                    Constant::Str("foo"),
                     Constant::Str("bar"),
                     Constant::Str("x"),
+                    Constant::Str("foo"),
                 ]),
             )
         }
@@ -3622,19 +3459,20 @@ z = y [0..20], |x| x > 1
                 &[
                     id(0),
                     SmallInt(42),
-                    map_block(&[(0, 1)]),
-                    Yield(2.into()),
+                    map_entry(0, 1),
+                    map_block(&[2]),
+                    Yield(3.into()),
                     Function(koto_parser::Function {
                         args: nodes(&[]),
                         local_count: 0,
                         accessed_non_locals: constants(&[]),
-                        body: 3.into(),
+                        body: 4.into(),
                         is_variadic: false,
                         is_generator: true,
                         output_type: None,
-                    }),
+                    }), // 5
                     MainBlock {
-                        body: nodes(&[4]),
+                        body: nodes(&[5]),
                         local_count: 0,
                     },
                 ],
@@ -3978,18 +3816,19 @@ x.takes_a_map
                     id(0), // x
                     id(2), // foo
                     SmallInt(42),
-                    map_block(&[(1, 2)]),
+                    map_entry(1, 2),
+                    map_block(&[3]),
                     Chain((
                         ChainNode::Call {
-                            args: nodes(&[3]),
+                            args: nodes(&[4]),
                             with_parens: false,
                         },
                         None,
-                    )),
-                    chain_id(1, Some(4)), // 5 - takes_a_map
-                    chain_root(0, Some(5)),
+                    )), // 5
+                    chain_id(1, Some(5)), // takes_a_map
+                    chain_root(0, Some(6)),
                     MainBlock {
-                        body: nodes(&[6]),
+                        body: nodes(&[7]),
                         local_count: 0,
                     },
                 ],
@@ -4287,7 +4126,7 @@ x = { y
                     id(0),
                     id(1),
                     id(2),
-                    map_with_braces(&[(1, None), (2, None)]),
+                    map_with_braces(&[1, 2]),
                     Chain((
                         ChainNode::Call {
                             args: nodes(&[]),
@@ -5129,14 +4968,16 @@ throw
             check_ast(
                 source,
                 &[
-                    id(0),                                  // data
-                    id(1),                                  // x
+                    id(0), // data
+                    id(1), // x
+                    map_entry(0, 1),
                     id(2),                                  // message
                     string_literal(3, StringQuote::Double), // error!
-                    map_block(&[(0, 1), (2, 3)]),
-                    Throw(4.into()), // 5
+                    map_entry(3, 4),                        // 5
+                    map_block(&[2, 5]),
+                    Throw(6.into()),
                     MainBlock {
-                        body: nodes(&[5]),
+                        body: nodes(&[7]),
                         local_count: 0,
                     },
                 ],


### PR DESCRIPTION
This PR introduces the initial version of the `koto_format` crate.

See #454, resolves #456.
