### PR TITLE
Show a clearer error message when a multiline call is missing a comma

### DIFF
--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -83,6 +83,8 @@ pub enum SyntaxError {
     ExpectedAssignmentAfterMetaKey,
     #[error("expected argument for catch expression")]
     ExpectedCatchArgument,
+    #[error("function arguments must be separated by commas")]
+    ExpectedCommaBetweenCallArgs,
     #[error("expected catch expression after try")]
     ExpectedCatch,
     #[error("expected closing parenthesis ')'")]

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1559,6 +1559,32 @@ impl<'source> Parser<'source> {
                 {
                     self.consume_next_token_on_same_line();
                 } else {
+                    // Check for multiline calls without commas
+                    //
+                    // e.g.:
+                    //
+                    // assert_eq
+                    //   foo
+                    //   bar
+                    //   ^
+                    //
+                    // Piped calls can follow the last argument reusing the arg column,
+                    // so `Token::Arrow` is excluded from the error check.
+                    //
+                    // do_something
+                    //   foo,
+                    //   bar
+                    //   -> other_thing
+                    if let Some(peeked) = self.peek_token_with_context(&arg_context)
+                        && peeked.info.line() > self.current_line()
+                        && peeked.token != Token::Arrow
+                    {
+                        return self.error_with_span(
+                            SyntaxError::ExpectedCommaBetweenCallArgs,
+                            peeked.info.span,
+                        );
+                    }
+
                     break;
                 }
             }

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -290,6 +290,24 @@ f = ||
             }
 
             #[test]
+            fn missing_commas_in_multiline_call() {
+                let source = "\
+assert_eq
+  'a'
+  'b'
+# ^
+";
+                check_parsing_fails_with_error_span(
+                    source,
+                    SyntaxError::ExpectedCommaBetweenCallArgs,
+                    Span {
+                        start: Position { line: 2, column: 2 },
+                        end: Position { line: 2, column: 3 },
+                    },
+                );
+            }
+
+            #[test]
             fn missing_commas_in_chained_call() {
                 check_parsing_fails("f.bar 1 2 3");
             }


### PR DESCRIPTION
```
assert_eq
  'a'
  'b'
```

Without this change the user is shown 'Unexpected token' which is
accurate but unhelpful.
