### PR TITLE
Introduce `Koto::spawn_shared`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The Koto project adheres to
   - `#[koto_get]`/`#[koto_set]` attributes (along with `_override` and `_fallback` attributes) have been added to make it easier to define field getters and setters.
   - Thanks to [@bluurryy](https://github.com/bluurryy) for the contributions.
 - The `KotoAccess` trait has replaced `KotoEntries`, and allows Rust objects to define how `.` access should behave on the object.
+- `Koto::spawn_shared` has been added to enable shared resources (like the core library and prelude) for applications that run parallel Koto instances.
 - `KotoVm::run_read_op` and `KotoVm::run_write_op` have been added to run overridden index / access operations.
 - `UnavailableStdin`, `UnavailableStdout` and `UnavailableStderr` have been added to represent unavailable io streams
 - `KotoSettings::inherit_args` and `KotoSettings::inherit_io` have been added to use the args / io of the current process

--- a/crates/cli/docs/api.md
+++ b/crates/cli/docs/api.md
@@ -151,6 +151,21 @@ default-features = false
 features = ["arc"]
 ```
 
+## Spawning shared Koto instances
+
+Sometimes it can be useful to have more that one Koto instance, while avoiding the setup cost of
+initializing the core library, prelude, module cache, and other resources that could be shared
+between instances.
+
+`Koto::spawn_shared` provides this feature, spawning a runtime with shared settings and resources.
+
+An exception to resource sharing is the spawned runtime's `exports` map, which is newly initialized
+with the assumption that the spawned instance will be used to initialize new modules.
+
+```rust_include
+spawn_shared.rs
+```
+
 ## Using Koto in a REPL
 
 Some applications (like REPLs) require assigned variables to persist between each script evaluation.

--- a/crates/koto/examples/spawn_shared.rs
+++ b/crates/koto/examples/spawn_shared.rs
@@ -1,0 +1,33 @@
+use anyhow::{Result, bail};
+use koto::prelude::*;
+
+fn main() -> Result<()> {
+    let script = "
+export x = a + b
+";
+    let mut koto = Koto::with_settings(KotoSettings::default().inherit_io());
+    koto.prelude().insert("a", 3);
+    koto.prelude().insert("b", 4);
+    koto.compile_and_run(script).unwrap();
+
+    let Some(KValue::Number(x1)) = koto.exports().get("x") else {
+        bail!("Expected 7");
+    };
+
+    // Spawn a Koto instance that uses shared resources.
+    let mut koto2 = koto.spawn_shared();
+    // `koto2` shares the same prelude as `koto` (here `a` is replaced while `b` is left alone).
+    koto2.prelude().insert("a", 10);
+    // ...although the spawned runtime is given a separate exports map.
+    assert!(koto2.exports().is_empty());
+
+    koto2.compile_and_run(script).unwrap();
+    let Some(KValue::Number(x2)) = koto2.exports().get("x") else {
+        bail!("Expected 14");
+    };
+
+    println!("x1: {x1}");
+    println!("x2: {x2}");
+
+    Ok(())
+}

--- a/crates/koto/src/koto.rs
+++ b/crates/koto/src/koto.rs
@@ -50,6 +50,19 @@ impl Koto {
         }
     }
 
+    /// Creates a new instance of Koto using shared runtime resources
+    ///
+    /// A new exports map is set up for the spawned runtime,
+    /// while the settings, prelude, core library, and module cache are shared.
+    pub fn spawn_shared(&self) -> Self {
+        let mut runtime = self.runtime.spawn_shared_vm();
+        *runtime.exports_mut() = KMap::default();
+        Self {
+            runtime,
+            run_tests: self.run_tests,
+        }
+    }
+
     /// Returns a reference to the runtime's prelude
     pub fn prelude(&self) -> &KMap {
         self.runtime.prelude()


### PR DESCRIPTION
This PR introduces `Koto::spawn_shared`, which acts a high-level counterpart to `KotoVm::spawn_shared_vm` for applications that want to run multiple `Koto` instances.