### PR TITLE
Treat descending ranges as empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ The Koto project adheres to
 ### Changed
 
 #### Language
+
+- Descending ranges are now considered to be empty, with the start value treated as the anchor for the empty range ([#536](https://github.com/koto-lang/koto/issues/536)).
+  - Descending ranges were mostly useful for writing descending `for` loops. `iterator.reversed` should be used instead, e.g.:
+    - ```koto
+      # Instead of `for i in 3..=1`:
+      for i in (1..=3).reversed() 
+        print i
+      #: 3
+      #: 2
+      #: 1
 - `io.stdin`, `io.stdout` and `io.stderr` are now provided as `File` instead of `|| -> File`
 
 #### API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ The Koto project adheres to
       #: 1
 - `io.stdin`, `io.stdout` and `io.stderr` are now provided as `File` instead of `|| -> File`
 
+#### Core Library
+
+- `range.union` now treats scalar inputs as an inclusive singleton range (i.e. `x..=x`),
+  and will produce inclusive results whenever the new end point was derived from an inclusive range.
+
 #### API
 
 - The `KotoEntries` trait has been replaced with `KotoAccess`, see the note in the `Added` section above for more info.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The Koto project adheres to
 #### Core Library
 
 - New functions:
+  - `number.step_to`
   - `os.env`
 
 ### Changed
@@ -89,10 +90,10 @@ The Koto project adheres to
 #### Language
 
 - Descending ranges are now considered to be empty, with the start value treated as the anchor for the empty range ([#536](https://github.com/koto-lang/koto/issues/536)).
-  - Descending ranges were mostly useful for writing descending `for` loops. `iterator.reversed` should be used instead, e.g.:
+  - Descending ranges were mostly useful for writing descending `for` loops. `number.step_to` can be used instead, e.g.:
     - ```koto
       # Instead of `for i in 3..=1`:
-      for i in (1..=3).reversed() 
+      for i in 3.step_to 1
         print i
       #: 3
       #: 2

--- a/crates/cli/docs/core_lib/koto.md
+++ b/crates/cli/docs/core_lib/koto.md
@@ -227,7 +227,7 @@ print! (size 'hello'), (size 'héllø'), (size '')
 check! (5, 7, 0)
 
 print! (size 10..20), (size 10..=20), (size 20..0)
-check! (10, 11, 20)
+check! (10, 11, 0)
 ```
 
 

--- a/crates/cli/docs/core_lib/number.md
+++ b/crates/cli/docs/core_lib/number.md
@@ -735,6 +735,35 @@ assert_eq 0.sinh(), 0
 assert_near 1.sinh(), 1.1752011936438014
 ```
 
+## step_to
+
+```kototype
+|start: Number, target: Number| -> Iterator
+```
+
+```kototype
+|start: Number, target: Number, step_size: Number| -> Iterator
+```
+
+Returns an iterator that yields a sequence of numbers starting from `start`,
+and ending at or before `target`.
+
+The sequence progresses in steps with a size given by `step_size`,
+defaulting to `1` when `step_size` is omitted.
+
+### Example
+
+```koto
+print! 1.step_to(3).to_tuple()
+check! (1, 2, 3)
+
+print! 3.5.step_to(1).to_list()
+check! [3.5, 2.5, 1.5]
+
+print! 0.step_to(0.9, 0.25).to_tuple()
+check! (0.0, 0.25, 0.5, 0.75)
+```
+
 ## sqrt
 
 ```kototype

--- a/crates/cli/docs/core_lib/range.md
+++ b/crates/cli/docs/core_lib/range.md
@@ -21,8 +21,12 @@ and false otherwise.
 print! (10..20).contains 15
 check! true
 
-print! (200..=100).contains 100
+print! (100..=200).contains 200
 check! true
+
+# Descending ranges are considered to be empty.
+print! (200..=100).contains 100 
+check! false
 
 x = 1..10
 print! x.contains -1
@@ -66,8 +70,7 @@ check! 0
 Returns a copy of the input range which has been 'expanded' in both directions
 by the provided `amount`.
 
-For an ascending range this will mean that `start` will decrease by the provided
-amount, while `end` will increase.
+This will mean that `start` will decrease by the provided amount, and `end` will increase by the same amount.
 
 Negative amounts will cause the range to shrink rather than grow.
 
@@ -80,14 +83,14 @@ check! 5..25
 print! (10..20).expanded -2
 check! 12..18
 
-print! (5..-5).expanded 5
-check! 10..-10
+print! (-5..5).expanded 5
+check! -10..10
 
-print! (5..-5).expanded -5
+print! (-5..5).expanded -5
 check! 0..0
 
-print! (5..-5).expanded -10
-check! -5..5
+print! (-5..5).expanded -10
+check! 5..-5
 ```
 
 ## intersection
@@ -106,7 +109,7 @@ If there is no intersecting region then `null` is returned.
 print! (10..20).intersection 5..15
 check! 10..15
 
-print! (100..200).intersection 250..=150
+print! (100..200).intersection 150..=250
 check! 150..200
 
 print! (0..10).intersection 90..99

--- a/crates/runtime/src/core_lib/number/step_to.rs
+++ b/crates/runtime/src/core_lib/number/step_to.rs
@@ -1,0 +1,123 @@
+use crate::{Result, prelude::*};
+
+#[derive(Clone, Debug)]
+pub struct StepToI64Iterator {
+    target: i64,
+    step_by: i64,
+    steps_to_target: i64,
+}
+
+impl StepToI64Iterator {
+    pub fn new(start: i64, target: i64, step_by: i64) -> Self {
+        let steps_to_target = (target - start).abs() / step_by;
+        let step_by = if target < start { -step_by } else { step_by };
+        let target = start + step_by * steps_to_target;
+
+        Self {
+            target,
+            step_by,
+            steps_to_target,
+        }
+    }
+}
+
+impl KotoIterator for StepToI64Iterator {
+    fn make_copy(&self) -> Result<KIterator> {
+        Ok(KIterator::new(self.clone()))
+    }
+
+    fn is_bidirectional(&self) -> bool {
+        true
+    }
+
+    fn next_back(&mut self) -> Option<KIteratorOutput> {
+        if self.steps_to_target >= 0 {
+            let result = self.target;
+            self.target -= self.step_by;
+            self.steps_to_target -= 1;
+            Some(KIteratorOutput::Value(result.into()))
+        } else {
+            None
+        }
+    }
+}
+
+impl Iterator for StepToI64Iterator {
+    type Item = KIteratorOutput;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.steps_to_target >= 0 {
+            let result = self.target - self.step_by * self.steps_to_target;
+            self.steps_to_target -= 1;
+            Some(KIteratorOutput::Value(result.into()))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let hint = (self.steps_to_target + 1) as usize;
+        (hint, Some(hint))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StepToF64Iterator {
+    target: f64,
+    step_by: f64,
+    steps_to_target: f64,
+}
+
+impl StepToF64Iterator {
+    pub fn new(start: f64, target: f64, step_by: f64) -> Self {
+        let steps_to_target = ((target - start).abs() / step_by).floor();
+        let step_by = if target < start { -step_by } else { step_by };
+        let target = start + step_by * steps_to_target;
+
+        Self {
+            target,
+            step_by,
+            steps_to_target,
+        }
+    }
+}
+
+impl KotoIterator for StepToF64Iterator {
+    fn make_copy(&self) -> Result<KIterator> {
+        Ok(KIterator::new(self.clone()))
+    }
+
+    fn is_bidirectional(&self) -> bool {
+        true
+    }
+
+    fn next_back(&mut self) -> Option<KIteratorOutput> {
+        if self.steps_to_target >= 0.0 {
+            let result = self.target;
+            self.target -= self.step_by;
+            self.steps_to_target -= 1.0;
+            Some(KIteratorOutput::Value(result.into()))
+        } else {
+            None
+        }
+    }
+}
+
+impl Iterator for StepToF64Iterator {
+    type Item = KIteratorOutput;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.steps_to_target >= 0.0 {
+            let result = self.target - self.step_by * self.steps_to_target;
+            self.steps_to_target -= 1.0;
+            Some(KIteratorOutput::Value(result.into()))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let hint = (self.steps_to_target + 1.0) as usize;
+        (hint, Some(hint))
+    }
+}

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -1430,13 +1430,8 @@ impl KotoVm {
                         );
                     };
 
-                    if r.is_ascending() {
-                        let end = if inclusive { end + 1 } else { end };
-                        end + index as i64
-                    } else {
-                        let end = if inclusive { end - 1 } else { end };
-                        end - index as i64
-                    }
+                    let end = if inclusive { end + 1 } else { end };
+                    end + index as i64
                 } else {
                     let Some(start) = r.start() else {
                         return runtime_error!(
@@ -1445,11 +1440,7 @@ impl KotoVm {
                             index
                         );
                     };
-                    if r.is_ascending() {
-                        start + index as i64
-                    } else {
-                        start - index as i64
-                    }
+                    start + index as i64
                 }
                 .into();
 
@@ -2662,11 +2653,7 @@ impl KotoVm {
             (Range(r), Number(n)) if r.start().is_some() => {
                 let start = r.start().unwrap();
                 let index = self.validate_index(n, r.size())?;
-                if r.is_ascending() {
-                    Number((start + index as i64).into())
-                } else {
-                    Number((start - index as i64).into())
-                }
+                Number((start + index as i64).into())
             }
             (Object(o), index) => o.try_borrow()?.index(&index)?,
             (unexpected_value, unexpected_index) => {

--- a/crates/runtime/tests/iterator_tests.rs
+++ b/crates/runtime/tests/iterator_tests.rs
@@ -407,6 +407,82 @@ repeat(3, 2).to_tuple()
         }
     }
 
+    mod step_to {
+        use super::*;
+
+        mod integer {
+            use super::*;
+
+            #[test]
+            fn one_to_four() {
+                let script = "
+1.step_to(4).to_tuple()
+";
+                check_script_output(script, number_tuple(&[1, 2, 3, 4]));
+            }
+
+            #[test]
+            fn four_to_one() {
+                let script = "
+4.step_to(1).to_tuple()
+";
+                check_script_output(script, number_tuple(&[4, 3, 2, 1]));
+            }
+
+            #[test]
+            fn three_to_zero_reversed() {
+                let script = "
+3.step_to(0).reversed().to_tuple()
+";
+                check_script_output(script, number_tuple(&[0, 1, 2, 3]));
+            }
+
+            #[test]
+            fn zero_to_ten_step_3() {
+                let script = "
+0.step_to(10, 3).to_tuple()
+";
+                check_script_output(script, number_tuple(&[0, 3, 6, 9]));
+            }
+
+            #[test]
+            fn one_to_eleven_step_3_reversed() {
+                let script = "
+1.step_to(11, 3).reversed().to_tuple()
+";
+                check_script_output(script, number_tuple(&[10, 7, 4, 1]));
+            }
+        }
+
+        mod float {
+            use super::*;
+
+            #[test]
+            fn one_to_four() {
+                let script = "
+1.5.step_to(4.9).to_tuple()
+";
+                check_script_output(script, float_tuple(&[1.5, 2.5, 3.5, 4.5]));
+            }
+
+            #[test]
+            fn five_to_six_step_by() {
+                let script = "
+5.step_to(6, 0.25).to_tuple()
+";
+                check_script_output(script, float_tuple(&[5.0, 5.25, 5.5, 5.75, 6.0]));
+            }
+
+            #[test]
+            fn ten_to_one_reversed() {
+                let script = "
+10.step_to(1, 3.5).reversed().to_tuple()
+";
+                check_script_output(script, float_tuple(&[3.0, 6.5, 10.0]));
+            }
+        }
+    }
+
     mod take {
         use super::*;
 

--- a/crates/runtime/tests/range_tests.rs
+++ b/crates/runtime/tests/range_tests.rs
@@ -8,8 +8,8 @@ mod range {
     #[test_case("1..10", "15", "1..16")]
     #[test_case("1..=10", "-5", "-5..=10")]
     #[test_case("1..=10", "15..=20", "1..=20")]
-    #[test_case("10..=1", "20..15", "20..=1")]
-    #[test_case("11..1", "20..=13", "20..1")]
+    #[test_case("10..=1", "20..15", "10..=19")]
+    #[test_case("11..1", "20..=13", "11..20")]
     #[test_case("10..20", "15..20", "10..20")]
     #[test_case("1..1", "3..3", "1..3")]
     fn union(a: &str, b: &str, expected: &str) {
@@ -25,8 +25,6 @@ assert_eq ({a}).union({b}), {expected}
     #[test_case("(1..=3).reversed()", "(3, 2, 1)")]
     #[test_case("-3..0", "(-3, -2, -1)")]
     #[test_case("(-3..0).reversed()", "(-1, -2, -3)")]
-    #[test_case("4..=1", "(4, 3, 2, 1)")]
-    #[test_case("(4..=1).reversed()", "(1, 2, 3, 4)")]
     fn as_iterator(range: &str, expected: &str) {
         let script = format!(
             "

--- a/crates/runtime/tests/range_tests.rs
+++ b/crates/runtime/tests/range_tests.rs
@@ -4,18 +4,40 @@ mod range {
     use super::*;
     use test_case::test_case;
 
-    #[test_case("1..=10", "15", "1..=15")]
-    #[test_case("1..10", "15", "1..16")]
-    #[test_case("1..=10", "-5", "-5..=10")]
-    #[test_case("1..=10", "15..=20", "1..=20")]
-    #[test_case("10..=1", "20..15", "10..=19")]
-    #[test_case("11..1", "20..=13", "11..20")]
-    #[test_case("10..20", "15..20", "10..20")]
     #[test_case("1..1", "3..3", "1..3")]
-    fn union(a: &str, b: &str, expected: &str) {
+    #[test_case("1..10", "10..20", "1..20")]
+    #[test_case("10..20", "15..20", "10..20")]
+    #[test_case("10..=20", "25..=30", "10..=30")]
+    #[test_case("10..=10", "20..20", "10..20")]
+    #[test_case("11..=11", "20..=20", "11..=20")]
+    #[test_case("11..=11", "20..=19", "11..20")]
+    #[test_case("12..12", "20..20", "12..20")]
+    #[test_case("10..1", "20..15", "10..20")]
+    #[test_case("11..1", "20..=13", "11..20")]
+    #[test_case("100..=10", "200..150", "100..200")]
+    #[test_case("100..=10", "200..=250", "100..=250")]
+    fn union_with_range(a: &str, b: &str, expected: &str) {
         let script = format!(
             "
 assert_eq ({a}).union({b}), {expected}
+assert_eq ({b}).union({a}), {expected}
+"
+        );
+        check_script_output(&script, ());
+    }
+
+    #[test_case("1..=10", "1", "1..=10")]
+    #[test_case("1..=10", "10", "1..=10")]
+    #[test_case("1..=10", "15", "1..=15")]
+    #[test_case("1..=10", "-5", "-5..=10")]
+    #[test_case("10..20", "0", "0..20")]
+    #[test_case("10..20", "20", "10..=20")]
+    #[test_case("10..20", "25", "10..=25")]
+    fn union_with_scalar(a: &str, b: &str, expected: &str) {
+        let script = format!(
+            "
+assert_eq ({a}).union({b}), {expected}
+assert_eq ({b}..={b}).union({a}), {expected}
 "
         );
         check_script_output(&script, ());

--- a/crates/runtime/tests/vm_tests.rs
+++ b/crates/runtime/tests/vm_tests.rs
@@ -240,7 +240,6 @@ a, b, c
         fn range_indexing() {
             check_script_output("(10..=20)[5]", 15);
             check_script_output("(100..)[100]", 200);
-            check_script_output("(-10..-20)[3]", -13);
         }
     }
 
@@ -1631,39 +1630,12 @@ f 0..100
             }
 
             #[test]
-            fn ellipsis_at_start_with_inclusive_descending_range() {
-                let script = "
-f = |(..., y, z)| y, z
-f -10..=-20
-";
-                check_script_output(script, number_tuple(&[-19, -20]));
-            }
-
-            #[test]
-            fn ellipsis_at_start_with_non_inclusive_descending_range() {
-                let script = "
-f = |(..., y, z)| y, z
-f 50..10
-";
-                check_script_output(script, number_tuple(&[12, 11]));
-            }
-
-            #[test]
             fn ellipsis_at_end_with_range() {
                 let script = "
 f = |(a, b, ...)| a, b
 f 0..=100
 ";
                 check_script_output(script, number_tuple(&[0, 1]));
-            }
-
-            #[test]
-            fn ellipsis_at_end_with_descending_range() {
-                let script = "
-f = |(a, b, ...)| a, b
-f -10..-20
-";
-                check_script_output(script, number_tuple(&[-10, -11]));
             }
 
             #[test]

--- a/crates/test_utils/src/type_helpers.rs
+++ b/crates/test_utils/src/type_helpers.rs
@@ -27,6 +27,19 @@ where
     tuple(&values)
 }
 
+/// Returns a KValue::Tuple from a slice of floats.
+pub fn float_tuple<T>(values: &[T]) -> KValue
+where
+    T: Copy,
+    f64: From<T>,
+{
+    let values = values
+        .iter()
+        .map(|n| f64::from(*n).into())
+        .collect::<Vec<_>>();
+    tuple(&values)
+}
+
 /// Returns a KValue::List from a slice of KValues
 pub fn list(values: &[KValue]) -> KValue {
     KList::from_slice(values).into()

--- a/libs/random/src/lib.rs
+++ b/libs/random/src/lib.rs
@@ -102,7 +102,7 @@ impl Xoshiro256PlusPlusRng {
                 }
             }
             Range(r) => {
-                let full_range = r.as_sorted_range();
+                let full_range = r.as_bounded_range();
                 if !full_range.is_empty() {
                     let result = self.0.random_range(full_range);
                     Ok(result.into())


### PR DESCRIPTION
Resolves #536, although rather than removing support for descending ranges entirely, instead they're now treated as if they're empty, which is in line with how Rust's ranges behave.
