### PR TITLE
Allow map blocks to be passed as the last arg in a paren-free call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,27 @@ The Koto project adheres to
 #### Language
 
 - Unpacking maps is now supported anywhere that variables can be created:
-  - ```koto
-    {x, y} = {x: 10, y: 20, z: 30}
-    x, y
-    #: (10, 20)
-    ```
+  ```koto
+  {x, y} = {x: 10, y: 20, z: 30}
+  x, y
+  #: (10, 20)
+  ```
+- Map blocks can now be used as the last argument in a parentheses-free function call:
+  ```koto
+  my_map.extend
+    abc: 123
+    xyz: 99
+  ```
 - `@access` and `@access_assign` metakeys have been added to support overriding the behavior of `.` access operations.
-  - ```koto
-    foo =
-      @access: |key| map.get(self, key) * 2
-      @access_assign: |key, value| map.insert(self, key, value * 100)
+  ```koto
+  foo =
+    @access: |key| map.get(self, key) * 2
+    @access_assign: |key, value| map.insert(self, key, value * 100)
 
-    foo.x = 1
-    foo.x
-    #: 200
-    ```
+  foo.x = 1
+  foo.x
+  #: 200
+  ```
 - `throw` can now be used with any value type, rather than only values that implement `@display`.
 
 #### API

--- a/crates/cli/docs/core_lib/map.md
+++ b/crates/cli/docs/core_lib/map.md
@@ -38,8 +38,10 @@ Extends the map with the output of the iterator, and returns the map.
 ### Example
 
 ```koto
-x = {foo: 42, bar: 99}
-print! x.extend {baz: 123}
+x = {foo: 42}
+print! x.extend
+  bar: 99
+  baz: 123
 check! {foo: 42, bar: 99, baz: 123}
 print! x.baz
 check! 123

--- a/crates/cli/docs/language_guide.md
+++ b/crates/cli/docs/language_guide.md
@@ -2056,6 +2056,23 @@ check! 3: 99
 check! 4: 100
 ```
 
+### Map Blocks as Last Argument
+
+Parentheses-free function calls can accept a map block as the last argument:
+
+```koto
+print_entries = |prefix, entries|
+  for key, value in entries
+    print '{prefix}-{key}: {value}'
+
+print_entries 'X',
+  name: 'Very'
+  flag: 'Important'
+
+check! X-name: Very
+check! X-flag: Important
+```
+
 ## Generators
 
 Generators are iterators that are made by calling _generator functions_,

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -1531,6 +1531,7 @@ impl<'source> Parser<'source> {
 
                 if new_line {
                     arg_context.expected_indentation = Indentation::Equal(peeked.info.indent);
+                    arg_context.allow_map_block = true;
                 } else if args.is_empty() && self.peek_token() != Some(Token::Whitespace) {
                     break;
                 }

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -2975,6 +2975,81 @@ foo x,
         }
 
         #[test]
+        fn call_with_map_block() {
+            let sources = [
+                "
+foo
+  abc: 99
+",
+                "
+foo
+    abc: 99
+",
+            ];
+
+            check_ast_for_equivalent_sources(
+                &sources,
+                &[
+                    id(0), // foo
+                    id(1), // abc
+                    SmallInt(99),
+                    map_entry(1, 2),
+                    map_block(&[3]),
+                    chain_call(&[4], false, None), // 5
+                    chain_root(0, Some(5)),
+                    MainBlock {
+                        body: nodes(&[6]),
+                        local_count: 0,
+                    },
+                ],
+                Some(&[Constant::Str("foo"), Constant::Str("abc")]),
+            )
+        }
+
+        #[test]
+        fn call_with_trailing_map_block() {
+            let sources = [
+                "
+foo bar,
+  abc: 99
+  xyz: 123
+",
+                "
+foo bar,
+    abc: 99
+    xyz: 123
+",
+            ];
+
+            check_ast_for_equivalent_sources(
+                &sources,
+                &[
+                    id(0), // foo
+                    id(1), // bar
+                    id(2), // abc
+                    SmallInt(99),
+                    map_entry(2, 3),
+                    id(3), // 5 - xyz
+                    SmallInt(123),
+                    map_entry(5, 6),
+                    map_block(&[4, 7]),
+                    chain_call(&[1, 8], false, None),
+                    chain_root(0, Some(9)), // 10
+                    MainBlock {
+                        body: nodes(&[10]),
+                        local_count: 0,
+                    },
+                ],
+                Some(&[
+                    Constant::Str("foo"),
+                    Constant::Str("bar"),
+                    Constant::Str("abc"),
+                    Constant::Str("xyz"),
+                ]),
+            )
+        }
+
+        #[test]
         fn call_with_parentheses() {
             let sources = [
                 "

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -2067,7 +2067,7 @@ export a
 export a =
   1 + 1",
                 "
-export 
+export
   a =
     1 + 1",
             ];
@@ -2101,11 +2101,11 @@ export a, b, c
 export a, b, c =
   foo",
                 "
-export 
+export
   a, b, c = foo",
                 "
-export 
-  a, b, c 
+export
+  a, b, c
     = foo",
             ];
 
@@ -2139,7 +2139,7 @@ export
         #[test]
         fn export_map_block() {
             let source = "
-export 
+export
   a: 123
   b: 99
 ";
@@ -2960,7 +2960,7 @@ foo x,
             check_ast_for_equivalent_sources(
                 &sources,
                 &[
-                    id(0), //foo
+                    id(0), // foo
                     id(1), // x
                     id(2), // y
                     chain_call(&[1, 2], false, None),
@@ -3240,10 +3240,10 @@ foo.bar x
   a
 ",
                 "
-| a, 
-  ( _, 
+| a,
+  ( _,
     (others..., c, _d)
-  ), 
+  ),
   _e
 |
   a
@@ -5133,9 +5133,9 @@ match {x: 1, @type: 'Foo'}
             let source = "\
 match {x: 1, y: 2}
   {
-    x as a, 
+    x as a,
     y as b
-  } then 
+  } then
     'ok'
 ";
             check_ast(

--- a/crates/parser/tests/parsing_failures.rs
+++ b/crates/parser/tests/parsing_failures.rs
@@ -208,7 +208,7 @@ z = if f x
             #[test]
             fn in_map_block() {
                 let source = "
-foo = 
+foo =
   bar: x = 1; x
 ";
                 check_parsing_fails(source);
@@ -323,6 +323,23 @@ f = || ?
                     Span {
                         start: Position { line: 0, column: 7 },
                         end: Position { line: 0, column: 8 },
+                    },
+                )
+            }
+
+            #[test]
+            fn call_arg_after_trailing_map_block() {
+                let source = "\
+foo bar,
+  abc: 99
+  , 'hello'
+# ^
+";
+                check_parsing_fails_with_span(
+                    source,
+                    Span {
+                        start: Position { line: 2, column: 2 },
+                        end: Position { line: 2, column: 3 },
                     },
                 )
             }


### PR DESCRIPTION
This PR adds support for passing a map block as the last argument in a parentheses-free call, e.g.:

```coffee
my_map.extend
  abc: 123
  xyz: 99
```
