### PR TITLE
Use `strum` over `derive-name`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,25 +281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "derive-name"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19af109a7f1118ab96e1fd2a0c87310787f791680fa71b4bbfa5dffbc358b08"
-dependencies = [
- "derive-name-macros",
-]
-
-[[package]]
-name = "derive-name-macros"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa60999fb9292247d7c7eec5dada22b4ba337394612b0d935616bf49964c8bfd"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,12 +665,12 @@ name = "koto_bytecode"
 version = "0.17.0"
 dependencies = [
  "circular-buffer",
- "derive-name",
  "dunce",
  "koto_memory",
  "koto_parser",
  "rustc-hash",
  "smallvec",
+ "strum",
  "thiserror",
 ]
 
@@ -745,10 +726,10 @@ dependencies = [
 name = "koto_format"
 version = "0.17.0"
 dependencies = [
- "derive-name",
  "koto_lexer",
  "koto_parser",
  "serde",
+ "strum",
  "thiserror",
  "unicode-width",
 ]
@@ -792,10 +773,10 @@ dependencies = [
 name = "koto_parser"
 version = "0.17.0"
 dependencies = [
- "derive-name",
  "koto_lexer",
  "koto_memory",
  "smallvec",
+ "strum",
  "thiserror",
  "unicode-segmentation",
 ]
@@ -1576,6 +1557,27 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,6 @@ criterion = { version = "0.5.1", default-features = false }
 crossterm = { version = "0.29", default-features = false }
 # Adds #[derive(x)] macros for more traits
 derive_more = "2.0.1"
-# Derive macro to get the name of a struct, enum or enum variant
-derive-name = "1.1.0"
 # Normalize Windows paths to the most compatible format
 dunce = "1.0.2"
 # A small cross-platform library for retrieving random data from system source
@@ -103,6 +101,8 @@ serde_json = { version = "1.0.0", features = ["preserve_order", "std"] }
 serde_yaml_ng = "0.10.0"
 # 'Small vector' optimization: store up to a small number of items on the stack
 smallvec = { version = "1.11.1", features = ["const_generics", "union"] }
+# Derive macro to get the name of a struct, enum or enum variant
+strum = { version = "0.28.0", features = ["derive"] }
 # Parser for Rust source code
 syn = { version = "2.0.41", features = ["full"] }
 # A library for managing temporary files and directories.

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -24,8 +24,8 @@ koto_memory = { workspace = true }
 koto_parser = { workspace = true }
 
 circular-buffer = { workspace = true }
-derive-name = { workspace = true }
 dunce = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/bytecode/src/compiler.rs
+++ b/crates/bytecode/src/compiler.rs
@@ -3,7 +3,6 @@ use crate::{
     frame::{Arg, AssignedOrReserved, Frame, FrameError},
 };
 use circular_buffer::CircularBuffer;
-use derive_name::VariantName;
 use koto_parser::{
     Ast, AstBinaryOp, AstFor, AstIf, AstIndex, AstNode, AstTry, AstUnaryOp, AstVec, ChainNode,
     ConstantIndex, Function, ImportItem, KString, MetaKeyId, Node, Parser, Span, StringContents,
@@ -16,7 +15,7 @@ use thiserror::Error;
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
 enum ErrorKind {
-    #[error("expected {expected}, found '{}'", unexpected.variant_name())]
+    #[error("expected {expected}, found '{unexpected}'")]
     UnexpectedNode { expected: String, unexpected: Node },
     #[error("attempting to assign to a temporary value")]
     AssigningToATemporaryValue,

--- a/crates/format/Cargo.toml
+++ b/crates/format/Cargo.toml
@@ -23,7 +23,7 @@ rc = ["koto_parser/rc"]
 koto_lexer = { workspace = true }
 koto_parser = { workspace = true }
 
-derive-name = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+strum = { workspace = true }
 thiserror = { workspace = true }
 unicode-width = { workspace = true }

--- a/crates/format/src/error.rs
+++ b/crates/format/src/error.rs
@@ -1,4 +1,3 @@
-use derive_name::VariantName;
 use koto_lexer::Span;
 use koto_parser::Node;
 use thiserror::Error;
@@ -9,7 +8,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Error, Clone, Debug)]
 #[allow(missing_docs)]
 pub enum ErrorKind {
-    #[error("expected {expected}, found '{}'", unexpected.variant_name())]
+    #[error("expected {expected}, found '{unexpected}'")]
     UnexpectedNode { expected: String, unexpected: Node },
     #[error("Multi-assign node is missing targets")]
     MissingMultiAssignTargets,

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -29,7 +29,7 @@ error_ast = []
 koto_lexer = { workspace = true }
 koto_memory = { workspace = true }
 
-derive-name = { workspace = true }
 smallvec = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 unicode-segmentation = { workspace = true }

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -15,7 +15,7 @@ pub use smallvec::smallvec as astvec;
 /// A parsed node that can be included in the [AST](crate::Ast).
 ///
 /// Nodes refer to each other via [`AstIndex`], see [`AstNode`](crate::AstNode).
-#[derive(Clone, Debug, Default, PartialEq, Eq, derive_name::VariantName)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, strum::Display)]
 pub enum Node {
     /// The `null` keyword
     #[default]


### PR DESCRIPTION
Closes #549 (the comment about using `strum`) - `derive-name` appears to be abandoned without any clear contributor information.