### PR TITLE
Throw out-of-memory runtime errors from iterator->collection consumers

### DIFF
--- a/crates/runtime/src/core_lib/iterator.rs
+++ b/crates/runtime/src/core_lib/iterator.rs
@@ -4,7 +4,7 @@ pub mod adaptors;
 pub mod generators;
 pub mod peekable;
 
-use crate::{KIteratorOutput as Output, Result, derive::*, prelude::*};
+use crate::{Error, ErrorKind, KIteratorOutput as Output, Result, derive::*, prelude::*};
 
 static MODULE_NAME: &str = "core.iterator";
 
@@ -766,11 +766,20 @@ pub fn make_module() -> KMap {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
                 let (size_hint, _) = iterator.size_hint();
-                let mut result = ValueVec::with_capacity(size_hint);
+                let mut result = ValueVec::new();
+                if result.try_reserve(size_hint).is_err() {
+                    return iter_out_of_memory_error("List");
+                }
 
                 for output in iterator.map(collect_pair) {
                     match output {
-                        Output::Value(value) => result.push(value),
+                        Output::Value(value) => {
+                            if result.capacity() == result.len() && result.try_reserve(1).is_err() {
+                                return iter_out_of_memory_error("List");
+                            }
+
+                            result.push(value);
+                        }
                         Output::Error(error) => return Err(error),
                         _ => unreachable!(),
                     }
@@ -790,7 +799,10 @@ pub fn make_module() -> KMap {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
                 let (size_hint, _) = iterator.size_hint();
-                let mut result = ValueMap::with_capacity(size_hint);
+                let mut result = ValueMap::default();
+                if result.try_reserve(size_hint).is_err() {
+                    return iter_out_of_memory_error("Map");
+                }
 
                 for output in iterator {
                     let (key, value) = match output {
@@ -804,7 +816,12 @@ pub fn make_module() -> KMap {
                         Output::Error(error) => return Err(error),
                     };
 
-                    result.insert(ValueKey::try_from(key)?, value);
+                    let key = ValueKey::try_from(key)?;
+                    if result.capacity() == result.len() && result.try_reserve(1).is_err() {
+                        return iter_out_of_memory_error("Map");
+                    }
+
+                    result.insert(key, value);
                 }
 
                 Ok(KValue::Map(KMap::with_data(result)))
@@ -821,11 +838,26 @@ pub fn make_module() -> KMap {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
                 let (size_hint, _) = iterator.size_hint();
-                let mut display_context = DisplayContext::with_vm_and_capacity(ctx.vm, size_hint);
+                let mut display_context = DisplayContext::with_vm(ctx.vm);
+                if display_context.try_reserve(size_hint).is_err() {
+                    return iter_out_of_memory_error("String");
+                }
+
                 for output in iterator.map(collect_pair) {
                     match output {
-                        Output::Value(KValue::Str(s)) => display_context.append(s),
-                        Output::Value(value) => value.display(&mut display_context)?,
+                        Output::Value(KValue::Str(s)) => {
+                            if display_context.try_append(s).is_err() {
+                                return iter_out_of_memory_error("String");
+                            }
+                        }
+                        Output::Value(value) => {
+                            let mut value_context = DisplayContext::with_vm(ctx.vm);
+                            value.display(&mut value_context)?;
+
+                            if display_context.try_append(value_context.result()).is_err() {
+                                return iter_out_of_memory_error("String");
+                            }
+                        }
                         Output::Error(error) => return Err(error),
                         _ => unreachable!(),
                     };
@@ -845,11 +877,21 @@ pub fn make_module() -> KMap {
                 let iterable = iterable.clone();
                 let iterator = ctx.vm.make_iterator(iterable)?;
                 let (size_hint, _) = iterator.size_hint();
-                let mut result = Vec::with_capacity(size_hint);
+
+                let mut result = Vec::new();
+                if result.try_reserve(size_hint).is_err() {
+                    return iter_out_of_memory_error("Tuple");
+                }
 
                 for output in iterator.map(collect_pair) {
                     match output {
-                        Output::Value(value) => result.push(value),
+                        Output::Value(value) => {
+                            if result.capacity() == result.len() && result.try_reserve(1).is_err() {
+                                return iter_out_of_memory_error("Tuple");
+                            }
+
+                            result.push(value)
+                        }
                         Output::Error(error) => return Err(error),
                         _ => unreachable!(),
                     }
@@ -915,6 +957,10 @@ pub(crate) fn iter_output_to_result(iterator_output: Option<Output>) -> Result<O
     };
 
     Ok(output)
+}
+
+fn iter_out_of_memory_error<T>(collection: &'static str) -> Result<T> {
+    Err(Error::new(ErrorKind::IteratorOutOfMemory { collection }))
 }
 
 /// The output type used by operations like `iterator.next()` and `next_back()`

--- a/crates/runtime/src/display_context.rs
+++ b/crates/runtime/src/display_context.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::TryReserveError, fmt, result::Result as StdResult};
 
 use koto_memory::Address;
 
@@ -38,6 +38,11 @@ impl<'a> DisplayContext<'a> {
         }
     }
 
+    /// Reserves capacity for appending to the end of the string
+    pub fn try_reserve(&mut self, additional: usize) -> StdResult<(), TryReserveError> {
+        self.result.try_reserve(additional)
+    }
+
     /// Enables the debug flag on the display context
     pub fn enable_debug(mut self) -> Self {
         self.debug = true;
@@ -52,6 +57,20 @@ impl<'a> DisplayContext<'a> {
     /// Appends to the end of the string
     pub fn append<'b>(&mut self, s: impl Into<StringBuilderAppend<'b>>) {
         s.into().append(&mut self.result);
+    }
+
+    /// Appends to the end of the string, returning an error if insufficient memory is available
+    pub fn try_append<'b>(
+        &mut self,
+        s: impl Into<StringBuilderAppend<'b>>,
+    ) -> StdResult<(), TryReserveError> {
+        let s = s.into();
+        let s_len = s.len();
+        if self.result.capacity() - self.result.len() < s_len {
+            self.try_reserve(s_len)?;
+        }
+        s.append(&mut self.result);
+        Ok(())
     }
 
     /// Returns a reference to the context's VM
@@ -139,6 +158,16 @@ impl<'a> From<&'a KString> for StringBuilderAppend<'a> {
 }
 
 impl StringBuilderAppend<'_> {
+    fn len(&self) -> usize {
+        match self {
+            StringBuilderAppend::Char(c) => c.len_utf8(),
+            StringBuilderAppend::Str(s) => s.len(),
+            StringBuilderAppend::String(s) => s.len(),
+            StringBuilderAppend::KString(s) => s.len(),
+            StringBuilderAppend::KStringRef(s) => s.len(),
+        }
+    }
+
     fn append(self, string: &mut String) {
         match self {
             StringBuilderAppend::Char(c) => string.push(c),

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -26,6 +26,9 @@ pub enum ErrorKind {
     },
     #[error("execution timed out (the limit of {} seconds was reached)", .0.as_secs_f64())]
     Timeout(Duration),
+
+    #[error("iterator output too large to collect into {collection}")]
+    IteratorOutOfMemory { collection: &'static str },
     #[error("unable to borrow an object that is already mutably borrowed")]
     UnableToBorrowObject,
     #[error(
@@ -55,7 +58,11 @@ pub enum ErrorKind {
         fn_name: &'static str,
         object_type: KString,
     },
-    #[error("unable to perform operation '{op}' with '{}' and '{}'", lhs.type_as_string(), rhs.type_as_string())]
+    #[error(
+        "unable to perform operation '{op}' with '{}' and '{}'",
+        lhs.type_as_string(),
+        rhs.type_as_string(),
+    )]
     InvalidBinaryOp {
         lhs: KValue,
         rhs: KValue,
@@ -70,7 +77,8 @@ pub enum ErrorKind {
     #[error("this operation is unsupported on this platform")]
     UnsupportedPlatform,
     #[error(
-        "an unexpected error occurred, please report this as a bug at\nhttps://github.com/koto-lang/koto/issues"
+        "an unexpected error occurred, please report this as a bug at
+https://github.com/koto-lang/koto/issues"
     )]
     UnexpectedError,
 


### PR DESCRIPTION
This PR throws runtime errors from the core library's iterator->collection consumers instead of panicking when unbounded inputs exhaust available memory.

Fixes #546.