### PR TITLE
Insert piped output as first call arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,14 @@ The Koto project adheres to
     - `{swap: |a, b| b, a}` should now written as `{swap: |a, b| (b, a)}`
   - Parentheses-free calls with multiple arguments that were wrapped in parentheses will need to be adjusted.
     - `(foo 1, 2, 3)` will now be parsed as `(foo(1), 2, 3)` and should be rewritten as `foo(1, 2, 3)`.
+- The `->` pipe operator now inserts the piped value as the first argument to the call to the right of the pipe.
+  - This makes it easier to build pipes with functions that treat the first argument as the subject of the operations, like instance functions.
+    ```koto
+    'hello!'
+      -> string.to_uppercase
+      -> string.repeat 3 # Previously this call would have failed due to the arguments being out of order
+    # -> HELLO!HELLO!HELLO!
+    ```
 - Maps that implement `@type` now have their type included by default when rendering the map as a string.
   [#478](https://github.com/koto-lang/koto/pull/478)
 

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -1508,9 +1508,9 @@ f x..., 'c', y...
 f = |args...| args
 x = (1, 2)
 y = (3, 4)
-5 -> f x..., y...
+0 -> f x..., y...
 ";
-                check_script_output(script, number_tuple(&[1, 2, 3, 4, 5]));
+                check_script_output(script, number_tuple(&[0, 1, 2, 3, 4]));
             }
 
             #[test]
@@ -1865,13 +1865,14 @@ f == g, f != g
             fn chained_piping() {
                 let script = "
 add = |a, b| a + b
-multiply = |a, b| a * b
 square = |x| x * x
-add 1, 2
-  -> square
-  -> multiply 10
+pow = |a, b| a ^ b
+
+add 1, 2    # 3
+  -> square # 9
+  -> pow 2  # 81
 ";
-                check_script_output(script, 90);
+                check_script_output(script, 81);
             }
 
             #[test]
@@ -1906,6 +1907,31 @@ get_op = |i| ops[i]
   -> get_op(1)  # 2
 ";
                 check_script_output(script, 2);
+            }
+
+            #[test]
+            fn with_core_lib_functions() {
+                let script = "
+'1x2x3'
+  -> string.split 'x'
+  -> iterator.to_string
+  -> string.repeat 2
+";
+                check_script_output(script, "123123");
+            }
+
+            #[test]
+            fn with_optional_argument() {
+                let script = "
+repeat = |input, n = 3| input.repeat n
+
+'O'
+  -> repeat
+  -> repeat 2
+
+# 3 * 2 repeats
+";
+                check_script_output(script, "OOOOOO");
             }
 
             #[test]


### PR DESCRIPTION
This PR changes the behaviour of the `->` pipe operator so that it inserts its output as the first arg in the following call, rather than appending it as the last.

This makes it easier to build pipelines with functions that treat the first argument as the subject (like core library functions, or object methods), and also allows pipelines to be built consistently with functions that have optional arguments.

E.g.:
```koto
'hello!'
  -> string.to_uppercase
  -> string.repeat 3 # Previously this call would have failed due to the arguments being out of order
# -> HELLO!HELLO!HELLO!
```

  

  
