### PR TITLE
Add argument conversion and overloading for `#[koto_method]`s, result value conversion for `#[koto_impl]` methods

### DIFF
--- a/crates/derive/src/function.rs
+++ b/crates/derive/src/function.rs
@@ -1,51 +1,45 @@
-use indexmap::IndexMap;
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{
-    Error, FnArg, Ident, ItemFn, PatType, Path, Result, ReturnType, Token, Type, TypePath,
-    TypeReference, TypeSlice,
+    Ident, ItemFn, Path, Result, Token,
     parse::{Parse, ParseStream},
     parse_macro_input, parse_quote,
-    spanned::Spanned,
+};
+
+use crate::overloading::{
+    AccessAttributeArgs, OverloadOptions, OverloadedFunctionCandidate, OverloadedFunctions,
 };
 
 pub fn koto_fn(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let FunctionDefinitions { runtime, functions } =
         parse_macro_input!(input as FunctionDefinitions);
 
-    let fn_wrappers: Vec<_> = functions
-        .iter()
-        .map(|(name, function_impls)| {
-            let mut match_arms = Vec::with_capacity(function_impls.len());
-            let mut unexpected_args_error = String::new();
+    let mut function_wrappers = vec![];
 
-            for (i, fn_impl) in function_impls.iter().enumerate() {
-                match_arms.push(fn_impl.match_arm());
+    for function in functions.inner.values() {
+        let name = function.first_ident();
+        let body = match function.match_arms() {
+            Ok(arms) => quote! {
+                use #runtime::{ KValue, __private::KotoFunctionReturn };
 
-                if i > 0 {
-                    unexpected_args_error.push_str(", ");
+                match ctx.args() {
+                    #arms
                 }
-                if function_impls.len() > 1 && i == function_impls.len() - 1 {
-                    unexpected_args_error.push_str("or ");
-                }
-                unexpected_args_error.push_str(&fn_impl.signature());
+            },
+            Err(error) => {
+                let compile_error = error.into_compile_error();
+                quote!(#compile_error)
             }
+        };
 
-            quote! {
-                fn #name(ctx: &mut #runtime::CallContext) -> #runtime::Result<#runtime::KValue> {
-                    use #runtime::KValue;
-
-                    match ctx.args() {
-                        #(#match_arms)*
-                        unexpected => unexpected_args(#unexpected_args_error, unexpected),
-                    }
-                }
+        function_wrappers.push(quote! {
+            fn #name(ctx: &mut #runtime::CallContext) -> #runtime::Result<#runtime::KValue> {
+                #body
             }
-        })
-        .collect();
+        });
+    }
 
     let output = quote! {
-        #(#fn_wrappers)*
+        #(#function_wrappers)*
     };
 
     output.into()
@@ -53,7 +47,7 @@ pub fn koto_fn(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 struct FunctionDefinitions {
     runtime: Path,
-    functions: IndexMap<Ident, Vec<FunctionDefinition>>,
+    functions: OverloadedFunctions,
 }
 
 impl Parse for FunctionDefinitions {
@@ -73,11 +67,16 @@ impl Parse for FunctionDefinitions {
             let _semicolon: Token![;] = input.parse()?;
         }
 
-        let mut functions = IndexMap::<Ident, Vec<FunctionDefinition>>::new();
+        let mut functions = OverloadedFunctions::default();
 
         while !input.is_empty() {
-            let f: FunctionDefinition = input.parse()?;
-            functions.entry(f.name.clone()).or_default().push(f);
+            let item: ItemFn = input.parse()?;
+
+            functions.insert(OverloadedFunctionCandidate::new(
+                item,
+                AccessAttributeArgs::default(),
+                OverloadOptions::Function,
+            )?);
         }
 
         Ok(Self {
@@ -85,329 +84,4 @@ impl Parse for FunctionDefinitions {
             functions,
         })
     }
-}
-
-struct FunctionDefinition {
-    name: Ident,
-    args: Vec<FunctionArg>,
-    output: Option<FunctionOutputInfo>,
-    item: ItemFn,
-}
-
-impl Parse for FunctionDefinition {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let item: ItemFn = input.parse()?;
-
-        let args = item
-            .sig
-            .inputs
-            .iter()
-            .enumerate()
-            .map(|(i, input)| match input {
-                FnArg::Receiver(_) => {
-                    Err(Error::new(input.span(), "self arguments are unsupported"))
-                }
-                FnArg::Typed(PatType { ty: arg_type, .. }) => {
-                    let is_last_arg = i == item.sig.inputs.len() - 1;
-                    FunctionArg::new(arg_type, i, is_last_arg)
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let output = match &item.sig.output {
-            ReturnType::Default => None,
-            ReturnType::Type(_, return_type) => {
-                let is_result = match return_type.as_ref() {
-                    Type::Path(type_path) => type_path
-                        .path
-                        .segments
-                        .last()
-                        .unwrap()
-                        .ident
-                        .to_string()
-                        .starts_with("Result"),
-                    _ => {
-                        return Err(Error::new(return_type.span(), "Unsupported return type"));
-                    }
-                };
-                Some(FunctionOutputInfo { is_result })
-            }
-        };
-
-        Ok(FunctionDefinition {
-            name: item.sig.ident.clone(),
-            args,
-            output,
-            item,
-        })
-    }
-}
-
-impl FunctionDefinition {
-    fn signature(&self) -> String {
-        let mut result = "|".to_string();
-
-        for (i, arg) in self
-            .args
-            .iter()
-            .filter_map(|arg| match arg {
-                FunctionArg::Koto(koto_arg) => Some(koto_arg),
-                _ => None,
-            })
-            .enumerate()
-        {
-            if i > 0 {
-                result.push_str(", ");
-            }
-            result.push_str(&arg.display_name);
-        }
-
-        result.push('|');
-        result
-    }
-
-    fn match_arm(&self) -> TokenStream {
-        let call_exprs = self
-            .args
-            .iter()
-            .map(|arg| match arg {
-                FunctionArg::CallContext { call_expr } => call_expr,
-                FunctionArg::Koto(KotoArg { call_expr, .. }) => call_expr,
-            })
-            .collect::<Vec<_>>();
-
-        let fn_name = &self.name;
-        let call = quote! {
-            #fn_name(#(#call_exprs, )*)
-        };
-
-        let (match_exprs, setup_exprs) = self
-            .args
-            .iter()
-            .filter_map(|arg| match arg {
-                FunctionArg::Koto(KotoArg {
-                    match_expr,
-                    setup_expr,
-                    ..
-                }) => Some((match_expr, setup_expr)),
-                _ => None,
-            })
-            .collect::<(Vec<_>, Vec<_>)>();
-
-        let match_conditions = self
-            .args
-            .iter()
-            .filter_map(|arg| match arg {
-                FunctionArg::Koto(KotoArg {
-                    match_condition, ..
-                }) => match_condition.as_ref(),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-
-        let condition = match match_conditions.as_slice() {
-            [] => quote! {},
-            [first, rest @ ..] => quote! { if #first #(&& #rest)*},
-        };
-
-        let wrapped_call = match &self.output {
-            Some(output_info) => {
-                if output_info.is_result {
-                    quote! { #call.map(KValue::from) }
-                } else {
-                    quote! { Ok(#call.into()) }
-                }
-            }
-            None => quote! {{
-                #call;
-                Ok(KValue::Null)
-            }},
-        };
-
-        let fn_impl = &self.item;
-        quote! {
-            [#(#match_exprs, )*] #condition => {
-                #fn_impl
-                #(#setup_exprs)*
-                return #wrapped_call;
-            }
-        }
-    }
-}
-
-#[derive(Default)]
-struct KotoArg {
-    // The type name to show in error messages
-    display_name: String,
-    // The KValue variant to match for the arg
-    match_expr: TokenStream,
-    // An optional condition to check on the matched value
-    match_condition: Option<TokenStream>,
-    // Pre-call setup (e.g. calling make_iterator)
-    setup_expr: Option<TokenStream>,
-    // How the arg should be passed to the user's function
-    call_expr: TokenStream,
-}
-
-enum FunctionArg {
-    CallContext { call_expr: TokenStream },
-    Koto(KotoArg),
-}
-
-impl FunctionArg {
-    fn new(arg_type: &Type, id: usize, is_last: bool) -> Result<Self> {
-        let arg_name = format_ident!("arg_{}", id);
-        Self::from_type_and_name(arg_type, arg_name, false, is_last)
-    }
-
-    fn from_type_and_name(
-        arg_type: &Type,
-        name: Ident,
-        as_ref: bool,
-        is_last: bool,
-    ) -> Result<Self> {
-        match arg_type {
-            Type::Path(TypePath { path, .. }) => {
-                let ident = &path.segments.last().unwrap().ident;
-                let ident_string = ident.to_string();
-
-                let mut result = match ident_string.as_str() {
-                    "bool" => Self::Koto(KotoArg {
-                        display_name: "Bool".into(),
-                        match_expr: quote! { KValue::Bool(#name) },
-                        ..Default::default()
-                    }),
-                    "str" => Self::Koto(KotoArg {
-                        display_name: "String".into(),
-                        match_expr: quote! { KValue::Str(#name) },
-                        call_expr: quote! { #name.as_str() },
-                        ..Default::default()
-                    }),
-                    "String" => Self::Koto(KotoArg {
-                        display_name: "String".into(),
-                        match_expr: quote! { KValue::Str(#name) },
-                        call_expr: quote! { #name.into() },
-                        ..Default::default()
-                    }),
-                    "KString" => Self::Koto(KotoArg {
-                        display_name: "String".into(),
-                        match_expr: quote! { KValue::Str(#name) },
-                        ..Default::default()
-                    }),
-                    "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" | "f32" | "f64" => {
-                        Self::Koto(KotoArg {
-                            display_name: "Number".into(),
-                            match_expr: quote! { KValue::Number(#name) },
-                            call_expr: quote! { #name.into() },
-                            ..Default::default()
-                        })
-                    }
-                    "KNumber" => Self::Koto(KotoArg {
-                        display_name: "Number".into(),
-                        match_expr: quote! { KValue::Number(#name) },
-                        ..Default::default()
-                    }),
-                    "KRange" => Self::Koto(KotoArg {
-                        display_name: "Range".into(),
-                        match_expr: quote! { KValue::Range(#name) },
-                        ..Default::default()
-                    }),
-                    "KList" => Self::Koto(KotoArg {
-                        display_name: "List".into(),
-                        match_expr: quote! { KValue::List(#name) },
-                        ..Default::default()
-                    }),
-                    "KTuple" => Self::Koto(KotoArg {
-                        display_name: "Tuple".into(),
-                        match_expr: quote! { KValue::Tuple(#name) },
-                        ..Default::default()
-                    }),
-                    "KMap" => Self::Koto(KotoArg {
-                        display_name: "Map".into(),
-                        match_expr: quote! { KValue::Map(#name) },
-                        ..Default::default()
-                    }),
-                    "KIterator" => Self::Koto(KotoArg {
-                        display_name: "Iterable".into(),
-                        match_expr: quote! { #name },
-                        match_condition: Some(quote! { #name.is_iterable() }),
-                        setup_expr: Some(quote! {
-                            let #name = #name.clone();
-                            let #name = ctx.vm.make_iterator(#name)?;
-                        }),
-                        ..Default::default()
-                    }),
-                    "KValue" => Self::Koto(KotoArg {
-                        display_name: "Any".into(),
-                        match_expr: quote! { #name },
-                        ..Default::default()
-                    }),
-                    "CallContext" => Self::CallContext {
-                        call_expr: quote! { ctx },
-                    },
-                    "KotoVm" => Self::CallContext {
-                        call_expr: quote! { ctx.vm },
-                    },
-                    // Unknown types can be assumed to implement `KotoObject`
-                    _ => Self::Koto(KotoArg {
-                        display_name: ident_string,
-                        match_expr: quote! { KValue::Object(#name) },
-                        match_condition: Some(quote! { #name.is_a::<#ident>() }),
-                        setup_expr: Some(quote! { let #name = #name.cast::<#ident>().unwrap(); }),
-                        ..Default::default()
-                    }),
-                };
-
-                match &mut result {
-                    Self::Koto(KotoArg { call_expr, .. }) if call_expr.is_empty() => {
-                        *call_expr = if as_ref {
-                            quote! { &#name }
-                        } else {
-                            quote! { #name.clone() }
-                        }
-                    }
-                    _ => {}
-                }
-
-                Ok(result)
-            }
-            // Support args that take a reference
-            Type::Reference(TypeReference { elem, .. }) => {
-                Self::from_type_and_name(elem, name, true, is_last)
-            }
-            // Pass remaining args to `&[KValue]` if it's the last arg
-            Type::Slice(TypeSlice { elem, .. }) => match elem.as_ref() {
-                Type::Path(TypePath { path, .. }) => {
-                    let ident_string = path.segments.last().unwrap().ident.to_string();
-                    if ident_string == "KValue" {
-                        if is_last {
-                            Ok(Self::Koto(KotoArg {
-                                display_name: "Any...".into(),
-                                match_expr: quote! { #name @ .. },
-                                call_expr: quote! { #name },
-                                ..Default::default()
-                            }))
-                        } else {
-                            Err(Error::new(
-                                arg_type.span(),
-                                "Variadic args are only supported as the last argument",
-                            ))
-                        }
-                    } else {
-                        unsupported_arg_type(arg_type)
-                    }
-                }
-                _ => unsupported_arg_type(arg_type),
-            },
-            _ => unsupported_arg_type(arg_type),
-        }
-    }
-}
-
-fn unsupported_arg_type<T>(arg_type: &Type) -> Result<T> {
-    Err(Error::new(arg_type.span(), "Unsupported argument type"))
-}
-
-struct FunctionOutputInfo {
-    is_result: bool,
 }

--- a/crates/derive/src/overloading.rs
+++ b/crates/derive/src/overloading.rs
@@ -1,0 +1,872 @@
+use std::iter;
+
+use indexmap::IndexMap;
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote, quote_spanned};
+use syn::{
+    Attribute, Error, FnArg, GenericArgument, Ident, ImplItemFn, ItemFn, LitStr, Meta, PatType,
+    PathArguments, PathSegment, Result, ReturnType, Signature, Type, TypePath, TypeReference,
+    TypeSlice, spanned::Spanned,
+};
+
+#[derive(Clone, Copy)]
+pub(crate) enum OverloadOptions {
+    Function,
+    Method,
+}
+
+impl OverloadOptions {
+    fn allow_self(&self) -> bool {
+        matches!(self, OverloadOptions::Method)
+    }
+
+    fn allow_method_context(&self) -> bool {
+        matches!(self, OverloadOptions::Method)
+    }
+
+    fn allow_call_context(&self) -> bool {
+        matches!(self, OverloadOptions::Function)
+    }
+
+    fn max_arguments(&self) -> usize {
+        // May be used in the future when overloading `#[koto_set]`.
+        usize::MAX
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct OverloadedFunctions {
+    pub(crate) inner: IndexMap<String, OverloadedFunction>,
+}
+
+impl OverloadedFunctions {
+    pub(crate) fn insert(&mut self, definition: OverloadedFunctionCandidate) {
+        self.inner
+            .entry(definition.name.value())
+            .or_default()
+            .candidates
+            .push(definition);
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct OverloadedFunction {
+    // The vec of candidates must not be empty or some methods will panic.
+    // In practice, this is ensured by the `OverloadedFunctions::insert` implementation,
+    // which is the only place `OverloadedFunction`s are created.
+    pub(crate) candidates: Vec<OverloadedFunctionCandidate>,
+}
+
+impl OverloadedFunction {
+    pub(crate) fn first_ident(&self) -> &Ident {
+        &self.candidates.first().unwrap().ident
+    }
+
+    pub(crate) fn name(&self) -> &LitStr {
+        // All candidates have the same name.
+        &self.candidates.first().unwrap().name
+    }
+
+    pub(crate) fn options(&self) -> OverloadOptions {
+        self.candidates.first().unwrap().options
+    }
+
+    pub(crate) fn name_and_aliases(&self) -> Vec<LitStr> {
+        iter::once(self.name())
+            .chain(
+                self.candidates
+                    .iter()
+                    .flat_map(|candidate| &candidate.aliases),
+            )
+            .map(|alias| (alias.value(), alias.clone()))
+            .collect::<IndexMap<_, _>>()
+            .into_values()
+            .collect()
+    }
+
+    pub(crate) fn match_arms(&self) -> Result<TokenStream> {
+        let mut match_arms = Vec::with_capacity(self.candidates.len());
+        let mut unexpected_args_error = String::new();
+
+        for (i, definition) in self.candidates.iter().enumerate() {
+            match_arms.push(definition.match_arm()?);
+
+            if i > 0 {
+                unexpected_args_error.push_str(", ");
+            }
+
+            if self.candidates.len() > 1 && i == self.candidates.len() - 1 {
+                unexpected_args_error.push_str("or ");
+            }
+
+            unexpected_args_error.push_str(&definition.args.signature());
+        }
+
+        let error_expr = quote! {
+            unexpected_args(#unexpected_args_error, unexpected)
+        };
+
+        let error_arm = if matches!(self.options(), OverloadOptions::Method) {
+            quote!((_, unexpected) => #error_expr,)
+        } else {
+            quote!(unexpected => #error_expr,)
+        };
+
+        let arms = quote! {
+            #(#match_arms)*
+            #error_arm
+        };
+
+        Ok(arms)
+    }
+}
+
+pub(crate) struct OverloadedFunctionCandidate {
+    pub(crate) name: LitStr,
+    pub(crate) aliases: Vec<LitStr>,
+    pub(crate) ident: Ident,
+    pub(crate) args: KotoArgs,
+    // This may originally have been an `ItemFn` or `ImplItemFn`.
+    // We use `ImplItemFn` because any `ItemFn` can also be represented by an `ImplItemFn`.
+    pub(crate) item: ImplItemFn,
+    pub(crate) options: OverloadOptions,
+}
+
+impl OverloadedFunctionCandidate {
+    pub(crate) fn new(
+        item: impl ItemFnOrImplItemFn,
+        args: AccessAttributeArgs,
+        options: OverloadOptions,
+    ) -> Result<Self> {
+        let item = item.into_impl_item_fn();
+        let ident = item.sig.ident.clone();
+        Self::with_name_fallback(item, args, options, || {
+            Ok(LitStr::new(&ident.to_string(), ident.span()))
+        })
+    }
+
+    pub(crate) fn with_name_fallback(
+        item: ImplItemFn,
+        args: AccessAttributeArgs,
+        options: OverloadOptions,
+        name_fallback: impl FnOnce() -> Result<LitStr>,
+    ) -> Result<Self> {
+        Ok(OverloadedFunctionCandidate {
+            name: match args.name {
+                Some(name) => name,
+                None => name_fallback()?,
+            },
+            aliases: args.aliases,
+            ident: item.sig.ident.clone(),
+            args: KotoArgs::from_sig(&item.sig, options)?,
+            item,
+            options,
+        })
+    }
+
+    pub(crate) fn match_arm(&self) -> Result<TokenStream> {
+        let call_exprs = self.args.call_exprs();
+        let fn_name = &self.item.sig.ident;
+
+        let mut call = quote! {
+            #fn_name(#(#call_exprs, )*)
+        };
+
+        if matches!(self.options, OverloadOptions::Method) {
+            call = quote!(Self::#call);
+        }
+
+        let match_pats = self
+            .value_args()
+            .map(|(arg, value)| value.match_pats(&arg.name))
+            .collect::<Vec<_>>();
+
+        let setup_exprs = self
+            .value_args()
+            .map(|(arg, _)| &arg.setup_expr)
+            .collect::<Vec<_>>();
+
+        let match_conditions = self
+            .value_args()
+            .flat_map(|(_, value)| value.match_condition.as_ref())
+            .collect::<Vec<_>>();
+
+        let condition = match match_conditions.as_slice() {
+            [] => quote!(),
+            [first, rest @ ..] => quote! {
+                if #first #(&& #rest)*
+            },
+        };
+
+        // Special handling of methods with a `MethodContext`.
+        if matches!(self.options, OverloadOptions::Method) {
+            let has_method_context_param = self.args.inner.iter().any(|arg| matches!(&arg.kind, KotoArgKind::Context(context) if matches!(context.kind, KotoContextArgKind::MethodContext)));
+
+            if has_method_context_param {
+                if self.args.inner.len() > 1 {
+                    return Err(Error::new_spanned(
+                        &self.item.sig.inputs,
+                        "Unexpected additional parameter for a `#[koto_method]` taking a `MethodContext`",
+                    ));
+                }
+
+                let wrapped_call = self.wrap_call(call);
+
+                let arm = quote! {
+                    (KValue::Object(o), extra_args) => { #wrapped_call }
+                };
+
+                return Ok(arm);
+            }
+        }
+
+        let mut pattern = quote! {
+            [#(#match_pats,)*]
+        };
+
+        if matches!(self.options, OverloadOptions::Method) {
+            pattern = quote!((KValue::Object(o), #pattern));
+        }
+
+        // For functions we insert the implementation in the match arm,
+        // but methods remain in the `impl` block and are called using `Self::fun(...)`.
+        let expr = match self.options {
+            OverloadOptions::Function => {
+                let fn_impl = &self.item;
+                let wrapped_call = self.wrap_call(call);
+
+                quote! {{
+                    #fn_impl
+                    #(#setup_exprs)*
+                    return #wrapped_call;
+                }}
+            }
+            OverloadOptions::Method => {
+                // Special handling of methods with `self`.
+                if let Some(KotoArg {
+                    kind: KotoArgKind::Receiver(receiver),
+                    ..
+                }) = self.args.inner.first()
+                {
+                    let cast = if receiver.is_mut {
+                        quote!(cast_mut)
+                    } else {
+                        quote!(cast)
+                    };
+
+                    let instance = if receiver.is_mut {
+                        quote!(mut instance)
+                    } else {
+                        quote!(instance)
+                    };
+
+                    enum ReturnKind {
+                        // `-> &Self` or `-> &mut Self`
+                        RefSelf,
+                        // `-> Result<&Self>` or `-> Result<&mut Self>`
+                        ResultRefSelf,
+                        // Any other return type
+                        Other,
+                    }
+
+                    let return_kind = match &self.item.sig.output {
+                        ReturnType::Default => ReturnKind::Other,
+                        ReturnType::Type(_, ty) => match &**ty {
+                            Type::Reference(ty) => match &*ty.elem {
+                                Type::Path(type_path) if type_path.path.is_ident("Self") => {
+                                    ReturnKind::RefSelf
+                                }
+                                _ => ReturnKind::Other,
+                            },
+                            Type::Path(type_path) => match type_path.path.segments.last() {
+                                Some(PathSegment {
+                                    arguments: PathArguments::AngleBracketed(args),
+                                    ..
+                                }) => match args.args.first() {
+                                    Some(GenericArgument::Type(Type::Reference(ty))) => {
+                                        match &*ty.elem {
+                                            Type::Path(type_path)
+                                                if type_path.path.is_ident("Self") =>
+                                            {
+                                                ReturnKind::ResultRefSelf
+                                            }
+                                            _ => ReturnKind::Other,
+                                        }
+                                    }
+                                    _ => ReturnKind::Other,
+                                },
+                                _ => ReturnKind::Other,
+                            },
+                            _ => ReturnKind::Other,
+                        },
+                    };
+
+                    let expr = match return_kind {
+                        ReturnKind::RefSelf => quote! {{
+                            #(#setup_exprs)*
+                            #call;
+                            return Ok(o.clone().into());
+                        }},
+                        ReturnKind::ResultRefSelf => quote! {{
+                            #(#setup_exprs)*
+                            #call?;
+                            return Ok(o.clone().into());
+                        }},
+                        ReturnKind::Other => {
+                            let wrapped_call = self.wrap_call(call);
+
+                            quote! {{
+                                #(#setup_exprs)*
+                                return #wrapped_call;
+                            }}
+                        }
+                    };
+
+                    quote! {
+                        match o.#cast::<Self>() {
+                            Ok(#instance) => #expr
+                            Err(e) => Err(e),
+                        }
+                    }
+                } else {
+                    let wrapped_call = self.wrap_call(call);
+
+                    quote! {{
+                        #(#setup_exprs)*
+                        return #wrapped_call;
+                    }}
+                }
+            }
+        };
+
+        let arm = quote! {
+            #pattern #condition => #expr
+        };
+
+        Ok(arm)
+    }
+
+    fn value_args(&self) -> impl Iterator<Item = (&KotoArg, &KotoValueArg)> {
+        self.args.inner.iter().filter_map(|arg| match &arg.kind {
+            KotoArgKind::Value(value) => Some((arg, value)),
+            _ => None,
+        })
+    }
+
+    fn wrap_call(&self, call: TokenStream) -> TokenStream {
+        let span = match &self.item.sig.output {
+            ReturnType::Type(_, ty) => ty.span(),
+            ReturnType::Default => Span::call_site(),
+        };
+
+        let return_trait = match self.options {
+            OverloadOptions::Function => quote_spanned!(span=> KotoFunctionReturn),
+            OverloadOptions::Method => quote_spanned!(span=> KotoMethodReturn),
+        };
+
+        // Attach a span to so a type error will point at the right place.
+        quote_spanned!(span=> #return_trait::into_result(#call))
+    }
+}
+
+/// Either an `ItemFn` or `ImplItemFn`.
+pub(crate) trait ItemFnOrImplItemFn {
+    fn into_impl_item_fn(self) -> ImplItemFn;
+}
+
+impl ItemFnOrImplItemFn for ImplItemFn {
+    fn into_impl_item_fn(self) -> ImplItemFn {
+        self
+    }
+}
+
+impl ItemFnOrImplItemFn for ItemFn {
+    fn into_impl_item_fn(self) -> ImplItemFn {
+        let Self {
+            attrs,
+            vis,
+            sig,
+            block,
+        } = self;
+        ImplItemFn {
+            attrs,
+            vis,
+            defaultness: None,
+            sig,
+            block: *block,
+        }
+    }
+}
+
+pub(crate) struct KotoArgs {
+    inner: Vec<KotoArg>,
+}
+
+impl KotoArgs {
+    pub(crate) fn from_sig(sig: &Signature, options: OverloadOptions) -> Result<Self> {
+        if sig.inputs.len() > options.max_arguments() {
+            return Err(Error::new_spanned(sig, "too many arguments"));
+        }
+
+        let args = sig
+            .inputs
+            .iter()
+            .enumerate()
+            .map(|(i, input)| match input {
+                FnArg::Receiver(receiver) => {
+                    if !options.allow_self() {
+                        return Err(Error::new_spanned(
+                            input,
+                            "`self` arguments are not supported",
+                        ));
+                    }
+
+                    Ok(KotoArg {
+                        name: format_ident!("instance"),
+                        kind: KotoArgKind::Receiver(KotoReceiverArg {
+                            is_mut: receiver.mutability.is_some(),
+                        }),
+                        setup_expr: None,
+                        call_expr: None,
+                    })
+                }
+                FnArg::Typed(PatType { ty: arg_type, .. }) => {
+                    let is_last_arg = i == sig.inputs.len() - 1;
+                    KotoArg::new(arg_type, i, is_last_arg, options)
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self { inner: args })
+    }
+
+    pub(crate) fn signature(&self) -> String {
+        let mut result = "|".to_string();
+
+        for (i, arg) in self
+            .inner
+            .iter()
+            .filter_map(|arg| match &arg.kind {
+                KotoArgKind::Value(value) => Some(value),
+                _ => None,
+            })
+            .enumerate()
+        {
+            if i > 0 {
+                result.push_str(", ");
+            }
+            result.push_str(&arg.display_name());
+        }
+
+        result.push('|');
+        result
+    }
+
+    fn call_exprs(&self) -> Vec<TokenStream> {
+        self.inner.iter().flat_map(|arg| arg.call_expr()).collect()
+    }
+}
+
+struct KotoArg {
+    name: Ident,
+    kind: KotoArgKind,
+    // Pre-call setup (e.g. calling make_iterator)
+    setup_expr: Option<TokenStream>,
+    // How the arg should be passed to the user's function
+    call_expr: Option<TokenStream>,
+}
+
+impl KotoArg {
+    fn new(arg_type: &Type, id: usize, is_last: bool, options: OverloadOptions) -> Result<Self> {
+        let arg_name = format_ident!("arg_{id}");
+        Self::from_type_and_name(arg_type, &arg_name, is_last, options)
+    }
+
+    fn from_type_and_name(
+        mut arg_type: &Type,
+        name: &Ident,
+        is_last: bool,
+        options: OverloadOptions,
+    ) -> Result<Self> {
+        use KotoContextArgKind::*;
+        use KotoValueArgKind::*;
+
+        let mut arg = KotoArg::builder(name.clone());
+
+        if let Type::Reference(TypeReference { elem, .. }) = arg_type {
+            arg_type = elem;
+            arg = arg.as_ref();
+        }
+
+        match arg_type {
+            Type::Path(TypePath { path, .. }) => {
+                let ident = &path.segments.last().unwrap().ident;
+                let ident_string = ident.to_string();
+
+                Ok(match ident_string.as_str() {
+                    "bool" => arg.value(Bool),
+                    "str" => arg.value(String).call_expr(quote!(#name.as_str())),
+                    "String" => arg.value(String).call_expr(quote!(#name.into())),
+                    "KString" => arg.value(String),
+                    "i8" | "u8" | "i16" | "u16" | "i32" | "u32" | "i64" | "u64" | "f32" | "f64" => {
+                        arg.value(Number).call_expr(quote!(#name.into()))
+                    }
+                    "KNumber" => arg.value(Number),
+                    "KRange" => arg.value(Range),
+                    "KList" => arg.value(List),
+                    "KTuple" => arg.value(Tuple),
+                    "KMap" => arg.value(Map),
+                    "KIterator" => arg
+                        .value(Iterable)
+                        .match_condition(quote!(#name.is_iterable()))
+                        .setup_expr(quote! {
+                            let #name = #name.clone();
+                            let #name = ctx.vm.make_iterator(#name)?;
+                        }),
+                    "KValue" => arg.value(Any),
+                    "KotoVm" => {
+                        if options.allow_call_context() {
+                            arg.context(KotoVm)
+                        } else {
+                            return Err(Error::new_spanned(
+                                ident,
+                                "`KotoVm` is not supported here",
+                            ));
+                        }
+                    }
+                    "CallContext" => {
+                        if options.allow_call_context() {
+                            arg.context(CallContext)
+                        } else {
+                            return Err(Error::new_spanned(
+                                ident,
+                                "`CallContext` is not supported here",
+                            ));
+                        }
+                    }
+                    "MethodContext" => {
+                        if options.allow_method_context() {
+                            arg.context(MethodContext)
+                        } else {
+                            return Err(Error::new_spanned(
+                                ident,
+                                "`MethodContext` is not supported here",
+                            ));
+                        }
+                    }
+                    // Unknown types can be assumed to implement `KotoObject`
+                    _ => arg
+                        .value(Object(ident_string))
+                        .match_condition(quote!(#name.is_a::<#ident>()))
+                        .setup_expr(quote!(let #name = #name.cast::<#ident>().unwrap();)),
+                }
+                .build())
+            }
+            // Pass remaining args to `&[KValue]` if it's the last arg
+            Type::Slice(TypeSlice { elem, .. }) => match elem.as_ref() {
+                Type::Path(TypePath { path, .. }) => {
+                    let ident_string = path.segments.last().unwrap().ident.to_string();
+                    if ident_string == "KValue" {
+                        if is_last {
+                            Ok(arg.value(Any).variadic().call_expr(quote!(#name)).build())
+                        } else {
+                            Err(Error::new(
+                                arg_type.span(),
+                                "Variadic args are only supported as the last argument",
+                            ))
+                        }
+                    } else {
+                        unsupported_arg_type(arg_type)
+                    }
+                }
+                _ => unsupported_arg_type(arg_type),
+            },
+            _ => unsupported_arg_type(arg_type),
+        }
+    }
+
+    fn builder(name: Ident) -> KotoArgBuilderStage1 {
+        KotoArgBuilderStage1 {
+            name,
+            as_ref: false,
+        }
+    }
+
+    fn call_expr(&self) -> Option<TokenStream> {
+        let Self {
+            name,
+            call_expr,
+            kind,
+            ..
+        } = self;
+
+        match call_expr {
+            Some(expr) => Some(expr.clone()),
+            None => match kind {
+                KotoArgKind::Value(value) => {
+                    if value.as_ref {
+                        Some(quote!(&#name))
+                    } else {
+                        Some(quote!(#name.clone()))
+                    }
+                }
+                KotoArgKind::Context(context) => match context.kind {
+                    KotoContextArgKind::KotoVm => Some(quote!(ctx.vm)),
+                    KotoContextArgKind::CallContext => Some(quote!(ctx)),
+                    KotoContextArgKind::MethodContext => Some(quote! {
+                        MethodContext::new(&o, extra_args, ctx.vm)
+                    }),
+                },
+                KotoArgKind::Receiver(receiver) => {
+                    if receiver.is_mut {
+                        Some(quote!(&mut *instance))
+                    } else {
+                        Some(quote!(&*instance))
+                    }
+                }
+            },
+        }
+    }
+}
+
+enum KotoArgKind {
+    Value(KotoValueArg),
+    Context(KotoContextArg),
+    Receiver(KotoReceiverArg),
+}
+
+struct KotoValueArg {
+    kind: KotoValueArgKind,
+    is_variadic: bool,
+    as_ref: bool,
+
+    // An optional condition to check on the matched value
+    match_condition: Option<TokenStream>,
+}
+
+impl KotoValueArg {
+    /// The type name to show in error messages
+    fn display_name(&self) -> String {
+        let name = match &self.kind {
+            KotoValueArgKind::Bool => "Bool",
+            KotoValueArgKind::String => "String",
+            KotoValueArgKind::Number => "Number",
+            KotoValueArgKind::Range => "Range",
+            KotoValueArgKind::List => "List",
+            KotoValueArgKind::Tuple => "Tuple",
+            KotoValueArgKind::Map => "Map",
+            KotoValueArgKind::Iterable => "Iterable",
+            KotoValueArgKind::Any => "Any",
+            KotoValueArgKind::Object(name) => name.as_str(),
+        };
+
+        let dots = if self.is_variadic { "..." } else { "" };
+
+        format!("{name}{dots}")
+    }
+
+    /// The KValue variant to match for the arg
+    fn match_pats(&self, name: &Ident) -> TokenStream {
+        if self.is_variadic {
+            quote!(#name @ ..)
+        } else {
+            match &self.kind {
+                KotoValueArgKind::Bool => quote!(KValue::Bool(#name)),
+                KotoValueArgKind::String => quote!(KValue::Str(#name)),
+                KotoValueArgKind::Number => quote!(KValue::Number(#name)),
+                KotoValueArgKind::Range => quote!(KValue::Range(#name)),
+                KotoValueArgKind::List => quote!(KValue::List(#name)),
+                KotoValueArgKind::Tuple => quote!(KValue::Tuple(#name)),
+                KotoValueArgKind::Map => quote!(KValue::Map(#name)),
+                KotoValueArgKind::Iterable => quote!(#name),
+                KotoValueArgKind::Any => quote!(#name),
+                KotoValueArgKind::Object(_) => quote!(KValue::Object(#name)),
+            }
+        }
+    }
+}
+
+enum KotoValueArgKind {
+    Bool,
+    String,
+    Number,
+    Range,
+    List,
+    Tuple,
+    Map,
+    Iterable,
+    Any,
+    Object(String),
+}
+
+struct KotoContextArg {
+    kind: KotoContextArgKind,
+}
+
+enum KotoContextArgKind {
+    MethodContext,
+    CallContext,
+    KotoVm,
+}
+
+struct KotoReceiverArg {
+    is_mut: bool,
+}
+
+struct KotoArgBuilderStage1 {
+    name: Ident,
+    as_ref: bool,
+}
+
+impl KotoArgBuilderStage1 {
+    #[expect(clippy::wrong_self_convention)]
+    fn as_ref(mut self) -> Self {
+        self.as_ref = true;
+        self
+    }
+
+    fn value(self, kind: KotoValueArgKind) -> KotoArgBuilderStage2 {
+        self.inner(KotoArgBuilderKind::Value(kind))
+    }
+
+    fn context(self, kind: KotoContextArgKind) -> KotoArgBuilderStage2 {
+        self.inner(KotoArgBuilderKind::Context(kind))
+    }
+
+    fn inner(self, kind: KotoArgBuilderKind) -> KotoArgBuilderStage2 {
+        let KotoArgBuilderStage1 { name, as_ref } = self;
+
+        KotoArgBuilderStage2 {
+            name,
+            as_ref,
+            kind,
+            is_variadic: false,
+            match_condition: None,
+            setup_expr: None,
+            call_expr: None,
+        }
+    }
+}
+
+struct KotoArgBuilderStage2 {
+    // Set by the first stage
+    name: Ident,
+    as_ref: bool,
+
+    // Set when transitioning from first stage
+    kind: KotoArgBuilderKind,
+
+    // Does the argument represent multiple values?
+    is_variadic: bool,
+    // An optional condition to check on the matched value
+    match_condition: Option<TokenStream>,
+    // Pre-call setup (e.g. calling make_iterator)
+    setup_expr: Option<TokenStream>,
+    // How the arg should be passed to the user's function
+    call_expr: Option<TokenStream>,
+}
+
+enum KotoArgBuilderKind {
+    Value(KotoValueArgKind),
+    Context(KotoContextArgKind),
+}
+
+impl KotoArgBuilderStage2 {
+    fn variadic(mut self) -> Self {
+        self.is_variadic = true;
+        self
+    }
+
+    fn match_condition(mut self, match_condition: TokenStream) -> Self {
+        self.match_condition = Some(match_condition);
+        self
+    }
+
+    fn setup_expr(mut self, setup_expr: TokenStream) -> Self {
+        self.setup_expr = Some(setup_expr);
+        self
+    }
+
+    fn call_expr(mut self, call_expr: TokenStream) -> Self {
+        self.call_expr = Some(call_expr);
+        self
+    }
+
+    fn build(self) -> KotoArg {
+        let Self {
+            name,
+            kind,
+            as_ref,
+            match_condition,
+            setup_expr,
+            is_variadic,
+            call_expr,
+        } = self;
+
+        KotoArg {
+            name,
+            kind: match kind {
+                KotoArgBuilderKind::Value(kind) => KotoArgKind::Value(KotoValueArg {
+                    kind,
+                    is_variadic,
+                    match_condition,
+                    as_ref,
+                }),
+                KotoArgBuilderKind::Context(kind) => KotoArgKind::Context(KotoContextArg { kind }),
+            },
+            setup_expr,
+            call_expr,
+        }
+    }
+}
+
+fn unsupported_arg_type<T>(arg_type: &Type) -> Result<T> {
+    Err(Error::new(arg_type.span(), "Unsupported argument type"))
+}
+
+#[derive(Default)]
+pub(crate) struct AccessAttributeArgs {
+    pub(crate) name: Option<LitStr>,
+    pub(crate) aliases: Vec<LitStr>,
+}
+
+impl AccessAttributeArgs {
+    pub(crate) fn new(attr: &Attribute) -> Result<Self> {
+        let mut name = None::<LitStr>;
+        let mut aliases = Vec::new();
+
+        if matches!(attr.meta, Meta::List(_)) {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("name") {
+                    name = meta.value()?.parse()?;
+                    Ok(())
+                } else if meta.path.is_ident("alias") {
+                    aliases.push(meta.value()?.parse()?);
+                    Ok(())
+                } else {
+                    Err(meta.error("unsupported attribute argument"))
+                }
+            })?;
+        }
+
+        Ok(Self { name, aliases })
+    }
+
+    /// Returns entries for all names that should be associated with this access.
+    ///
+    /// If there is no `name` attribute, then `name_fallback` will be invoked to
+    /// produce a name in its stead.
+    pub(crate) fn names(
+        self,
+        name_fallback: impl FnOnce() -> Result<LitStr>,
+    ) -> Result<Vec<LitStr>> {
+        let name = match self.name {
+            Some(name) => name,
+            None => name_fallback()?,
+        };
+
+        let mut names = vec![name];
+        names.extend(self.aliases);
+        Ok(names)
+    }
+}

--- a/crates/koto/examples/rust_object.rs
+++ b/crates/koto/examples/rust_object.rs
@@ -38,20 +38,15 @@ impl MyType {
 
     // A simple getter function
     #[koto_method]
-    fn get(&self) -> runtime::Result<KValue> {
-        Ok(self.0.into())
+    fn get(&self) -> i64 {
+        self.0
     }
 
     // A function that returns the object instance as the result
     #[koto_method]
-    fn set(ctx: MethodContext<Self>) -> runtime::Result<KValue> {
-        match ctx.args {
-            [KValue::Number(n)] => {
-                ctx.instance_mut()?.0 = n.into();
-                ctx.instance_result()
-            }
-            unexpected => unexpected_args("|Number|", unexpected),
-        }
+    fn set(&mut self, n: i64) -> &mut Self {
+        self.0 = n;
+        self
     }
 }
 

--- a/crates/koto/tests/derive_koto_impl_doc.rs
+++ b/crates/koto/tests/derive_koto_impl_doc.rs
@@ -253,15 +253,9 @@ mod example {
         }
 
         #[koto_method]
-        fn add(ctx: MethodContext<Self>) -> Result<KValue> {
-            match ctx.args {
-                [KValue::Number(addend)] => {
-                    ctx.instance_mut()?.x += f64::from(addend);
-                    // Return a clone of the instance that's being modified
-                    ctx.instance_result()
-                }
-                unexpected => unexpected_args("|Number|", unexpected),
-            }
+        fn add(&mut self, addend: f64) -> &mut Self {
+            self.x += addend;
+            self
         }
     }
 

--- a/crates/runtime/src/__private.rs
+++ b/crates/runtime/src/__private.rs
@@ -16,7 +16,28 @@ impl<T: ?Sized> Clone for MethodOrField<T> {
 }
 
 #[diagnostic::on_unimplemented(
-    message = "a `#[koto_method]` method must return `()`, `KValue`, or `koto_runtime::Result<KValue>`",
+    message = "a `#[koto_fn]` must return a value that implements `Into<KValue>`, optionally wrapped in `koto_runtime::Result`",
+    label = "wrong return type",
+    note = "for more info see the `#[koto_fn]` documentation"
+)]
+pub trait KotoFunctionReturn {
+    fn into_result(self) -> Result<KValue>;
+}
+
+impl<T: Into<KValue>> KotoFunctionReturn for Result<T> {
+    fn into_result(self) -> Result<KValue> {
+        self.map(Into::into)
+    }
+}
+
+impl<T: Into<KValue>> KotoFunctionReturn for T {
+    fn into_result(self) -> Result<KValue> {
+        Ok(self.into())
+    }
+}
+
+#[diagnostic::on_unimplemented(
+    message = "a `#[koto_method]` method must return a value that implements `Into<KValue>`, optionally wrapped in `koto_runtime::Result`",
     label = "wrong return type",
     note = "for more info see the `#[koto_impl]` documentation"
 )]
@@ -24,26 +45,20 @@ pub trait KotoMethodReturn {
     fn into_result(self) -> Result<KValue>;
 }
 
-impl KotoMethodReturn for Result<KValue> {
+impl<T: Into<KValue>> KotoMethodReturn for Result<T> {
     fn into_result(self) -> Result<KValue> {
-        self
+        self.map(Into::into)
     }
 }
 
-impl KotoMethodReturn for KValue {
+impl<T: Into<KValue>> KotoMethodReturn for T {
     fn into_result(self) -> Result<KValue> {
-        Ok(self)
-    }
-}
-
-impl KotoMethodReturn for () {
-    fn into_result(self) -> Result<KValue> {
-        Ok(KValue::Null)
+        Ok(self.into())
     }
 }
 
 #[diagnostic::on_unimplemented(
-    message = "a `#[koto_get]` method must return `KValue` or `koto_runtime::Result<KValue>`",
+    message = "a `#[koto_get]` method must return a value that implements `Into<KValue>`, optionally wrapped in `koto_runtime::Result`",
     label = "wrong return type",
     note = "for more info see the `#[koto_impl]` documentation"
 )]
@@ -51,15 +66,15 @@ pub trait KotoGetReturn {
     fn into_result(self) -> Result<KValue>;
 }
 
-impl KotoGetReturn for Result<KValue> {
+impl<T: Into<KValue>> KotoGetReturn for Result<T> {
     fn into_result(self) -> Result<KValue> {
-        self
+        self.map(Into::into)
     }
 }
 
-impl KotoGetReturn for KValue {
+impl<T: Into<KValue>> KotoGetReturn for T {
     fn into_result(self) -> Result<KValue> {
-        Ok(self)
+        Ok(self.into())
     }
 }
 
@@ -85,7 +100,7 @@ impl KotoSetReturn for () {
 }
 
 #[diagnostic::on_unimplemented(
-    message = "a `#[koto_get_fallback]` method must return `Option<KValue>` or `koto_runtime::Result<Option<KValue>>`",
+    message = "a `#[koto_get_fallback]` method must return a value that implements `Into<KValue>`, wrapped in an option, optionally wrapped in `koto_runtime::Result`",
     label = "wrong return type",
     note = "for more info see the `#[koto_impl]` documentation"
 )]
@@ -93,15 +108,15 @@ pub trait KotoGetFallbackReturn {
     fn into_result(self) -> Result<Option<KValue>>;
 }
 
-impl KotoGetFallbackReturn for Result<Option<KValue>> {
+impl<T: Into<KValue>> KotoGetFallbackReturn for Result<Option<T>> {
     fn into_result(self) -> Result<Option<KValue>> {
-        self
+        self.map(|o| o.map(Into::into))
     }
 }
 
-impl KotoGetFallbackReturn for Option<KValue> {
+impl<T: Into<KValue>> KotoGetFallbackReturn for Option<T> {
     fn into_result(self) -> Result<Option<KValue>> {
-        Ok(self)
+        Ok(self.map(Into::into))
     }
 }
 
@@ -127,7 +142,7 @@ impl KotoSetFallbackReturn for () {
 }
 
 #[diagnostic::on_unimplemented(
-    message = "a `#[koto_get_override]` method must return `Option<KValue>` or `koto_runtime::Result<Option<KValue>>`",
+    message = "a `#[koto_get_override]` method must return a value that implements `Into<KValue>`, wrapped in an option, optionally wrapped in `koto_runtime::Result`",
     label = "wrong return type",
     note = "for more info see the `#[koto_impl]` documentation"
 )]
@@ -135,15 +150,15 @@ pub trait KotoGetOverrideReturn {
     fn into_result(self) -> Result<Option<KValue>>;
 }
 
-impl KotoGetOverrideReturn for Result<Option<KValue>> {
+impl<T: Into<KValue>> KotoGetOverrideReturn for Result<Option<T>> {
     fn into_result(self) -> Result<Option<KValue>> {
-        self
+        self.map(|o| o.map(Into::into))
     }
 }
 
-impl KotoGetOverrideReturn for Option<KValue> {
+impl<T: Into<KValue>> KotoGetOverrideReturn for Option<T> {
     fn into_result(self) -> Result<Option<KValue>> {
-        Ok(self)
+        Ok(self.map(Into::into))
     }
 }
 

--- a/crates/runtime/src/core_lib/io.rs
+++ b/crates/runtime/src/core_lib/io.rs
@@ -180,18 +180,18 @@ impl File {
     }
 
     #[koto_method]
-    fn flush(&mut self) -> Result<KValue> {
-        self.0.flush().map(|_| KValue::Null)
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush()
     }
 
     #[koto_method]
-    fn is_terminal(&self) -> KValue {
-        self.0.is_terminal().into()
+    fn is_terminal(&self) -> bool {
+        self.0.is_terminal()
     }
 
     #[koto_method]
-    fn path(&self) -> Result<KValue> {
-        self.0.path().map(KValue::from)
+    fn path(&self) -> Result<KString> {
+        self.0.path()
     }
 
     #[koto_method]
@@ -210,8 +210,8 @@ impl File {
     }
 
     #[koto_method]
-    fn read_to_string(&mut self) -> Result<KValue> {
-        self.0.read_to_string().map(KValue::from)
+    fn read_to_string(&mut self) -> Result<String> {
+        self.0.read_to_string()
     }
 
     #[koto_method]

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -32,81 +32,67 @@ impl Rect {
     }
 
     #[koto_method]
-    fn left(&self) -> KValue {
-        self.x.start.into()
+    fn left(&self) -> f64 {
+        self.x.start
     }
 
     #[koto_method]
-    fn right(&self) -> KValue {
-        self.x.end.into()
+    fn right(&self) -> f64 {
+        self.x.end
     }
 
     #[koto_method]
-    fn bottom(&self) -> KValue {
-        self.y.start.into()
+    fn bottom(&self) -> f64 {
+        self.y.start
     }
 
     #[koto_method]
-    fn top(&self) -> KValue {
-        self.y.end.into()
+    fn top(&self) -> f64 {
+        self.y.end
     }
 
     #[koto_method]
-    fn width(&self) -> KValue {
-        self.x.len().into()
+    fn width(&self) -> f64 {
+        self.x.len()
     }
 
     #[koto_method]
-    fn height(&self) -> KValue {
-        self.y.len().into()
+    fn height(&self) -> f64 {
+        self.y.len()
     }
 
     #[koto_method]
-    fn center(&self) -> KValue {
-        Vec2::new(self.x.center(), self.y.center()).into()
+    fn center(&self) -> Vec2 {
+        Vec2::new(self.x.center(), self.y.center())
     }
 
     #[koto_method]
-    fn x(&self) -> KValue {
-        self.x.center().into()
+    fn x(&self) -> f64 {
+        self.x.center()
     }
 
     #[koto_method]
-    fn y(&self) -> KValue {
-        self.y.center().into()
+    fn y(&self) -> f64 {
+        self.y.center()
     }
 
     #[koto_method]
-    fn contains(&self, args: &[KValue]) -> Result<KValue> {
-        match args {
-            [KValue::Object(p)] if p.is_a::<Vec2>() => {
-                let p = p.cast::<Vec2>().unwrap();
-                let result = self.x.contains(p.inner().x) && self.y.contains(p.inner().y);
-                Ok(result.into())
-            }
-            unexpected => unexpected_args("|Vec2|", unexpected),
-        }
+    fn contains(&self, p: &Vec2) -> bool {
+        self.x.contains(p.inner().x) && self.y.contains(p.inner().y)
     }
 
-    #[koto_method]
-    fn set_center(ctx: MethodContext<Self>) -> Result<KValue> {
-        use KValue::{Number, Object};
+    #[koto_method(name = "set_center")]
+    fn set_center_point(&mut self, p: &Vec2) -> &mut Self {
+        self.x.set_center(p.inner().x);
+        self.y.set_center(p.inner().y);
+        self
+    }
 
-        let (x, y) = match ctx.args {
-            [Number(x), Number(y)] => (x.into(), y.into()),
-            [Object(p)] if p.is_a::<Vec2>() => {
-                let p = p.cast::<Vec2>().unwrap();
-                (p.inner().x, p.inner().y)
-            }
-            unexpected => return unexpected_args("|Vec2|, or |Number, Number|", unexpected),
-        };
-
-        let mut this = ctx.instance_mut()?;
-        this.x.set_center(x);
-        this.y.set_center(y);
-
-        // Return a clone of the Rect instance
-        ctx.instance_result()
+    #[koto_method(name = "set_center")]
+    fn set_center_xy(&mut self, x: f64, y: f64) -> &mut Self {
+        self.x.set_center(x);
+        self.y.set_center(y);
+        self
     }
 }
 
@@ -135,7 +121,7 @@ impl KotoObject for Rect {
                 3 => r.height(),
                 _ => unreachable!(),
             };
-            KIteratorOutput::Value(result)
+            KIteratorOutput::Value(result.into())
         });
 
         Ok(KIterator::with_std_iter(iter))

--- a/libs/geometry/src/vec2.rs
+++ b/libs/geometry/src/vec2.rs
@@ -18,23 +18,23 @@ impl Vec2 {
     }
 
     #[koto_method]
-    fn angle(&self) -> KValue {
-        Inner::X.angle_to(self.0).into()
+    fn angle(&self) -> f64 {
+        Inner::X.angle_to(self.0)
     }
 
     #[koto_method]
-    fn length(&self) -> KValue {
-        self.0.length().into()
+    fn length(&self) -> f64 {
+        self.0.length()
     }
 
     #[koto_get]
-    fn x(&self) -> KValue {
-        self.0.x.into()
+    fn x(&self) -> f64 {
+        self.0.x
     }
 
     #[koto_get]
-    fn y(&self) -> KValue {
-        self.0.y.into()
+    fn y(&self) -> f64 {
+        self.0.y
     }
 
     #[koto_set]
@@ -125,8 +125,8 @@ impl KotoObject for Vec2 {
     fn index(&self, index: &KValue) -> Result<KValue> {
         match index {
             KValue::Number(n) => match usize::from(n) {
-                0 => Ok(self.x()),
-                1 => Ok(self.y()),
+                0 => Ok(self.x().into()),
+                1 => Ok(self.y().into()),
                 other => runtime_error!("index out of range (got {other}, should be <= 1)"),
             },
             unexpected => unexpected_type("Number", unexpected),

--- a/libs/geometry/src/vec3.rs
+++ b/libs/geometry/src/vec3.rs
@@ -13,18 +13,18 @@ impl Vec3 {
     }
 
     #[koto_get]
-    fn x(&self) -> KValue {
-        self.0.x.into()
+    fn x(&self) -> f64 {
+        self.0.x
     }
 
     #[koto_get]
-    fn y(&self) -> KValue {
-        self.0.y.into()
+    fn y(&self) -> f64 {
+        self.0.y
     }
 
     #[koto_get]
-    fn z(&self) -> KValue {
-        self.0.z.into()
+    fn z(&self) -> f64 {
+        self.0.z
     }
 
     #[koto_set]
@@ -61,8 +61,8 @@ impl Vec3 {
     }
 
     #[koto_method]
-    fn length(&self) -> KValue {
-        (self.0.length()).into()
+    fn length(&self) -> f64 {
+        self.0.length()
     }
 }
 
@@ -131,9 +131,9 @@ impl KotoObject for Vec3 {
     fn index(&self, index: &KValue) -> Result<KValue> {
         match index {
             KValue::Number(n) => match usize::from(n) {
-                0 => Ok(self.x()),
-                1 => Ok(self.y()),
-                2 => Ok(self.z()),
+                0 => Ok(self.x().into()),
+                1 => Ok(self.y().into()),
+                2 => Ok(self.z().into()),
                 other => runtime_error!("index out of range (got {other}, should be <= 2)"),
             },
             unexpected => unexpected_type("Number", unexpected),

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -9,7 +9,7 @@ pub fn make_module() -> KMap {
     koto_fn! {
         runtime = koto_runtime;
 
-        fn gen_bool() -> Result<KValue> {
+        fn gen_bool() -> bool {
             THREAD_RNG.with_borrow_mut(|rng| rng.bool())
         }
 
@@ -22,7 +22,7 @@ pub fn make_module() -> KMap {
             Xoshiro256PlusPlusRng::make_value(Xoshiro256PlusPlus::seed_from_u64(seed.to_bits()))
         }
 
-        fn gen_number() -> Result<KValue> {
+        fn gen_number() -> f64 {
             THREAD_RNG.with_borrow_mut(|rng| rng.number())
         }
 
@@ -62,13 +62,13 @@ impl Xoshiro256PlusPlusRng {
     }
 
     #[koto_method]
-    fn bool(&mut self) -> Result<KValue> {
-        Ok(self.0.random::<bool>().into())
+    fn bool(&mut self) -> bool {
+        self.0.random()
     }
 
     #[koto_method]
-    fn number(&mut self) -> Result<KValue> {
-        Ok(self.0.random::<f64>().into())
+    fn number(&mut self) -> f64 {
+        self.0.random()
     }
 
     #[koto_method]
@@ -139,15 +139,8 @@ impl Xoshiro256PlusPlusRng {
     }
 
     #[koto_method]
-    fn seed(&mut self, args: &[KValue]) -> Result<KValue> {
-        use KValue::*;
-        match args {
-            [Number(n)] => {
-                self.seed_inner(n);
-                Ok(Null)
-            }
-            unexpected => unexpected_args("|Number|", unexpected),
-        }
+    fn seed(&mut self, n: &KNumber) {
+        self.seed_inner(n);
     }
 
     fn seed_inner(&mut self, n: &KNumber) {

--- a/libs/random/tests/shuffle.rs
+++ b/libs/random/tests/shuffle.rs
@@ -17,8 +17,8 @@ impl TestContainer {
     }
 
     #[koto_method]
-    fn to_tuple(&self) -> KValue {
-        KTuple::from(self.data.clone()).into()
+    fn to_tuple(&self) -> KTuple {
+        self.data.clone().into()
     }
 }
 


### PR DESCRIPTION
Closes #511 

#### This PR adds:
- automatic return value conversion for `T` and `Result<T>` where `T: Into<KValue>` using the conversion traits in `koto_runtime::__private` for all `#[koto_impl]` attributes that only allowed `KValue` or `Result<KValue>` before
  - `koto_fn!` now also uses a trait for return value conversion instead of inspecting the tokens to decide how to convert return values
- automatic argument conversions and overloading for `#[koto_method]`s similar to `koto_fn!`s
  - for that I've moved the overloading mechanism out of `function.rs` into `overloading.rs` that is now used by both `koto_fn!` and `#[koto_method]`
  - to overload a method you need to have two methods with the same `name` attribute:
    ```rust
    #[koto_method(name = "foo")]
    fn foo_number(&mut self, number: f64) {
        ...
    }

    #[koto_method(name = "foo")]
    fn foo_string(&mut self, string: &str) {
        ...
    }
    ``` 
  - `alias` attributes get accumulated across all the `koto_method`s of the same name
- `#[koto_method]`s that return `&Self`, `&mut Self`, `Result<&Self>`, or `Result<&mut Self>` now get translated to koto functions that return a clone of the `KObject`

As part of this PR I've made use of these new features in existing usages of `#[koto_impl]`s. Let me know if I should split this out of this PR.

#### In follow-up PRs we could:
- implement overloading and argument conversion for `#[koto_set]`
- accept `&str`, `String` and `KString` for the key argument of  `#[koto_get_*]` and `#[koto_set_*]`