### PR TITLE
Update to Rust 1.95

### DIFF
--- a/crates/derive/src/koto_impl.rs
+++ b/crates/derive/src/koto_impl.rs
@@ -1064,116 +1064,127 @@ fn add_access_getter(ctx: &Context) -> Result<()> {
         // Non-generic types can cache the entries map in a `thread_local`/`LazyLock`
         let ty = ctx.ty();
 
-        if cfg!(feature = "rc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str) -> Option<#runtime::__private::MethodOrField<#ty>> {
-                    use ::std::{collections::HashMap, hash::BuildHasherDefault};
-                    use #runtime::{KotoHasher, __private::MethodOrField};
+        cfg_select! {
+            feature = "rc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str) -> Option<#runtime::__private::MethodOrField<#ty>> {
+                        use ::std::{collections::HashMap, hash::BuildHasherDefault};
+                        use #runtime::{KotoHasher, __private::MethodOrField};
 
-                    thread_local! {
-                        static ENTRIES: HashMap<
+                        thread_local! {
+                            static ENTRIES: HashMap<
+                                &'static str,
+                                MethodOrField<#ty>,
+                                BuildHasherDefault<KotoHasher>,
+                            > = #ty_turbofish::#create_access_map();
+                        }
+
+                        ENTRIES.with(|entries| entries.get(key).cloned())
+                    }
+                }
+            }
+            feature = "arc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str) -> Option<#runtime::__private::MethodOrField<#ty>> {
+                        use ::std::{collections::HashMap, hash::BuildHasherDefault, sync::LazyLock};
+                        use #runtime::{lazy, __private::MethodOrField, KotoHasher};
+
+                        static ENTRIES: LazyLock<HashMap<
                             &'static str,
                             MethodOrField<#ty>,
                             BuildHasherDefault<KotoHasher>,
-                        > = #ty_turbofish::#create_access_map();
+                        >> = LazyLock::new(#ty_turbofish::#create_access_map);
+
+                        LazyLock::force(&ENTRIES).get(key).cloned()
                     }
-
-                    ENTRIES.with(|entries| entries.get(key).cloned())
                 }
             }
-        } else if cfg!(feature = "arc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str) -> Option<#runtime::__private::MethodOrField<#ty>> {
-                    use ::std::{collections::HashMap, sync::LazyLock, hash::BuildHasherDefault};
-                    use #runtime::{lazy, __private::MethodOrField, KotoHasher};
-
-                    static ENTRIES: LazyLock<HashMap<
-                        &'static str,
-                        MethodOrField<#ty>,
-                        BuildHasherDefault<KotoHasher>,
-                    >> = LazyLock::new(#ty_turbofish::#create_access_map);
-
-                    LazyLock::force(&ENTRIES).get(key).cloned()
-                }
+            _ => {
+                return missing_memory_feature()
             }
-        } else {
-            no_feature_set!()
         }
     } else {
         // Rust doesn't support generic statics, so entries are cached in a hashmap with the
         // concrete instantiation type used as the key.
 
-        if cfg!(feature = "rc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str)
-                    -> Option<#runtime::__private::MethodOrField<dyn ::std::any::Any>>
-                {
-                    use ::std::{
-                        any::TypeId, cell::RefCell, collections::HashMap, hash::BuildHasherDefault,
-                    };
-                    use #runtime::{KMap, KotoHasher, __private::MethodOrField};
+        cfg_select! {
+            feature = "rc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str)
+                        -> Option<#runtime::__private::MethodOrField<dyn ::std::any::Any>>
+                    {
+                        use ::std::{
+                            any::TypeId, cell::RefCell, collections::HashMap,
+                            hash::BuildHasherDefault,
+                        };
+                        use #runtime::{KMap, KotoHasher, __private::MethodOrField};
 
-                    type PerTypeEntriesMap = HashMap<
-                        TypeId,
-                        HashMap<
-                            &'static str,
-                            MethodOrField<dyn ::std::any::Any>,
+                        type PerTypeEntriesMap = HashMap<
+                            TypeId,
+                            HashMap<
+                                &'static str,
+                                MethodOrField<dyn ::std::any::Any>,
+                                BuildHasherDefault<KotoHasher>,
+                            >,
                             BuildHasherDefault<KotoHasher>,
-                        >,
-                        BuildHasherDefault<KotoHasher>,
-                    >;
+                        >;
 
-                    thread_local! {
-                        static PER_TYPE_ENTRIES: RefCell<PerTypeEntriesMap> = RefCell::default();
+                        thread_local! {
+                            static PER_TYPE_ENTRIES: RefCell<PerTypeEntriesMap>
+                                = RefCell::default();
+                        }
+
+                        PER_TYPE_ENTRIES
+                            .with_borrow_mut(|per_type_entries| {
+                                per_type_entries
+                                    .entry(TypeId::of::<Self>())
+                                    .or_insert_with(#ty_turbofish::#create_access_map)
+                                    .get(key).cloned()
+                            })
                     }
-
-                    PER_TYPE_ENTRIES
-                        .with_borrow_mut(|per_type_entries| {
-                            per_type_entries
-                                .entry(TypeId::of::<Self>())
-                                .or_insert_with(#ty_turbofish::#create_access_map)
-                                .get(key).cloned()
-                        })
                 }
             }
-        } else if cfg!(feature = "arc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str)
-                    -> Option<#runtime::__private::MethodOrField<dyn ::std::any::Any>>
-                {
-                    use ::std::{
-                        any::TypeId, collections::HashMap, hash::BuildHasherDefault, sync::LazyLock,
-                    };
-                    use #runtime::{
-                        KCell, KMap, KotoHasher, KNativeFunction, __private::MethodOrField,
-                    };
+            feature = "arc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str)
+                        -> Option<#runtime::__private::MethodOrField<dyn ::std::any::Any>>
+                    {
+                        use ::std::{
+                            any::TypeId, collections::HashMap, hash::BuildHasherDefault,
+                            sync::LazyLock,
+                        };
+                        use #runtime::{
+                            KCell, KMap, KotoHasher, KNativeFunction, __private::MethodOrField,
+                        };
 
-                    type PerTypeEntriesMap = HashMap<
-                        TypeId,
-                        HashMap<
-                            &'static str,
-                            MethodOrField<dyn ::std::any::Any>,
+                        type PerTypeEntriesMap = HashMap<
+                            TypeId,
+                            HashMap<
+                                &'static str,
+                                MethodOrField<dyn ::std::any::Any>,
+                                BuildHasherDefault<KotoHasher>
+                            >,
                             BuildHasherDefault<KotoHasher>
-                        >,
-                        BuildHasherDefault<KotoHasher>
-                    >;
+                        >;
 
-                    static PER_TYPE_ENTRIES: LazyLock<KCell<PerTypeEntriesMap>> =
-                        LazyLock::new(KCell::default);
+                        static PER_TYPE_ENTRIES: LazyLock<KCell<PerTypeEntriesMap>> =
+                            LazyLock::new(KCell::default);
 
-                    PER_TYPE_ENTRIES
-                        .borrow_mut()
-                        .entry(TypeId::of::<Self>())
-                        .or_insert_with(#ty_turbofish::#create_access_map)
-                        .get(key).cloned()
+                        PER_TYPE_ENTRIES
+                            .borrow_mut()
+                            .entry(TypeId::of::<Self>())
+                            .or_insert_with(#ty_turbofish::#create_access_map)
+                            .get(key).cloned()
+                    }
                 }
             }
-        } else {
-            no_feature_set!()
+            _ => {
+                return missing_memory_feature()
+            }
         }
     };
 
@@ -1196,114 +1207,124 @@ fn add_access_assign_getter(ctx: &Context) -> Result<()> {
     let getter_fn = if ctx.impl_item.generics.params.is_empty() {
         // Non-generic types can cache the entries map in a `thread_local`/`LazyLock`
 
-        if cfg!(feature = "rc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str) -> Option<fn(&mut #ty, &KValue) -> #runtime::Result<()>> {
-                    use ::std::{collections::HashMap, hash::BuildHasherDefault};
-                    use #runtime::{Result, KotoHasher};
+        cfg_select! {
+            feature = "rc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str) -> Option<fn(&mut #ty, &KValue) -> #runtime::Result<()>> {
+                        use ::std::{collections::HashMap, hash::BuildHasherDefault};
+                        use #runtime::{Result, KotoHasher};
 
-                    thread_local! {
-                        static ENTRIES: HashMap<
+                        thread_local! {
+                            static ENTRIES: HashMap<
+                                &'static str,
+                                fn(&mut #ty, &KValue) -> Result<()>,
+                                BuildHasherDefault<KotoHasher>,
+                            > = #ty_turbofish::#create_access_map();
+                        }
+
+                        ENTRIES.with(|entries| entries.get(key).cloned())
+                    }
+                }
+            }
+            feature = "arc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str) -> Option<fn(&mut #ty, &KValue) -> #runtime::Result<()>> {
+                        use ::std::{collections::HashMap, hash::BuildHasherDefault, sync::LazyLock};
+                        use #runtime::{lazy, KotoHasher};
+
+                        static ENTRIES: LazyLock<HashMap<
                             &'static str,
                             fn(&mut #ty, &KValue) -> Result<()>,
                             BuildHasherDefault<KotoHasher>,
-                        > = #ty_turbofish::#create_access_map();
+                        >> = LazyLock::new(#ty_turbofish::#create_access_map);
+
+                        LazyLock::force(&ENTRIES).get(key).cloned()
                     }
-
-                    ENTRIES.with(|entries| entries.get(key).cloned())
                 }
             }
-        } else if cfg!(feature = "arc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str) -> Option<fn(&mut #ty, &KValue) -> #runtime::Result<()>> {
-                    use ::std::{collections::HashMap, sync::LazyLock, hash::BuildHasherDefault};
-                    use #runtime::{lazy, KotoHasher};
-
-                    static ENTRIES: LazyLock<HashMap<
-                        &'static str,
-                        fn(&mut #ty, &KValue) -> Result<()>,
-                        BuildHasherDefault<KotoHasher>,
-                    >> = LazyLock::new(#ty_turbofish::#create_access_map);
-
-                    LazyLock::force(&ENTRIES).get(key).cloned()
-                }
+            _ => {
+                return missing_memory_feature()
             }
-        } else {
-            no_feature_set!()
         }
     } else {
         // Rust doesn't support generic statics, so entries are cached in a hashmap with the
         // concrete instantiation type used as the key.
 
-        if cfg!(feature = "rc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str) -> Option<fn(&mut dyn ::std::any::Any, &#runtime::KValue)
-                    -> #runtime::Result<()>>
-                {
-                    use ::std::{
-                        any::TypeId, cell::RefCell, collections::HashMap, hash::BuildHasherDefault,
-                    };
-                    use #runtime::{KMap, KotoHasher, KValue, Result};
+        cfg_select! {
+            feature = "rc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str) -> Option<fn(&mut dyn ::std::any::Any, &#runtime::KValue)
+                        -> #runtime::Result<()>>
+                    {
+                        use ::std::{
+                            any::TypeId, cell::RefCell, collections::HashMap,
+                            hash::BuildHasherDefault,
+                        };
+                        use #runtime::{KMap, KotoHasher, KValue, Result};
 
-                    type PerTypeEntriesMap = HashMap<
-                        TypeId,
-                        HashMap<
-                            &'static str,
-                            fn(&mut dyn ::std::any::Any, &KValue) -> Result<()>,
+                        type PerTypeEntriesMap = HashMap<
+                            TypeId,
+                            HashMap<
+                                &'static str,
+                                fn(&mut dyn ::std::any::Any, &KValue) -> Result<()>,
+                                BuildHasherDefault<KotoHasher>,
+                            >,
                             BuildHasherDefault<KotoHasher>,
-                        >,
-                        BuildHasherDefault<KotoHasher>,
-                    >;
+                        >;
 
-                    thread_local! {
-                        static PER_TYPE_ENTRIES: RefCell<PerTypeEntriesMap> = RefCell::default();
+                        thread_local! {
+                            static PER_TYPE_ENTRIES: RefCell<PerTypeEntriesMap> = RefCell::default();
+                        }
+
+                        PER_TYPE_ENTRIES
+                            .with_borrow_mut(|per_type_entries| {
+                                per_type_entries
+                                    .entry(TypeId::of::<Self>())
+                                    .or_insert_with(#ty_turbofish::#create_access_map)
+                                    .get(key).cloned()
+                            })
                     }
-
-                    PER_TYPE_ENTRIES
-                        .with_borrow_mut(|per_type_entries| {
-                            per_type_entries
-                                .entry(TypeId::of::<Self>())
-                                .or_insert_with(#ty_turbofish::#create_access_map)
-                                .get(key).cloned()
-                        })
                 }
             }
-        } else if cfg!(feature = "arc") {
-            quote! {
-                #[automatically_derived]
-                fn #name(key: &str)
-                    -> Option<fn(&mut dyn ::std::any::Any, &KValue) -> #runtime::Result<()>>
-                {
-                    use ::std::{
-                        any::TypeId, collections::HashMap, hash::BuildHasherDefault, sync::LazyLock,
-                    };
-                    use #runtime::{KCell, KMap, KotoHasher, KNativeFunction, Result};
+            feature = "arc" => {
+                quote! {
+                    #[automatically_derived]
+                    fn #name(key: &str)
+                        -> Option<fn(&mut dyn ::std::any::Any, &KValue) -> #runtime::Result<()>>
+                    {
+                        use ::std::{
+                            any::TypeId, collections::HashMap, hash::BuildHasherDefault,
+                            sync::LazyLock,
+                        };
+                        use #runtime::{KCell, KMap, KotoHasher, KNativeFunction, Result};
 
-                    type PerTypeEntriesMap = HashMap<
-                        TypeId,
-                        HashMap<
-                            &'static str,
-                            fn(&mut dyn ::std::any::Any, &KValue) -> Result<()>,
+                        type PerTypeEntriesMap = HashMap<
+                            TypeId,
+                            HashMap<
+                                &'static str,
+                                fn(&mut dyn ::std::any::Any, &KValue) -> Result<()>,
+                                BuildHasherDefault<KotoHasher>,
+                            >,
                             BuildHasherDefault<KotoHasher>,
-                        >,
-                        BuildHasherDefault<KotoHasher>,
-                    >;
+                        >;
 
-                    static PER_TYPE_ENTRIES: LazyLock<KCell<PerTypeEntriesMap>> =
-                        LazyLock::new(KCell::default);
+                        static PER_TYPE_ENTRIES: LazyLock<KCell<PerTypeEntriesMap>> =
+                            LazyLock::new(KCell::default);
 
-                    PER_TYPE_ENTRIES
-                        .borrow_mut()
-                        .entry(TypeId::of::<Self>())
-                        .or_insert_with(#ty_turbofish::#create_access_map)
-                        .get(key).cloned()
+                        PER_TYPE_ENTRIES
+                            .borrow_mut()
+                            .entry(TypeId::of::<Self>())
+                            .or_insert_with(#ty_turbofish::#create_access_map)
+                            .get(key).cloned()
+                    }
                 }
             }
-        } else {
-            no_feature_set!()
+            _ => {
+                return missing_memory_feature()
+            }
         }
     };
 
@@ -1346,16 +1367,13 @@ fn parse2<T: Parse>(tokens: proc_macro2::TokenStream, what: &str) -> Result<T> {
     })
 }
 
-macro_rules! no_feature_set {
-    () => {
-        return Err(Error::new(
-            Span::call_site(),
-            r#"Either the \"rc\" or \"arc\" feature must be enabled!"#,
-        ))
-    };
+#[allow(dead_code)]
+fn missing_memory_feature<T>() -> Result<T> {
+    Err(Error::new(
+        Span::call_site(),
+        r#"Either the \"rc\" or \"arc\" feature must be enabled!"#,
+    ))
 }
-
-use no_feature_set;
 
 fn check_method_args(sig: &Signature, check: CheckMethodArgs) -> Result<()> {
     let CheckMethodArgs {

--- a/crates/derive/src/overloading.rs
+++ b/crates/derive/src/overloading.rs
@@ -557,8 +557,7 @@ impl KotoArg {
                     // Unknown types can be assumed to implement `KotoObject`
                     _ => arg
                         .value(Object(ident_string))
-                        .match_condition(quote!(#name.is_a::<#ident>()))
-                        .setup_expr(quote!(let #name = #name.cast::<#ident>().unwrap();)),
+                        .match_condition(quote!(let Ok(#name) = #name.cast::<#ident>())),
                 }
                 .build())
             }

--- a/crates/format/src/format.rs
+++ b/crates/format/src/format.rs
@@ -1312,10 +1312,8 @@ impl<'source, 'trivia> GroupBuilder<'source, 'trivia> {
                 }
 
                 match position_info {
-                    TriviaPosition::LineStart => {
-                        if item.span.end.line < position.line {
-                            self.group_break(GroupBreak::LineStart);
-                        }
+                    TriviaPosition::LineStart if item.span.end.line < position.line => {
+                        self.group_break(GroupBreak::LineStart);
                     }
                     _ if self.items.last().is_some_and(|item| !item.is_break()) => {
                         self.group_break(GroupBreak::SpaceOrIndentIfNecessary);
@@ -1512,10 +1510,8 @@ impl<'source> FormatItem<'source> {
                                 output.push('\n');
                                 group_break = GroupBreak::None;
                             }
-                            GroupBreak::IndentedBreak => {
-                                if indented {
-                                    group_break = GroupBreak::MaybeIndent;
-                                }
+                            GroupBreak::IndentedBreak if indented => {
+                                group_break = GroupBreak::MaybeIndent;
                             }
                             _ => {}
                         }

--- a/crates/lexer/src/lexer.rs
+++ b/crates/lexer/src/lexer.rs
@@ -302,21 +302,17 @@ impl<'a> TokenLexer<'a> {
                 char_bytes += c.len_utf8();
                 position.column += c.width().unwrap_or(0) as u32;
                 match c {
-                    '#' => {
-                        if chars.peek() == Some(&'-') {
-                            chars.next();
-                            char_bytes += 1;
-                            position.column += 1;
-                        }
+                    '#' if chars.peek() == Some(&'-') => {
+                        chars.next();
+                        char_bytes += 1;
+                        position.column += 1;
                     }
-                    '-' => {
-                        if chars.peek() == Some(&'#') {
-                            chars.next();
-                            char_bytes += 1;
-                            position.column += 1;
-                            end_found = true;
-                            break;
-                        }
+                    '-' if chars.peek() == Some(&'#') => {
+                        chars.next();
+                        char_bytes += 1;
+                        position.column += 1;
+                        end_found = true;
+                        break;
                     }
                     '\r' => {
                         if chars.next() != Some('\n') {

--- a/crates/memory/src/ptr_impl/mod.rs
+++ b/crates/memory/src/ptr_impl/mod.rs
@@ -1,9 +1,10 @@
-#[cfg(feature = "arc")]
-mod arc;
-#[cfg(feature = "arc")]
-pub(crate) use arc::*;
-
-#[cfg(feature = "rc")]
-mod rc;
-#[cfg(feature = "rc")]
-pub(crate) use rc::*;
+cfg_select! {
+    feature = "arc" => {
+        mod arc;
+        pub(crate) use arc::*;
+    }
+    feature = "rc" => {
+        mod rc;
+        pub(crate) use rc::*;
+    }
+}

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -3451,10 +3451,7 @@ impl<'source> Parser<'source> {
         let mut items = Vec::new();
         let mut context = *context;
 
-        loop {
-            let Some(item) = self.parse_id_or_string(&context)? else {
-                break;
-            };
+        while let Some(item) = self.parse_id_or_string(&context)? {
             let name = match self.peek_token_with_context(&context) {
                 Some(peeked) if peeked.token == Token::As => {
                     self.consume_token_with_context(&context);

--- a/crates/runtime/src/core_lib/koto.rs
+++ b/crates/runtime/src/core_lib/koto.rs
@@ -88,8 +88,7 @@ pub fn make_module() -> KMap {
             let chunk = try_load_koto_script(ctx, s)?;
             ctx.vm.run(chunk.inner())
         }
-        [KValue::Object(o)] if o.is_a::<Chunk>() => {
-            let chunk = o.cast::<Chunk>().unwrap().inner();
+        [KValue::Object(o)] if let Ok(chunk) = o.cast::<Chunk>().map(|chunk| chunk.inner()) => {
             ctx.vm.run(chunk)
         }
         unexpected => unexpected_args("|String|, or |Chunk|", unexpected),

--- a/crates/runtime/src/core_lib/list.rs
+++ b/crates/runtime/src/core_lib/list.rs
@@ -368,9 +368,7 @@ pub fn make_module() -> KMap {
 
                 let sorted = sort_by_key(ctx.vm, l.data().as_ref(), f.clone())?;
 
-                for (target_value, (_key, source_value)) in
-                    l.data_mut().iter_mut().zip(sorted.into_iter())
-                {
+                for (target_value, (_key, source_value)) in l.data_mut().iter_mut().zip(sorted) {
                     *target_value = source_value;
                 }
 

--- a/crates/runtime/src/core_lib/os.rs
+++ b/crates/runtime/src/core_lib/os.rs
@@ -187,9 +187,7 @@ impl KotoObject for Timer {
 
     fn subtract(&self, other: &KValue) -> Result<KValue> {
         match other {
-            KValue::Object(o) if o.is_a::<Self>() => {
-                let other_timer = o.cast::<Self>().unwrap();
-
+            KValue::Object(o) if let Ok(other_timer) = o.cast::<Self>() => {
                 let result = if self.0 >= other_timer.0 {
                     self.0.duration_since(other_timer.0).as_secs_f64()
                 } else {

--- a/crates/runtime/src/send_sync.rs
+++ b/crates/runtime/src/send_sync.rs
@@ -3,21 +3,24 @@
 //! When Koto is being used in a single-threaded context [KotoSend] and [KotoSync] are empty
 //! traits implemented for all types.
 
-#[cfg(feature = "rc")]
-mod traits {
-    /// An empty trait for single-threaded contexts, implemented for all types
-    pub trait KotoSend {}
-    impl<T> KotoSend for T {}
+cfg_select! {
+    feature = "rc" => {
+        mod traits {
+            /// An empty trait for single-threaded contexts, implemented for all types
+            pub trait KotoSend {}
+            impl<T> KotoSend for T {}
 
-    /// An empty trait for single-threaded contexts, implemented for all types
-    pub trait KotoSync {}
-    impl<T> KotoSync for T {}
-}
-
-#[cfg(not(feature = "rc"))]
-mod traits {
-    pub use Send as KotoSend;
-    pub use Sync as KotoSync;
+            /// An empty trait for single-threaded contexts, implemented for all types
+            pub trait KotoSync {}
+            impl<T> KotoSync for T {}
+        }
+    }
+    _ => {
+        mod traits {
+            pub use Send as KotoSend;
+            pub use Sync as KotoSync;
+        }
+    }
 }
 
 pub use traits::*;

--- a/crates/runtime/src/vm.rs
+++ b/crates/runtime/src/vm.rs
@@ -4361,7 +4361,7 @@ mod macros {
                     (Map(m), _) if m.contains_meta_key(&$op.into()) => {
                         macros::call_metamap_binary_op!($self, $op, m, lhs_value, rhs_value);
                     }
-                    (Object(o), Object(o2)) if o2.is_same_instance(o2) => {
+                    (Object(o), Object(o2)) if o.is_same_instance(o2) => {
                         let o2 = Object(o2.try_borrow()?.copy());
                         o.try_borrow_mut()?.$trait_fn(&o2)
                     }

--- a/crates/runtime/tests/object_tests.rs
+++ b/crates/runtime/tests/object_tests.rs
@@ -42,8 +42,8 @@ mod objects {
         #[koto_method]
         fn set_all_instances(ctx: MethodContext<Self>) -> Result<KValue> {
             match ctx.args {
-                [KValue::Object(b)] if b.is_a::<TestObject>() => {
-                    let b_x = b.cast::<TestObject>().unwrap().x;
+                [KValue::Object(b)] if let Ok(b) = b.cast::<TestObject>() => {
+                    let b_x = b.x;
                     ctx.instance_mut()?.x = b_x;
                     Ok(KValue::Null)
                 }
@@ -57,8 +57,7 @@ mod objects {
             {
                 use KValue::*;
                 match $other {
-                    Object(other) if other.is_a::<Self>() => {
-                        let other = other.cast::<Self>().unwrap();
+                    Object(other) if let Ok(other) = other.cast::<Self>() => {
                         Ok(Self::make_value($self.x $op other.x))
                     }
                     Number(n) => {
@@ -92,8 +91,7 @@ mod objects {
             {
                 use KValue::*;
                 match $other {
-                    Object(other) if other.is_a::<Self>() => {
-                        let other = other.cast::<Self>().unwrap();
+                    Object(other) if let Ok(other) = other.cast::<Self>() => {
                         $self.x $op other.x;
                         Ok(())
                     }
@@ -114,8 +112,7 @@ mod objects {
             {
                 use KValue::*;
                 match $other {
-                    Object(other) if other.is_a::<Self>() => {
-                        let other = other.cast::<Self>().unwrap();
+                    Object(other) if let Ok(other) = other.cast::<Self>() => {
                         #[allow(clippy::float_cmp)]
                         Ok($self.x $op other.x)
                     }
@@ -241,8 +238,7 @@ mod objects {
 
         fn power(&self, other: &KValue) -> Result<KValue> {
             match other {
-                KValue::Object(other) if other.is_a::<Self>() => {
-                    let other = other.cast::<Self>().unwrap();
+                KValue::Object(other) if let Ok(other) = other.cast::<Self>() => {
                     Ok(Self::make_value(self.x.pow(other.x as u32)))
                 }
                 KValue::Number(n) => Ok(Self::make_value(self.x.pow(u32::from(n)))),
@@ -284,8 +280,7 @@ mod objects {
         fn power_assign(&mut self, other: &KValue) -> Result<()> {
             use KValue::*;
             match other {
-                Object(other) if other.is_a::<Self>() => {
-                    let other = other.cast::<Self>().unwrap();
+                Object(other) if let Ok(other) = other.cast::<Self>() => {
                     self.x = self.x.pow(other.x as u32);
                     Ok(())
                 }

--- a/libs/color/src/color.rs
+++ b/libs/color/src/color.rs
@@ -272,11 +272,9 @@ impl Color {
     #[koto_method]
     pub fn mix(ctx: MethodContext<Self>) -> Result<Self> {
         let (a, b, amount) = match ctx.args {
-            [KValue::Object(b)] if b.is_a::<Color>() => {
-                (*ctx.instance()?, *b.cast::<Color>()?, 0.5)
-            }
-            [KValue::Object(b), KValue::Number(x)] if b.is_a::<Color>() => {
-                (*ctx.instance()?, *b.cast::<Color>()?, f32::from(x))
+            [KValue::Object(b)] if let Ok(b) = b.cast::<Color>() => (*ctx.instance()?, *b, 0.5),
+            [KValue::Object(b), KValue::Number(x)] if let Ok(b) = b.cast::<Color>() => {
+                (*ctx.instance()?, *b, f32::from(x))
             }
             unexpected => return unexpected_args("|Color|, or |Color, Number|", unexpected),
         };
@@ -347,20 +345,14 @@ impl KotoObject for Color {
 
     fn equal(&self, other: &KValue) -> Result<bool> {
         match other {
-            KValue::Object(o) if o.is_a::<Self>() => {
-                let other = o.cast::<Self>().unwrap();
-                Ok(*self == *other)
-            }
+            KValue::Object(o) if let Ok(other) = o.cast::<Self>() => Ok(*self == *other),
             unexpected => unexpected_type(Self::type_static(), unexpected),
         }
     }
 
     fn not_equal(&self, other: &KValue) -> Result<bool> {
         match other {
-            KValue::Object(o) if o.is_a::<Self>() => {
-                let other = o.cast::<Self>().unwrap();
-                Ok(*self != *other)
-            }
+            KValue::Object(o) if let Ok(other) = o.cast::<Self>() => Ok(*self != *other),
             unexpected => unexpected_type(Self::type_static(), unexpected),
         }
     }

--- a/libs/geometry/src/macros.rs
+++ b/libs/geometry/src/macros.rs
@@ -64,8 +64,7 @@ macro_rules! geometry_arithmetic_op {
     ($self:ident, $other:expr, $op:tt) => {
         {
             match $other {
-                KValue::Object(other) if other.is_a::<Self>() => {
-                    let other = other.cast::<Self>().unwrap();
+                KValue::Object(other) if let Ok(other) = other.cast::<Self>() => {
                     Ok((*$self $op *other).into())
                 }
                 KValue::Number(n) => {
@@ -100,8 +99,7 @@ macro_rules! geometry_compound_assign_op {
     ($self:ident, $other:expr, $op:tt) => {
         {
             match $other {
-                KValue::Object(other) if other.is_a::<Self>() => {
-                    let other = other.cast::<Self>().unwrap();
+                KValue::Object(other) if let Ok(other) = other.cast::<Self>() => {
                     *$self $op *other;
                     Ok(())
                 }
@@ -122,8 +120,7 @@ macro_rules! geometry_comparison_op {
     ($self:ident, $other:expr, $op:tt) => {
         {
             match $other {
-                KValue::Object(other) if other.is_a::<Self>() => {
-                    let other = other.cast::<Self>().unwrap();
+                KValue::Object(other) if let Ok(other) = other.cast::<Self>() => {
                     Ok(*$self $op *other)
                 }
                 unexpected => {


### PR DESCRIPTION
- **Listen to clippy**
- **Make use of match if let guards to simplify object is_a/cast pattern**
- **Make use of cfg_select**
- **Fix 'is same instance' comparison in compound assignments**
