### PR TITLE
Add `lazy` macro to `memory` and use it in `derive` and `runtime`

### DIFF
--- a/crates/derive/src/attributes.rs
+++ b/crates/derive/src/attributes.rs
@@ -1,9 +1,19 @@
-use syn::{Attribute, LitStr};
+use syn::{Attribute, LitStr, Path, parse_quote};
 
-#[derive(Default)]
 pub(crate) struct KotoAttributes {
     pub type_name: Option<String>,
     pub use_copy: bool,
+    pub runtime: Path,
+}
+
+impl Default for KotoAttributes {
+    fn default() -> Self {
+        Self {
+            type_name: None,
+            use_copy: false,
+            runtime: parse_quote! { ::koto::runtime },
+        }
+    }
 }
 
 pub(crate) fn koto_derive_attributes(attrs: &[Attribute]) -> KotoAttributes {
@@ -18,6 +28,9 @@ pub(crate) fn koto_derive_attributes(attrs: &[Attribute]) -> KotoAttributes {
                 Ok(())
             } else if meta.path.is_ident("use_copy") {
                 result.use_copy = true;
+                Ok(())
+            } else if meta.path.is_ident("runtime") {
+                result.runtime = meta.value()?.parse()?;
                 Ok(())
             } else {
                 Err(meta.error("unsupported koto attribute"))

--- a/crates/derive/src/koto_impl.rs
+++ b/crates/derive/src/koto_impl.rs
@@ -317,11 +317,8 @@ fn koto_entries_getter(
         quote! {
             #[automatically_derived]
             fn #entries_getter_name() -> #runtime::KMap {
-                use std::sync::LazyLock;
-
-                static ENTRIES: LazyLock<KMap> = LazyLock::new(#struct_ident::#entries_initializer_name);
-
-                ENTRIES.clone()
+                use #runtime::lazy;
+                lazy!(#runtime::KMap; #struct_ident::#entries_initializer_name())
             }
         }
     } else {
@@ -367,11 +364,8 @@ fn koto_entries_getter(
         quote! {
             #[automatically_derived]
             fn #entries_getter_name() -> #runtime::KMap {
-                thread_local! {
-                    static ENTRIES: KMap = #struct_ident::#entries_initializer_name();
-                }
-
-                ENTRIES.with(KMap::clone)
+                use #runtime::lazy;
+                lazy!(#runtime::KMap; #struct_ident::#entries_initializer_name())
             }
         }
     } else {

--- a/crates/derive/src/koto_type.rs
+++ b/crates/derive/src/koto_type.rs
@@ -1,6 +1,6 @@
-use crate::{PREFIX_STATIC, attributes::koto_derive_attributes};
+use crate::attributes::koto_derive_attributes;
 use proc_macro::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{DeriveInput, parse_macro_input};
 
 pub fn derive_koto_type(input: TokenStream) -> TokenStream {
@@ -10,27 +10,23 @@ pub fn derive_koto_type(input: TokenStream) -> TokenStream {
     let attributes = koto_derive_attributes(&input.attrs);
 
     let name = input.ident;
+
     let type_name = attributes
         .type_name
         .unwrap_or_else(|| quote!(#name).to_string());
 
-    let type_string_name = format_ident!("{PREFIX_STATIC}TYPE_STRING_{}", type_name.to_uppercase());
+    let runtime = attributes.runtime;
 
     let result = quote! {
         #[automatically_derived]
-        impl #impl_generics KotoType for #name #ty_generics #where_clause {
+        impl #impl_generics #runtime::KotoType for #name #ty_generics #where_clause {
             fn type_static() -> &'static str {
                 #type_name
             }
 
-            fn type_string(&self) -> KString {
-                #type_string_name.with(KString::clone)
+            fn type_string(&self) -> #runtime::KString {
+                #runtime::lazy!(#runtime::KString; #type_name)
             }
-        }
-
-        #[automatically_derived]
-        thread_local! {
-            static #type_string_name: KString = #type_name.into();
         }
     };
 

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -145,6 +145,15 @@ pub fn koto_fn(input: TokenStream) -> TokenStream {
 /// If another name should be displayed in the Koto runtime then use
 /// `#[koto(type_name = "other_name)]`.
 ///
+/// ## `runtime` attribute
+///
+/// The macro generates code assuming that the top-level `koto` crate is being used,
+/// with the `koto_runtime` crate re-exported at `::koto::runtime`.
+///
+/// If the runtime crate is located at a different path (e.g., if your crate depends on
+/// `koto_runtime` directly), then use the `runtime` attribute to define the alternative path,
+/// e.g. `#[koto(runtime = koto_runtime)]`.
+///
 /// ## Example
 ///
 /// ```ignore
@@ -271,5 +280,4 @@ pub fn koto_method(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
 
-const PREFIX_STATIC: &str = "__KOTO_";
 const PREFIX_FUNCTION: &str = "__koto_";

--- a/crates/memory/src/arc/ptr.rs
+++ b/crates/memory/src/arc/ptr.rs
@@ -8,6 +8,39 @@ use std::{
 
 use crate::Address;
 
+/// Provides access to a shared value that is initialized on first use
+///
+/// This macro will return a value of type `$ty`.
+/// On the first use, the value is initialized using `$expr.into()`.
+/// Subsequent acccesses return a clone of the stored value.
+///
+/// # Feature-specific behavior
+///
+/// - With the "rc" feature, the value is stored in a `thread_local`.
+/// - With the "arc" feature, the value is stored in a `static`.
+///
+/// # Examples
+///
+/// ```
+/// use koto_memory::{ Ptr, lazy };
+///
+/// fn my_string_constant() -> Ptr<str> {
+///     lazy!(Ptr<str>; "foo")
+/// }
+///
+/// let s0 = my_string_constant();
+/// let s1 = my_string_constant();
+///
+/// assert!(Ptr::ptr_eq(&s0, &s1));
+/// ```
+#[macro_export]
+macro_rules! lazy {
+    ($ty:ty; $expr:expr) => {{
+        static VALUE: ::std::sync::LazyLock<$ty> = ::std::sync::LazyLock::new(|| $expr.into());
+        ::std::sync::LazyLock::force(&VALUE).clone()
+    }};
+}
+
 /// Makes a Ptr, with support for casting to trait objects
 ///
 /// Although `Ptr::from` can be used, the challenge comes when a trait object needs to be used as

--- a/crates/memory/src/rc/ptr.rs
+++ b/crates/memory/src/rc/ptr.rs
@@ -8,6 +8,41 @@ use std::{
 
 use crate::Address;
 
+/// Provides access to a shared value that is initialized on first use
+///
+/// This macro will return a value of type `$ty`.
+/// On the first use, the value is initialized using `$expr.into()`.
+/// Subsequent acccesses return a clone of the stored value.
+///
+/// # Feature-specific behavior
+///
+/// - With the "rc" feature, the value is stored in a `thread_local`.
+/// - With the "arc" feature, the value is stored in a `static`.
+///
+/// # Examples
+///
+/// ```
+/// use koto_memory::{ Ptr, lazy };
+///
+/// fn my_string_constant() -> Ptr<str> {
+///     lazy!(Ptr<str>; "foo")
+/// }
+///
+/// let s0 = my_string_constant();
+/// let s1 = my_string_constant();
+///
+/// assert!(Ptr::ptr_eq(&s0, &s1));
+/// ```
+#[macro_export]
+macro_rules! lazy {
+    ($ty:ty; $expr:expr) => {{
+        thread_local! {
+            static VALUE: $ty = $expr.into();
+        }
+        VALUE.with(Clone::clone)
+    }};
+}
+
 /// Makes a Ptr, with support for casting to trait objects
 ///
 /// Although `Ptr::from` can be used, the challenge comes when a trait object needs to be used as

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -149,6 +149,7 @@ pub fn make_module() -> KMap {
 
 /// The File type used in the io module
 #[derive(Clone, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct File(Ptr<dyn KotoFile>);
 
 #[koto_impl(runtime = crate)]

--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -919,6 +919,7 @@ pub(crate) fn iter_output_to_result(iterator_output: Option<Output>) -> Result<O
 
 /// The output type used by operations like `iterator.next()` and `next_back()`
 #[derive(Clone, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct IteratorOutput(KValue);
 
 #[koto_impl(runtime = crate)]

--- a/crates/runtime/src/core_lib/iterator/peekable.rs
+++ b/crates/runtime/src/core_lib/iterator/peekable.rs
@@ -7,6 +7,7 @@ use crate::{KIteratorOutput as Output, Result, prelude::*};
 
 /// A double-ended peekable iterator for Koto
 #[derive(Clone, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct Peekable {
     iter: KIterator,
     peeked_front: Option<KValue>,

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -110,6 +110,7 @@ fn try_load_koto_script(ctx: &CallContext<'_>, script: &str) -> Result<Chunk> {
 
 /// The Chunk type used in the koto module
 #[derive(Clone, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct Chunk(Ptr<koto_bytecode::Chunk>);
 
 impl Chunk {
@@ -145,6 +146,7 @@ impl From<Chunk> for KValue {
 
 /// A type error type used in the koto module
 #[derive(Clone, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct Unimplemented;
 
 impl KotoEntries for Unimplemented {}

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -60,6 +60,7 @@ pub fn make_module() -> KMap {
 
 /// The underlying data type returned by `os.time()`
 #[derive(Clone, Debug, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct DateTime(chrono::DateTime<FixedOffset>);
 
 #[koto_impl(runtime = crate)]
@@ -153,6 +154,7 @@ impl KotoObject for DateTime {
 
 /// The underlying data type returned by `os.start_timer()`
 #[derive(Clone, Debug, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct Timer(Instant);
 
 #[koto_impl(runtime = crate)]

--- a/crates/runtime/src/core_lib/os/command.rs
+++ b/crates/runtime/src/core_lib/os/command.rs
@@ -41,6 +41,7 @@ macro_rules! stdio_setter {
 
 /// A wrapper for [std::process::Command], used by `os.command`
 #[derive(Clone, Debug, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 pub struct Command(PtrMut<process::Command>);
 
 #[koto_impl(runtime = crate)]
@@ -170,6 +171,7 @@ impl KotoObject for Command {
 
 /// A wrapper for [std::process::Output], used by `os.command`
 #[derive(Clone, Debug, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 struct CommandOutput(process::Output);
 
 #[koto_impl(runtime = crate)]
@@ -219,6 +221,7 @@ impl KotoObject for CommandOutput {}
 
 /// A wrapper for [std::process::Child], used by `os.command.spawn`
 #[derive(Clone, KotoCopy, KotoType)]
+#[koto(runtime = crate)]
 struct Child {
     handle: PtrMut<Option<process::Child>>,
     // Keep track of stream handles that have been accessed by the user. This allows the streams to

--- a/crates/runtime/src/io/stdio.rs
+++ b/crates/runtime/src/io/stdio.rs
@@ -1,4 +1,4 @@
-use crate::{KString, KotoFile, KotoRead, KotoWrite, Result, core_lib::io::map_io_err};
+use crate::{KString, KotoFile, KotoRead, KotoWrite, Result, core_lib::io::map_io_err, lazy};
 use std::io::{self, IsTerminal, Read, Write};
 
 /// The default stdin used in Koto
@@ -7,7 +7,7 @@ pub struct DefaultStdin {}
 
 impl KotoFile for DefaultStdin {
     fn id(&self) -> KString {
-        STDIN_ID.with(|id| id.clone())
+        lazy!(KString; "_stdin_")
     }
 
     fn is_terminal(&self) -> bool {
@@ -43,7 +43,7 @@ pub struct DefaultStdout {}
 
 impl KotoFile for DefaultStdout {
     fn id(&self) -> KString {
-        STDOUT_ID.with(|id| id.clone())
+        lazy!(KString; "_stdout_")
     }
 
     fn is_terminal(&self) -> bool {
@@ -75,7 +75,7 @@ pub struct DefaultStderr {}
 
 impl KotoFile for DefaultStderr {
     fn id(&self) -> KString {
-        STDERR_ID.with(|id| id.clone())
+        lazy!(KString; "_stderr_")
     }
 
     fn is_terminal(&self) -> bool {
@@ -99,10 +99,4 @@ impl KotoWrite for DefaultStderr {
     fn flush(&self) -> Result<()> {
         io::stderr().flush().map_err(map_io_err)
     }
-}
-
-thread_local! {
-    static STDIN_ID: KString = "_stdin_".into();
-    static STDOUT_ID: KString = "_stdout_".into();
-    static STDERR_ID: KString = "_stderr_".into();
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -29,4 +29,4 @@ pub use crate::{
     vm::{CallArgs, KotoVm, KotoVmSettings, ModuleImportedCallback, ReturnOrYield},
 };
 pub use koto_derive as derive;
-pub use koto_memory::{Borrow, BorrowMut, KCell, Ptr, PtrMut, make_ptr, make_ptr_mut};
+pub use koto_memory::{Borrow, BorrowMut, KCell, Ptr, PtrMut, lazy, make_ptr, make_ptr_mut};

--- a/crates/runtime/src/types/object.rs
+++ b/crates/runtime/src/types/object.rs
@@ -66,6 +66,7 @@ pub trait KotoEntries {
 /// use koto_runtime::{derive::*, prelude::*, Result};
 ///
 /// #[derive(Clone, Default, KotoType, KotoCopy)]
+/// #[koto(runtime = koto_runtime)]
 /// pub struct Foo {
 ///     data: i32,
 /// }

--- a/crates/runtime/src/types/tuple.rs
+++ b/crates/runtime/src/types/tuple.rs
@@ -1,4 +1,4 @@
-use crate::{Ptr, Result, prelude::*};
+use crate::{Ptr, Result, lazy, prelude::*};
 use std::ops::{Deref, Range};
 
 /// The Tuple type used by the Koto runtime
@@ -175,13 +175,9 @@ impl Deref for KTuple {
     }
 }
 
-thread_local! {
-    static EMPTY_TUPLE: Ptr<Vec<KValue>> = Vec::new().into();
-}
-
 impl Default for KTuple {
     fn default() -> Self {
-        Self::from(EMPTY_TUPLE.with(|x| x.clone()))
+        Self::from(lazy!(Ptr<Vec<KValue>>; Vec::new()))
     }
 }
 

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -3,7 +3,7 @@ mod objects {
     use koto_test_utils::*;
 
     #[derive(Clone, Copy, Debug, KotoCopy, KotoType)]
-    #[koto(use_copy)]
+    #[koto(runtime = koto_runtime, use_copy)]
     struct TestObject {
         x: i64,
     }
@@ -329,6 +329,7 @@ mod objects {
     }
 
     #[derive(Clone, Debug, KotoCopy, KotoType)]
+    #[koto(runtime = koto_runtime)]
     struct TestIterator {
         x: i64,
     }
@@ -358,6 +359,7 @@ mod objects {
     }
 
     #[derive(Clone, KotoCopy, KotoType)]
+    #[koto(runtime = koto_runtime)]
     struct GenericObject<T>
     where
         T: KotoField,

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -4,7 +4,7 @@ use palette::FromColor;
 use std::fmt;
 
 #[derive(Copy, Clone, PartialEq, KotoCopy, KotoType)]
-#[koto(use_copy)]
+#[koto(runtime = koto_runtime, use_copy)]
 pub struct Color {
     pub color: Encoding,
     pub alpha: f32,

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[derive(Copy, Clone, PartialEq, KotoCopy, KotoType)]
-#[koto(use_copy)]
+#[koto(runtime = koto_runtime, use_copy)]
 pub struct Rect {
     x: Bounds<f64>,
     y: Bounds<f64>,

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -4,7 +4,7 @@ use std::{fmt, ops};
 type Inner = glam::DVec2;
 
 #[derive(Copy, Clone, PartialEq, KotoCopy, KotoType)]
-#[koto(use_copy)]
+#[koto(runtime = koto_runtime, use_copy)]
 pub struct Vec2(Inner);
 
 #[koto_impl(runtime = koto_runtime)]

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -3,7 +3,7 @@ use koto_runtime::{Result, derive::*, prelude::*};
 use std::{fmt, ops};
 
 #[derive(Copy, Clone, PartialEq, KotoCopy, KotoType)]
-#[koto(use_copy)]
+#[koto(runtime = koto_runtime, use_copy)]
 pub struct Vec3(DVec3);
 
 #[koto_impl(runtime = koto_runtime)]

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -52,7 +52,7 @@ pub fn make_module() -> KMap {
 }
 
 #[derive(Clone, Debug, KotoCopy, KotoType)]
-#[koto(type_name = "Rng")]
+#[koto(runtime = koto_runtime, type_name = "Rng")]
 struct Xoshiro256PlusPlusRng(Xoshiro256PlusPlus);
 
 #[koto_impl(runtime = koto_runtime)]

--- a/libs/random/tests/shuffle.rs
+++ b/libs/random/tests/shuffle.rs
@@ -4,6 +4,7 @@ use koto_test_utils::*;
 use std::{error::Error, fs, path::PathBuf, result::Result as StdResult};
 
 #[derive(Clone, Debug, Default, KotoCopy, KotoType)]
+#[koto(runtime = koto_runtime)]
 struct TestContainer {
     data: Vec<KValue>,
 }

--- a/libs/regex/src/lib.rs
+++ b/libs/regex/src/lib.rs
@@ -12,6 +12,7 @@ pub fn make_module() -> KMap {
 }
 
 #[derive(Clone, Debug, KotoType, KotoCopy)]
+#[koto(runtime = koto_runtime)]
 pub struct Regex(Ptr<regex::Regex>);
 
 #[koto_impl(runtime = koto_runtime)]
@@ -129,6 +130,7 @@ impl From<Regex> for KValue {
 }
 
 #[derive(Clone, Debug, KotoType, KotoCopy)]
+#[koto(runtime = koto_runtime)]
 pub struct Matches {
     text: KString,
     matches: Vec<(usize, usize)>,
@@ -171,6 +173,7 @@ impl From<Matches> for KValue {
 }
 
 #[derive(Clone, Debug, KotoType, KotoCopy)]
+#[koto(runtime = koto_runtime)]
 pub struct Match {
     text: KString,
     bounds: KRange,


### PR DESCRIPTION
`#[derive(KotoType)]` and the contant values in `runtime` were using `thread_local` regardless of feature.

This PR changes those instances to use static `LazyLock`s if "arc" is enabled.

For `runtime` i created a new macro to make creating these static values easier.