### PR TITLE
Add format options to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ The Koto project adheres to
 
 #### CLI
 
+- The CLI now has a `--format` argument that formats Koto scripts.
+  - If a script path is provided then the file will be formatted in place,
+    otherwise the script will be read from `stdin` and the formatted version
+    will be written to `stdout`.
 - The REPL now supports tab completion for variables and help searches.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,6 @@ dependencies = [
  "koto_json",
  "koto_random",
  "koto_regex",
- "koto_serde",
  "koto_tempfile",
  "koto_toml",
  "koto_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "derive-name",
  "koto_lexer",
  "koto_parser",
+ "serde",
  "thiserror",
  "unicode-width",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,8 +16,8 @@ default = ["rc"]
 
 # Only one memory management strategy can be enabled at a time.
 # To use `arc`, default features must be disabled.
-arc = ["koto/arc"]
-rc = ["koto/rc"]
+arc = ["koto/arc", "koto/serde"]
+rc = ["koto/rc", "koto/serde"]
 
 [[bin]]
 name = "koto"
@@ -26,7 +26,6 @@ path = "src/main.rs"
 [dependencies]
 koto = { path = "../koto", version = "^0.16.0", default-features = false }
 koto_format = { path = "../format", version = "^0.16.0", default-features = false }
-koto_serde = { path = "..//serde", version = "^0.16.0", default-features = false }
 
 koto_color = { path = "../../libs/color", version = "^0.16.0", default-features = false }
 koto_geometry = { path = "../../libs/geometry", version = "^0.16.0", default-features = false }

--- a/crates/cli/docs/cli.md
+++ b/crates/cli/docs/cli.md
@@ -104,6 +104,37 @@ Welcome to Koto
   ...
 ```
 
+## Formatting
+
+The `koto` CLI can format scripts with the `--format` flag.
+If a script path is provided then the file will be formatted in place,
+otherwise the script will be read from `stdin` and written to `stdout`.
+
+## Configuration
+
+Options for formatting and the REPL can be chosen by exporting them from a `config.koto` file, which is expected to be placed in `~/.koto/config.koto`.
+
+The default configuration can be displayed with the `--print_config` flag.
+
+### Format Options
+
+- `always_indent_arms`: Whether or not `match` and `switch` arms should always be indented. (default: `false`)
+- `chain_break_threshold`: The threshold that causes chain expressions to be broken onto multiple lines. (default: `3`)
+  - The threshold counts against the number of `.` accesses that are followed by a call or index.
+    - `a.b.c().d()` - 2 `.` accesses that count against the threshold.
+    - `a[0].b[1].c().d` - 3 `.` accesses that count against the threshold.
+  - A value of `0` disables the threshold.
+- `indent_width`: The width in characters to use when inserting indents. (default: `2`)
+- `line_length`: The maximum line length. (default: `100`)
+
+### REPL Options
+
+- `edit_mode`: The editing keybindings that should be enabled in the REPL. (`emacs` or `vim`, default: `emacs`)
+- `colored_output`: Whether or not the REPL should use colored output. (default: `true`)
+- `max_history`: The maximum number of entries to keep in its persistent history (default: `100`)
+  - The history is stored in `~/.koto/repl_history.txt`
+
+
 [cli]: https://en.wikipedia.org/wiki/Command-line_interface
 [core]: ./core_lib/
 [os-args]: ./core_lib/os.md#args

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -34,7 +34,7 @@ ARGS:
     <args>...    Arguments to pass into the script
 
 REPL CONFIGURATION:
-    Koto will read configuration settings from $HOME/.koto/repl_config.koto,
+    Koto will read configuration settings from $HOME/.koto/config.koto,
     or from a file provided with the --config flag.
 
     The default configuration settings are:
@@ -222,6 +222,7 @@ fn main() -> Result<()> {
                 show_bytecode: args.show_bytecode,
                 colored_output: config.colored_output,
                 edit_mode: config.edit_mode,
+                max_history_size: config.max_history,
             },
             koto_settings,
         )?

--- a/crates/cli/src/render_export_map.koto
+++ b/crates/cli/src/render_export_map.koto
@@ -1,0 +1,16 @@
+# Given a map as the first argument, prints a Koto script that exports the map
+
+indent = '  '
+
+render_map = |map_to_render: Map, map_indent: String = indent| -> String
+  '\n' + map_to_render
+    .each |(key, value)|
+      rendered_value = match value
+        _: Map then render_map value, map_indent + indent
+        else '{value}'
+      '{map_indent}{key}: {rendered_value}'
+    .intersperse '\n'
+    .to_string()
+
+export render_export_map = |map|
+  'export{render_map map}'

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use crossterm::{execute, style, tty::IsTty};
 use koto::prelude::*;
 use rustyline::{CompletionType, Config, Editor, error::ReadlineError, history::DefaultHistory};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     help::{HELP_INDENT, Help},
@@ -48,7 +48,7 @@ pub struct ReplSettings {
     pub max_history_size: usize,
 }
 
-#[derive(Deserialize, Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EditMode {
     #[default]

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -8,9 +8,8 @@ use std::{
 use anyhow::Result;
 use crossterm::{execute, style, tty::IsTty};
 use koto::prelude::*;
-use rustyline::{
-    CompletionType, Config, EditMode, Editor, error::ReadlineError, history::DefaultHistory,
-};
+use rustyline::{CompletionType, Config, Editor, error::ReadlineError, history::DefaultHistory};
+use serde::Deserialize;
 
 use crate::{
     help::{HELP_INDENT, Help},
@@ -47,6 +46,23 @@ pub struct ReplSettings {
     pub colored_output: bool,
     pub edit_mode: EditMode,
     pub max_history_size: usize,
+}
+
+#[derive(Deserialize, Copy, Clone, Debug, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EditMode {
+    #[default]
+    Emacs,
+    Vi,
+}
+
+impl From<EditMode> for rustyline::EditMode {
+    fn from(mode: EditMode) -> Self {
+        match mode {
+            EditMode::Emacs => rustyline::EditMode::Emacs,
+            EditMode::Vi => rustyline::EditMode::Vi,
+        }
+    }
 }
 
 type ReplEditor = Editor<ReplHelper, DefaultHistory>;
@@ -92,7 +108,7 @@ impl Repl {
         let mut editor = ReplEditor::with_config(
             Config::builder()
                 .max_history_size(settings.max_history_size)?
-                .edit_mode(settings.edit_mode)
+                .edit_mode(settings.edit_mode.into())
                 .completion_type(CompletionType::List)
                 .build(),
         )?;

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -40,13 +40,13 @@ const RESULT_PROMPT: &str = "➝ ";
 const INDENT_SIZE: usize = 2;
 const HISTORY_DIR: &str = ".koto";
 const HISTORY_FILE: &str = "repl_history.txt";
-const MAX_HISTORY_ENTRIES: usize = 500;
 
 pub struct ReplSettings {
     pub show_bytecode: bool,
     pub show_instructions: bool,
     pub colored_output: bool,
     pub edit_mode: EditMode,
+    pub max_history_size: usize,
 }
 
 type ReplEditor = Editor<ReplHelper, DefaultHistory>;
@@ -85,14 +85,14 @@ fn help() -> Rc<Help> {
 }
 
 impl Repl {
-    pub fn with_settings(repl_settings: ReplSettings, koto_settings: KotoSettings) -> Result<Self> {
+    pub fn with_settings(settings: ReplSettings, koto_settings: KotoSettings) -> Result<Self> {
         let koto = Koto::with_settings(koto_settings);
         super::add_modules(&koto);
 
         let mut editor = ReplEditor::with_config(
             Config::builder()
-                .max_history_size(MAX_HISTORY_ENTRIES)?
-                .edit_mode(repl_settings.edit_mode)
+                .max_history_size(settings.max_history_size)?
+                .edit_mode(settings.edit_mode)
                 .completion_type(CompletionType::List)
                 .build(),
         )?;
@@ -106,11 +106,11 @@ impl Repl {
         }
 
         let stdout = io::stdout();
-        let colored_output = repl_settings.colored_output && stdout.is_tty();
+        let colored_output = settings.colored_output && stdout.is_tty();
 
         Ok(Self {
             koto,
-            settings: repl_settings,
+            settings,
             editor,
             stdout,
             continued_lines: Vec::new(),

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -23,5 +23,6 @@ koto_lexer = { path = "../lexer", version = "^0.16.0" }
 koto_parser = { path = "../parser", version = "^0.16.0", default-features = false }
 
 derive-name = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 unicode-width = { workspace = true }

--- a/crates/format/src/format.rs
+++ b/crates/format/src/format.rs
@@ -499,7 +499,7 @@ fn format_node<'source>(
                             nested = nested.space_or_indent_if_necessary().str("then");
                         }
 
-                        if ctx.options.match_and_switch_always_indent_arm_bodies {
+                        if ctx.options.always_indent_arms {
                             nested = nested.indented_break();
                         } else {
                             nested = nested.space_or_indent();
@@ -525,7 +525,7 @@ fn format_node<'source>(
                         nested.str("else")
                     };
 
-                    if ctx.options.match_and_switch_always_indent_arm_bodies {
+                    if ctx.options.always_indent_arms {
                         nested = nested.indented_break();
                     } else {
                         nested = nested.space_or_indent();

--- a/crates/format/src/options.rs
+++ b/crates/format/src/options.rs
@@ -1,5 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 /// Formatting options provided to [`format`]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct FormatOptions {
     /// The width in characters to use when inserting indents. (default: 2)
     pub indent_width: u8,

--- a/crates/format/src/options.rs
+++ b/crates/format/src/options.rs
@@ -4,19 +4,18 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct FormatOptions {
+    ///Whether or not `match` and `switch` arms should always be indented. (default: `false`)
+    pub always_indent_arms: bool,
     /// The width in characters to use when inserting indents. (default: 2)
     pub indent_width: u8,
     /// The maximum line length. (default: 100)
     pub line_length: u8,
-    /// Whether or not indented linebreaks will always be inserted after `then` and `else` in
-    /// `match` and `switch` arms. (default: false)
-    pub match_and_switch_always_indent_arm_bodies: bool,
     /// The threshold that causes chain expressions to be broken onto multiple lines. (default: 3)
     ///
     /// The threshold counts against the number of `.` accesses that are followed by a call or index.
     ///
     /// `a.b.c().d()` - 2 `.` accesses that count against the threshold.
-    /// `a[0].b[1].c().d - 3 `.` accesses that count against the threshold`.
+    /// `a[0].b[1].c().d` - 3 `.` accesses that count against the threshold.
     ///
     /// A value of `0` disables the threshold.
     pub chain_break_threshold: u8,
@@ -25,10 +24,10 @@ pub struct FormatOptions {
 impl Default for FormatOptions {
     fn default() -> Self {
         Self {
+            always_indent_arms: false,
+            chain_break_threshold: 3,
             indent_width: 2,
             line_length: 100,
-            match_and_switch_always_indent_arm_bodies: false,
-            chain_break_threshold: 3,
         }
     }
 }

--- a/crates/format/tests/format_tests.rs
+++ b/crates/format/tests/format_tests.rs
@@ -700,7 +700,7 @@ switch
     42 # xyz
 ",
                 FormatOptions {
-                    match_and_switch_always_indent_arm_bodies: true,
+                    always_indent_arms: true,
                     ..Default::default()
                 },
             );
@@ -759,7 +759,7 @@ match foo() # abc
     0
 ",
                 FormatOptions {
-                    match_and_switch_always_indent_arm_bodies: true,
+                    always_indent_arms: true,
                     ..Default::default()
                 },
             );
@@ -792,7 +792,7 @@ finally
   print 'bye' # xyz
 ",
                 FormatOptions {
-                    match_and_switch_always_indent_arm_bodies: true,
+                    always_indent_arms: true,
                     ..Default::default()
                 },
             );


### PR DESCRIPTION
- **Make use of the REPL's max_history config setting**
- **Use koto_serde to simplify loading the CLI config file**
- **Add a note about the --format CLI arg to the changelog**
- **Remove support for KOTO_ prefixed env vars**
- **Document the format options in cli.md**
